### PR TITLE
Fix HttpHeaderMapper to support MimeType

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -55,6 +55,7 @@ import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.MimeType;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
@@ -740,15 +741,16 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 		if (!CollectionUtils.isEmpty(valuesToAccept)) {
 			List<MediaType> acceptableMediaTypes = new ArrayList<>();
 			for (Object type : valuesToAccept) {
-				if (type instanceof MediaType) {
-					acceptableMediaTypes.add((MediaType) type);
+				if (type instanceof MimeType) {
+					acceptableMediaTypes.add(MediaType.asMediaType((MimeType) type));
 				}
 				else if (type instanceof String) {
 					acceptableMediaTypes.addAll(MediaType.parseMediaTypes((String) type));
 				}
 				else {
 					throwIllegalArgumentForUnexpectedValue(
-							"Expected MediaType or String value for 'Accept' header value, but received: ", type);
+							"Expected org.springframework.util.MimeType " +
+									"or String value for 'Accept' header value, but received: ", type);
 
 				}
 			}
@@ -841,15 +843,16 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	}
 
 	private void setContentType(HttpHeaders target, Object value) {
-		if (value instanceof MediaType) {
-			target.setContentType((MediaType) value);
+		if (value instanceof MimeType) {
+			target.setContentType(MediaType.asMediaType((MimeType) value));
 		}
 		else if (value instanceof String) {
 			target.setContentType(MediaType.parseMediaType((String) value));
 		}
 		else {
 			throwIllegalArgumentForUnexpectedValue(
-					"Expected MediaType or String value for 'Content-Type' header value, but received: ", value);
+					"Expected org.springframework.util.MimeType " +
+							"or String value for 'Content-Type' header value, but received: ", value);
 		}
 	}
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -40,6 +40,7 @@ import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.util.MimeType;
 import org.springframework.util.StopWatch;
 
 /**
@@ -341,6 +342,18 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
 		assertThat(headers.getContentType().getType()).isEqualTo("text");
 		assertThat(headers.getContentType().getSubtype()).isEqualTo("html");
+	}
+
+	@Test
+	public void validateContentTypeAsMimeType() {
+		HeaderMapper<HttpHeaders> mapper = DefaultHttpHeaderMapper.outboundMapper();
+		Map<String, Object> messageHeaders = new HashMap<>();
+		messageHeaders.put(MessageHeaders.CONTENT_TYPE, new MimeType("text", "plain"));
+		HttpHeaders headers = new HttpHeaders();
+
+		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
+		assertThat(headers.getContentType().getType()).isEqualTo("text");
+		assertThat(headers.getContentType().getSubtype()).isEqualTo("plain");
 	}
 
 	// Date test


### PR DESCRIPTION
It turns out that `contentType` header (as well as `Accept`) may be
converted into `MimeType` upstream before the message is sent into HTTP
Outbound Channel Adapter meanwhile the logic is only to support String
and MediaType

* Change the `DefaultHttpHeaderMapper` to support more generic `MimeType`
for the `Content-Type` and `Accept` HTTP headers which can simply be
converted to the expected `MediaType`

**Cherry-pick to 5.1.x & 5.0.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
