### PR TITLE
[2962] Mismatch between mechanism to check if nullChannel bean exists and mechanism to fetch that bean

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
@@ -85,6 +85,7 @@ import org.springframework.util.ClassUtils;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Michael Wiles
  *
  * @see IntegrationContextUtils
  */
@@ -183,12 +184,11 @@ class DefaultConfiguringBeanFactoryPostProcessor
 								.getBeanDefinition(IntegrationContextUtils.NULL_CHANNEL_BEAN_NAME);
 					}
 				}
-				// don't think it will hurt to always find the parent
 				if (beanFactory instanceof HierarchicalBeanFactory) {
 					beanFactory = ((HierarchicalBeanFactory) beanFactory).getParentBeanFactory();
 				}
-				// will definitely be found as containsBean returned true - but also want to be defensive in case of NPE
-			} while (nullChannelDefinition == null && beanFactory != null); // not sure if beanFactroy not null is necessary
+			}
+			while (nullChannelDefinition == null);
 
 			if (nullChannelDefinition != null &&
 					!NullChannel.class.getName().equals(nullChannelDefinition.getBeanClassName())) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -470,6 +470,28 @@ public class EnableIntegrationTests {
 		assertThat(this.asyncAnnotationProcessThread.get()).isNotSameAs(Thread.currentThread());
 	}
 
+	/**
+	 * Just creates an interim context to confirm that the DefaultConfiguringBeanFactoryPostProcessor 
+	 * does not fail when there is an extra application context in the hierarchy.
+	 */
+	@Test
+	public void testDoubleParentChildAnnotationConfiguration() {
+		AnnotationConfigApplicationContext parent;
+		parent = new AnnotationConfigApplicationContext();
+		parent.register(ChildConfiguration.class);
+		parent.setParent(this.context);
+		parent.refresh();
+
+		AnnotationConfigApplicationContext child;
+		child = new AnnotationConfigApplicationContext();
+		child.register(ChildConfiguration.class);
+		child.setParent(parent);
+		child.refresh();
+
+		parent.close();
+		child.close();
+	}
+	
 	@Test
 	public void testParentChildAnnotationConfiguration() {
 		AnnotationConfigApplicationContext child = new AnnotationConfigApplicationContext();

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -90,6 +90,7 @@ import org.springframework.integration.config.ExpressionControlBusFactoryBean;
 import org.springframework.integration.config.GlobalChannelInterceptor;
 import org.springframework.integration.config.IntegrationConverter;
 import org.springframework.integration.config.SpelFunctionFactoryBean;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.endpoint.AbstractEndpoint;
@@ -136,6 +137,7 @@ import reactor.core.publisher.Mono;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Michael Wiles
  *
  * @since 4.0
  */
@@ -471,16 +473,22 @@ public class EnableIntegrationTests {
 	}
 
 	/**
-	 * Just creates an interim context to confirm that the DefaultConfiguringBeanFactoryPostProcessor 
-	 * does not fail when there is an extra application context in the hierarchy.
+	 * Just creates an interim context to confirm that the
+	 * DefaultConfiguringBeanFactoryPostProcessor does not fail when there is an extra
+	 * application context in the hierarchy.
 	 */
 	@Test
 	public void testDoubleParentChildAnnotationConfiguration() {
+
+		assertThat(this.context.containsBeanDefinition(IntegrationContextUtils.NULL_CHANNEL_BEAN_NAME)).isTrue();
+
 		AnnotationConfigApplicationContext parent;
 		parent = new AnnotationConfigApplicationContext();
 		parent.register(ChildConfiguration.class);
 		parent.setParent(this.context);
 		parent.refresh();
+
+		assertThat(parent.containsBeanDefinition(IntegrationContextUtils.NULL_CHANNEL_BEAN_NAME)).isFalse();
 
 		AnnotationConfigApplicationContext child;
 		child = new AnnotationConfigApplicationContext();
@@ -488,10 +496,12 @@ public class EnableIntegrationTests {
 		child.setParent(parent);
 		child.refresh();
 
+		assertThat(child.containsBeanDefinition(IntegrationContextUtils.NULL_CHANNEL_BEAN_NAME)).isFalse();
+
 		parent.close();
 		child.close();
 	}
-	
+
 	@Test
 	public void testParentChildAnnotationConfiguration() {
 		AnnotationConfigApplicationContext child = new AnnotationConfigApplicationContext();


### PR DESCRIPTION
…2962

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
Pull request to resolve https://github.com/spring-projects/spring-integration/issues/2962

I did it very defensively so with lots of type checking etc as I can't be sure of the parent factories. I think this is all necessary as we're having to fetch the bean definition from the outside.

Also apologies if the formatting is not correct. I did try to use the eclipse formatter spec but the section of code I changed may not be formatted correctly.

Also see some of my inline comments.