### PR TITLE
Added getMetricsCaptor method to AbstractMessageHandler

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
@@ -35,6 +35,7 @@ import org.springframework.integration.support.management.metrics.MetricsCaptor;
 import org.springframework.integration.support.management.metrics.SampleFacade;
 import org.springframework.integration.support.management.metrics.TimerFacade;
 import org.springframework.integration.support.utils.IntegrationUtils;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
@@ -51,6 +51,7 @@ import reactor.core.CoreSubscriber;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Amit Sadafule
  */
 @SuppressWarnings("deprecation")
 @IntegrationManagedResource
@@ -98,6 +99,11 @@ public abstract class AbstractMessageHandler extends IntegrationObjectSupport
 	@Override
 	public void registerMetricsCaptor(MetricsCaptor metricsCaptorToRegister) {
 		this.metricsCaptor = metricsCaptorToRegister;
+	}
+
+	@Nullable
+	protected MetricsCaptor getMetricsCaptor() {
+		return this.metricsCaptor;
 	}
 
 	@Override


### PR DESCRIPTION
GH-2956 : https://github.com/spring-projects/spring-integration/issues/2956

Added getMetricsCaptor method to AbstractMessageHandler, so that user can add custom metrics in message handler sub classes