### PR TITLE
SFTP: Add channelConnectTimeout

### DIFF
--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpOutboundTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -380,7 +381,7 @@ public class SftpOutboundTests {
 	}
 
 	private void noopConnect(ChannelSftp channel1) throws JSchException {
-		doAnswer(invocation -> null).when(channel1).connect();
+		doNothing().when(channel1).connect(5000);
 	}
 
 	public static class TestSftpSessionFactory extends DefaultSftpSessionFactory {

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpSessionFactoryTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpSessionFactoryTests.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.time.Duration;
 import java.util.Collections;
 
 import org.apache.sshd.server.SshServer;
@@ -153,8 +154,11 @@ public class SftpSessionFactoryTests {
 		SshServer server = SshServer.setUpDefaultServer();
 		try {
 			DefaultSftpSessionFactory f = createServerAndClient(server);
+			f.setChannelConnectTimeout(Duration.ofSeconds(6));
 			f.setAllowUnknownKeys(true);
-			f.getSession().close();
+			SftpSession session = f.getSession();
+			assertThat(TestUtils.getPropertyValue(session, "channelConnectTimeout", Integer.class)).isEqualTo(6_000);
+			session.close();
 		}
 		finally {
 			server.stop(true);


### PR DESCRIPTION
While investigating an SI build failure, I noticed that there is
a timeout available for when connecting channels.

This won't resolve the build issue (where the session closed) but
worth adding as a property.
