### PR TITLE
Encoding in AbstractHttpRequestExecutingMessageHandler.java is now done when flag is set

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
@@ -73,6 +73,7 @@ import org.springframework.web.util.UriComponentsBuilder;
  * @author Artem Bilan
  * @author Wallace Wadge
  * @author Shiliang Li
+ * @author Florian Schöffl
  *
  * @since 5.0
  */

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
@@ -301,7 +301,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 						: UriComponentsBuilder.fromUri((URI) uri);
 		UriComponents uriComponents = uriComponentsBuilder.buildAndExpand(uriVariables);
 		try {
-			return this.encodeUri ? uriComponents.toUri() : new URI(uriComponents.toUriString());
+			return this.encodeUri ? uriComponents.encode().toUri() : new URI(uriComponents.toUriString());
 		}
 		catch (URISyntaxException e) {
 			throw new MessageHandlingException(requestMessage, "Invalid URI [" + uri + "]", e);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -27,7 +27,11 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.xml.transform.Source;
@@ -763,7 +767,8 @@ public class HttpRequestExecutingMessageHandlerTests {
 		try {
 			handler.handleMessage(message);
 		}
-		catch (Exception ignored) { }
+		catch (Exception ignored) {
+		}
 		assertThat(restTemplate.actualUrl.get()).isEqualTo("http://example.com?query=test-%C3%A4%C3%B6%C3%BC%26%25");
 	}
 
@@ -785,7 +790,8 @@ public class HttpRequestExecutingMessageHandlerTests {
 		try {
 			handler.handleMessage(message);
 		}
-		catch (Exception ignored) { }
+		catch (Exception ignored) {
+		}
 		assertThat(restTemplate.actualUrl.get()).isEqualTo("http://example.com?query=test-äöü");
 	}
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -27,11 +27,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.xml.transform.Source;
@@ -73,6 +69,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Florian Schöffl
  */
 public class HttpRequestExecutingMessageHandlerTests {
 
@@ -744,6 +741,52 @@ public class HttpRequestExecutingMessageHandlerTests {
 		catch (Exception e) {
 		}
 		assertThat(restTemplate.actualUrl.get()).isEqualTo(theURL);
+	}
+
+	@Test
+	public void testUriEncoded() {
+		SpelExpressionParser parser = new SpelExpressionParser();
+		MockRestTemplate restTemplate = new MockRestTemplate();
+
+		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
+			"http://example.com?query={query}",
+			restTemplate
+		);
+
+		// This flag is set by default to true, but for sake of clarity for the reader we explicitly set it here again
+		handler.setEncodeUri(true);
+
+		handler.setUriVariableExpressions(Collections.singletonMap("query", parser.parseExpression("payload")));
+		setBeanFactory(handler);
+		handler.afterPropertiesSet();
+		Message<?> message = new GenericMessage<>("test-äöü&%");
+		try {
+			handler.handleMessage(message);
+		}
+		catch (Exception ignored) { }
+		assertThat(restTemplate.actualUrl.get()).isEqualTo("http://example.com?query=test-%C3%A4%C3%B6%C3%BC%26%25");
+	}
+
+	@Test
+	public void testUriEncodedDisabled() {
+		SpelExpressionParser parser = new SpelExpressionParser();
+		MockRestTemplate restTemplate = new MockRestTemplate();
+
+		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
+				"http://example.com?query={query}",
+				restTemplate
+		);
+
+		handler.setEncodeUri(false);
+		handler.setUriVariableExpressions(Collections.singletonMap("query", parser.parseExpression("payload")));
+		setBeanFactory(handler);
+		handler.afterPropertiesSet();
+		Message<?> message = new GenericMessage<>("test-äöü");
+		try {
+			handler.handleMessage(message);
+		}
+		catch (Exception ignored) { }
+		assertThat(restTemplate.actualUrl.get()).isEqualTo("http://example.com?query=test-äöü");
 	}
 
 	@Test


### PR DESCRIPTION
Before we did not actually encode the URI. You can see this in the screenshot below, where the String "häuser" is not actually encoded to the correct percentage encoding.

![withoutEncode](https://user-images.githubusercontent.com/5598040/57678488-98c08000-7629-11e9-9240-b7b9d04f14fe.PNG)

When we first encode it and then call the .toUri() we can see that the "häuser" is now propoerly encoded to "h%C3%A4user"

![withEncode](https://user-images.githubusercontent.com/5598040/57678526-ae35aa00-7629-11e9-86b9-9daf0671ba4b.PNG)
