### PR TITLE
Make spring-ws-core optional for SI-xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -769,7 +769,7 @@ project('spring-integration-xml') {
 		compile project(":spring-integration-core")
 		compile "org.springframework:spring-oxm:$springVersion"
 		compile ("org.springframework.ws:spring-xml:$springWsVersion")
-		compile ("org.springframework.ws:spring-ws-core:$springWsVersion")
+		compile ("org.springframework.ws:spring-ws-core:$springWsVersion", optional)
 	}
 }
 

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/UnmarshallingTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/UnmarshallingTransformer.java
@@ -147,7 +147,7 @@ public class UnmarshallingTransformer extends AbstractPayloadTransformer<Object,
 			this.delegate = unmarshaller;
 		}
 
-		public Object maybeUnmarshalMimeMessage(Object payload) throws IOException {
+		Object maybeUnmarshalMimeMessage(Object payload) throws IOException {
 			if (payload instanceof org.springframework.ws.mime.MimeMessage) {
 				return org.springframework.ws.support.MarshallingUtils.unmarshal(this.delegate,
 						(org.springframework.ws.mime.MimeMessage) payload);


### PR DESCRIPTION
It turns out that `spring-ws-core` brings too much WS stuff which
triggers and auto-configuration to be enabled in Spring Boot app when
we don't expect it.

* The `UnmarshallingTransformer` is already aware of `MimeMessage` and
`MarshallingUtils` being optional, so just remove redundant `public`
modifier for `maybeUnmarshalMimeMessage()` method
* Load `ServletContextResource` class in the `XsltPayloadTransformer`
on demand making such a dependency as optional

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
