### PR TITLE
GH-2936: Add custom converters for MongoDbMS

### DIFF
--- a/src/reference/asciidoc/mongodb.adoc
+++ b/src/reference/asciidoc/mongodb.adoc
@@ -123,9 +123,9 @@ The `MongoDbMessageStore` expands the `Message` as a Mongo document with all nes
 It is useful when you need to have access to the `payload` or `headers` for auditing or analytics -- for example, against stored messages.
 
 IMPORTANT: The `MongoDbMessageStore` uses a custom `MappingMongoConverter` implementation to store `Message` instances as MongoDB documents, and there are some limitations for the properties (`payload` and `header` values) of the `Message`.
-For example, there is no ability to configure custom converters for complex domain `payload` instances or `header` values.
-There is also no way to provide a custom `MongoTemplate` (or `MappingMongoConverter`).
-To achieve these capabilities, an alternative MongoDB `MessageStore` implementation has been introduced (we describe it next).
+
+Starting with version 5.1.6, the `MongoDbMessageStore` can be configured with custom converters which are propagated into an internal `MappingMongoConverter` implementation.
+See `MongoDbMessageStore.setCustomConverters(Object... customConverters)` JavaDocs for more information.
 
 Spring Integration 3.0 introduced the `ConfigurableMongoDbMessageStore`.
 It implements both the `MessageStore` and `MessageGroupStore` interfaces.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -77,3 +77,8 @@ See <<./mail.adoc#mail-inbound,Mail-receiving Channel Adapter>> for more informa
 
 The `WebFluxRequestExecutingMessageHandler` now supports a `Publisher`, `Resource` and `MultiValueMap` as a request message `payload`.
 See <<./webflux.adoc#webflux,WebFlux Support>> for more information.
+[[x5.2-mongodb]]
+==== MongoDb Changes
+
+The `MongoDbMessageStore` can now be configured with custom converters.
+See <<./mongodb.adoc#mongodb, MongoDB Support>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2936

* Add `MongoDbMessageStore.setCustomConverters()` to allow to inject
any custom converters for `payload` as well as header values

**Cherry-pick to 5.1.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
