### PR TITLE
GH-2987: Add HTTPS entries into spring.schemas

### DIFF
--- a/spring-integration-amqp/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-amqp/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/amqp/spring-integration-amqp-5.2.xsd=org/springframework/integration/amqp/config/spring-integration-amqp-5.2.xsd
 http\://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd=org/springframework/integration/amqp/config/spring-integration-amqp-5.2.xsd
+https\://www.springframework.org/schema/integration/amqp/spring-integration-amqp-5.2.xsd=org/springframework/integration/amqp/config/spring-integration-amqp-5.2.xsd
+https\://www.springframework.org/schema/integration/amqp/spring-integration-amqp.xsd=org/springframework/integration/amqp/config/spring-integration-amqp-5.2.xsd

--- a/spring-integration-core/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-core/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/spring-integration-5.2.xsd=org/springframework/integration/config/spring-integration-5.2.xsd
 http\://www.springframework.org/schema/integration/spring-integration.xsd=org/springframework/integration/config/spring-integration-5.2.xsd
+https\://www.springframework.org/schema/integration/spring-integration-5.2.xsd=org/springframework/integration/config/spring-integration-5.2.xsd
+https\://www.springframework.org/schema/integration/spring-integration.xsd=org/springframework/integration/config/spring-integration-5.2.xsd

--- a/spring-integration-event/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-event/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/event/spring-integration-event-5.2.xsd=org/springframework/integration/event/config/spring-integration-event-5.2.xsd
 http\://www.springframework.org/schema/integration/event/spring-integration-event.xsd=org/springframework/integration/event/config/spring-integration-event-5.2.xsd
+https\://www.springframework.org/schema/integration/event/spring-integration-event-5.2.xsd=org/springframework/integration/event/config/spring-integration-event-5.2.xsd
+https\://www.springframework.org/schema/integration/event/spring-integration-event.xsd=org/springframework/integration/event/config/spring-integration-event-5.2.xsd

--- a/spring-integration-feed/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-feed/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/feed/spring-integration-feed-5.2.xsd=org/springframework/integration/feed/config/spring-integration-feed-5.2.xsd
 http\://www.springframework.org/schema/integration/feed/spring-integration-feed.xsd=org/springframework/integration/feed/config/spring-integration-feed-5.2.xsd
+https\://www.springframework.org/schema/integration/feed/spring-integration-feed-5.2.xsd=org/springframework/integration/feed/config/spring-integration-feed-5.2.xsd
+https\://www.springframework.org/schema/integration/feed/spring-integration-feed.xsd=org/springframework/integration/feed/config/spring-integration-feed-5.2.xsd

--- a/spring-integration-file/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-file/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/file/spring-integration-file-5.2.xsd=org/springframework/integration/file/config/spring-integration-file-5.2.xsd
 http\://www.springframework.org/schema/integration/file/spring-integration-file.xsd=org/springframework/integration/file/config/spring-integration-file-5.2.xsd
+https\://www.springframework.org/schema/integration/file/spring-integration-file-5.2.xsd=org/springframework/integration/file/config/spring-integration-file-5.2.xsd
+https\://www.springframework.org/schema/integration/file/spring-integration-file.xsd=org/springframework/integration/file/config/spring-integration-file-5.2.xsd

--- a/spring-integration-ftp/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-ftp/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/ftp/spring-integration-ftp-5.2.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-5.2.xsd
 http\://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-5.2.xsd
+https\://www.springframework.org/schema/integration/ftp/spring-integration-ftp-5.2.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-5.2.xsd
+https\://www.springframework.org/schema/integration/ftp/spring-integration-ftp.xsd=org/springframework/integration/ftp/config/spring-integration-ftp-5.2.xsd

--- a/spring-integration-gemfire/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-gemfire/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire-5.2.xsd=org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-5.2.xsd
 http\://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire.xsd=org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-5.2.xsd
+https\://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire-5.2.xsd=org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-5.2.xsd
+https\://www.springframework.org/schema/integration/gemfire/spring-integration-gemfire.xsd=org/springframework/integration/gemfire/config/xml/spring-integration-gemfire-5.2.xsd

--- a/spring-integration-groovy/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-groovy/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/groovy/spring-integration-groovy-5.2.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-5.2.xsd
 http\://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-5.2.xsd
+https\://www.springframework.org/schema/integration/groovy/spring-integration-groovy-5.2.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-5.2.xsd
+https\://www.springframework.org/schema/integration/groovy/spring-integration-groovy.xsd=org/springframework/integration/groovy/config/spring-integration-groovy-5.2.xsd

--- a/spring-integration-http/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-http/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/http/spring-integration-http-5.2.xsd=org/springframework/integration/http/config/spring-integration-http-5.2.xsd
 http\://www.springframework.org/schema/integration/http/spring-integration-http.xsd=org/springframework/integration/http/config/spring-integration-http-5.2.xsd
+https\://www.springframework.org/schema/integration/http/spring-integration-http-5.2.xsd=org/springframework/integration/http/config/spring-integration-http-5.2.xsd
+https\://www.springframework.org/schema/integration/http/spring-integration-http.xsd=org/springframework/integration/http/config/spring-integration-http-5.2.xsd

--- a/spring-integration-ip/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-ip/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/ip/spring-integration-ip-5.2.xsd=org/springframework/integration/ip/config/spring-integration-ip-5.2.xsd
 http\://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd=org/springframework/integration/ip/config/spring-integration-ip-5.2.xsd
+https\://www.springframework.org/schema/integration/ip/spring-integration-ip-5.2.xsd=org/springframework/integration/ip/config/spring-integration-ip-5.2.xsd
+https\://www.springframework.org/schema/integration/ip/spring-integration-ip.xsd=org/springframework/integration/ip/config/spring-integration-ip-5.2.xsd

--- a/spring-integration-jdbc/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-jdbc/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc-5.2.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-5.2.xsd
 http\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-5.2.xsd
+https\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc-5.2.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-5.2.xsd
+https\://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd=org/springframework/integration/jdbc/config/spring-integration-jdbc-5.2.xsd

--- a/spring-integration-jms/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-jms/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/jms/spring-integration-jms-5.2.xsd=org/springframework/integration/jms/config/spring-integration-jms-5.2.xsd
 http\://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd=org/springframework/integration/jms/config/spring-integration-jms-5.2.xsd
+https\://www.springframework.org/schema/integration/jms/spring-integration-jms-5.2.xsd=org/springframework/integration/jms/config/spring-integration-jms-5.2.xsd
+https\://www.springframework.org/schema/integration/jms/spring-integration-jms.xsd=org/springframework/integration/jms/config/spring-integration-jms-5.2.xsd

--- a/spring-integration-jmx/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-jmx/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/jmx/spring-integration-jmx-5.2.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-5.2.xsd
 http\://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-5.2.xsd
+https\://www.springframework.org/schema/integration/jmx/spring-integration-jmx-5.2.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-5.2.xsd
+https\://www.springframework.org/schema/integration/jmx/spring-integration-jmx.xsd=org/springframework/integration/jmx/config/spring-integration-jmx-5.2.xsd

--- a/spring-integration-jpa/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-jpa/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/jpa/spring-integration-jpa-5.2.xsd=org/springframework/integration/jpa/config/spring-integration-jpa-5.2.xsd
 http\://www.springframework.org/schema/integration/jpa/spring-integration-jpa.xsd=org/springframework/integration/jpa/config/spring-integration-jpa-5.2.xsd
+https\://www.springframework.org/schema/integration/jpa/spring-integration-jpa-5.2.xsd=org/springframework/integration/jpa/config/spring-integration-jpa-5.2.xsd
+https\://www.springframework.org/schema/integration/jpa/spring-integration-jpa.xsd=org/springframework/integration/jpa/config/spring-integration-jpa-5.2.xsd

--- a/spring-integration-mail/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-mail/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/mail/spring-integration-mail-5.2.xsd=org/springframework/integration/mail/config/spring-integration-mail-5.2.xsd
 http\://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd=org/springframework/integration/mail/config/spring-integration-mail-5.2.xsd
+https\://www.springframework.org/schema/integration/mail/spring-integration-mail-5.2.xsd=org/springframework/integration/mail/config/spring-integration-mail-5.2.xsd
+https\://www.springframework.org/schema/integration/mail/spring-integration-mail.xsd=org/springframework/integration/mail/config/spring-integration-mail-5.2.xsd

--- a/spring-integration-mongodb/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-mongodb/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb-5.2.xsd=org/springframework/integration/mongodb/config/spring-integration-mongodb-5.2.xsd
 http\://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd=org/springframework/integration/mongodb/config/spring-integration-mongodb-5.2.xsd
+https\://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb-5.2.xsd=org/springframework/integration/mongodb/config/spring-integration-mongodb-5.2.xsd
+https\://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd=org/springframework/integration/mongodb/config/spring-integration-mongodb-5.2.xsd

--- a/spring-integration-mqtt/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-mqtt/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/mqtt/spring-integration-mqtt-5.2.xsd=org/springframework/integration/mqtt/config/spring-integration-mqtt-5.2.xsd
 http\://www.springframework.org/schema/integration/mqtt/spring-integration-mqtt.xsd=org/springframework/integration/mqtt/config/spring-integration-mqtt-5.2.xsd
+https\://www.springframework.org/schema/integration/mqtt/spring-integration-mqtt-5.2.xsd=org/springframework/integration/mqtt/config/spring-integration-mqtt-5.2.xsd
+https\://www.springframework.org/schema/integration/mqtt/spring-integration-mqtt.xsd=org/springframework/integration/mqtt/config/spring-integration-mqtt-5.2.xsd

--- a/spring-integration-redis/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-redis/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/redis/spring-integration-redis-5.2.xsd=org/springframework/integration/redis/config/spring-integration-redis-5.2.xsd
 http\://www.springframework.org/schema/integration/redis/spring-integration-redis.xsd=org/springframework/integration/redis/config/spring-integration-redis-5.2.xsd
+https\://www.springframework.org/schema/integration/redis/spring-integration-redis-5.2.xsd=org/springframework/integration/redis/config/spring-integration-redis-5.2.xsd
+https\://www.springframework.org/schema/integration/redis/spring-integration-redis.xsd=org/springframework/integration/redis/config/spring-integration-redis-5.2.xsd

--- a/spring-integration-rmi/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-rmi/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/rmi/spring-integration-rmi-5.2.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-5.2.xsd
 http\://www.springframework.org/schema/integration/rmi/spring-integration-rmi.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-5.2.xsd
+https\://www.springframework.org/schema/integration/rmi/spring-integration-rmi-5.2.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-5.2.xsd
+https\://www.springframework.org/schema/integration/rmi/spring-integration-rmi.xsd=org/springframework/integration/rmi/config/spring-integration-rmi-5.2.xsd

--- a/spring-integration-rsocket/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-rsocket/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/rsocket/spring-integration-rsocket-5.2.xsd=org/springframework/integration/rsocket/config/spring-integration-rsocket-5.2.xsd
 http\://www.springframework.org/schema/integration/rsocket/spring-integration-rsocket.xsd=org/springframework/integration/rsocket/config/spring-integration-rsocket-5.2.xsd
+https\://www.springframework.org/schema/integration/rsocket/spring-integration-rsocket-5.2.xsd=org/springframework/integration/rsocket/config/spring-integration-rsocket-5.2.xsd
+https\://www.springframework.org/schema/integration/rsocket/spring-integration-rsocket.xsd=org/springframework/integration/rsocket/config/spring-integration-rsocket-5.2.xsd

--- a/spring-integration-scripting/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-scripting/src/main/resources/META-INF/spring.schemas
@@ -2,3 +2,8 @@ http\://www.springframework.org/schema/integration/scripting/spring-integration-
 http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-5.2.xsd
 http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core-5.2.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-core-5.2.xsd
 http\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-core-5.2.xsd
+https\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-5.2.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-5.2.xsd
+https\://www.springframework.org/schema/integration/scripting/spring-integration-scripting.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-5.2.xsd
+https\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core-5.2.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-core-5.2.xsd
+https\://www.springframework.org/schema/integration/scripting/spring-integration-scripting-core.xsd=org/springframework/integration/scripting/config/spring-integration-scripting-core-5.2.xsd
+

--- a/spring-integration-security/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-security/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/security/spring-integration-security-5.2.xsd=org/springframework/integration/security/config/spring-integration-security-5.2.xsd
 http\://www.springframework.org/schema/integration/security/spring-integration-security.xsd=org/springframework/integration/security/config/spring-integration-security-5.2.xsd
+https\://www.springframework.org/schema/integration/security/spring-integration-security-5.2.xsd=org/springframework/integration/security/config/spring-integration-security-5.2.xsd
+https\://www.springframework.org/schema/integration/security/spring-integration-security.xsd=org/springframework/integration/security/config/spring-integration-security-5.2.xsd

--- a/spring-integration-sftp/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-sftp/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,5 @@
 http\://www.springframework.org/schema/integration/sftp/spring-integration-sftp-5.2.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-5.2.xsd
 http\://www.springframework.org/schema/integration/sftp/spring-integration-sftp.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-5.2.xsd
+https\://www.springframework.org/schema/integration/sftp/spring-integration-sftp-5.2.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-5.2.xsd
+https\://www.springframework.org/schema/integration/sftp/spring-integration-sftp.xsd=org/springframework/integration/sftp/config/spring-integration-sftp-5.2.xsd
+

--- a/spring-integration-stomp/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-stomp/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,5 @@
 http\://www.springframework.org/schema/integration/stomp/spring-integration-stomp-5.2.xsd=org/springframework/integration/stomp/config/spring-integration-stomp-5.2.xsd
 http\://www.springframework.org/schema/integration/stomp/spring-integration-stomp.xsd=org/springframework/integration/stomp/config/spring-integration-stomp-5.2.xsd
+https\://www.springframework.org/schema/integration/stomp/spring-integration-stomp-5.2.xsd=org/springframework/integration/stomp/config/spring-integration-stomp-5.2.xsd
+https\://www.springframework.org/schema/integration/stomp/spring-integration-stomp.xsd=org/springframework/integration/stomp/config/spring-integration-stomp-5.2.xsd
+

--- a/spring-integration-stream/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-stream/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,5 @@
 http\://www.springframework.org/schema/integration/stream/spring-integration-stream-5.2.xsd=org/springframework/integration/stream/config/spring-integration-stream-5.2.xsd
 http\://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd=org/springframework/integration/stream/config/spring-integration-stream-5.2.xsd
+https\://www.springframework.org/schema/integration/stream/spring-integration-stream-5.2.xsd=org/springframework/integration/stream/config/spring-integration-stream-5.2.xsd
+https\://www.springframework.org/schema/integration/stream/spring-integration-stream.xsd=org/springframework/integration/stream/config/spring-integration-stream-5.2.xsd
+

--- a/spring-integration-syslog/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-syslog/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,5 @@
 http\://www.springframework.org/schema/integration/syslog/spring-integration-syslog-5.2.xsd=org/springframework/integration/syslog/config/spring-integration-syslog-5.2.xsd
 http\://www.springframework.org/schema/integration/syslog/spring-integration-syslog.xsd=org/springframework/integration/syslog/config/spring-integration-syslog-5.2.xsd
+https\://www.springframework.org/schema/integration/syslog/spring-integration-syslog-5.2.xsd=org/springframework/integration/syslog/config/spring-integration-syslog-5.2.xsd
+https\://www.springframework.org/schema/integration/syslog/spring-integration-syslog.xsd=org/springframework/integration/syslog/config/spring-integration-syslog-5.2.xsd
+

--- a/spring-integration-webflux/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-webflux/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/webflux/spring-integration-webflux-5.2.xsd=org/springframework/integration/webflux/config/spring-integration-webflux-5.2.xsd
 http\://www.springframework.org/schema/integration/webflux/spring-integration-webflux.xsd=org/springframework/integration/webflux/config/spring-integration-webflux-5.2.xsd
+https\://www.springframework.org/schema/integration/webflux/spring-integration-webflux-5.2.xsd=org/springframework/integration/webflux/config/spring-integration-webflux-5.2.xsd
+https\://www.springframework.org/schema/integration/webflux/spring-integration-webflux.xsd=org/springframework/integration/webflux/config/spring-integration-webflux-5.2.xsd

--- a/spring-integration-websocket/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-websocket/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/websocket/spring-integration-websocket-5.2.xsd=org/springframework/integration/websocket/config/spring-integration-websocket-5.2.xsd
 http\://www.springframework.org/schema/integration/websocket/spring-integration-websocket.xsd=org/springframework/integration/websocket/config/spring-integration-websocket-5.2.xsd
+https\://www.springframework.org/schema/integration/websocket/spring-integration-websocket-5.2.xsd=org/springframework/integration/websocket/config/spring-integration-websocket-5.2.xsd
+https\://www.springframework.org/schema/integration/websocket/spring-integration-websocket.xsd=org/springframework/integration/websocket/config/spring-integration-websocket-5.2.xsd

--- a/spring-integration-ws/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-ws/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/ws/spring-integration-ws-5.2.xsd=org/springframework/integration/ws/config/spring-integration-ws-5.2.xsd
 http\://www.springframework.org/schema/integration/ws/spring-integration-ws.xsd=org/springframework/integration/ws/config/spring-integration-ws-5.2.xsd
+https\://www.springframework.org/schema/integration/ws/spring-integration-ws-5.2.xsd=org/springframework/integration/ws/config/spring-integration-ws-5.2.xsd
+https\://www.springframework.org/schema/integration/ws/spring-integration-ws.xsd=org/springframework/integration/ws/config/spring-integration-ws-5.2.xsd

--- a/spring-integration-xml/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-xml/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/xml/spring-integration-xml-5.2.xsd=org/springframework/integration/xml/config/spring-integration-xml-5.2.xsd
 http\://www.springframework.org/schema/integration/xml/spring-integration-xml.xsd=org/springframework/integration/xml/config/spring-integration-xml-5.2.xsd
+https\://www.springframework.org/schema/integration/xml/spring-integration-xml-5.2.xsd=org/springframework/integration/xml/config/spring-integration-xml-5.2.xsd
+https\://www.springframework.org/schema/integration/xml/spring-integration-xml.xsd=org/springframework/integration/xml/config/spring-integration-xml-5.2.xsd

--- a/spring-integration-xmpp/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-xmpp/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp-5.2.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-5.2.xsd
 http\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-5.2.xsd
+https\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp-5.2.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-5.2.xsd
+https\://www.springframework.org/schema/integration/xmpp/spring-integration-xmpp.xsd=org/springframework/integration/xmpp/config/spring-integration-xmpp-5.2.xsd

--- a/spring-integration-zookeeper/src/main/resources/META-INF/spring.schemas
+++ b/spring-integration-zookeeper/src/main/resources/META-INF/spring.schemas
@@ -1,2 +1,4 @@
 http\://www.springframework.org/schema/integration/zookeeper/spring-integration-zookeeper-5.2.xsd=org/springframework/integration/zookeeper/config/spring-integration-zookeeper-5.2.xsd
 http\://www.springframework.org/schema/integration/zookeeper/spring-integration-zookeeper.xsd=org/springframework/integration/zookeeper/config/spring-integration-zookeeper-5.2.xsd
+https\://www.springframework.org/schema/integration/zookeeper/spring-integration-zookeeper-5.2.xsd=org/springframework/integration/zookeeper/config/spring-integration-zookeeper-5.2.xsd
+https\://www.springframework.org/schema/integration/zookeeper/spring-integration-zookeeper.xsd=org/springframework/integration/zookeeper/config/spring-integration-zookeeper-5.2.xsd


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2987

To resolve XSD files properly from the classpath, their HTTPS reference
must be present in the `spring.schemas` to avoid the Internet interaction
for resolving an XSD file

**Cherry-pick to 5.1.x, 5.0.x & 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
