### PR TITLE
GH-2988: Use `@Config(proxyBeanMethods=false)`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
@@ -44,7 +44,7 @@ import org.springframework.util.StringUtils;
  *
  * @since 4.2
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class IntegrationManagementConfiguration implements ImportAware, EnvironmentAware {
 
 	private AnnotationAttributes attributes;
@@ -60,7 +60,7 @@ public class IntegrationManagementConfiguration implements ImportAware, Environm
 	public void setImportMetadata(AnnotationMetadata importMetadata) {
 		Map<String, Object> map = importMetadata.getAnnotationAttributes(EnableIntegrationManagement.class.getName());
 		this.attributes = AnnotationAttributes.fromMap(map);
-		Assert.notNull(this.attributes,
+		Assert.notNull(this.attributes, ()->
 				"@EnableIntegrationManagement is not present on importing class " + importMetadata.getClassName());
 	}
 
@@ -85,7 +85,7 @@ public class IntegrationManagementConfiguration implements ImportAware, Environm
 	}
 
 	private void setupCountsEnabledNamePatterns(IntegrationManagementConfigurer configurer) {
-		List<String> patterns = new ArrayList<String>();
+		List<String> patterns = new ArrayList<>();
 		String[] countsEnabled = this.attributes.getStringArray("countsEnabled");
 		for (String managedComponent : countsEnabled) {
 			String pattern = this.environment.resolvePlaceholders(managedComponent);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
@@ -60,7 +60,7 @@ public class IntegrationManagementConfiguration implements ImportAware, Environm
 	public void setImportMetadata(AnnotationMetadata importMetadata) {
 		Map<String, Object> map = importMetadata.getAnnotationAttributes(EnableIntegrationManagement.class.getName());
 		this.attributes = AnnotationAttributes.fromMap(map);
-		Assert.notNull(this.attributes, ()->
+		Assert.notNull(this.attributes, () ->
 				"@EnableIntegrationManagement is not present on importing class " + importMetadata.getClassName());
 	}
 

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/IntegrationMBeanExportConfiguration.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/IntegrationMBeanExportConfiguration.java
@@ -58,10 +58,13 @@ import org.springframework.util.StringUtils;
  *
  * @since 4.0
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class IntegrationMBeanExportConfiguration implements ImportAware, EnvironmentAware, BeanFactoryAware {
 
-	private static final String MBEAN_EXPORTER_NAME = "integrationMbeanExporter";
+	/**
+	 * A name for default {@link IntegrationMBeanExporter} bean.
+	 */
+	public static final String MBEAN_EXPORTER_NAME = "integrationMbeanExporter";
 
 	private AnnotationAttributes attributes;
 
@@ -95,7 +98,7 @@ public class IntegrationMBeanExportConfiguration implements ImportAware, Environ
 	public void setImportMetadata(AnnotationMetadata importMetadata) {
 		Map<String, Object> map = importMetadata.getAnnotationAttributes(EnableIntegrationMBeanExport.class.getName());
 		this.attributes = AnnotationAttributes.fromMap(map);
-		Assert.notNull(this.attributes,
+		Assert.notNull(this.attributes, () ->
 				"@EnableIntegrationMBeanExport is not present on importing class " + importMetadata.getClassName());
 	}
 
@@ -121,7 +124,7 @@ public class IntegrationMBeanExportConfiguration implements ImportAware, Environ
 
 	private void setupDomain(IntegrationMBeanExporter exporter) {
 		String defaultDomain = this.attributes.getString("defaultDomain");
-		if (defaultDomain != null && this.environment != null) {
+		if (this.environment != null) {
 			defaultDomain = this.environment.resolvePlaceholders(defaultDomain);
 		}
 		if (StringUtils.hasText(defaultDomain)) {
@@ -131,11 +134,11 @@ public class IntegrationMBeanExportConfiguration implements ImportAware, Environ
 
 	private void setupServer(IntegrationMBeanExporter exporter) {
 		String server = this.attributes.getString("server");
-		if (server != null && this.environment != null) {
+		if (this.environment != null) {
 			server = this.environment.resolvePlaceholders(server);
 		}
 		if (StringUtils.hasText(server)) {
-			MBeanServer bean = null;
+			MBeanServer bean;
 			if (server.startsWith("#{") && server.endsWith("}")) {
 				bean = (MBeanServer) this.resolver.evaluate(server, this.expressionContext);
 			}
@@ -159,7 +162,7 @@ public class IntegrationMBeanExportConfiguration implements ImportAware, Environ
 			String pattern = this.environment.resolvePlaceholders(managedComponent);
 			patterns.addAll(Arrays.asList(StringUtils.commaDelimitedListToStringArray(pattern)));
 		}
-		exporter.setComponentNamePatterns(patterns.toArray(new String[patterns.size()]));
+		exporter.setComponentNamePatterns(patterns.toArray(new String[0]));
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2988

For faster startup (and possibility to compile to native code with GraalVM)
use a `proxyBeanMethods = false` on all the `@Configuration` classes
in the Framework
* Provide some other code style polishing

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
