### PR TITLE
GH-2748: Add bean definition info into exceptions

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/AbstractConsumerEndpointParser.java
@@ -58,6 +58,7 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 	@Override
 	protected String resolveId(Element element, AbstractBeanDefinition definition, ParserContext parserContext)
 			throws BeanDefinitionStoreException {
+
 		String id = element.getAttribute(ID_ATTRIBUTE);
 		if (!StringUtils.hasText(id)) {
 			id = element.getAttribute("name");
@@ -103,10 +104,12 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		}
 
 		AbstractBeanDefinition handlerBeanDefinition = handlerBuilder.getBeanDefinition();
-		String inputChannelAttributeName = this.getInputChannelAttributeName();
+		handlerBeanDefinition.setResource(parserContext.getReaderContext().getResource());
+		String elementDescription = IntegrationNamespaceUtils.createElementDescription(element);
+		handlerBeanDefinition.setSource(elementDescription);
+		String inputChannelAttributeName = getInputChannelAttributeName();
 		boolean hasInputChannelAttribute = element.hasAttribute(inputChannelAttributeName);
 		if (parserContext.isNested()) {
-			String elementDescription = IntegrationNamespaceUtils.createElementDescription(element);
 			if (hasInputChannelAttribute) {
 				parserContext.getReaderContext().error("The '" + inputChannelAttributeName
 						+ "' attribute isn't allowed for a nested (e.g. inside a <chain/>) endpoint element: "
@@ -122,7 +125,6 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		}
 		else {
 			if (!hasInputChannelAttribute) {
-				String elementDescription = IntegrationNamespaceUtils.createElementDescription(element);
 				parserContext.getReaderContext().error("The '" + inputChannelAttributeName
 						+ "' attribute is required for the top-level endpoint element: "
 						+ elementDescription + ".", element);
@@ -135,9 +137,11 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 			builder.addPropertyValue("adviceChain", adviceChain);
 		}
 
-		String handlerBeanName = BeanDefinitionReaderUtils.generateBeanName(handlerBeanDefinition, parserContext.getRegistry());
+		String handlerBeanName =
+				BeanDefinitionReaderUtils.generateBeanName(handlerBeanDefinition, parserContext.getRegistry());
 		String[] handlerAlias = IntegrationNamespaceUtils.generateAlias(element);
-		parserContext.registerBeanComponent(new BeanComponentDefinition(handlerBeanDefinition, handlerBeanName, handlerAlias));
+		parserContext.registerBeanComponent(
+				new BeanComponentDefinition(handlerBeanDefinition, handlerBeanName, handlerAlias));
 
 		builder.addPropertyReference("handler", handlerBeanName);
 
@@ -157,7 +161,7 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, IntegrationNamespaceUtils.ROLE);
 
 		AbstractBeanDefinition beanDefinition = builder.getBeanDefinition();
-		String beanName = this.resolveId(element, beanDefinition, parserContext);
+		String beanName = resolveId(element, beanDefinition, parserContext);
 		parserContext.registerBeanComponent(new BeanComponentDefinition(beanDefinition, beanName));
 		return null;
 	}
@@ -187,12 +191,13 @@ public abstract class AbstractConsumerEndpointParser extends AbstractBeanDefinit
 
 			@SuppressWarnings("unchecked")
 			Collection<String> channelCandidateNames =
-					(Collection<String>) caValues.getArgumentValue(0, Collection.class).getValue(); // NOSONAR see comment above
+					(Collection<String>) caValues.getArgumentValue(0, Collection.class)
+							.getValue(); // NOSONAR see comment above
 			channelCandidateNames.add(inputChannelName); // NOSONAR
 		}
 		else {
 			parserContext.getReaderContext().error("Failed to locate '" +
-					IntegrationContextUtils.AUTO_CREATE_CHANNEL_CANDIDATES_BEAN_NAME + "'",
+							IntegrationContextUtils.AUTO_CREATE_CHANNEL_CANDIDATES_BEAN_NAME + "'",
 					parserContext.getRegistry());
 		}
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -150,8 +150,11 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 			source = beanDefinition.getSource();
 		}
 
-		StringBuilder sb = new StringBuilder("component '")
-				.append(getComponentName()).append("'");
+		StringBuilder sb = new StringBuilder("bean '")
+				.append(this.beanName).append("'");
+		if (!this.beanName.equals(getComponentName())) {
+			sb.append("for component '").append(getComponentName()).append("'");
+		}
 		if (description != null) {
 			sb.append("; defined in: '").append(description).append("'");
 		}
@@ -322,7 +325,7 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	@Override
 	public String toString() {
-		return (this.beanName != null) ? "bean '" + this.beanName + "' for " + getBeanDescription() : super.toString();
+		return (this.beanName != null) ? getBeanDescription() : super.toString();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -87,7 +87,7 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	private String componentName;
 
-	private ConfigurableListableBeanFactory beanFactory;
+	private BeanFactory beanFactory;
 
 	private TaskScheduler taskScheduler;
 
@@ -142,8 +142,10 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 		String description = null;
 		Object source = null;
 
-		if (this.beanFactory.containsBeanDefinition(this.beanName)) {
-			BeanDefinition beanDefinition = this.beanFactory.getBeanDefinition(this.beanName);
+		if (this.beanFactory instanceof ConfigurableListableBeanFactory &&
+				((ConfigurableListableBeanFactory) this.beanFactory).containsBeanDefinition(this.beanName)) {
+			BeanDefinition beanDefinition =
+					((ConfigurableListableBeanFactory) this.beanFactory).getBeanDefinition(this.beanName);
 			description = beanDefinition.getResourceDescription();
 			source = beanDefinition.getSource();
 		}
@@ -162,7 +164,7 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
 		Assert.notNull(beanFactory, "'beanFactory' must not be null");
-		this.beanFactory = (ConfigurableListableBeanFactory) beanFactory;
+		this.beanFactory = beanFactory;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -322,7 +322,7 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	@Override
 	public String toString() {
-		return (this.beanName != null) ? "bean '" + this.beanName + "' for " + getBeanDescription(): super.toString();
+		return (this.beanName != null) ? "bean '" + this.beanName + "' for " + getBeanDescription() : super.toString();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -28,6 +28,8 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.convert.ConversionService;
@@ -85,7 +87,7 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	private String componentName;
 
-	private BeanFactory beanFactory;
+	private ConfigurableListableBeanFactory beanFactory;
 
 	private TaskScheduler taskScheduler;
 
@@ -136,10 +138,31 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 		return null;
 	}
 
+	public String getBeanDescription() {
+		String description = null;
+		Object source = null;
+
+		if (this.beanFactory.containsBeanDefinition(this.beanName)) {
+			BeanDefinition beanDefinition = this.beanFactory.getBeanDefinition(this.beanName);
+			description = beanDefinition.getResourceDescription();
+			source = beanDefinition.getSource();
+		}
+
+		StringBuilder sb = new StringBuilder("component '")
+				.append(getComponentName()).append("'");
+		if (description != null) {
+			sb.append("; defined in: '").append(description).append("'");
+		}
+		if (source != null) {
+			sb.append("; from source: '").append(source).append("'");
+		}
+		return sb.toString();
+	}
+
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
 		Assert.notNull(beanFactory, "'beanFactory' must not be null");
-		this.beanFactory = beanFactory;
+		this.beanFactory = (ConfigurableListableBeanFactory) beanFactory;
 	}
 
 	@Override
@@ -297,7 +320,7 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	@Override
 	public String toString() {
-		return (this.beanName != null) ? this.beanName : super.toString();
+		return (this.beanName != null) ? "bean '" + this.beanName + "' for " + getBeanDescription(): super.toString();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
@@ -432,7 +432,7 @@ public class IntegrationFlowBeanPostProcessor
 				.applyCustomizers(customizers)
 				.getRawBeanDefinition();
 
-		if (parentName != null) {
+		if (parentName != null && this.beanFactory.containsBeanDefinition(parentName)) {
 			AbstractBeanDefinition parentBeanDefinition =
 					(AbstractBeanDefinition) this.beanFactory.getBeanDefinition(parentName);
 			beanDefinition.setResource(parentBeanDefinition.getResource());

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
@@ -49,6 +49,7 @@ import org.springframework.context.MessageSourceAware;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.core.io.DescriptiveResource;
+import org.springframework.core.type.MethodMetadata;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.FixedSubscriberChannel;
@@ -426,16 +427,25 @@ public class IntegrationFlowBeanPostProcessor
 	private void registerComponent(Object component, String beanName, String parentName,
 			BeanDefinitionCustomizer... customizers) {
 
-		BeanDefinition beanDefinition =
+		AbstractBeanDefinition beanDefinition =
 				BeanDefinitionBuilder.genericBeanDefinition((Class<Object>) component.getClass(), () -> component)
-						.applyCustomizers(customizers)
-						.getRawBeanDefinition();
+				.applyCustomizers(customizers)
+				.getRawBeanDefinition();
+
+		if (parentName != null) {
+			AbstractBeanDefinition parentBeanDefinition =
+					(AbstractBeanDefinition) this.beanFactory.getBeanDefinition(parentName);
+			beanDefinition.setResource(parentBeanDefinition.getResource());
+			Object source = parentBeanDefinition.getSource();
+			if (source instanceof MethodMetadata) {
+				source = "bean method " + ((MethodMetadata) source).getMethodName();
+			}
+			beanDefinition.setSource(source);
+			this.beanFactory.registerDependentBean(parentName, beanName);
+		}
 
 		((BeanDefinitionRegistry) this.beanFactory).registerBeanDefinition(beanName, beanDefinition);
 
-		if (parentName != null) {
-			this.beanFactory.registerDependentBean(parentName, beanName);
-		}
 
 		this.beanFactory.getBean(beanName);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
@@ -225,6 +225,7 @@ public interface IntegrationFlowContext {
 		 * a messaging exception happens at runtime.
 		 * @param source the configuration source representation.
 		 * @return the current builder instance
+		 * @since 5.2
 		 */
 		IntegrationFlowRegistrationBuilder setSource(Object source);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
@@ -220,6 +220,15 @@ public interface IntegrationFlowContext {
 		IntegrationFlowRegistrationBuilder addBean(String name, Object bean);
 
 		/**
+		 * Set the configuration source {@code Object} for this manual Integration flow definition.
+		 * Can be any arbitrary object which could easily lead to a source code for the flow when
+		 * a messaging exception happens at runtime.
+		 * @param source the configuration source representation.
+		 * @return the current builder instance
+		 */
+		IntegrationFlowRegistrationBuilder setSource(Object source);
+
+		/**
 		 * Invoke this method to prefix bean names in the flow with the (required) flow id
 		 * and a period. This is useful if you wish to register the same flow multiple times
 		 * while retaining the ability to reference beans within the flow; adding the unique

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
@@ -177,7 +177,7 @@ public class MessageFilter extends AbstractReplyProducingPostProcessingMessageHa
 				this.messagingTemplate.send(channel, message);
 			}
 			if (this.throwExceptionOnRejection) {
-				throw new MessageRejectedException(message, "MessageFilter '" + getBeanName() + "' rejected Message");
+				throw new MessageRejectedException(message, "message has been rejected in filter: " + this);
 			}
 		}
 		return result;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
@@ -30,9 +30,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.integration.context.IntegrationContextUtils;
-import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -111,7 +109,8 @@ public class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFac
 		}
 		catch (Exception e) {
 			throw new IllegalStateException(
-					"error occurred during processing message in 'LambdaMessageProcessor' [" + this + "]", e);
+					"error occurred during processing message in 'LambdaMessageProcessor' for method [" +
+							this.method + "]", e);
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
@@ -100,17 +100,18 @@ public class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFac
 		}
 		catch (InvocationTargetException e) {
 			if (e.getTargetException() instanceof ClassCastException) {
-				LOGGER.error("Could not invoke the method due to a class cast exception, " +
+				LOGGER.error("Could not invoke the method '" + this.method + "' due to a class cast exception, " +
 						"if using a lambda in the DSL, consider using an overloaded EIP method " +
 						"that takes a Class<?> argument to explicitly  specify the type. " +
 						"An example of when this often occurs is if the lambda is configured to " +
 						"receive a Message<?> argument.", e.getCause());
 			}
-			throw new MessageHandlingException(message, e.getCause()); // NOSONAR lost stack trace
+			throw new IllegalStateException(
+					"Could not invoke the method '" + this.method + "'", e.getCause()); // NOSONAR lost stack trace
 		}
 		catch (Exception e) {
-			throw IntegrationUtils.wrapInHandlingExceptionIfNecessary(message,
-					() -> "error occurred during processing message in 'LambdaMessageProcessor' [" + this + "]", e);
+			throw new IllegalStateException(
+					"error occurred during processing message in 'LambdaMessageProcessor' [" + this + "]", e);
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
@@ -112,7 +112,8 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 			if (e instanceof MessageTransformationException) {
 				throw (MessageTransformationException) e;
 			}
-			throw new MessageTransformationException(message, "Failed to transform Message", e);
+			throw new MessageTransformationException(message,
+					"Failed to transform Message in " + this, e);
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
@@ -94,7 +94,6 @@ public class AggregatorIntegrationTests {
 		Message<?> receive = output.receive(10000);
 		assertThat(receive).isNotNull();
 		assertThat(receive.getPayload()).isEqualTo(1 + 2 + 3 + 4);
-		assertThat(receive.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER)).isEqualTo(0);
 	}
 
 	@Test
@@ -187,7 +186,8 @@ public class AggregatorIntegrationTests {
 
 	@Test
 	public void testGroupTimeoutExpressionScheduling() {
-		// Since group-timeout-expression="size() >= 2 ? 100 : null". The first message won't be scheduled to 'forceComplete'
+		// Since group-timeout-expression="size() >= 2 ? 100 : null". The first message won't be scheduled to
+		// 'forceComplete'
 		this.groupTimeoutExpressionAggregatorInput.send(new GenericMessage<>(1, stubHeaders(1, 6, 1)));
 		assertThat(this.output.receive(0)).isNull();
 		assertThat(this.discard.receive(0)).isNull();
@@ -239,7 +239,9 @@ public class AggregatorIntegrationTests {
 			ErrorMessage em = (ErrorMessage) this.errors.receive(10000);
 			assertThat(em).isNotNull();
 			assertThat(em.getPayload().getMessage().toLowerCase())
-					.contains("failed to send message to channel 'output' within timeout: 10");
+					.contains("failed to send message to channel")
+					.contains("output")
+					.contains("within timeout: 10");
 		}
 		finally {
 			this.output.purge(null);
@@ -261,6 +263,7 @@ public class AggregatorIntegrationTests {
 	}
 
 	public static class SummingAggregator {
+
 		public Integer sum(List<Integer> numbers) {
 			int result = 0;
 			for (Integer number : numbers) {
@@ -268,8 +271,8 @@ public class AggregatorIntegrationTests {
 			}
 			return result;
 		}
-	}
 
+	}
 
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -156,9 +156,9 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 			assertThat(receive).isInstanceOf(ErrorMessage.class);
 			assertThat(receive.getPayload()).isInstanceOf(MessageRejectedException.class);
 			MessageRejectedException exception = (MessageRejectedException) receive.getPayload();
-			assertThat(exception.getMessage()).contains("MessageFilter " +
-					"'messagingAnnotationsWithBeanAnnotationTests.ContextConfiguration.filter.filter.handler'" +
-					" rejected Message");
+			assertThat(exception.getMessage())
+					.contains("message has been rejected in filter: bean " +
+							"'messagingAnnotationsWithBeanAnnotationTests.ContextConfiguration.filter.filter.handler'");
 
 		}
 		for (Message<?> message : this.collector) {
@@ -166,12 +166,12 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 			MessageHistory messageHistory = MessageHistory.read(message);
 			assertThat(messageHistory).isNotNull();
 			String messageHistoryString = messageHistory.toString();
-			assertThat(messageHistoryString).contains("routerChannel");
-			assertThat(messageHistoryString).contains("filterChannel");
-			assertThat(messageHistoryString).contains("aggregatorChannel");
-			assertThat(messageHistoryString).contains("splitterChannel");
-			assertThat(messageHistoryString).contains("serviceChannel");
-			assertThat(messageHistoryString).doesNotContain("discardChannel");
+			assertThat(messageHistoryString).contains("routerChannel")
+					.contains("filterChannel")
+					.contains("aggregatorChannel")
+					.contains("splitterChannel")
+					.contains("serviceChannel")
+					.doesNotContain("discardChannel");
 		}
 
 		assertThat(this.skippedServiceActivator).isNull();

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherParserTests.java
@@ -17,9 +17,9 @@
 package org.springframework.integration.config.xml;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -30,68 +30,82 @@ import org.springframework.integration.transformer.MessageTransformationExceptio
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class HeaderEnricherParserTests {
+@SpringJUnitConfig
+class HeaderEnricherParserTests {
 
 	@Autowired
 	private ApplicationContext context;
 
 
-	@Test // INT-1154
-	public void sendTimeoutDefault() {
+	@Test
+		// INT-1154
+	void sendTimeoutDefault() {
 		Object endpoint = context.getBean("headerEnricherWithDefaults");
 		long sendTimeout = TestUtils.getPropertyValue(endpoint, "handler.messagingTemplate.sendTimeout", Long.class);
 		assertThat(sendTimeout).isEqualTo(-1L);
 	}
 
-	@Test // INT-1154
-	public void sendTimeoutConfigured() {
+	@Test
+		// INT-1154
+	void sendTimeoutConfigured() {
 		Object endpoint = context.getBean("headerEnricherWithSendTimeout");
 		long sendTimeout = TestUtils.getPropertyValue(endpoint, "handler.messagingTemplate.sendTimeout", Long.class);
 		assertThat(sendTimeout).isEqualTo(1234L);
 	}
 
-	@Test // INT-1167
-	public void shouldSkipNullsDefault() {
+	@Test
+		// INT-1167
+	void shouldSkipNullsDefault() {
 		Object endpoint = context.getBean("headerEnricherWithDefaults");
-		Boolean shouldSkipNulls = TestUtils.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls", Boolean.class);
+		Boolean shouldSkipNulls = TestUtils
+				.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls", Boolean.class);
 		assertThat(shouldSkipNulls).isEqualTo(Boolean.TRUE);
-	}
-
-	@Test // INT-1167
-	public void shouldSkipNullsFalseConfigured() {
-		Object endpoint = context.getBean("headerEnricherWithShouldSkipNullsFalse");
-		Boolean shouldSkipNulls = TestUtils.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls", Boolean.class);
-		assertThat(shouldSkipNulls).isEqualTo(Boolean.FALSE);
-	}
-
-	@Test // INT-1167
-	public void shouldSkipNullsTrueConfigured() {
-		Object endpoint = context.getBean("headerEnricherWithShouldSkipNullsTrue");
-		Boolean shouldSkipNulls = TestUtils.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls", Boolean.class);
-		assertThat(shouldSkipNulls).isEqualTo(Boolean.TRUE);
-	}
-
-	@Test(expected = MessageTransformationException.class)
-	public void testStringPriorityHeader() {
-		MessageHandler messageHandler =
-				TestUtils.getPropertyValue(context.getBean("headerEnricherWithPriorityAsString"), "handler", MessageHandler.class);
-		Message<?> message = new GenericMessage<String>("hello");
-		messageHandler.handleMessage(message);
 	}
 
 	@Test
-	public void testStringPriorityHeaderWithType() {
+		// INT-1167
+	void shouldSkipNullsFalseConfigured() {
+		Object endpoint = context.getBean("headerEnricherWithShouldSkipNullsFalse");
+		Boolean shouldSkipNulls = TestUtils
+				.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls", Boolean.class);
+		assertThat(shouldSkipNulls).isEqualTo(Boolean.FALSE);
+	}
+
+	@Test
+		// INT-1167
+	void shouldSkipNullsTrueConfigured() {
+		Object endpoint = context.getBean("headerEnricherWithShouldSkipNullsTrue");
+		Boolean shouldSkipNulls = TestUtils
+				.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls", Boolean.class);
+		assertThat(shouldSkipNulls).isEqualTo(Boolean.TRUE);
+	}
+
+	@Test
+	void testStringPriorityHeader() {
 		MessageHandler messageHandler =
-				TestUtils.getPropertyValue(context.getBean("headerEnricherWithPriorityAsStringAndType"), "handler", MessageHandler.class);
+				TestUtils.getPropertyValue(this.context.getBean("headerEnricherWithPriorityAsString"),
+						"handler", MessageHandler.class);
+		Message<?> message = new GenericMessage<>("hello");
+		assertThatExceptionOfType(MessageTransformationException.class)
+				.isThrownBy(() -> messageHandler.handleMessage(message))
+				.withMessageContaining(
+						"; defined in class path resource " +
+								"[org/springframework/integration/config/xml/HeaderEnricherParserTests-context.xml]");
+	}
+
+	@Test
+	void testStringPriorityHeaderWithType() {
+		MessageHandler messageHandler =
+				TestUtils.getPropertyValue(context.getBean("headerEnricherWithPriorityAsStringAndType"),
+						"handler", MessageHandler.class);
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message = MessageBuilder.withPayload("foo").setReplyChannel(replyChannel).build();
 		messageHandler.handleMessage(message);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherParserTests.java
@@ -46,7 +46,6 @@ class HeaderEnricherParserTests {
 
 
 	@Test
-		// INT-1154
 	void sendTimeoutDefault() {
 		Object endpoint = context.getBean("headerEnricherWithDefaults");
 		long sendTimeout = TestUtils.getPropertyValue(endpoint, "handler.messagingTemplate.sendTimeout", Long.class);
@@ -54,7 +53,6 @@ class HeaderEnricherParserTests {
 	}
 
 	@Test
-		// INT-1154
 	void sendTimeoutConfigured() {
 		Object endpoint = context.getBean("headerEnricherWithSendTimeout");
 		long sendTimeout = TestUtils.getPropertyValue(endpoint, "handler.messagingTemplate.sendTimeout", Long.class);
@@ -62,7 +60,6 @@ class HeaderEnricherParserTests {
 	}
 
 	@Test
-		// INT-1167
 	void shouldSkipNullsDefault() {
 		Object endpoint = context.getBean("headerEnricherWithDefaults");
 		Boolean shouldSkipNulls = TestUtils
@@ -71,7 +68,6 @@ class HeaderEnricherParserTests {
 	}
 
 	@Test
-		// INT-1167
 	void shouldSkipNullsFalseConfigured() {
 		Object endpoint = context.getBean("headerEnricherWithShouldSkipNullsFalse");
 		Boolean shouldSkipNulls = TestUtils
@@ -80,7 +76,6 @@ class HeaderEnricherParserTests {
 	}
 
 	@Test
-		// INT-1167
 	void shouldSkipNullsTrueConfigured() {
 		Object endpoint = context.getBean("headerEnricherWithShouldSkipNullsTrue");
 		Boolean shouldSkipNulls = TestUtils
@@ -97,8 +92,8 @@ class HeaderEnricherParserTests {
 		assertThatExceptionOfType(MessageTransformationException.class)
 				.isThrownBy(() -> messageHandler.handleMessage(message))
 				.withMessageContaining(
-						"; defined in class path resource " +
-								"[org/springframework/integration/config/xml/HeaderEnricherParserTests-context.xml]");
+						"; defined in: 'class path resource " +
+								"[org/springframework/integration/config/xml/HeaderEnricherParserTests-context.xml]'");
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
@@ -31,7 +31,6 @@ import org.springframework.integration.handler.LambdaMessageProcessor;
 import org.springframework.integration.support.converter.ConfigurableCompositeMessageConverter;
 import org.springframework.integration.transformer.GenericTransformer;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.support.GenericMessage;
 
@@ -61,12 +60,12 @@ public class LambdaMessageProcessorTests {
 		LambdaMessageProcessor lmp = new LambdaMessageProcessor(
 				new GenericTransformer<Message<?>, Message<?>>() { // Must not be lambda
 
-			@Override
-			public Message<?> transform(Message<?> source) {
-				return messageTransformer(source);
-			}
+					@Override
+					public Message<?> transform(Message<?> source) {
+						return messageTransformer(source);
+					}
 
-		}, null);
+				}, null);
 		lmp.setBeanFactory(mock(BeanFactory.class));
 		GenericMessage<String> testMessage = new GenericMessage<>("foo");
 		Object result = lmp.processMessage(testMessage);
@@ -79,7 +78,7 @@ public class LambdaMessageProcessorTests {
 				(GenericTransformer<Message<?>, Message<?>>) this::messageTransformer, null);
 		lmp.setBeanFactory(mock(BeanFactory.class));
 		GenericMessage<String> testMessage = new GenericMessage<>("foo");
-		assertThatExceptionOfType(MessageHandlingException.class)
+		assertThatExceptionOfType(IllegalStateException.class)
 				.isThrownBy(() -> lmp.processMessage(testMessage))
 				.withCauseInstanceOf(ClassCastException.class);
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
@@ -78,7 +78,12 @@ public class GatewayDslTests {
 		assertThat(receive).isNotNull();
 		assertThat(receive).isInstanceOf(ErrorMessage.class);
 		assertThat(receive.getPayload()).isInstanceOf(MessageRejectedException.class);
-		assertThat(((Exception) receive.getPayload()).getMessage()).contains("' rejected Message");
+		String exceptionMessage = ((Exception) receive.getPayload()).getMessage();
+		assertThat(exceptionMessage)
+				.contains("message has been rejected in filter")
+				.contains("defined in: " +
+						"'org.springframework.integration.dsl.gateway.GatewayDslTests$ContextConfiguration'; " +
+						"from source: 'bean method gatewayRequestFlow'");
 	}
 
 	@Autowired
@@ -89,7 +94,7 @@ public class GatewayDslTests {
 	void testNestedGatewayErrorPropagation() {
 		assertThatExceptionOfType(RuntimeException.class)
 				.isThrownBy(() -> this.nestedGatewayErrorPropagationFlowInput.send(new GenericMessage<>("test")))
-				.withMessageContaining("intentional");
+				.withStackTraceContaining("intentional");
 	}
 
 	@Configuration

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
@@ -538,6 +538,8 @@ public class ManualFlowTests {
 				.withRootCauseInstanceOf(ClassCastException.class)
 				.withMessageContaining("from source: '" + source + "'")
 				.withStackTraceContaining("java.util.Date cannot be cast to java.lang.String");
+
+		flowRegistration.destroy();
 	}
 
 	@Configuration

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -73,6 +74,7 @@ import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.support.SmartLifecycleRoleController;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.integration.transformer.MessageTransformationException;
 import org.springframework.integration.transformer.MessageTransformingHandler;
 import org.springframework.integration.util.NoBeansOverrideAnnotationConfigContextLoader;
 import org.springframework.messaging.Message;
@@ -86,6 +88,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.util.ReflectionUtils;
 
 import reactor.core.publisher.Flux;
 
@@ -519,6 +522,22 @@ public class ManualFlowTests {
 				.isExactlyInstanceOf(BeanCreationException.class)
 				.withCauseExactlyInstanceOf(BeanDefinitionOverrideException.class)
 				.withMessageContaining("Invalid bean definition with name 'doNotOverrideChannel'");
+	}
+
+	@Test
+	public void testBeanDefinitionInfoInTheException() {
+		IntegrationFlow testFlow = f -> f.<String, String>transform(String::toUpperCase);
+		Method source = ReflectionUtils.findMethod(ManualFlowTests.class, "testBeanDefinitionInfoInTheException");
+		IntegrationFlowRegistration flowRegistration =
+				this.integrationFlowContext.registration(testFlow)
+						.setSource(source)
+						.register();
+		assertThatExceptionOfType(MessageTransformationException.class)
+				.isThrownBy(() -> flowRegistration.getInputChannel().send(new GenericMessage<>(new Date())))
+				.withCauseExactlyInstanceOf(IllegalStateException.class)
+				.withRootCauseInstanceOf(ClassCastException.class)
+				.withMessageContaining("from source: '" + source + "'")
+				.withStackTraceContaining("java.util.Date cannot be cast to java.lang.String");
 	}
 
 	@Configuration

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -123,7 +123,7 @@ public class AdvisedMessageHandlerTests {
 		handler.setComponentName(componentName);
 		QueueChannel replies = new QueueChannel();
 		handler.setOutputChannel(replies);
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 
 		// no advice
 		handler.handleMessage(message);
@@ -142,7 +142,7 @@ public class AdvisedMessageHandlerTests {
 
 		List<Advice> adviceChain = new ArrayList<Advice>();
 		adviceChain.add(advice);
-		final AtomicReference<String> compName = new AtomicReference<String>();
+		final AtomicReference<String> compName = new AtomicReference<>();
 		adviceChain.add(new AbstractRequestHandlerAdvice() {
 
 			@Override
@@ -229,7 +229,7 @@ public class AdvisedMessageHandlerTests {
 		};
 		QueueChannel replies = new QueueChannel();
 		handler.setOutputChannel(replies);
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 
 		PollableChannel successChannel = new QueueChannel();
 		PollableChannel failureChannel = new QueueChannel();
@@ -293,7 +293,7 @@ public class AdvisedMessageHandlerTests {
 		};
 		QueueChannel replies = new QueueChannel();
 		handler.setOutputChannel(replies);
-		Message<String> message = new GenericMessage<String>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!");
 
 		PollableChannel successChannel = new QueueChannel();
 		PollableChannel failureChannel = new QueueChannel();
@@ -375,7 +375,7 @@ public class AdvisedMessageHandlerTests {
 		advice.setThreshold(2);
 		advice.setHalfOpenAfter(1000);
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 		adviceChain.add(advice);
 		handler.setAdviceChain(adviceChain);
 		handler.setBeanFactory(mock(BeanFactory.class));
@@ -402,7 +402,7 @@ public class AdvisedMessageHandlerTests {
 			fail("Expected failure");
 		}
 		catch (Exception e) {
-			assertThat(e.getMessage()).isEqualTo("Circuit Breaker is Open for baz");
+			assertThat(e.getMessage()).isEqualTo("Circuit Breaker is Open for bean 'baz'");
 			assertThat(((MessagingException) e).getFailedMessage()).isSameAs(message);
 		}
 
@@ -426,7 +426,7 @@ public class AdvisedMessageHandlerTests {
 			fail("Expected failure");
 		}
 		catch (Exception e) {
-			assertThat(e.getMessage()).isEqualTo("Circuit Breaker is Open for baz");
+			assertThat(e.getMessage()).isEqualTo("Circuit Breaker is Open for bean 'baz'");
 		}
 
 		// Simulate some timeout in between requests
@@ -454,7 +454,7 @@ public class AdvisedMessageHandlerTests {
 			fail("Expected failure");
 		}
 		catch (Exception e) {
-			assertThat(e.getMessage()).isEqualTo("Circuit Breaker is Open for baz");
+			assertThat(e.getMessage()).isEqualTo("Circuit Breaker is Open for bean 'baz'");
 		}
 	}
 
@@ -475,7 +475,7 @@ public class AdvisedMessageHandlerTests {
 		handler.setOutputChannel(replies);
 		RequestHandlerRetryAdvice advice = new RequestHandlerRetryAdvice();
 
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 		adviceChain.add(advice);
 		handler.setAdviceChain(adviceChain);
 		handler.setBeanFactory(mock(BeanFactory.class));
@@ -937,7 +937,7 @@ public class AdvisedMessageHandlerTests {
 		MessageFilter filter = new MessageFilter(message -> false);
 		final QueueChannel discardChannel = new QueueChannel();
 		filter.setDiscardChannel(discardChannel);
-		List<Advice> adviceChain = new ArrayList<Advice>();
+		List<Advice> adviceChain = new ArrayList<>();
 		final AtomicReference<Message<?>> discardedWithinAdvice = new AtomicReference<Message<?>>();
 		adviceChain.add(new AbstractRequestHandlerAdvice() {
 
@@ -1017,7 +1017,7 @@ public class AdvisedMessageHandlerTests {
 
 		RetryTemplate retryTemplate = new RetryTemplate();
 
-		Map<Class<? extends Throwable>, Boolean> retryableExceptions = new HashMap<Class<? extends Throwable>, Boolean>();
+		Map<Class<? extends Throwable>, Boolean> retryableExceptions = new HashMap<>();
 		retryableExceptions.put(MyException.class, retryForMyException);
 
 		retryTemplate.setRetryPolicy(new SimpleRetryPolicy(3, retryableExceptions, true));

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/ContentEnricherTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/ContentEnricherTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.transformer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Mockito.mock;
 
@@ -143,7 +144,8 @@ public class ContentEnricherTests {
 		}
 		catch (ReplyRequiredException e) {
 			assertThat(e.getMessage())
-					.isEqualTo("No reply produced by handler 'Enricher', and its 'requiresReply' property is set to true.");
+					.isEqualTo("No reply produced by handler 'Enricher', and its 'requiresReply' property is set to " +
+							"true.");
 			return;
 		}
 		finally {
@@ -174,14 +176,11 @@ public class ContentEnricherTests {
 		Target target = new Target("replace me");
 		Message<?> requestMessage = MessageBuilder.withPayload(target).setReplyChannel(replyChannel).build();
 
-		try {
-			enricher.handleMessage(requestMessage);
-		}
-		catch (MessageDeliveryException e) {
-			assertThat(e.getMessage()).isEqualToIgnoringCase("failed to send message to channel '" + requestChannelName
-					+ "' within timeout: " + requestTimeout);
-		}
-
+		assertThatExceptionOfType(MessageDeliveryException.class)
+				.isThrownBy(() -> enricher.handleMessage(requestMessage))
+				.withMessageContaining("Failed to send message to channel")
+				.withMessageContaining(requestChannelName)
+				.withMessageContaining("within timeout: " + requestTimeout);
 	}
 
 	@Test
@@ -189,6 +188,7 @@ public class ContentEnricherTests {
 		QueueChannel replyChannel = new QueueChannel();
 		DirectChannel requestChannel = new DirectChannel();
 		requestChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return new Source("John", "Doe");
@@ -199,7 +199,7 @@ public class ContentEnricherTests {
 		enricher.setRequestChannel(requestChannel);
 
 		SpelExpressionParser parser = new SpelExpressionParser();
-		Map<String, Expression> propertyExpressions = new HashMap<String, Expression>();
+		Map<String, Expression> propertyExpressions = new HashMap<>();
 		propertyExpressions.put("name", parser.parseExpression("payload.lastName + ', ' + payload.firstName"));
 		enricher.setPropertyExpressions(propertyExpressions);
 		enricher.setBeanFactory(mock(BeanFactory.class));
@@ -308,6 +308,7 @@ public class ContentEnricherTests {
 		QueueChannel replyChannel = new QueueChannel();
 		DirectChannel requestChannel = new DirectChannel();
 		requestChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return new Source("John", "Doe");
@@ -337,6 +338,7 @@ public class ContentEnricherTests {
 		QueueChannel replyChannel = new QueueChannel();
 		DirectChannel requestChannel = new DirectChannel();
 		requestChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return new Source("John", "Doe");
@@ -367,6 +369,7 @@ public class ContentEnricherTests {
 		QueueChannel replyChannel = new QueueChannel();
 		DirectChannel requestChannel = new DirectChannel();
 		requestChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return new Source("John", "Doe");
@@ -400,6 +403,7 @@ public class ContentEnricherTests {
 		QueueChannel replyChannel = new QueueChannel();
 		DirectChannel requestChannel = new DirectChannel();
 		requestChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return new Source("John", "Doe");
@@ -450,6 +454,7 @@ public class ContentEnricherTests {
 
 		DirectChannel requestChannel = new DirectChannel();
 		requestChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return new Source("John", "Doe");
@@ -483,6 +488,7 @@ public class ContentEnricherTests {
 
 		final DirectChannel requestChannel = new DirectChannel();
 		requestChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				throw new RuntimeException();
@@ -492,6 +498,7 @@ public class ContentEnricherTests {
 
 		final DirectChannel errorChannel = new DirectChannel();
 		errorChannel.subscribe(new AbstractReplyProducingMessageHandler() {
+
 			@Override
 			protected Object handleRequestMessage(Message<?> requestMessage) {
 				return new Target("failed");

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
@@ -289,7 +289,7 @@ public class ConnectionEventTests {
 		String actual = theEvent.toString();
 		assertThat(actual).contains("cause=java.net.BindException");
 		assertThat(actual).contains("source="
-				+ "sf, port=" + factory.getPort());
+				+ "bean 'sf', port=" + factory.getPort());
 
 		ArgumentCaptor<String> reasonCaptor = ArgumentCaptor.forClass(String.class);
 		ArgumentCaptor<Throwable> throwableCaptor = ArgumentCaptor.forClass(Throwable.class);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
@@ -240,7 +240,7 @@ public class ConnectionFactoryTests {
 		assertThat(n < 200).as("Stop was not invoked in time").isTrue();
 		latch2.countDown();
 		assertThat(latch3.await(10, TimeUnit.SECONDS)).as("missing debug log").isTrue();
-		String expected = "foo, port=" + factory.getPort() + message;
+		String expected = "bean 'foo', port=" + factory.getPort() + message;
 		ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
 		verify(logger, atLeast(1)).debug(captor.capture());
 		assertThat(captor.getAllValues()).contains(expected);

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
@@ -1017,7 +1017,13 @@ public class IntegrationMBeanExporter extends MBeanExporter
 		 * Short hack to makes sure object names are unique if more than one endpoint has the same input
 		 * channel
 		 */
-		return messageChannel + (total > 1 ? "#" + total : "");
+
+		String channelName =
+				messageChannel instanceof NamedComponent
+						? ((NamedComponent) messageChannel).getBeanName()
+						: messageChannel.toString();
+
+		return channelName + (total > 1 ? "#" + total : "");
 	}
 
 	/**

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/HandlerMonitoringIntegrationTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/HandlerMonitoringIntegrationTests.java
@@ -38,7 +38,7 @@ import org.springframework.messaging.support.GenericMessage;
  */
 public class HandlerMonitoringIntegrationTests {
 
-	private static Log logger = LogFactory.getLog(HandlerMonitoringIntegrationTests.class);
+	private static final Log logger = LogFactory.getLog(HandlerMonitoringIntegrationTests.class);
 
 	private MessageChannel channel;
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2748

In many cases Spring Integration stack traces doesn't contain any
relations to end-user code.
Just because a target project code mostly contains only a configuration
for out-of-the-box components without any custom code.
When exception is thrown from such an out-of-the-box component, it is
hard from the stack trace to determine a configuration source for those
components.

* Add a logic into the `IntegrationObjectSupport` to obtain a its own
`BeanDefinition` from the `BeanFactory` to include a `resource` and
`source` (if any) into the `toString()` representation, as well as add
a new `getBeanDescription()` to get such an info at runtime
* The `toString()` is simply used by `this` reference in the message
for `MessagingException` thrown from the `IntegrationObjectSupport`
implementations
* Modify an exception message for the `MessageTransformingHandler` and
`MessageFilter` to make it based on `this`.
The `AbstractMessageHandler` already includes `this` into its exception
message
* Modify a `AbstractConsumerEndpointParser` and
`AbstractAmqpInboundAdapterParser` (as a sample) to include a `resource`
and `source` into a `MessageHandler` `BeanDefinition`.
* Include an `IntegrationFlow` `BeanDefinition` `resource`
(`@Configuration` class) and its bean method as a `source` into all
child beans declared during flow parsing in the `IntegrationFlowBeanPostProcessor`
* Add `IntegrationFlowRegistrationBuilder.setSource()` for manually
registered flows: there is no configuration parsing phase to extract
such an info from `BeanFactory`
* Propagate that `source` into all the child beans provided by the
`IntegrationFlow`
* Modify a `LambdaMessageProcessor` exception message to include a
method info in case of `InvocationTargetException`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
