### PR TITLE
Add validation support into WebFlux Inbound

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/IntegrationWebExchangeBindException.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/IntegrationWebExchangeBindException.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.http.support;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.support.WebExchangeBindException;
+
+/**
+ * A {@link WebExchangeBindException} extension for validation error with a failed
+ * message context.
+ * We can't rely on the default {@link WebExchangeBindException} behavior since
+ * there is no POJO method invocation in Spring Integration Web endpoint implementations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.2
+ */
+@SuppressWarnings("serial")
+public class IntegrationWebExchangeBindException extends WebExchangeBindException {
+
+	private final String endpointId;
+
+	private final Object failedPayload;
+
+	public IntegrationWebExchangeBindException(String endpointId, Object failedPayload,
+			BindingResult bindingResult) {
+
+		super(null, bindingResult); // NOSONAR - we ignore a MethodParameter in favor of payload and endpoint context
+		this.endpointId = endpointId;
+		this.failedPayload = failedPayload;
+	}
+
+
+	@Override
+	public String getMessage() {
+		BindingResult bindingResult = getBindingResult();
+		StringBuilder sb = new StringBuilder("Validation failed for payload ")
+				.append(this.failedPayload)
+				.append(" in the endpoint ")
+				.append(this.endpointId)
+				.append(", with ")
+				.append(bindingResult.getErrorCount())
+				.append(" error(s): ");
+		for (ObjectError error : bindingResult.getAllErrors()) {
+			sb.append("[").append(error).append("] ");
+		}
+		return sb.toString();
+	}
+
+}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/IntegrationWebExchangeBindException.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/IntegrationWebExchangeBindException.java
@@ -16,9 +16,6 @@
 
 package org.springframework.integration.http.support;
 
-import org.springframework.core.MethodParameter;
-import org.springframework.messaging.Message;
-import org.springframework.util.Assert;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.support.WebExchangeBindException;

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/dsl/WebFluxInboundEndpointSpec.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/dsl/WebFluxInboundEndpointSpec.java
@@ -20,6 +20,7 @@ import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.integration.http.dsl.HttpInboundEndpointSupportSpec;
 import org.springframework.integration.webflux.inbound.WebFluxInboundEndpoint;
+import org.springframework.validation.Validator;
 import org.springframework.web.reactive.accept.RequestedContentTypeResolver;
 
 /**
@@ -50,6 +51,17 @@ public class WebFluxInboundEndpointSpec
 
 	public WebFluxInboundEndpointSpec reactiveAdapterRegistry(ReactiveAdapterRegistry adapterRegistry) {
 		this.target.setReactiveAdapterRegistry(adapterRegistry);
+		return this;
+	}
+
+	/**
+	 * Specify a {@link Validator} to validate a converted payload from request.
+	 * @param validator the {@link Validator} to use.
+	 * @return the spec
+	 * @since 5.2
+	 */
+	public WebFluxInboundEndpointSpec validator(Validator validator) {
+		this.target.setValidator(validator);
 		return this;
 	}
 

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/inbound/WebFluxInboundEndpointTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/inbound/WebFluxInboundEndpointTests.java
@@ -69,8 +69,7 @@ public class WebFluxInboundEndpointTests {
 
 		this.webTestClient.get().uri("/test")
 				.exchange()
-				.expectStatus().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE)
-				.expectBody(String.class).isEqualTo("Endpoint is stopped");
+				.expectStatus().isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
 	}
 
 	@Test

--- a/src/reference/asciidoc/webflux.adoc
+++ b/src/reference/asciidoc/webflux.adoc
@@ -91,6 +91,11 @@ See <<./http.adoc#http-request-mapping,Request Mapping Support>> and <<./http.ad
 
 When the request body is empty or `payloadExpression` returns `null`, the request params (`MultiValueMap<String, String>`) is used for a `payload` of the target message to process.
 
+Starting with version 5.2, the `WebFluxInboundEndpoint` can be configured with a `Validator`.
+It is used to validate elements in the `Publisher` to which a request has been converted by the `HttpMessageReader`.
+An invalid payload is rejected with an `IntegrationWebExchangeBindException` (a `WebExchangeBindException` extension), containing all the validation `Errors`.
+See more in Spring Framework https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation[Reference Manual] about validation.
+
 [[webflux-outbound]]
 === WebFlux Outbound Components
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -97,7 +97,9 @@ See <<./mail.adoc#mail-inbound,Mail-receiving Channel Adapter>> for more informa
 ==== WebFlux Changes
 
 The `WebFluxRequestExecutingMessageHandler` now supports a `Publisher`, `Resource` and `MultiValueMap` as a request message `payload`.
+The `WebFluxInboundEndpoint` now supports a request payload validation.
 See <<./webflux.adoc#webflux,WebFlux Support>> for more information.
+
 [[x5.2-mongodb]]
 ==== MongoDb Changes
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/56729517/spring-integration-webflux-validate-input-json-body

* Introduce a `WebFluxInboundEndpoint.validator` option to validate
a request payload after conversion HTTP request into a `Publisher`
* Expose a `WebFluxInboundEndpointSpec.validator()` option
* Introduce a `IntegrationWebExchangeBindException` to extend a
`WebExchangeBindException` for Spring Integration use-case.
such an exception is used in the `ResponseStatusExceptionHandler`
extensions, like one in Spring Boot for proper response rendering
* Test and document the solution

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
