### PR TITLE
Fix nullability issue in queuechannel

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
@@ -110,6 +110,7 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 	}
 
 	@Override
+	@Nullable
 	protected Message<?> doReceive(long timeout) {
 		try {
 			if (timeout > 0) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
@@ -167,7 +167,7 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 			((BlockingQueue<Message<?>>) this.queue).drainTo(clearedMessages);
 		}
 		else {
-			Message<?> message = null;
+			Message<?> message;
 			while ((message = this.queue.poll()) != null) {
 				clearedMessages.add(message);
 			}


### PR DESCRIPTION
As per`@Nullable` annotation description, 

> Methods override should repeat parent {@code @Nullable} annotations unless they behave differently.

`QueueChannel` inherits from `AbstractPollableChannel`, which has annotation `@Nullable` on `doReceive`, but `QueueChannel` lacked it. It presents a problem in some cases, see discussion here:
https://discuss.kotlinlang.org/t/override-java-method-return-type-nullability/13633