### PR TITLE
Fix race condition around Redis key

### DIFF
--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests-context.xml
@@ -12,13 +12,17 @@
 	<util:constant id="redisConnectionFactory"
 				   static-field="org.springframework.integration.redis.rules.RedisAvailableRule.connectionFactory"/>
 
+	<util:constant id="TEST_QUEUE"
+				   static-field="org.springframework.integration.redis.inbound.RedisQueueMessageDrivenEndpointTests.TEST_QUEUE"/>
+
 	<int:channel id="fromChannel">
 		<int:queue/>
 	</int:channel>
 
-	<int-redis:queue-inbound-channel-adapter queue="si.test.Int3017IntegrationInbound"
+	<int-redis:queue-inbound-channel-adapter id="fromChannelEndpoint" queue="#{TEST_QUEUE}"
 											 channel="fromChannel"
 											 expect-message="true"
+											 auto-startup="false"
 											 serializer="testSerializer"/>
 
 	<bean id="testSerializer" class="org.springframework.integration.redis.util.CustomJsonSerializer"/>
@@ -28,8 +32,9 @@
 		<int-redis:queue-outbound-channel-adapter queue-expression="headers.redis_queue"/>
 	</int:chain>
 
-	<int-redis:queue-inbound-channel-adapter queue="si.test.Int3017IntegrationSymmetrical"
+	<int-redis:queue-inbound-channel-adapter id="symmetricalRedisChannelEndpoint" queue="#{TEST_QUEUE}"
 											 channel="symmetricalRedisChannel"
+											 auto-startup="false"
 											 serializer=""/>
 
 


### PR DESCRIPTION
https://build.spring.io/browse/INT-FATS5IC-922/
https://build.spring.io/browse/INT-MJATS41-1764/

The `RedisQueueMessageDrivenEndpointTests` may be called from different
CI plans against the same Redis instance.

So, clean up keys before and after every unit test

**Cherry-pick until 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
