### PR TITLE
Fix `SmartLifecycle.stop(Runnable)` usage

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -247,11 +247,6 @@ public class ConsumerEndpointFactoryBean
 	}
 
 	@Override
-	public boolean isSingleton() {
-		return true;
-	}
-
-	@Override
 	public AbstractEndpoint getObject() {
 		if (!this.initialized) {
 			this.initializeEndpoint();
@@ -302,8 +297,9 @@ public class ConsumerEndpointFactoryBean
 	}
 
 	private void eventDrivenConsumer(MessageChannel channel) {
-		Assert.isNull(this.pollerMetadata, "A poller should not be specified for endpoint '" + this.beanName
-				+ "', since '" + channel + "' is a SubscribableChannel (not pollable).");
+		Assert.isNull(this.pollerMetadata,
+				() -> "A poller should not be specified for endpoint '" + this.beanName
+						+ "', since '" + channel + "' is a SubscribableChannel (not pollable).");
 		this.endpoint = new EventDrivenConsumer((SubscribableChannel) channel, this.handler);
 		if (logger.isWarnEnabled()
 				&& Boolean.FALSE.equals(this.autoStartup)
@@ -316,8 +312,9 @@ public class ConsumerEndpointFactoryBean
 		PollingConsumer pollingConsumer = new PollingConsumer((PollableChannel) channel, this.handler);
 		if (this.pollerMetadata == null) {
 			this.pollerMetadata = PollerMetadata.getDefaultPollerMetadata(this.beanFactory);
-			Assert.notNull(this.pollerMetadata, "No poller has been defined for endpoint '" + this.beanName
-					+ "', and no default poller is available within the context.");
+			Assert.notNull(this.pollerMetadata,
+					() -> "No poller has been defined for endpoint '" + this.beanName
+							+ "', and no default poller is available within the context.");
 		}
 		pollingConsumer.setTaskExecutor(this.pollerMetadata.getTaskExecutor());
 		pollingConsumer.setTrigger(this.pollerMetadata.getTrigger());

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBean.java
@@ -157,11 +157,6 @@ public class SourcePollingChannelAdapterFactoryBean implements FactoryBean<Sourc
 		return SourcePollingChannelAdapter.class;
 	}
 
-	@Override
-	public boolean isSingleton() {
-		return true;
-	}
-
 	private void initializeAdapter() {
 		synchronized (this.initializationMonitor) {
 			if (this.initialized) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
@@ -127,16 +127,21 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 
 	@Override
 	public void stop(Runnable callback) {
-		AggregatingCallback aggregatingCallback = new AggregatingCallback(this.lifecycles.size(), callback);
-		ListIterator<SmartLifecycle> iterator = this.lifecycles.listIterator(this.lifecycles.size());
-		while (iterator.hasPrevious()) {
-			SmartLifecycle lifecycle = iterator.previous();
-			if (lifecycle.isRunning()) {
-				lifecycle.stop(aggregatingCallback);
+		if (this.lifecycles.size() > 0) {
+			AggregatingCallback aggregatingCallback = new AggregatingCallback(this.lifecycles.size(), callback);
+			ListIterator<SmartLifecycle> iterator = this.lifecycles.listIterator(this.lifecycles.size());
+			while (iterator.hasPrevious()) {
+				SmartLifecycle lifecycle = iterator.previous();
+				if (lifecycle.isRunning()) {
+					lifecycle.stop(aggregatingCallback);
+				}
+				else {
+					aggregatingCallback.run();
+				}
 			}
-			else {
-				aggregatingCallback.run();
-			}
+		}
+		else {
+			callback.run();
 		}
 		this.running = false;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistoryConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistoryConfigurer.java
@@ -52,7 +52,7 @@ import org.springframework.util.StringUtils;
 @IntegrationManagedResource
 public class MessageHistoryConfigurer implements SmartLifecycle, BeanFactoryAware, DestructionAwareBeanPostProcessor {
 
-	private final Log logger = LogFactory.getLog(this.getClass());
+	private final static Log logger = LogFactory.getLog(MessageHistoryConfigurer.class);
 
 	private final Set<TrackableComponent> currentlyTrackedComponents = ConcurrentHashMap.newKeySet();
 
@@ -228,12 +228,6 @@ public class MessageHistoryConfigurer implements SmartLifecycle, BeanFactoryAwar
 				this.running = false;
 			}
 		}
-	}
-
-	@Override
-	public void stop(Runnable callback) {
-		this.stop();
-		callback.run();
 	}
 
 	private static Collection<TrackableComponent> getTrackableComponents(ListableBeanFactory beanFactory) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistoryConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistoryConfigurer.java
@@ -52,7 +52,7 @@ import org.springframework.util.StringUtils;
 @IntegrationManagedResource
 public class MessageHistoryConfigurer implements SmartLifecycle, BeanFactoryAware, DestructionAwareBeanPostProcessor {
 
-	private final static Log logger = LogFactory.getLog(MessageHistoryConfigurer.class);
+	private static final Log logger = LogFactory.getLog(MessageHistoryConfigurer.class);
 
 	private final Set<TrackableComponent> currentlyTrackedComponents = ConcurrentHashMap.newKeySet();
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStoreReaper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStoreReaper.java
@@ -39,19 +39,19 @@ public class MessageGroupStoreReaper implements Runnable, DisposableBean, Initia
 
 	private static Log logger = LogFactory.getLog(MessageGroupStoreReaper.class);
 
+	private final ReentrantLock lifecycleLock = new ReentrantLock();
+
 	private MessageGroupStore messageGroupStore;
 
 	private boolean expireOnDestroy = false;
 
 	private long timeout = -1;
 
+	private int phase = 0;
+
+	private boolean autoStartup = true;
+
 	private volatile boolean running;
-
-	private final ReentrantLock lifecycleLock = new ReentrantLock();
-
-	private volatile int phase = 0;
-
-	private volatile boolean autoStartup = true;
 
 	public MessageGroupStoreReaper(MessageGroupStore messageGroupStore) {
 		this.messageGroupStore = messageGroupStore;
@@ -63,7 +63,6 @@ public class MessageGroupStoreReaper implements Runnable, DisposableBean, Initia
 	/**
 	 * Flag to indicate that the stores should be expired when this component is destroyed (i.e. usually when its
 	 * enclosing {@link org.springframework.context.ApplicationContext} is closed).
-	 *
 	 * @param expireOnDestroy the flag value to set
 	 */
 	public void setExpireOnDestroy(boolean expireOnDestroy) {
@@ -73,7 +72,6 @@ public class MessageGroupStoreReaper implements Runnable, DisposableBean, Initia
 	/**
 	 * Timeout in milliseconds (default -1). If negative then no groups ever time out. If greater than zero then all
 	 * groups older than that value are expired when this component is {@link #run()}.
-	 *
 	 * @param timeout the timeout to set
 	 */
 	public void setTimeout(long timeout) {
@@ -82,7 +80,6 @@ public class MessageGroupStoreReaper implements Runnable, DisposableBean, Initia
 
 	/**
 	 * A message group store to expire according the other configurations.
-	 *
 	 * @param messageGroupStore the {@link MessageGroupStore} to set
 	 */
 	public void setMessageGroupStore(MessageGroupStore messageGroupStore) {
@@ -185,18 +182,6 @@ public class MessageGroupStoreReaper implements Runnable, DisposableBean, Initia
 
 	public void setAutoStartup(boolean autoStartup) {
 		this.autoStartup = autoStartup;
-	}
-
-	@Override
-	public void stop(Runnable callback) {
-		this.lifecycleLock.lock();
-		try {
-			this.stop();
-			callback.run();
-		}
-		finally {
-			this.lifecycleLock.unlock();
-		}
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
@@ -308,12 +308,6 @@ public class LockRegistryLeaderInitiator implements SmartLifecycle, DisposableBe
 		}
 	}
 
-	@Override
-	public void stop(Runnable runnable) {
-		stop();
-		runnable.run();
-	}
-
 	/**
 	 * Stop the registration of the {@link #candidate} for leader election. If the
 	 * candidate is currently leader, its leadership will be revoked.

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -51,6 +51,7 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChannel>
@@ -64,83 +65,83 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	private final JmsTemplate jmsTemplate = new DynamicJmsTemplate();
 
-	private volatile AbstractMessageListenerContainer listenerContainer;
+	private AbstractMessageListenerContainer listenerContainer;
 
-	private volatile Class<? extends AbstractMessageListenerContainer> containerType;
+	private Class<? extends AbstractMessageListenerContainer> containerType;
 
-	private volatile boolean acceptMessagesWhileStopping;
+	private boolean acceptMessagesWhileStopping;
 
-	private volatile boolean autoStartup = true;
+	private boolean autoStartup = true;
 
-	private volatile String cacheLevelName;
+	private String cacheLevelName;
 
-	private volatile Integer cacheLevel;
+	private Integer cacheLevel;
 
-	private volatile String clientId;
+	private String clientId;
 
-	private volatile String concurrency;
+	private String concurrency;
 
-	private volatile Integer concurrentConsumers;
+	private Integer concurrentConsumers;
 
-	private volatile ConnectionFactory connectionFactory;
+	private ConnectionFactory connectionFactory;
 
-	private volatile Destination destination;
+	private Destination destination;
 
-	private volatile String destinationName;
+	private String destinationName;
 
-	private volatile DestinationResolver destinationResolver;
+	private DestinationResolver destinationResolver;
 
-	private volatile String durableSubscriptionName;
+	private String durableSubscriptionName;
 
-	private volatile ErrorHandler errorHandler;
+	private ErrorHandler errorHandler;
 
-	private volatile ExceptionListener exceptionListener;
+	private ExceptionListener exceptionListener;
 
-	private volatile Boolean exposeListenerSession;
+	private Boolean exposeListenerSession;
 
-	private volatile Integer idleTaskExecutionLimit;
+	private Integer idleTaskExecutionLimit;
 
-	private volatile Integer maxConcurrentConsumers;
+	private Integer maxConcurrentConsumers;
 
-	private volatile Integer maxMessagesPerTask;
+	private Integer maxMessagesPerTask;
 
-	private volatile String messageSelector;
+	private String messageSelector;
 
-	private volatile Integer phase;
+	private Integer phase;
 
-	private volatile Boolean pubSubDomain;
+	private Boolean pubSubDomain;
 
-	private volatile boolean pubSubNoLocal;
+	private boolean pubSubNoLocal;
 
-	private volatile Long receiveTimeout;
+	private Long receiveTimeout;
 
-	private volatile Long recoveryInterval;
+	private Long recoveryInterval;
 
-	private volatile String beanName;
+	private String beanName;
 
-	private volatile boolean subscriptionShared;
+	private boolean subscriptionShared;
 
 	/**
 	 * This value differs from the container implementations' default (which is AUTO_ACKNOWLEDGE)
 	 */
-	private volatile int sessionAcknowledgeMode = Session.SESSION_TRANSACTED;
+	private int sessionAcknowledgeMode = Session.SESSION_TRANSACTED;
 
 	/**
 	 * This value differs from the container implementations' default (which is false).
 	 */
-	private volatile boolean sessionTransacted = true;
+	private boolean sessionTransacted = true;
 
-	private volatile boolean subscriptionDurable;
+	private boolean subscriptionDurable;
 
-	private volatile Executor taskExecutor;
+	private Executor taskExecutor;
 
-	private volatile PlatformTransactionManager transactionManager;
+	private PlatformTransactionManager transactionManager;
 
-	private volatile String transactionName;
+	private String transactionName;
 
-	private volatile Integer transactionTimeout;
+	private Integer transactionTimeout;
 
-	private volatile int maxSubscribers = Integer.MAX_VALUE;
+	private int maxSubscribers = Integer.MAX_VALUE;
 
 
 	public JmsChannelFactoryBean() {
@@ -204,8 +205,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	public void setCacheLevelName(String cacheLevelName) {
 		Assert.isTrue(this.messageDriven, "'cacheLevelName' is allowed only in case of 'messageDriven = true'");
-		Assert.state(this.cacheLevel == null,
-				"'cacheLevelName' and 'cacheLevel' are mutually exclusive");
+		Assert.state(this.cacheLevel == null, "'cacheLevelName' and 'cacheLevel' are mutually exclusive");
 		this.cacheLevelName = cacheLevelName;
 	}
 
@@ -376,7 +376,8 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 		this.initializeJmsTemplate();
 		if (this.messageDriven) {
 			this.listenerContainer = createContainer();
-			SubscribableJmsChannel subscribableJmsChannel = new SubscribableJmsChannel(this.listenerContainer, this.jmsTemplate);
+			SubscribableJmsChannel subscribableJmsChannel =
+					new SubscribableJmsChannel(this.listenerContainer, this.jmsTemplate);
 			subscribableJmsChannel.setMaxSubscribers(this.maxSubscribers);
 			this.channel = subscribableJmsChannel;
 		}
@@ -519,9 +520,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	@Override
 	protected void destroyInstance(AbstractJmsChannel instance) {
-		if (instance instanceof SubscribableJmsChannel) {
-			((SubscribableJmsChannel) this.channel).destroy();
-		}
+		instance.destroy();
 	}
 
 }

--- a/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/AbstractStompSessionManager.java
+++ b/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/AbstractStompSessionManager.java
@@ -307,16 +307,6 @@ public abstract class AbstractStompSessionManager implements StompSessionManager
 	}
 
 	@Override
-	public void stop(Runnable callback) {
-		synchronized (this.lifecycleMonitor) {
-			stop();
-			if (callback != null) {
-				callback.run();
-			}
-		}
-	}
-
-	@Override
 	public void stop() {
 		synchronized (this.lifecycleMonitor) {
 			if (isRunning()) {

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppConnectionFactoryBean.java
@@ -208,12 +208,6 @@ public class XmppConnectionFactoryBean extends AbstractFactoryBean<XMPPConnectio
 	}
 
 	@Override
-	public void stop(Runnable callback) {
-		stop();
-		callback.run();
-	}
-
-	@Override
 	public boolean isRunning() {
 		return this.running;
 	}

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CuratorFrameworkFactoryBean.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CuratorFrameworkFactoryBean.java
@@ -130,12 +130,6 @@ public class CuratorFrameworkFactoryBean implements FactoryBean<CuratorFramework
 	}
 
 	@Override
-	public void stop(Runnable runnable) {
-		stop();
-		runnable.run();
-	}
-
-	@Override
 	public CuratorFramework getObject() {
 		return this.client;
 	}
@@ -143,11 +137,6 @@ public class CuratorFrameworkFactoryBean implements FactoryBean<CuratorFramework
 	@Override
 	public Class<?> getObjectType() {
 		return CuratorFramework.class;
-	}
-
-	@Override
-	public boolean isSingleton() {
-		return true;
 	}
 
 }

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBean.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBean.java
@@ -166,9 +166,4 @@ public class LeaderInitiatorFactoryBean
 		return LeaderInitiator.class;
 	}
 
-	@Override
-	public boolean isSingleton() {
-		return true;
-	}
-
 }

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/leader/LeaderInitiator.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/leader/LeaderInitiator.java
@@ -96,15 +96,18 @@ public class LeaderInitiator implements SmartLifecycle {
 	 */
 	private volatile boolean running;
 
-	/** Base path in a zookeeper */
+	/**
+	 * Base path in a zookeeper
+	 */
 	private final String namespace;
 
-	/** Leader event publisher if set */
+	/**
+	 * Leader event publisher if set
+	 */
 	private volatile LeaderEventPublisher leaderEventPublisher;
 
 	/**
 	 * Construct a {@link LeaderInitiator}.
-	 *
 	 * @param client     Curator client
 	 * @param candidate  leadership election candidate
 	 */
@@ -114,7 +117,6 @@ public class LeaderInitiator implements SmartLifecycle {
 
 	/**
 	 * Construct a {@link LeaderInitiator}.
-	 *
 	 * @param client     Curator client
 	 * @param candidate  leadership election candidate
 	 * @param namespace  namespace base path in zookeeper
@@ -199,15 +201,8 @@ public class LeaderInitiator implements SmartLifecycle {
 		}
 	}
 
-	@Override
-	public void stop(Runnable runnable) {
-		stop();
-		runnable.run();
-	}
-
 	/**
 	 * Sets the {@link LeaderEventPublisher}.
-	 *
 	 * @param leaderEventPublisher the event publisher
 	 */
 	public void setLeaderEventPublisher(LeaderEventPublisher leaderEventPublisher) {
@@ -230,13 +225,12 @@ public class LeaderInitiator implements SmartLifecycle {
 	 * @return the ZooKeeper path used for leadership election by Curator
 	 */
 	private String buildLeaderPath() {
-
 		String ns = StringUtils.hasText(this.namespace) ? this.namespace : DEFAULT_NAMESPACE;
 		if (!ns.startsWith("/")) {
-			ns = "/" + ns;
+			ns = '/' + ns;
 		}
 		if (!ns.endsWith("/")) {
-			ns = ns + "/";
+			ns = ns + '/';
 		}
 		return ns + this.candidate.getRole();
 	}
@@ -283,6 +277,7 @@ public class LeaderInitiator implements SmartLifecycle {
 				}
 			}
 		}
+
 	}
 
 	/**

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStore.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStore.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.zookeeper.metadata;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -66,7 +67,7 @@ public class ZookeeperMetadataStore implements ListenableMetadataStore, SmartLif
 
 	private String root = "/SpringIntegration-MetadataStore";
 
-	private String encoding = "UTF-8";
+	private String encoding = StandardCharsets.UTF_8.name();
 
 	private PathChildrenCache cache;
 
@@ -304,12 +305,6 @@ public class ZookeeperMetadataStore implements ListenableMetadataStore, SmartLif
 				}
 			}
 		}
-	}
-
-	@Override
-	public void stop(Runnable callback) {
-		stop();
-		callback.run();
 	}
 
 	@Override


### PR DESCRIPTION
We always have to call `callback` in the `SmartLifecycle.stop(Runnable)`
implementation independently of component state
* Fix `StandardIntegrationFlow.stop(Runnable)` for a logic when we
don't have any `this.lifecycles`
* Remove those `stop(Runnable)` which are fully equivalent of the
`default` on in the `SmartLifecycle`
* Some other simple polishing for the affected classes, e.g.
`isSingleton()` is `default` with `true` in the `InitializingBean`

**Cherry-pick to 5.1.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
