### PR TITLE
Add `AnnotationMetadataAdapter`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AnnotationMetadataAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AnnotationMetadataAdapter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config.annotation;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.core.type.MethodMetadata;
+
+/**
+ * An {@link AnnotationMetadata} implementation to expose a metadata
+ * by the provided {@link Map} of attributes.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.2
+ */
+public abstract class AnnotationMetadataAdapter implements AnnotationMetadata {
+
+	private static final RuntimeException UNSUPPORTED_OPERATION =
+			new UnsupportedOperationException("The class doesn't support this operation");
+
+	@Override
+	public Set<MethodMetadata> getAnnotatedMethods(String annotationName) {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public MergedAnnotations getAnnotations() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public String getClassName() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public boolean isInterface() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public boolean isAnnotation() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public boolean isAbstract() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public boolean isFinal() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public boolean isIndependent() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public String getEnclosingClassName() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public String getSuperClassName() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public String[] getInterfaceNames() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+	@Override
+	public String[] getMemberClassNames() {
+		throw UNSUPPORTED_OPERATION;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AnnotationConfigParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AnnotationConfigParser.java
@@ -24,9 +24,9 @@ import org.w3c.dom.Element;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.integration.config.EnablePublisher;
 import org.springframework.integration.config.IntegrationRegistrar;
+import org.springframework.integration.config.annotation.AnnotationMetadataAdapter;
 import org.springframework.util.xml.DomUtils;
 
 /**
@@ -41,31 +41,27 @@ public class AnnotationConfigParser implements BeanDefinitionParser {
 
 	@Override
 	public BeanDefinition parse(final Element element, ParserContext parserContext) {
-		new IntegrationRegistrar().registerBeanDefinitions(new ExtendedAnnotationMetadata(Object.class, element),
+		new IntegrationRegistrar().registerBeanDefinitions(new ExtendedAnnotationMetadata(element),
 				parserContext.getRegistry());
 		return null;
 	}
 
-	private static final class ExtendedAnnotationMetadata extends StandardAnnotationMetadata {
+	private static final class ExtendedAnnotationMetadata extends AnnotationMetadataAdapter {
 
 		private final Element element;
 
-		ExtendedAnnotationMetadata(Class<?> introspectedClass, Element element) {
-			super(introspectedClass);
+		ExtendedAnnotationMetadata(Element element) {
 			this.element = element;
 		}
 
 		@Override
 		public Map<String, Object> getAnnotationAttributes(String annotationType) {
 			if (EnablePublisher.class.getName().equals(annotationType)) {
-				Element enablePublisherElement =
-						DomUtils.getChildElementByTagName(this.element, "enable-publisher");
+				Element enablePublisherElement = DomUtils.getChildElementByTagName(this.element, "enable-publisher");
 				if (enablePublisherElement != null) {
 					Map<String, Object> attributes = new HashMap<>();
-					attributes.put("defaultChannel",
-							enablePublisherElement.getAttribute("default-publisher-channel"));
-					attributes.put("proxyTargetClass",
-							enablePublisherElement.getAttribute("proxy-target-class"));
+					attributes.put("defaultChannel", enablePublisherElement.getAttribute("default-publisher-channel"));
+					attributes.put("proxyTargetClass", enablePublisherElement.getAttribute("proxy-target-class"));
 					attributes.put("order", enablePublisherElement.getAttribute("order"));
 					return attributes;
 				}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/MessageHistoryParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/MessageHistoryParser.java
@@ -24,8 +24,8 @@ import org.w3c.dom.Element;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.integration.config.MessageHistoryRegistrar;
+import org.springframework.integration.config.annotation.AnnotationMetadataAdapter;
 
 /**
  * The {@code <message-history/>} parser.
@@ -43,14 +43,16 @@ public class MessageHistoryParser implements BeanDefinitionParser {
 
 	@Override
 	public BeanDefinition parse(final Element element, ParserContext parserContext) {
-		this.messageHistoryRegistrar.registerBeanDefinitions(new StandardAnnotationMetadata(MessageHistoryParser.class) {
+		this.messageHistoryRegistrar.registerBeanDefinitions(
+				new AnnotationMetadataAdapter() {
 
-			@Override
-			public Map<String, Object> getAnnotationAttributes(String annotationType) {
-				return Collections.<String, Object>singletonMap("value", element.getAttribute("tracked-components"));
-			}
+					@Override
+					public Map<String, Object> getAnnotationAttributes(String annotationType) {
+						return Collections.singletonMap("value", element.getAttribute("tracked-components"));
+					}
 
-		}, parserContext.getRegistry());
+				}, parserContext.getRegistry());
 		return null;
 	}
+
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/enablecomponentscan/EnableComponentScanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/enablecomponentscan/EnableComponentScanTests.java
@@ -30,7 +30,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.core.type.StandardAnnotationMetadata;
 import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.config.IntegrationComponentScanRegistrar;
@@ -42,6 +41,7 @@ import org.springframework.util.ClassUtils;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 4.0
  */
 @RunWith(SpringRunner.class)
@@ -68,8 +68,8 @@ public class EnableComponentScanTests {
 		@Override
 		public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata,
 				BeanDefinitionRegistry registry) {
-			super.registerBeanDefinitions(new StandardAnnotationMetadata(
-					IntegrationComponentScanConfiguration.class, true), registry);
+			super.registerBeanDefinitions(
+					AnnotationMetadata.introspect(IntegrationComponentScanConfiguration.class), registry);
 		}
 
 		@Override

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/IntegrationGraphControllerParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/IntegrationGraphControllerParser.java
@@ -24,7 +24,7 @@ import org.w3c.dom.Element;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.xml.BeanDefinitionParser;
 import org.springframework.beans.factory.xml.ParserContext;
-import org.springframework.core.type.StandardAnnotationMetadata;
+import org.springframework.integration.config.annotation.AnnotationMetadataAdapter;
 
 /**
  * The {@link BeanDefinitionParser} for the {@code <int-http:graph-controller>} component.
@@ -41,11 +41,11 @@ public class IntegrationGraphControllerParser implements BeanDefinitionParser {
 	public BeanDefinition parse(final Element element, ParserContext parserContext) {
 		if (HttpContextUtils.WEB_MVC_PRESENT) {
 			this.graphControllerRegistrar.registerBeanDefinitions(
-					new StandardAnnotationMetadata(IntegrationGraphControllerParser.class) {
+					new AnnotationMetadataAdapter() {
 
 						@Override
 						public Map<String, Object> getAnnotationAttributes(String annotationType) {
-							return Collections.<String, Object>singletonMap("value", element.getAttribute("path"));
+							return Collections.singletonMap("value", element.getAttribute("path"));
 						}
 
 					}, parserContext.getRegistry());


### PR DESCRIPTION
Since SF has deprecated `StandardAnnotationMetadata` ctors in favor
of factory method, we can't extend it any more to adapt annotation
attributed by the map generated from the XML attributes

* Introduce an `AnnotationMetadataAdapter` to request a
`getAnnotationAttributes()` implementation which is only a method used
in the target `registerBeanDefinitions()` implementations
* Use a new `AnnotationMetadataAdapter` whenever the `StandardAnnotationMetadata`
has been used before

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
