### PR TITLE
Fix TimeoutCountSequenceSizeReleaseStrategy (#2999)

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/TimeoutCountSequenceSizeReleaseStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/TimeoutCountSequenceSizeReleaseStrategy.java
@@ -31,6 +31,7 @@ import org.springframework.messaging.Message;
  *
  * @author Dave Syer
  * @author Gary Russell
+ * @author Peter Uhlenbruck
  *
  * @since 2.0
  */
@@ -79,9 +80,6 @@ public class TimeoutCountSequenceSizeReleaseStrategy implements ReleaseStrategy 
 			Long timestamp = message.getHeaders().getTimestamp();
 			if (timestamp != null && timestamp < result) {
 				result = timestamp;
-			}
-			else {
-				return Long.MAX_VALUE; // can't release based on time if there is no timestamp
 			}
 		}
 		return result;

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/TimeoutCountSequenceSizeReleaseStrategyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/TimeoutCountSequenceSizeReleaseStrategyTests.java
@@ -27,6 +27,7 @@ import org.springframework.messaging.Message;
 /**
  * @author Dave Syer
  * @author Artme Bilan
+ * @author Peter Uhlenbruck
  */
 public class TimeoutCountSequenceSizeReleaseStrategyTests {
 
@@ -46,6 +47,21 @@ public class TimeoutCountSequenceSizeReleaseStrategyTests {
 				.setSequenceSize(2).build();
 		SimpleMessageGroup messages = new SimpleMessageGroup("FOO");
 		messages.add(message);
+		TimeoutCountSequenceSizeReleaseStrategy releaseStrategy =
+				new TimeoutCountSequenceSizeReleaseStrategy(TimeoutCountSequenceSizeReleaseStrategy.DEFAULT_THRESHOLD,
+						-100);
+		assertThat(releaseStrategy.canRelease(messages)).isTrue();
+	}
+
+	@Test
+	public void testIncompleteListWithTimeoutForMultipleMessages() {
+		Message<String> message1 = MessageBuilder.withPayload("test1")
+				.setSequenceSize(3).build();
+		Message<String> message2 = MessageBuilder.withPayload("test2")
+				.setSequenceSize(3).build();
+		SimpleMessageGroup messages = new SimpleMessageGroup("FOO");
+		messages.add(message1);
+		messages.add(message2);
 		TimeoutCountSequenceSizeReleaseStrategy releaseStrategy =
 				new TimeoutCountSequenceSizeReleaseStrategy(TimeoutCountSequenceSizeReleaseStrategy.DEFAULT_THRESHOLD,
 						-100);


### PR DESCRIPTION
Fixes #2999

Remove else block from findEarliestTimestamp causing
the method to return with Long.MAX_VALUE if the condition was ever
false.

If accepted this change should also be included in 5.1.x I think, but I'm unclear on the process for that.

The added test fails before the fix but passes after.

Please let me know if anything else is needed.

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
