### PR TITLE
[WIP] JmsMessageDrivenChannelAdapterDefaultListenerContainerSpec

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
@@ -221,10 +221,10 @@ public final class Jms {
 	 * @param connectionFactory the JMS ConnectionFactory to build on
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 */
-	public static JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer>
+	public static JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterDefaultListenerContainerSpec
 	messageDrivenChannelAdapter(ConnectionFactory connectionFactory) {
 		try {
-			return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<>(
+			return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterDefaultListenerContainerSpec(
 					new JmsDefaultListenerContainerSpec()
 							.connectionFactory(connectionFactory));
 		}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageDrivenChannelAdapterSpec.java
@@ -28,7 +28,9 @@ import org.springframework.integration.jms.ChannelPublishingJmsMessageListener;
 import org.springframework.integration.jms.JmsHeaderMapper;
 import org.springframework.integration.jms.JmsMessageDrivenEndpoint;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
+import org.springframework.jms.listener.DefaultMessageListenerContainer;
 import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.Assert;
 
 /**
@@ -91,6 +93,23 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 	public S shutdownContainerOnStop(boolean shutdown) {
 		this.target.setShutdownContainerOnStop(shutdown);
 		return _this();
+	}
+
+	public static class JmsMessageDrivenChannelAdapterDefaultListenerContainerSpec extends
+	JmsMessageDrivenChannelAdapterListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer> {
+
+		private final JmsDefaultListenerContainerSpec spec;
+
+		JmsMessageDrivenChannelAdapterDefaultListenerContainerSpec(JmsDefaultListenerContainerSpec spec) {
+			super(spec);
+			this.spec = spec;
+		}
+
+		public JmsMessageDrivenChannelAdapterDefaultListenerContainerSpec transactionManager(PlatformTransactionManager transactionManager) {
+			this.spec.transactionManager(transactionManager);
+			return this;
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
Create class for concrete implementation of `JmsMessageDrivenChannelAdapterListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer>` to avoid usage of `JmsMessageDrivenChannelAdapterListenerContainerSpec#configureListenerContainer(...)` and expose all (?) methods of `JmsDefaultListenerContainerSpec` for convenience. 