### PR TITLE
Test for GH-2938

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -334,6 +334,10 @@ public class TcpNioConnectionTests {
 				logger.debug("Expected timeout", e);
 				throw (Exception) e.getCause();
 			}
+			finally {
+				connection.setPipeTimeout(15);
+				connection.close();
+			}
 			return null;
 		});
 		try {


### PR DESCRIPTION
Close connection in `TcpNioConnection.testInsufficientThreads()`.
Before the fix, this would block for 15 seconds, causing the assert
on the future completion to fail.

