### PR TITLE
Fix SplitterMH for primitive arrays cast

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageSplitter.java
@@ -34,6 +34,7 @@ import org.springframework.integration.support.AbstractIntegrationMessageBuilder
 import org.springframework.integration.support.json.JacksonPresent;
 import org.springframework.integration.util.FunctionIterator;
 import org.springframework.messaging.Message;
+import org.springframework.util.ObjectUtils;
 
 import com.fasterxml.jackson.core.TreeNode;
 import reactor.core.publisher.Flux;
@@ -62,7 +63,7 @@ public abstract class AbstractMessageSplitter extends AbstractReplyProducingMess
 	@Override
 	@SuppressWarnings("unchecked")
 	protected final Object handleRequestMessage(Message<?> message) {
-		Object result = this.splitMessage(message);
+		Object result = splitMessage(message);
 		// return null if 'null'
 		if (result == null) {
 			return null;
@@ -87,7 +88,7 @@ public abstract class AbstractMessageSplitter extends AbstractReplyProducingMess
 			}
 		}
 		else if (result.getClass().isArray()) {
-			Object[] items = (Object[]) result;
+			Object[] items = ObjectUtils.toObjectArray(result);;
 			sequenceSize = items.length;
 			if (reactive) {
 				flux = Flux.fromArray(items);

--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageSplitter.java
@@ -88,7 +88,7 @@ public abstract class AbstractMessageSplitter extends AbstractReplyProducingMess
 			}
 		}
 		else if (result.getClass().isArray()) {
-			Object[] items = ObjectUtils.toObjectArray(result);;
+			Object[] items = ObjectUtils.toObjectArray(result);
 			sequenceSize = items.length;
 			if (reactive) {
 				flux = Flux.fromArray(items);

--- a/spring-integration-core/src/test/java/org/springframework/integration/splitter/DefaultSplitterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/splitter/DefaultSplitterTests.java
@@ -54,7 +54,7 @@ import reactor.test.StepVerifier;
 public class DefaultSplitterTests {
 
 	@Test
-	public void splitMessageWithArrayPayload() throws Exception {
+	public void splitMessageWithArrayPayload() {
 		String[] payload = new String[] { "x", "y", "z" };
 		Message<String[]> message = MessageBuilder.withPayload(payload).build();
 		QueueChannel replyChannel = new QueueChannel();
@@ -75,7 +75,7 @@ public class DefaultSplitterTests {
 	}
 
 	@Test
-	public void splitMessageWithCollectionPayload() throws Exception {
+	public void splitMessageWithCollectionPayload() {
 		List<String> payload = Arrays.asList("x", "y", "z");
 		Message<List<String>> message = MessageBuilder.withPayload(payload).build();
 		QueueChannel replyChannel = new QueueChannel();
@@ -163,20 +163,20 @@ public class DefaultSplitterTests {
 
 	@Test
 	public void splitArrayPayloadReactive() {
-		Message<?> message = new GenericMessage<>(new String[] { "x", "y", "z" });
+		Message<?> message = new GenericMessage<>(new int[] { 0, 1, 2 });
 		FluxMessageChannel replyChannel = new FluxMessageChannel();
 		DefaultMessageSplitter splitter = new DefaultMessageSplitter();
 		splitter.setOutputChannel(replyChannel);
 
 		splitter.handleMessage(message);
 
-		Flux<String> testFlux =
+		Flux<Integer> testFlux =
 				Flux.from(replyChannel)
 						.map(Message::getPayload)
-						.cast(String.class);
+						.cast(Integer.class);
 
 		StepVerifier.create(testFlux)
-				.expectNext("x", "y", "z")
+				.expectNext(0, 1, 2)
 				.then(() ->
 						((Subscriber<?>) TestUtils.getPropertyValue(replyChannel, "subscribers", List.class).get(0))
 								.onComplete())


### PR DESCRIPTION
The plain cast like `(Object[]) array` doesn't work for array of
primitives - fails with `ClassCastException`

* Use `ObjectUtils.toObjectArray()` instead which does a smart job to
determine a wrapper for primitive and cast into that array of types
afterwards

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
