### PR TITLE
Polishing for nohttp plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,16 +6,24 @@ buildscript {
 	dependencies {
 		classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
 		classpath "org.jetbrains.kotlin:kotlin-allopen:$kotlinVersion"
-		classpath "org.asciidoctor:asciidoctor-gradle-plugin:1.5.6"
-		classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.16'
-		classpath 'io.spring.nohttp:nohttp-gradle:0.0.1.RELEASE'
+		classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.18'
+		classpath 'io.spring.nohttp:nohttp-gradle:0.0.2.RELEASE'
 	}
 }
 
 plugins {
-	id 'org.sonarqube' version '2.7'
-	id 'org.asciidoctor.convert' version '1.5.10'
+	id 'org.sonarqube' version '2.7.1'
+	id 'org.asciidoctor.convert' version '1.6.1'
 	id 'org.ajoberstar.grgit' version '3.1.1'
+}
+
+if (System.getenv('TRAVIS') || System.getenv('bamboo_buildKey')) {
+	apply plugin: 'io.spring.nohttp'
+
+	nohttp {
+		source.include '**/src/**'
+		source.exclude '**/*.gif', '**/*.jpg', '**/*.png', '**/*.svg', '**/*.ks'
+	}
 }
 
 description = 'Spring Integration'
@@ -68,9 +76,6 @@ subprojects { subproject ->
 	apply plugin: 'checkstyle'
 	apply plugin: 'kotlin'
 	apply plugin: 'kotlin-spring'
-	if (System.getenv('TRAVIS') || System.getenv('bamboo_buildKey')) {
-		apply plugin: 'io.spring.nohttp'
-	}
 
 	sourceSets {
 		test {
@@ -97,7 +102,7 @@ subprojects { subproject ->
 		apacheSshdVersion = '2.2.0'
 		aspectjVersion = '1.9.4'
 		assertjVersion = '3.12.2'
-		assertkVersion = '0.14'
+		assertkVersion = '0.17'
 		awaitilityVersion = '3.1.6'
 		boonVersion = '0.34'
 		commonsDbcp2Version = '2.6.0'
@@ -308,15 +313,7 @@ subprojects { subproject ->
 
 	checkstyle {
 		configFile = file("$rootDir/src/checkstyle/checkstyle.xml")
-		toolVersion = "8.20"
-	}
-
-
-	if (System.getenv('TRAVIS') || System.getenv('bamboo_buildKey')) {
-		nohttp {
-			source.include 'src/**'
-			source.exclude '**/*.gif', '**/*.ks'
-		}
+		toolVersion = "8.21"
 	}
 
 	artifacts {

--- a/src/checkstyle/whitelist.lines
+++ b/src/checkstyle/whitelist.lines
@@ -1,0 +1,1 @@
+^\Qhttp://www.jcraft.com/jsch\E$

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -65,7 +65,7 @@ You can configure the SFTP session factory with a regular bean definition, as th
 ====
 
 Every time an adapter requests a session object from its `SessionFactory`, a new SFTP session is created.
-Under the covers, the SFTP Session Factory relies on the http://www.jcraft.com/jsch/[JSch] library to provide the SFTP capabilities.
+Under the covers, the SFTP Session Factory relies on the https://github.com/is/jsch[JSch] library to provide the SFTP capabilities.
 
 However, Spring Integration also supports the caching of SFTP sessions.
 See <<sftp-session-caching>> for more information.
@@ -99,7 +99,7 @@ The following list describes all the properties that are exposed by the https://
 It defaults to `false`.
 
 `clientVersion`::Lets you set the client version property.
-It's default depends on the underlying JSch version but it will look like:_SSH-2.0-JSCH-0.1.45_
+It's default depends on the underlying JSch version but it will look like: _SSH-2.0-JSCH-0.1.45_
 
 `enableDaemonThread`::If `true`, all threads are daemon threads.
 If set to `false`, normal non-daemon threads are used instead.
@@ -1349,7 +1349,7 @@ Its `cause` is another `PartialSuccessException` with `derivedInput` of `file2.t
 [[sftp-jsch-logging]]
 === SFTP/JSCH Logging
 
-Since we use JSch libraries (http://www.jcraft.com/jsch/) to provide SFTP support, you may at times require more information from the JSch API itself, especially if something is not working properly (such as authentication exceptions).
+Since we use JSch libraries to provide SFTP support, you may at times require more information from the JSch API itself, especially if something is not working properly (such as authentication exceptions).
 Unfortunately JSch does not use `commons-logging` but instead relies on custom implementations of their `com.jcraft.jsch.Logger` interface.
 As of Spring Integration 2.0.1, we have implemented this interface.
 So now, to enable JSch logging, you can configure your logger the way you usually do.


### PR DESCRIPTION
* Move the plugin and its task into the root project configuration
* Add more image file extensions to exclude
* Fix `sftp.adoc` do not use HTTP url for the JSCH library project page;
 use GitHub repo link instead

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
