### PR TITLE
Add Validation to HTTP Inbound

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/SimpleMessageListenerContainerSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/SimpleMessageListenerContainerSpec.java
@@ -22,6 +22,8 @@ import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
  * Spec for a {@link SimpleMessageListenerContainer}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -108,10 +110,22 @@ public class SimpleMessageListenerContainerSpec extends
 	/**
 	 * @param txSize the txSize.
 	 * @return the spec.
-	 * @see SimpleMessageListenerContainer#setTxSize(int)
+	 * @see SimpleMessageListenerContainer#setBatchSize(int)
+	 * @deprecated since 5.2 in favor of {@link #batchSize(int)}
 	 */
 	public SimpleMessageListenerContainerSpec txSize(int txSize) {
-		this.listenerContainer.setTxSize(txSize);
+		return batchSize(txSize);
+	}
+
+	/**
+	 * The batch size to use.
+	 * @param batchSize the batchSize.
+	 * @return the spec.
+	 * @see SimpleMessageListenerContainer#setBatchSize(int)
+	 * @since 5.2
+	 */
+	public SimpleMessageListenerContainerSpec batchSize(int batchSize) {
+		this.listenerContainer.setBatchSize(batchSize);
 		return this;
 	}
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpInboundEndpointParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpInboundEndpointParser.java
@@ -107,12 +107,13 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 		List<Element> headerElements = DomUtils.getChildElementsByTagName(element, "header");
 
 		if (!CollectionUtils.isEmpty(headerElements)) {
-			ManagedMap<String, Object> headerElementsMap = new ManagedMap<String, Object>();
+			ManagedMap<String, Object> headerElementsMap = new ManagedMap<>();
 			for (Element headerElement : headerElements) {
 				String name = headerElement.getAttribute(NAME_ATTRIBUTE);
 				BeanDefinition headerExpressionDef =
-						IntegrationNamespaceUtils.createExpressionDefIfAttributeDefined(IntegrationNamespaceUtils.EXPRESSION_ATTRIBUTE,
-								headerElement);
+						IntegrationNamespaceUtils
+								.createExpressionDefIfAttributeDefined(IntegrationNamespaceUtils.EXPRESSION_ATTRIBUTE,
+										headerElement);
 				if (headerExpressionDef != null) {
 					headerElementsMap.put(name, headerExpressionDef);
 				}
@@ -133,8 +134,8 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 		}
 
 		BeanDefinition expressionDef =
-				IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression("view-name", "view-expression",
-						parserContext, element, false);
+				IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression("view-name",
+						"view-expression", parserContext, element, false);
 		if (expressionDef != null) {
 			builder.addPropertyValue("viewExpression", expressionDef);
 		}
@@ -154,13 +155,16 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 
 		if (StringUtils.hasText(headerMapper)) {
 			if (hasMappedRequestHeaders || hasMappedResponseHeaders) {
-				parserContext.getReaderContext().error("Neither 'mapped-request-headers' or 'mapped-response-headers' " +
-						"attributes are allowed when a 'header-mapper' has been specified.", parserContext.extractSource(element));
+				parserContext.getReaderContext()
+						.error("Neither 'mapped-request-headers' or 'mapped-response-headers' " +
+								"attributes are allowed when a 'header-mapper' has been specified.",
+								parserContext.extractSource(element));
 			}
 			builder.addPropertyReference("headerMapper", headerMapper);
 		}
 		else {
-			BeanDefinitionBuilder headerMapperBuilder = BeanDefinitionBuilder.genericBeanDefinition(DefaultHttpHeaderMapper.class);
+			BeanDefinitionBuilder headerMapperBuilder =
+					BeanDefinitionBuilder.genericBeanDefinition(DefaultHttpHeaderMapper.class);
 			headerMapperBuilder.setFactoryMethod("inboundMapper");
 
 			if (hasMappedRequestHeaders) {
@@ -181,7 +185,7 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 		if (crossOriginElement != null) {
 			BeanDefinitionBuilder crossOriginBuilder =
 					BeanDefinitionBuilder.genericBeanDefinition(CrossOrigin.class);
-			String[] attributes = {"origin", "allowed-headers", "exposed-headers", "max-age", "method"};
+			String[] attributes = { "origin", "allowed-headers", "exposed-headers", "max-age", "method" };
 			for (String crossOriginAttribute : attributes) {
 				IntegrationNamespaceUtils.setValueIfAttributeDefined(crossOriginBuilder, crossOriginElement,
 						crossOriginAttribute);
@@ -191,7 +195,8 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 			builder.addPropertyValue("crossOrigin", crossOriginBuilder.getBeanDefinition());
 		}
 
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "request-payload-type", "requestPayloadTypeClass");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element,
+				"request-payload-type", "requestPayloadTypeClass");
 
 		BeanDefinition statusCodeExpressionDef =
 				IntegrationNamespaceUtils.createExpressionDefIfAttributeDefined("status-code-expression", element);
@@ -205,6 +210,7 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, IntegrationNamespaceUtils.AUTO_STARTUP);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, IntegrationNamespaceUtils.PHASE);
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "validator");
 	}
 
 	private String getInputChannelAttributeName() {
@@ -212,7 +218,8 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 	}
 
 	private BeanDefinition createRequestMapping(Element element) {
-		BeanDefinitionBuilder requestMappingDefBuilder = BeanDefinitionBuilder.genericBeanDefinition(RequestMapping.class);
+		BeanDefinitionBuilder requestMappingDefBuilder =
+				BeanDefinitionBuilder.genericBeanDefinition(RequestMapping.class);
 
 		String methods = element.getAttribute("supported-methods");
 		if (StringUtils.hasText(methods)) {
@@ -224,7 +231,7 @@ public class HttpInboundEndpointParser extends AbstractSingleBeanDefinitionParse
 		Element requestMappingElement = DomUtils.getChildElementByTagName(element, "request-mapping");
 
 		if (requestMappingElement != null) {
-			for (String requestMappingAttribute : new String[]{"params", "headers", "consumes", "produces"}) {
+			for (String requestMappingAttribute : new String[] { "params", "headers", "consumes", "produces" }) {
 				IntegrationNamespaceUtils.setValueIfAttributeDefined(requestMappingDefBuilder, requestMappingElement,
 						requestMappingAttribute);
 			}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpInboundEndpointSupportSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpInboundEndpointSupportSpec.java
@@ -37,6 +37,7 @@ import org.springframework.integration.http.inbound.RequestMapping;
 import org.springframework.integration.http.support.DefaultHttpHeaderMapper;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.util.Assert;
+import org.springframework.validation.Validator;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
@@ -45,7 +46,8 @@ import org.springframework.web.bind.annotation.RequestMethod;
  *
  * @since 5.0
  */
-public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpointSupportSpec<S, E>, E extends BaseHttpInboundEndpoint>
+public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpointSupportSpec<S, E>,
+		E extends BaseHttpInboundEndpoint>
 		extends MessagingGatewaySpec<S, E>
 		implements ComponentsRegistration {
 
@@ -93,7 +95,7 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * Specify a SpEL expression to evaluate in order to generate the Message payload.
 	 * @param payloadExpression The payload expression.
 	 * @return the spec
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setPayloadExpression(Expression)
+	 * @see BaseHttpInboundEndpoint#setPayloadExpression(Expression)
 	 */
 	public S payloadExpression(String payloadExpression) {
 		return payloadExpression(PARSER.parseExpression(payloadExpression));
@@ -103,7 +105,7 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * Specify a SpEL expression to evaluate in order to generate the Message payload.
 	 * @param payloadExpression The payload expression.
 	 * @return the spec
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setPayloadExpression(Expression)
+	 * @see BaseHttpInboundEndpoint#setPayloadExpression(Expression)
 	 */
 	public S payloadExpression(Expression payloadExpression) {
 		this.target.setPayloadExpression(payloadExpression);
@@ -115,7 +117,7 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * @param payloadFunction The payload {@link Function}.
 	 * @param <P> the expected HTTP request body type.
 	 * @return the spec
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setPayloadExpression(Expression)
+	 * @see BaseHttpInboundEndpoint#setPayloadExpression(Expression)
 	 */
 	public <P> S payloadFunction(Function<HttpEntity<P>, ?> payloadFunction) {
 		return payloadExpression(new FunctionExpression<>(payloadFunction));
@@ -125,7 +127,7 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * Specify a Map of SpEL expressions to evaluate in order to generate the Message headers.
 	 * @param expressions The {@link Map} of SpEL expressions for headers.
 	 * @return the spec
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setHeaderExpressions(Map)
+	 * @see BaseHttpInboundEndpoint#setHeaderExpressions(Map)
 	 */
 	public S headerExpressions(Map<String, Expression> expressions) {
 		Assert.notNull(expressions, "'headerExpressions' must not be null");
@@ -139,7 +141,7 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * @param header the header name to populate.
 	 * @param expression the SpEL expression for the header.
 	 * @return the spec
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setHeaderExpressions(Map)
+	 * @see BaseHttpInboundEndpoint#setHeaderExpressions(Map)
 	 */
 	public S headerExpression(String header, String expression) {
 		return headerExpression(header, PARSER.parseExpression(expression));
@@ -150,7 +152,7 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * @param header the header name to populate.
 	 * @param expression the SpEL expression for the header.
 	 * @return the spec
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setHeaderExpressions(Map)
+	 * @see BaseHttpInboundEndpoint#setHeaderExpressions(Map)
 	 */
 	public S headerExpression(String header, Expression expression) {
 		this.headerExpressions.put(header, expression);
@@ -163,7 +165,7 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * @param headerFunction the function to evaluate the header value against {@link HttpEntity}.
 	 * @param <P> the expected HTTP body type.
 	 * @return the current Spec.
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setHeaderExpressions(Map)
+	 * @see BaseHttpInboundEndpoint#setHeaderExpressions(Map)
 	 */
 	public <P> S headerFunction(String header, Function<HttpEntity<P>, ?> headerFunction) {
 		return headerExpression(header, new FunctionExpression<>(headerFunction));
@@ -251,7 +253,7 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * the default '200 OK' or '500 Internal Server Error' for a timeout.
 	 * @param statusCodeExpression The status code Expression.
 	 * @return the current Spec.
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setStatusCodeExpression(Expression)
+	 * @see BaseHttpInboundEndpoint#setStatusCodeExpression(Expression)
 	 */
 	public S statusCodeExpression(String statusCodeExpression) {
 		this.target.setStatusCodeExpressionString(statusCodeExpression);
@@ -263,7 +265,7 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * the default '200 OK' or '500 Internal Server Error' for a timeout.
 	 * @param statusCodeExpression The status code Expression.
 	 * @return the current Spec.
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setStatusCodeExpression(Expression)
+	 * @see BaseHttpInboundEndpoint#setStatusCodeExpression(Expression)
 	 */
 	public S statusCodeExpression(Expression statusCodeExpression) {
 		this.target.setStatusCodeExpression(statusCodeExpression);
@@ -275,10 +277,21 @@ public abstract class HttpInboundEndpointSupportSpec<S extends HttpInboundEndpoi
 	 * the default '200 OK' or '500 Internal Server Error' for a timeout.
 	 * @param statusCodeFunction The status code {@link Function}.
 	 * @return the current Spec.
-	 * @see org.springframework.integration.http.inbound.HttpRequestHandlingEndpointSupport#setStatusCodeExpression(Expression)
+	 * @see BaseHttpInboundEndpoint#setStatusCodeExpression(Expression)
 	 */
 	public S statusCodeFunction(Function<RequestEntity<?>, ?> statusCodeFunction) {
 		return statusCodeExpression(new FunctionExpression<>(statusCodeFunction));
+	}
+
+	/**
+	 * Specify a {@link Validator} to validate a converted payload from request.
+	 * @param validator the {@link Validator} to use.
+	 * @return the spec
+	 * @since 5.2
+	 */
+	public S validator(Validator validator) {
+		this.target.setValidator(validator);
+		return _this();
 	}
 
 	@Override

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -319,6 +319,10 @@ public abstract class HttpRequestHandlingEndpointSupport extends BaseHttpInbound
 
 		AbstractIntegrationMessageBuilder<?> messageBuilder;
 
+		if (getValidator() != null) {
+			validate(payload);
+		}
+
 		if (payload instanceof Message<?>) {
 			messageBuilder =
 					getMessageBuilderFactory()

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-5.2.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http-5.2.xsd
@@ -362,6 +362,18 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="validator" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.validation.Validator" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+					A 'Validator' bean reference to validate a payload converted from the HTTP request.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:attributeGroup>
 
 	<xsd:element name="outbound-channel-adapter">

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests-context.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans
-	xmlns="http://www.springframework.org/schema/integration/http"
-			xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			xmlns:beans="http://www.springframework.org/schema/beans"
-			xmlns:si="http://www.springframework.org/schema/integration"
-			xmlns:util="http://www.springframework.org/schema/util"
-			xsi:schemaLocation="http://www.springframework.org/schema/beans
+		xmlns="http://www.springframework.org/schema/integration/http"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:si="http://www.springframework.org/schema/integration"
+		xmlns:util="http://www.springframework.org/schema/util"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans
 			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
 			https://www.springframework.org/schema/integration/spring-integration.xsd
@@ -20,20 +20,25 @@
 		<si:queue capacity="1"/>
 	</si:channel>
 
+	<beans:bean id="validator" class="org.mockito.Mockito" factory-method="mock">
+		<beans:constructor-arg value="org.springframework.validation.Validator"/>
+	</beans:bean>
+
 	<inbound-channel-adapter id="defaultAdapter" channel="requests" error-channel="errorChannel"
-			auto-startup="false"
-			phase="1001"
-			status-code-expression="'101'"/>
+							 auto-startup="false"
+							 phase="1001"
+							 status-code-expression="'101'"
+							 validator="validator"/>
 
 	<inbound-channel-adapter id="postOnlyAdapter" path="/postOnly" channel="requests" supported-methods="POST"/>
 
 	<inbound-channel-adapter id="adapterWithCustomConverterWithDefaults" message-converters="customConverters"
-							channel="requests" supported-methods="DELETE" merge-with-default-converters="true"/>
+							 channel="requests" supported-methods="DELETE" merge-with-default-converters="true"/>
 
 	<inbound-channel-adapter id="adapterWithCustomConverterNoDefaults" message-converters="customConverters"
-							channel="requests" supported-methods="HEAD" />
+							 channel="requests" supported-methods="HEAD"/>
 
-	<inbound-channel-adapter id="adapterNoCustomConverterNoDefaults" channel="requests" supported-methods="POST" />
+	<inbound-channel-adapter id="adapterNoCustomConverterNoDefaults" channel="requests" supported-methods="POST"/>
 
 	<util:list id="customConverters">
 		<beans:bean class="org.springframework.integration.http.converter.SerializingHttpMessageConverter"/>
@@ -42,7 +47,7 @@
 	<inbound-channel-adapter id="putOrDeleteAdapter" channel="requests" supported-methods="PUT, delete"/>
 
 	<inbound-channel-adapter id="inboundController" channel="requests" view-name="foo" error-code="oops"
-			status-code-expression="T(org.springframework.http.HttpStatus).ACCEPTED">
+							 status-code-expression="T(org.springframework.http.HttpStatus).ACCEPTED">
 		<request-mapping headers="BAR"/>
 	</inbound-channel-adapter>
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests.java
@@ -19,7 +19,6 @@ package org.springframework.integration.http.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyChar;
 import static org.mockito.BDDMockito.willReturn;
 
 import java.io.ByteArrayOutputStream;
@@ -53,8 +52,6 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.AntPathMatcher;
 import org.springframework.util.MultiValueMap;

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/dsl/WebFluxInboundEndpointSpec.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/dsl/WebFluxInboundEndpointSpec.java
@@ -20,7 +20,6 @@ import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.http.codec.ServerCodecConfigurer;
 import org.springframework.integration.http.dsl.HttpInboundEndpointSupportSpec;
 import org.springframework.integration.webflux.inbound.WebFluxInboundEndpoint;
-import org.springframework.validation.Validator;
 import org.springframework.web.reactive.accept.RequestedContentTypeResolver;
 
 /**
@@ -51,17 +50,6 @@ public class WebFluxInboundEndpointSpec
 
 	public WebFluxInboundEndpointSpec reactiveAdapterRegistry(ReactiveAdapterRegistry adapterRegistry) {
 		this.target.setReactiveAdapterRegistry(adapterRegistry);
-		return this;
-	}
-
-	/**
-	 * Specify a {@link Validator} to validate a converted payload from request.
-	 * @param validator the {@link Validator} to use.
-	 * @return the spec
-	 * @since 5.2
-	 */
-	public WebFluxInboundEndpointSpec validator(Validator validator) {
-		this.target.setValidator(validator);
 		return this;
 	}
 

--- a/spring-integration-webflux/src/main/resources/org/springframework/integration/webflux/config/spring-integration-webflux-5.2.xsd
+++ b/spring-integration-webflux/src/main/resources/org/springframework/integration/webflux/config/spring-integration-webflux-5.2.xsd
@@ -327,6 +327,18 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="validator" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.validation.Validator" />
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+					A 'Validator' bean reference to validate a payload converted from the HTTP request.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 	</xsd:attributeGroup>
 
 	<xsd:element name="outbound-channel-adapter">

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxInboundChannelAdapterParserTests-context.xml
@@ -10,7 +10,11 @@
 
 	<si:channel id="requests"/>
 
-	<inbound-channel-adapter id="reactiveMinimalConfig" channel="requests"/>
+	<beans:bean id="validator" class="org.mockito.Mockito" factory-method="mock">
+		<beans:constructor-arg value="org.springframework.validation.Validator"/>
+	</beans:bean>
+
+	<inbound-channel-adapter id="reactiveMinimalConfig" channel="requests" validator="validator"/>
 
 	<inbound-channel-adapter id="reactiveFullConfig" channel="requests"
 							 path="test1"

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxInboundChannelAdapterParserTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxInboundChannelAdapterParserTests.java
@@ -37,6 +37,7 @@ import org.springframework.integration.webflux.inbound.WebFluxInboundEndpoint;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.validation.Validator;
 import org.springframework.web.reactive.accept.RequestedContentTypeResolver;
 
 /**
@@ -71,6 +72,9 @@ public class WebFluxInboundChannelAdapterParserTests {
 	@Autowired
 	private ReactiveAdapterRegistry reactiveAdapterRegistry;
 
+	@Autowired
+	private Validator validator;
+
 	@Test
 	public void reactiveMinimalConfig() {
 		DirectFieldAccessor endpointAccessor = new DirectFieldAccessor(this.reactiveMinimalConfig);
@@ -88,6 +92,7 @@ public class WebFluxInboundChannelAdapterParserTests {
 		assertThat(endpointAccessor.getPropertyValue("requestedContentTypeResolver"))
 				.isNotSameAs(this.requestedContentTypeResolver);
 		assertThat(endpointAccessor.getPropertyValue("adapterRegistry")).isNotSameAs(this.reactiveAdapterRegistry);
+		assertThat(endpointAccessor.getPropertyValue("validator")).isSameAs(this.validator);
 	}
 
 	@Test

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/dsl/WebFluxDslTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/dsl/WebFluxDslTests.java
@@ -330,7 +330,7 @@ public class WebFluxDslTests {
 
 		@Override
 		public Validator getValidator() {
-			return webFluxValidator();
+			return new TestModelValidator();
 		}
 
 		@Bean
@@ -453,11 +453,6 @@ public class WebFluxDslTests {
 		@Bean
 		public AccessDecisionManager accessDecisionManager() {
 			return new AffirmativeBased(Collections.singletonList(new RoleVoter()));
-		}
-
-		@Bean
-		public Validator webFluxValidator() {
-			return new TestModelValidator();
 		}
 
 	}

--- a/src/reference/asciidoc/endpoint-summary.adoc
+++ b/src/reference/asciidoc/endpoint-summary.adoc
@@ -90,6 +90,12 @@ The following table summarizes the various endpoints with quick links to the app
 | <<./http.adoc#http-inbound,Http Inbound Components>>
 | <<./http.adoc#http-outbound,HTTP Outbound Components>>
 
+| *WebFlux*
+| <<./webflux.adoc#webflux-namespace,WebFlux Namespace Support>>
+| <<./webflux.adoc#webflux-namespace,WebFlux Namespace Support>>
+| <<./webflux.adoc#webflux-inbound,WebFlux Inbound Components>>
+| <<./webflux.adoc#webflux-outbound,WebFlux Outbound Components>>
+
 | *JDBC*
 | <<./jdbc.adoc#jdbc-inbound-channel-adapter,Inbound Channel Adapter>> and <<./jdbc.adoc#stored-procedure-inbound-channel-adapter,Stored Procedure Inbound Channel Adapter>>
 | <<./jdbc.adoc#jdbc-outbound-channel-adapter,Outbound Channel Adapter>> and <<./jdbc.adoc#stored-procedure-outbound-channel-adapter,Stored Procedure Outbound Channel Adapter>>

--- a/src/reference/asciidoc/http.adoc
+++ b/src/reference/asciidoc/http.adoc
@@ -32,8 +32,7 @@ The `javax.servlet:javax.servlet-api` dependency must be provided on the target 
 
 To receive messages over HTTP, you need to use an HTTP inbound channel adapter or an HTTP inbound gateway.
 To support the HTTP inbound adapters, they need to be deployed within a servlet container such as https://tomcat.apache.org/[Apache Tomcat] or https://www.eclipse.org/jetty/[Jetty].
-The easiest way to do this is to use Spring's
-https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/context/support/HttpRequestHandlerServlet.html[`HttpRequestHandlerServlet`], by providing the following servlet definition in the `web.xml` file:
+The easiest way to do this is to use Spring's https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/context/support/HttpRequestHandlerServlet.html[`HttpRequestHandlerServlet`], by providing the following servlet definition in the `web.xml` file:
 
 ====
 [source,xml]
@@ -46,9 +45,7 @@ https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/c
 ====
 
 Notice that the servlet name matches the bean name.
-For more information on using the `HttpRequestHandlerServlet`, see
-https://docs.spring.io/spring/docs/current/spring-framework-reference/html/remoting.html[Remoting and web services using Spring],
-which is part of the Spring Framework Reference documentation.
+For more information on using the `HttpRequestHandlerServlet`, see https://docs.spring.io/spring/docs/current/spring-framework-reference/html/remoting.html[Remoting and web services using Spring], which is part of the Spring Framework Reference documentation.
 
 If you are running within a Spring MVC application, then the aforementioned explicit servlet definition is not necessary.
 In that case, the bean name for your gateway can be matched against the URL path as you would for a Spring MVC Controller bean.
@@ -79,8 +76,7 @@ An additional flag (`mergeWithDefaultConverters`) can be set along with the list
 By default, this flag is set to `false`, meaning that the custom converters replace the default list.
 
 The message conversion process uses the (optional) `requestPayloadType` property and the incoming `Content-Type` header.
-Starting with version 4.3, if a request has no content type header, `application/octet-stream` is assumed, as
-recommended by `RFC 2616`.
+Starting with version 4.3, if a request has no content type header, `application/octet-stream` is assumed, as recommended by `RFC 2616`.
 Previously, the body of such messages was ignored.
 
 Spring Integration 2.0 implemented multipart file support.
@@ -146,10 +142,17 @@ The preceding example also shows how to customize the HTTP methods accepted by t
 The reply message is available in the model map.
 By default, the key for that map entry is 'reply', but you can override this default by setting the 'replyKey' property on the endpoint's configuration.
 
+[[http-validation]]
+==== Payload Validation
+
+Starting with version 5.2, the HTTP inbound endpoints can be supplied with a `Validator` to check a payload before sending into the channel.
+This payload is already a result of conversion and extraction after `payloadExpression` to narrow a validation scope in regards to the valuable data.
+The validation failure handling is fully the same what we have in Spring MVC https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-exceptionhandlers[Error Handling].
+
 [[http-outbound]]
 === HTTP Outbound Components
 
-This section describes Spring Integration's HTTP outbound components
+This section describes Spring Integration's HTTP outbound components.
 
 ==== Using `HttpRequestExecutingMessageHandler`
 
@@ -205,8 +208,7 @@ If `transfer-cookies` is `false`, any `Set-Cookie` header received remains as `S
 HTTP is a request-response protocol.
 However, the response may not have a body, only headers.
 In this case, the `HttpRequestExecutingMessageHandler` produces a reply `Message` with the payload being an `org.springframework.http.ResponseEntity`, regardless of any provided `expected-response-type`.
-According to the https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html[HTTP RFC Status Code Definitions], there are many statuses that mandate that a response must not contain a message-body (for example,
-`204 No Content`).
+According to the https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html[HTTP RFC Status Code Definitions], there are many statuses that mandate that a response must not contain a message-body (for example, `204 No Content`).
 There are also cases where calls to the same URL might or might not return a response body.
 For example, the first request to an HTTP resource returns content, but the second does not (returning a `304 Not Modified`).
 In all cases, however, the `http_statusCode` message header is populated.
@@ -350,8 +352,7 @@ For more information regarding handler mappings, see https://docs.spring.io/spri
 [[http-cors]]
 ==== Cross-origin Resource Sharing (CORS) Support
 
-Starting with version 4.2, you can configure the `<http:inbound-channel-adapter>` and `<http:inbound-gateway>` with
-a `<cross-origin>` element.
+Starting with version 4.2, you can configure the `<http:inbound-channel-adapter>` and `<http:inbound-gateway>` with a `<cross-origin>` element.
 It represents the same options as Spring MVC's `@CrossOrigin` for `@Controller` annotations and allows the configuration of cross-origin resource sharing (CORS) for Spring Integration HTTP endpoints:
 
 * `origin`: List of allowed origins.
@@ -376,8 +377,7 @@ This property controls the value of the `Access-Control-Max-Age` header in the p
 A value of `-1` means undefined.
 The default value is 1800 seconds (30 minutes).
 
-The CORS Java Configuration is represented by the `org.springframework.integration.http.inbound.CrossOrigin` class,
-instances of which can be injected into the `HttpRequestHandlingEndpointSupport` beans.
+The CORS Java Configuration is represented by the `org.springframework.integration.http.inbound.CrossOrigin` class, instances of which can be injected into the `HttpRequestHandlingEndpointSupport` beans.
 
 [[http-response-statuscode]]
 ==== Response Status Code
@@ -403,8 +403,7 @@ The following example shows how to set the status code to `ACCEPTED`:
 ====
 
 The `<http:inbound-gateway>` resolves the 'status code' from the `http_statusCode` header of the reply `Message`.
-Starting with version 4.2, the default response status code when no reply is received within the `reply-timeout`
-is `500 Internal Server Error`.
+Starting with version 4.2, the default response status code when no reply is received within the `reply-timeout` is `500 Internal Server Error`.
 There are two ways to modify this behavior:
 
 * Add a `reply-timeout-status-code-expression`.
@@ -427,8 +426,7 @@ The payload of the `ErrorMessage` is a `MessageTimeoutException`.
 It must be transformed to something that can be converted by the gateway, such as a `String`.
 A good candidate is the exception's message property, which is the value used when you use the `expression` technique.
 
-If the error flow times out after a main flow timeout, `500 Internal Server Error` is returned, or, if the
-`reply-timeout-status-code-expression` is present, it is evaluated.
+If the error flow times out after a main flow timeout, `500 Internal Server Error` is returned, or, if the `reply-timeout-status-code-expression` is present, it is evaluated.
 
 NOTE: Previously, the default status code for a timeout was `200 OK`.
 To restore that behavior, set `reply-timeout-status-code-expression="200"`.
@@ -655,7 +653,7 @@ The `uriVariablesExpression` property provides a very powerful mechanism for eva
 We anticipate that people mostly use simple expressions, such as the preceding example.
 However, you can also configure something such as `"@uriVariablesBean.populate(#root)"` with an expression in the returned map being `variables.put("thing1", EXPRESSION_PARSER.parseExpression(message.getHeaders().get("thing2", String.class)));`, where the expression is dynamically provided in the message header named `thing2`.
 Since the header may come from an untrusted source, the HTTP outbound endpoints use `SimpleEvaluationContext` when evaluating these expressions.
-`SimpleEvaluationContext` uses only a subset of SpEL features.
+The `SimpleEvaluationContext` uses only a subset of SpEL features.
 If you trust your message sources and wish to use the restricted SpEL constructs, set the `trustedSpel` property of the outbound endpoint to `true`.
 ====
 
@@ -830,8 +828,7 @@ image::images/http-outbound-gateway.png[align="center"]
 //TODO These images are too small, and the text within them is much too small.
 
 You may want to configure the HTTP related timeout behavior, when making active HTTP requests by using the HTTP outbound gateway or the HTTP outbound channel adapter.
-In those instances, these two components use Spring's
-https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html[`RestTemplate`] support to execute HTTP requests.
+In those instances, these two components use Spring's https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html[`RestTemplate`] support to execute HTTP requests.
 
 To configure timeouts for the HTTP outbound gateway and the HTTP outbound channel adapter, you can either reference a `RestTemplate` bean directly (by using the `rest-template` attribute) or you can provide a reference to a https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/http/client/ClientHttpRequestFactory.html[`ClientHttpRequestFactory`] bean (by using the `request-factory` attribute).
 Spring provides the following implementations of the `ClientHttpRequestFactory` interface:

--- a/src/reference/asciidoc/webflux.adoc
+++ b/src/reference/asciidoc/webflux.adoc
@@ -91,8 +91,14 @@ See <<./http.adoc#http-request-mapping,Request Mapping Support>> and <<./http.ad
 
 When the request body is empty or `payloadExpression` returns `null`, the request params (`MultiValueMap<String, String>`) is used for a `payload` of the target message to process.
 
+[[webflux-validation]]
+==== Payload Validation
+
 Starting with version 5.2, the `WebFluxInboundEndpoint` can be configured with a `Validator`.
-It is used to validate elements in the `Publisher` to which a request has been converted by the `HttpMessageReader`.
+Unlike the MVC validation in the <<./http.adoc#http-validation,HTTP Support>>, it is used to validate elements in the `Publisher` to which a request has been converted by the `HttpMessageReader`, before performing a fallback and `payloadExpression` functions.
+The Framework can't assume how complex the `Publisher` object can be after building the final payload.
+If there is a requirements to restrict validation visibility for exactly final payload (or its `Publisher` elements), the validation should go downstream instead of WebFlux endpoint.
+See more information in the Spring WebFlux https://docs.spring.io/spring/docs/5.1.8.RELEASE/spring-framework-reference/web-reactive.html#webflux-fn-handler-validation[documentation].
 An invalid payload is rejected with an `IntegrationWebExchangeBindException` (a `WebExchangeBindException` extension), containing all the validation `Errors`.
 See more in Spring Framework https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#validation[Reference Manual] about validation.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -95,6 +95,12 @@ See <<./ip.adoc#tcp-connection-factory, TCP Connection Factories>> for more info
 The `AbstractMailReceiver` has now an `autoCloseFolder` option (`true` by default), to disable an automatic folder close after a fetch, but populate `IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE` header instead for downstream interaction.
 See <<./mail.adoc#mail-inbound,Mail-receiving Channel Adapter>> for more information.
 
+[[x5.2-http]]
+==== HTTP Changes
+
+The HTTP inbound endpoint now support a request payload validation.
+See <<./http.adoc#http,HTTP Support>> for more information.
+
 [[x5.2-webflux]]
 ==== WebFlux Changes
 


### PR DESCRIPTION
* Pull a validation functionality from `WebFluxInboundEndpoint` to its
super class `BaseHttpInboundEndpoint` making a validation available for
the `HttpRequestHandlingEndpointSupport` as well
* Do the same for the `validator()` option in DSL for the
`HttpInboundEndpointSupportSpec`
* Add `validator` XML attribute for both HTTP and WebFlux inbound
endpoint XSDs
* Test parsers for a new `validator` option
* Document validation in the `http.adoc`
* Apply some polishing in the `http.adoc`, as well as in the
`HttpRequestHandlingEndpointSupport` JavaDocs
* Clarify in `webflux.adoc` that validation is applied for the
`Publisher` items before the payload is finally built for the message to
send.
* Add WebFlux into the table of endpoints in the `endpoint-summary.adoc`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
