### PR TITLE
GH-3003: Fix pub/sub with dynamic DSL flows

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublishSubscribeSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublishSubscribeSpec.java
@@ -25,12 +25,15 @@ import org.springframework.util.Assert;
 
 /**
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 5.0
  */
 public class PublishSubscribeSpec extends PublishSubscribeChannelSpec<PublishSubscribeSpec> {
 
 	private final Map<Object, String> subscriberFlows = new LinkedHashMap<>();
+
+	private int order;
 
 	PublishSubscribeSpec() {
 		super();
@@ -50,7 +53,7 @@ public class PublishSubscribeSpec extends PublishSubscribeChannelSpec<PublishSub
 
 		IntegrationFlowBuilder flowBuilder =
 				IntegrationFlows.from(this.channel)
-						.bridge();
+						.bridge(consumer -> consumer.order(this.order++));
 
 		MessageChannel subFlowInput = subFlow.getInputChannel();
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3003

Statically defined flows with a publish/subscribe channel invoke the
subscriptions in natural (declared) order.

The components in the flow are started by the application context in
phases (consumers, then producers) and bean declaration order within
each phase.

When a dynamically declared flow is started, the components are started
by the `StandardIntegrationFlow` in reverse order (last to first) so that
we don't start producing messages before the flow is fully wired.

This has the side-effect that pub/sub subscribers are invoked in an
unnatural (last to first) order.

All subscription sub-flows start with a bridge from the pub/sub channel
to the first component's input channel.

The `BroadcastingDispatcher` honors the `Ordered` interface.

Change the `PublishSubscribeSpec` to set the `order` property so that
subscribers are always invoked in the natural order, regardless of whether
the flow is statically or dynamically defined.
