### PR TITLE
GH-3043: Add FileHeaders.REMOTE_HOST header

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
@@ -55,6 +55,6 @@ public abstract class FileHeaders {
 	/**
 	 * A remote host/port the file has been polled from
 	 */
-	public static final String REMOTE_HOST = PREFIX + "remoteHost";
+	public static final String REMOTE_HOST_PORT = PREFIX + "remoteHostPort";
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileHeaders.java
@@ -52,4 +52,9 @@ public abstract class FileHeaders {
 	 */
 	public static final String REMOTE_FILE_INFO = PREFIX + "remoteFileInfo";
 
+	/**
+	 * A remote host/port the file has been polled from
+	 */
+	public static final String REMOTE_HOST = PREFIX + "remoteHost";
+
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/AbstractRemoteFileInboundChannelAdapterParser.java
@@ -45,14 +45,15 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 
 	@Override
 	protected final BeanMetadataElement parseSource(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder synchronizerBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-				this.getInboundFileSynchronizerClass());
+		BeanDefinitionBuilder synchronizerBuilder =
+				BeanDefinitionBuilder.genericBeanDefinition(getInboundFileSynchronizerClass());
 
 		synchronizerBuilder.addConstructorArgReference(element.getAttribute("session-factory"));
 
 		// configure the InboundFileSynchronizer properties
-		BeanDefinition expressionDef = IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression(
-				"remote-directory", "remote-directory-expression", parserContext, element, false);
+		BeanDefinition expressionDef =
+				IntegrationNamespaceUtils.createExpressionDefinitionFromValueOrExpression(
+						"remote-directory", "remote-directory-expression", parserContext, element, false);
 		if (expressionDef != null) {
 			synchronizerBuilder.addPropertyValue("remoteDirectoryExpression", expressionDef);
 		}
@@ -62,6 +63,9 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 		String remoteFileSeparator = element.getAttribute("remote-file-separator");
 		synchronizerBuilder.addPropertyValue("remoteFileSeparator", remoteFileSeparator);
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(synchronizerBuilder, element, "temporary-file-suffix");
+		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(synchronizerBuilder, element,
+				"remote-file-metadata-store");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(synchronizerBuilder, element, "metadata-store-prefix");
 
 		FileParserUtils.configureFilter(synchronizerBuilder, element, parserContext,
 				getSimplePatternFileListFilterClass(), getRegexPatternFileListFilterClass(),
@@ -100,6 +104,7 @@ public abstract class AbstractRemoteFileInboundChannelAdapterParser extends Abst
 
 	protected abstract Class<? extends FileListFilter<?>> getRegexPatternFileListFilterClass();
 
-	protected abstract Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>> getPersistentAcceptOnceFileListFilterClass();
+	protected abstract Class<? extends AbstractPersistentAcceptOnceFileListFilter<?>>
+	getPersistentAcceptOnceFileListFilterClass();
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileInboundChannelAdapterSpec.java
@@ -29,6 +29,7 @@ import org.springframework.integration.file.filters.ExpressionFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.remote.synchronizer.AbstractInboundFileSynchronizer;
 import org.springframework.integration.file.remote.synchronizer.AbstractInboundFileSynchronizingMessageSource;
+import org.springframework.integration.metadata.MetadataStore;
 
 /**
  * A {@link MessageSourceSpec} for an {@link AbstractInboundFileSynchronizingMessageSource}.
@@ -245,15 +246,37 @@ public abstract class RemoteFileInboundChannelAdapterSpec<F, S extends RemoteFil
 		return _this();
 	}
 
+	/**
+	 * Configure a {@link MetadataStore} for remote files metadata.
+	 * @param remoteFileMetadataStore the {@link MetadataStore} to use.
+	 * @return the spec.
+	 * @since 5.2
+	 * @see AbstractInboundFileSynchronizer#setRemoteFileMetadataStore(MetadataStore)
+	 */
+	public S remoteFileMetadataStore(MetadataStore remoteFileMetadataStore) {
+		this.synchronizer.setRemoteFileMetadataStore(remoteFileMetadataStore);
+		return _this();
+	}
+
+	/**
+	 * Configure a prefix for remote files metadata keys.
+	 * @param metadataStorePrefix the metadata key prefix to use.
+	 * @return the spec.
+	 * @since 5.2
+	 * @see #remoteFileMetadataStore
+	 */
+	public S metadataStorePrefix(String metadataStorePrefix) {
+		this.synchronizer.setMetadataStorePrefix(metadataStorePrefix);
+		return _this();
+	}
+
 	@Override
 	public Map<Object, String> getComponentsToRegister() {
 		Map<Object, String> componentsToRegister = new LinkedHashMap<>();
 		componentsToRegister.put(this.synchronizer, null);
-
 		if (this.expressionFileListFilter != null) {
 			componentsToRegister.put(this.expressionFileListFilter, null);
 		}
-
 		return componentsToRegister;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -205,6 +205,7 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 								.setHeader(IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE, session)
 								.setHeader(FileHeaders.REMOTE_DIRECTORY, file.getRemoteDirectory())
 								.setHeader(FileHeaders.REMOTE_FILE, file.getFilename())
+								.setHeader(FileHeaders.REMOTE_HOST, session.getHost())
 								.setHeader(FileHeaders.REMOTE_FILE_INFO,
 										this.fileInfoJson ? file.toJson() : file);
 					}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -205,7 +205,7 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 								.setHeader(IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE, session)
 								.setHeader(FileHeaders.REMOTE_DIRECTORY, file.getRemoteDirectory())
 								.setHeader(FileHeaders.REMOTE_FILE, file.getFilename())
-								.setHeader(FileHeaders.REMOTE_HOST, session.getHost())
+								.setHeader(FileHeaders.REMOTE_HOST_PORT, session.getHostPort())
 								.setHeader(FileHeaders.REMOTE_FILE_INFO,
 										this.fileInfoJson ? file.toJson() : file);
 					}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -494,7 +494,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 			return getMessageBuilderFactory()
 					.withPayload(payload)
 					.setHeader(FileHeaders.REMOTE_DIRECTORY, fullDir)
-					.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+					.setHeader(FileHeaders.REMOTE_HOST_PORT, session.getHostPort());
 		});
 
 	}
@@ -512,7 +512,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 			return getMessageBuilderFactory()
 					.withPayload(payload)
 					.setHeader(FileHeaders.REMOTE_DIRECTORY, fullDir)
-					.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+					.setHeader(FileHeaders.REMOTE_HOST_PORT, session.getHostPort());
 		});
 	}
 
@@ -550,7 +550,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 						.withPayload(payload)
 						.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
 						.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
-						.setHeader(FileHeaders.REMOTE_HOST, session.getHost())
+						.setHeader(FileHeaders.REMOTE_HOST_PORT, session.getHostPort())
 						.setHeader(IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE, session);
 			}
 			catch (IOException e) {
@@ -566,7 +566,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 						.withPayload(getPayload)
 						.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
 						.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
-						.setHeader(FileHeaders.REMOTE_HOST, session1.getHost());
+						.setHeader(FileHeaders.REMOTE_HOST_PORT, session1.getHostPort());
 			});
 		}
 	}
@@ -581,7 +581,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 							.withPayload(payload)
 							.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
 							.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
-							.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+							.setHeader(FileHeaders.REMOTE_HOST_PORT, session.getHostPort());
 				}
 		);
 	}
@@ -597,7 +597,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 					.withPayload(payload)
 					.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
 					.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
-					.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+					.setHeader(FileHeaders.REMOTE_HOST_PORT, session.getHostPort());
 		});
 	}
 
@@ -630,7 +630,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 							.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
 							.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
 							.setHeader(FileHeaders.RENAME_TO, remoteFileNewPath)
-							.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+							.setHeader(FileHeaders.REMOTE_HOST_PORT, session.getHostPort());
 				}
 		);
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -72,7 +72,6 @@ import org.springframework.util.StringUtils;
  */
 public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReplyProducingMessageHandler {
 
-
 	private final RemoteFileTemplate<F> remoteFileTemplate;
 
 	private final Command command;
@@ -118,7 +117,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	public AbstractRemoteFileOutboundGateway(SessionFactory<F> sessionFactory,
 			MessageSessionCallback<F, ?> messageSessionCallback) {
 
-		this(new RemoteFileTemplate<F>(sessionFactory), messageSessionCallback);
+		this(new RemoteFileTemplate<>(sessionFactory), messageSessionCallback);
 	}
 
 	/**
@@ -161,7 +160,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	public AbstractRemoteFileOutboundGateway(SessionFactory<F> sessionFactory, Command command,
 			@Nullable String expression) {
 
-		this(new RemoteFileTemplate<F>(sessionFactory), command, expression);
+		this(new RemoteFileTemplate<>(sessionFactory), command, expression);
 	}
 
 	/**
@@ -317,7 +316,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	 * @since 4.3
 	 */
 	public void setRenameExpression(Expression renameExpression) {
-		this.renameProcessor = new ExpressionEvaluatingMessageProcessor<String>(renameExpression);
+		this.renameProcessor = new ExpressionEvaluatingMessageProcessor<>(renameExpression);
 	}
 
 	/**
@@ -490,10 +489,14 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 			dir += this.remoteFileTemplate.getRemoteFileSeparator();
 		}
 		final String fullDir = dir;
-		List<?> payload = this.remoteFileTemplate.execute(session -> ls(requestMessage, session, fullDir));
-		return getMessageBuilderFactory()
-				.withPayload(payload)
-				.setHeader(FileHeaders.REMOTE_DIRECTORY, dir);
+		return this.remoteFileTemplate.execute(session -> {
+			List<?> payload = ls(requestMessage, session, fullDir);
+			return getMessageBuilderFactory()
+					.withPayload(payload)
+					.setHeader(FileHeaders.REMOTE_DIRECTORY, fullDir)
+					.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+		});
+
 	}
 
 	private Object doNlst(Message<?> requestMessage) {
@@ -504,11 +507,13 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 			dir += this.remoteFileTemplate.getRemoteFileSeparator();
 		}
 		final String fullDir = dir;
-		List<?> payload = this.remoteFileTemplate.execute(session -> nlst(requestMessage, session, fullDir));
-
-		return getMessageBuilderFactory()
-				.withPayload(payload)
-				.setHeader(FileHeaders.REMOTE_DIRECTORY, dir);
+		return this.remoteFileTemplate.execute(session -> {
+			List<?> payload = nlst(requestMessage, session, fullDir);
+			return getMessageBuilderFactory()
+					.withPayload(payload)
+					.setHeader(FileHeaders.REMOTE_DIRECTORY, fullDir)
+					.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+		});
 	}
 
 	/**
@@ -541,6 +546,12 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 			session = this.remoteFileTemplate.getSessionFactory().getSession();
 			try {
 				payload = session.readRaw(remoteFilePath);
+				return getMessageBuilderFactory()
+						.withPayload(payload)
+						.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
+						.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
+						.setHeader(FileHeaders.REMOTE_HOST, session.getHost())
+						.setHeader(IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE, session);
 			}
 			catch (IOException e) {
 				throw new MessageHandlingException(requestMessage,
@@ -549,26 +560,30 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 			}
 		}
 		else {
-			payload = this.remoteFileTemplate.execute(session1 ->
-					get(requestMessage, session1, remoteDir, remoteFilePath, remoteFilename, null));
+			return this.remoteFileTemplate.execute(session1 -> {
+				Object getPayload = get(requestMessage, session1, remoteDir, remoteFilePath, remoteFilename, null);
+				return getMessageBuilderFactory()
+						.withPayload(getPayload)
+						.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
+						.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
+						.setHeader(FileHeaders.REMOTE_HOST, session1.getHost());
+			});
 		}
-		return getMessageBuilderFactory()
-				.withPayload(payload)
-				.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
-				.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
-				.setHeader(IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE, session);
 	}
 
 	private Object doMget(final Message<?> requestMessage) {
 		String remoteFilePath = obtainRemoteFilePath(requestMessage);
-		final String remoteFilename = getRemoteFilename(remoteFilePath);
-		final String remoteDir = getRemoteDirectory(remoteFilePath, remoteFilename);
-		List<File> payload = this.remoteFileTemplate.execute(session ->
-				mGet(requestMessage, session, remoteDir, remoteFilename));
-		return getMessageBuilderFactory()
-				.withPayload(payload)
-				.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
-				.setHeader(FileHeaders.REMOTE_FILE, remoteFilename);
+		String remoteFilename = getRemoteFilename(remoteFilePath);
+		String remoteDir = getRemoteDirectory(remoteFilePath, remoteFilename);
+		return this.remoteFileTemplate.execute(session -> {
+					List<File> payload = mGet(requestMessage, session, remoteDir, remoteFilename);
+					return getMessageBuilderFactory()
+							.withPayload(payload)
+							.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
+							.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
+							.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+				}
+		);
 	}
 
 	private Object doRm(Message<?> requestMessage) {
@@ -576,12 +591,14 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		String remoteFilename = getRemoteFilename(remoteFilePath);
 		String remoteDir = getRemoteDirectory(remoteFilePath, remoteFilename);
 
-		boolean payload = this.remoteFileTemplate.execute(session -> rm(requestMessage, session, remoteFilePath));
-
-		return getMessageBuilderFactory()
-				.withPayload(payload)
-				.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
-				.setHeader(FileHeaders.REMOTE_FILE, remoteFilename);
+		return this.remoteFileTemplate.execute(session -> {
+			boolean payload = rm(requestMessage, session, remoteFilePath);
+			return getMessageBuilderFactory()
+					.withPayload(payload)
+					.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
+					.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
+					.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+		});
 	}
 
 	/**
@@ -606,15 +623,16 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		String remoteFileNewPath = this.renameProcessor.processMessage(requestMessage);
 		Assert.hasLength(remoteFileNewPath, "New filename cannot be empty");
 
-		Boolean result =
-				this.remoteFileTemplate.execute(session ->
-						mv(requestMessage, session, remoteFilePath, remoteFileNewPath));
-
-		return getMessageBuilderFactory()
-				.withPayload(result)
-				.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
-				.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
-				.setHeader(FileHeaders.RENAME_TO, remoteFileNewPath);
+		return this.remoteFileTemplate.execute(session -> {
+					Boolean result = mv(requestMessage, session, remoteFilePath, remoteFileNewPath);
+					return getMessageBuilderFactory()
+							.withPayload(result)
+							.setHeader(FileHeaders.REMOTE_DIRECTORY, remoteDir)
+							.setHeader(FileHeaders.REMOTE_FILE, remoteFilename)
+							.setHeader(FileHeaders.RENAME_TO, remoteFileNewPath)
+							.setHeader(FileHeaders.REMOTE_HOST, session.getHost());
+				}
+		);
 	}
 
 	private String obtainRemoteFilePath(Message<?> requestMessage) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/CachingSessionFactory.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/CachingSessionFactory.java
@@ -291,8 +291,8 @@ public class CachingSessionFactory<F> implements SessionFactory<F>, DisposableBe
 		}
 
 		@Override
-		public String getHost() {
-			return this.targetSession.getHost();
+		public String getHostPort() {
+			return this.targetSession.getHostPort();
 		}
 
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/Session.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/Session.java
@@ -109,6 +109,13 @@ public interface Session<F> extends Closeable {
 	Object getClientInstance();
 
 	/**
+	 * Return the host:port this session is connected to.
+	 * @return the host:port this session is connected to.
+	 * @since 5.2
+	 */
+	String getHost();
+
+	/**
 	 * Test the session is still alive, e.g. when checking out from a pool.
 	 * The default implementation simply delegates to {@link #isOpen()}.
 	 * @return true if the test is successful.

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/Session.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/Session.java
@@ -109,11 +109,11 @@ public interface Session<F> extends Closeable {
 	Object getClientInstance();
 
 	/**
-	 * Return the host:port this session is connected to.
-	 * @return the host:port this session is connected to.
+	 * Return the host:port pair this session is connected to.
+	 * @return the host:port pair this session is connected to.
 	 * @since 5.2
 	 */
-	String getHost();
+	String getHostPort();
 
 	/**
 	 * Test the session is still alive, e.g. when checking out from a pool.

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -493,7 +493,7 @@ public abstract class AbstractInboundFileSynchronizer<F>
 				if (this.preserveTimestamp && !localFile.setLastModified(modified)) {
 					throw new IllegalStateException("Could not sent last modified on file: " + localFile);
 				}
-				String[] hostPort = session.getHost().split(":");
+				String[] hostPort = session.getHostPort().split(":");
 				try {
 					String remoteFileMetadata =
 							new URI(protocol(), null, hostPort[0], Integer.parseInt(hostPort[1]),

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
@@ -270,7 +270,7 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F>
 			String remoteFileUri = this.synchronizer.getRemoteFileMetadata(messageBuilder.getPayload());
 			if (remoteFileUri != null) {
 				URI uri = URI.create(remoteFileUri);
-				messageBuilder.setHeader(FileHeaders.REMOTE_HOST, uri.getHost() + ':' + uri.getPort())
+				messageBuilder.setHeader(FileHeaders.REMOTE_HOST_PORT, uri.getHost() + ':' + uri.getPort())
 						.setHeader(FileHeaders.REMOTE_DIRECTORY, uri.getPath())
 						.setHeader(FileHeaders.REMOTE_FILE, uri.getFragment());
 			}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizingMessageSource.java
@@ -19,6 +19,7 @@ package org.springframework.integration.file.remote.synchronizer;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.regex.Pattern;
@@ -28,6 +29,7 @@ import org.springframework.context.Lifecycle;
 import org.springframework.integration.endpoint.AbstractFetchLimitingMessageSource;
 import org.springframework.integration.file.DefaultDirectoryScanner;
 import org.springframework.integration.file.DirectoryScanner;
+import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.FileReadingMessageSource;
 import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
@@ -94,7 +96,6 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F>
 	private boolean scannerExplicitlySet = false;
 
 	private volatile boolean running;
-
 
 	public AbstractInboundFileSynchronizingMessageSource(AbstractInboundFileSynchronizer<F> synchronizer) {
 		this(synchronizer, null);
@@ -192,7 +193,7 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F>
 			this.fileSource.setDirectory(this.localDirectory);
 			initFiltersAndScanner();
 			if (this.getBeanFactory() != null) {
-				this.fileSource.setBeanFactory(this.getBeanFactory());
+				this.fileSource.setBeanFactory(getBeanFactory());
 			}
 			this.fileSource.afterPropertiesSet();
 			this.synchronizer.afterPropertiesSet();
@@ -265,6 +266,16 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F>
 			messageBuilder = this.fileSource.doReceive();
 		}
 
+		if (messageBuilder != null) {
+			String remoteFileUri = this.synchronizer.getRemoteFileMetadata(messageBuilder.getPayload());
+			if (remoteFileUri != null) {
+				URI uri = URI.create(remoteFileUri);
+				messageBuilder.setHeader(FileHeaders.REMOTE_HOST, uri.getHost() + ':' + uri.getPort())
+						.setHeader(FileHeaders.REMOTE_DIRECTORY, uri.getPath())
+						.setHeader(FileHeaders.REMOTE_FILE, uri.getFragment());
+			}
+		}
+
 		return messageBuilder;
 	}
 
@@ -273,7 +284,6 @@ public abstract class AbstractInboundFileSynchronizingMessageSource<F>
 		return new CompositeFileListFilter<>(
 				Arrays.asList(this.localFileListFilter, new RegexPatternFileListFilter(completePattern)));
 	}
-
 
 	/**
 	 * The {@link FileReadingMessageSource} extension to increase visibility

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -1024,7 +1024,7 @@ public class RemoteFileOutboundGatewayTests {
 		}
 
 		@Override
-		public String getHost() {
+		public String getHostPort() {
 			return null;
 		}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -17,7 +17,8 @@
 package org.springframework.integration.file.remote.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -58,6 +59,7 @@ import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.GenericMessage;
@@ -81,11 +83,11 @@ public class RemoteFileOutboundGatewayTests {
 	public final TemporaryFolder tempFolder = new TemporaryFolder();
 
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void testBad() {
 		SessionFactory sessionFactory = mock(SessionFactory.class);
-		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(sessionFactory, "bad", "payload");
-		gw.afterPropertiesSet();
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new TestRemoteFileOutboundGateway(sessionFactory, "bad", "payload"));
 	}
 
 	@Test
@@ -93,13 +95,10 @@ public class RemoteFileOutboundGatewayTests {
 		SessionFactory sessionFactory = mock(SessionFactory.class);
 		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(sessionFactory, "get", "payload");
 		gw.setFilter(new TestPatternFilter(""));
-		try {
-			gw.afterPropertiesSet();
-			fail("Exception expected");
-		}
-		catch (IllegalArgumentException e) {
-			assertThat(e.getMessage().startsWith("Filters are not supported")).isTrue();
-		}
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(gw::afterPropertiesSet)
+				.withMessageStartingWith("Filters are not supported");
 	}
 
 	@Test
@@ -107,13 +106,10 @@ public class RemoteFileOutboundGatewayTests {
 		SessionFactory sessionFactory = mock(SessionFactory.class);
 		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(sessionFactory, "rm", "payload");
 		gw.setFilter(new TestPatternFilter(""));
-		try {
-			gw.afterPropertiesSet();
-			fail("Exception expected");
-		}
-		catch (IllegalArgumentException e) {
-			assertThat(e.getMessage().startsWith("Filters are not supported")).isTrue();
-		}
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(gw::afterPropertiesSet)
+				.withMessageStartingWith("Filters are not supported");
 	}
 
 	@Test
@@ -139,11 +135,6 @@ public class RemoteFileOutboundGatewayTests {
 		testMGetWildGuts("f1", "f2");
 	}
 
-	/**
-	 * Test a wildcard mget where the full path is returned for each file
-	 *
-	 * @throws Exception
-	 */
 	@Test
 	public void testMGetWildFullPath() {
 		testMGetWildGuts("testremote/f1", "testremote/f2");
@@ -547,7 +538,7 @@ public class RemoteFileOutboundGatewayTests {
 	}
 
 	@Test
-	public void testGet() throws Exception {
+	public void testGet() {
 		SessionFactory sessionFactory = mock(SessionFactory.class);
 		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(sessionFactory, "get", "payload");
 		gw.setLocalDirectory(new File(this.tmpDir));
@@ -609,22 +600,16 @@ public class RemoteFileOutboundGatewayTests {
 
 		// default (null)
 		MessageBuilder<File> out;
-		try {
-			out = (MessageBuilder<File>) gw.handleRequestMessage(new GenericMessage<>("f1"));
-			fail("Exception expected");
-		}
-		catch (MessageHandlingException e) {
-			assertThat(e.getMessage()).contains("already exists");
-		}
+
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> gw.handleRequestMessage(new GenericMessage<>("f1")))
+				.withMessageContaining("already exists");
 
 		gw.setFileExistsMode(FileExistsMode.FAIL);
-		try {
-			out = (MessageBuilder<File>) gw.handleRequestMessage(new GenericMessage<>("f1"));
-			fail("Exception expected");
-		}
-		catch (MessageHandlingException e) {
-			assertThat(e.getMessage()).contains("already exists");
-		}
+
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> gw.handleRequestMessage(new GenericMessage<>("f1")))
+				.withMessageContaining("already exists");
 
 		gw.setFileExistsMode(FileExistsMode.IGNORE);
 		out = (MessageBuilder<File>) gw.handleRequestMessage(new GenericMessage<>("f1"));
@@ -652,7 +637,8 @@ public class RemoteFileOutboundGatewayTests {
 
 	@Test
 	public void testGetTempFileDelete() {
-		SessionFactory sessionFactory = mock(SessionFactory.class);
+		@SuppressWarnings("unchecked")
+		SessionFactory<TestLsEntry> sessionFactory = mock(SessionFactory.class);
 		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(sessionFactory, "get", "payload");
 		gw.setLocalDirectory(new File(this.tmpDir));
 		gw.afterPropertiesSet();
@@ -672,18 +658,15 @@ public class RemoteFileOutboundGatewayTests {
 			}
 
 		});
-		try {
-			gw.handleRequestMessage(new GenericMessage<>("f1"));
-			fail("Expected exception");
-		}
-		catch (MessagingException e) {
-			assertThat(e.getCause()).isInstanceOf(RuntimeException.class);
-			assertThat(e.getCause().getMessage()).isEqualTo("test remove .writing");
-			@SuppressWarnings("unchecked")
-			RemoteFileTemplate template = new RemoteFileTemplate(sessionFactory);
-			File outFile = new File(this.tmpDir + "/f1" + template.getTemporaryFileSuffix());
-			assertThat(outFile.exists()).isFalse();
-		}
+
+		assertThatExceptionOfType(MessagingException.class)
+				.isThrownBy(() -> gw.handleRequestMessage(new GenericMessage<>("f1")))
+				.withCauseInstanceOf(RuntimeException.class)
+				.withMessageContaining("test remove .writing");
+
+		RemoteFileTemplate<?> template = new RemoteFileTemplate<>(sessionFactory);
+		File outFile = new File(this.tmpDir + "/f1" + template.getTemporaryFileSuffix());
+		assertThat(outFile.exists()).isFalse();
 	}
 
 
@@ -743,8 +726,7 @@ public class RemoteFileOutboundGatewayTests {
 			}
 
 			@Override
-			public void read(String source, OutputStream outputStream)
-					throws IOException {
+			public void read(String source, OutputStream outputStream) throws IOException {
 				outputStream.write("testfile".getBytes());
 			}
 
@@ -844,13 +826,10 @@ public class RemoteFileOutboundGatewayTests {
 		verify(session).rename("foo/bar.txt.writing", "foo/bar.txt");
 
 		gw.setFileExistsMode(FileExistsMode.FAIL);
-		try {
-			path = (String) gw.handleRequestMessage(requestMessage);
-			fail("Exception expected");
-		}
-		catch (Exception e) {
-			assertThat(e.getMessage()).contains("The destination file already exists");
-		}
+
+		assertThatExceptionOfType(MessageDeliveryException.class)
+				.isThrownBy(() -> gw.handleRequestMessage(requestMessage))
+				.withMessageContaining("The destination file already exists");
 
 		gw.setFileExistsMode(FileExistsMode.REPLACE);
 		path = (String) gw.handleRequestMessage(requestMessage);
@@ -876,10 +855,9 @@ public class RemoteFileOutboundGatewayTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testMput() throws Exception {
-		@SuppressWarnings("unchecked")
 		SessionFactory<TestLsEntry> sessionFactory = mock(SessionFactory.class);
-		@SuppressWarnings("unchecked")
 		Session<TestLsEntry> session = mock(Session.class);
 		RemoteFileTemplate<TestLsEntry> template = new RemoteFileTemplate<>(sessionFactory);
 		template.setRemoteDirectoryExpression(new LiteralExpression("foo/"));
@@ -897,7 +875,6 @@ public class RemoteFileOutboundGatewayTests {
 		tempFolder.newFile("qux.txt");
 		Message<File> requestMessage = MessageBuilder.withPayload(tempFolder.getRoot())
 				.build();
-		@SuppressWarnings("unchecked")
 		List<String> out = (List<String>) gw.handleRequestMessage(requestMessage);
 		assertThat(out.size()).isEqualTo(2);
 		assertThat(out.get(0)).isNotEqualTo(out.get(1));
@@ -906,10 +883,9 @@ public class RemoteFileOutboundGatewayTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testMputRecursive() throws Exception {
-		@SuppressWarnings("unchecked")
 		SessionFactory<TestLsEntry> sessionFactory = mock(SessionFactory.class);
-		@SuppressWarnings("unchecked")
 		Session<TestLsEntry> session = mock(Session.class);
 		RemoteFileTemplate<TestLsEntry> template = new RemoteFileTemplate<>(sessionFactory);
 		template.setRemoteDirectoryExpression(new LiteralExpression("foo/"));
@@ -931,7 +907,6 @@ public class RemoteFileOutboundGatewayTests {
 
 		Message<File> requestMessage = MessageBuilder.withPayload(tempFolder.getRoot())
 				.build();
-		@SuppressWarnings("unchecked")
 		List<String> out = (List<String>) gw.handleRequestMessage(requestMessage);
 		assertThat(out.size()).isEqualTo(3);
 		assertThat(out.get(0)).isNotEqualTo(out.get(1));
@@ -941,10 +916,9 @@ public class RemoteFileOutboundGatewayTests {
 	}
 
 	@Test
+	@SuppressWarnings("unchecked")
 	public void testMputCollection() throws Exception {
-		@SuppressWarnings("unchecked")
 		SessionFactory<TestLsEntry> sessionFactory = mock(SessionFactory.class);
-		@SuppressWarnings("unchecked")
 		Session<TestLsEntry> session = mock(Session.class);
 		RemoteFileTemplate<TestLsEntry> template = new RemoteFileTemplate<>(sessionFactory);
 		template.setRemoteDirectoryExpression(new LiteralExpression("foo/"));
@@ -963,7 +937,6 @@ public class RemoteFileOutboundGatewayTests {
 		files.add(tempFolder.newFile("buz.txt"));
 		Message<List<File>> requestMessage = MessageBuilder.withPayload(files)
 				.build();
-		@SuppressWarnings("unchecked")
 		List<String> out = (List<String>) gw.handleRequestMessage(requestMessage);
 		assertThat(out.size()).isEqualTo(2);
 		assertThat(out.get(0)).isNotEqualTo(out.get(1));
@@ -1022,7 +995,7 @@ public class RemoteFileOutboundGatewayTests {
 
 		@Override
 		public boolean isOpen() {
-			return open;
+			return this.open;
 		}
 
 		@Override
@@ -1047,6 +1020,11 @@ public class RemoteFileOutboundGatewayTests {
 
 		@Override
 		public Object getClientInstance() {
+			return null;
+		}
+
+		@Override
+		public String getHost() {
 			return null;
 		}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/session/CachingSessionFactoryTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/session/CachingSessionFactoryTests.java
@@ -198,7 +198,7 @@ public class CachingSessionFactoryTests {
 		}
 
 		@Override
-		public String getHost() {
+		public String getHostPort() {
 			return null;
 		}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
@@ -17,7 +17,7 @@
 package org.springframework.integration.file.remote.synchronizer;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
 import java.io.File;
@@ -83,19 +83,14 @@ public class AbstractRemoteFileSynchronizerTests {
 			}
 
 		};
-		sync.setFilter(new AcceptOnceFileListFilter<String>());
+		sync.setFilter(new AcceptOnceFileListFilter<>());
 		sync.setRemoteDirectory("foo");
 
-		try {
-			sync.synchronizeToLocalDirectory(mock(File.class));
-			assertThat(count.get()).isEqualTo(1);
-			fail("Expected exception");
-		}
-		catch (MessagingException e) {
-			assertThat(e.getCause()).isInstanceOf(MessagingException.class);
-			assertThat(e.getCause().getCause()).isInstanceOf(IOException.class);
-			assertThat(e.getCause().getCause().getMessage()).isEqualTo("fail");
-		}
+		assertThatExceptionOfType(MessagingException.class)
+				.isThrownBy(() -> sync.synchronizeToLocalDirectory(mock(File.class)))
+				.withRootCauseInstanceOf(IOException.class)
+				.withMessageContaining("fail");
+
 		sync.synchronizeToLocalDirectory(mock(File.class));
 		assertThat(count.get()).isEqualTo(3);
 		sync.close();
@@ -269,13 +264,13 @@ public class AbstractRemoteFileSynchronizerTests {
 			}
 
 		};
-		sync.setFilter(new AcceptOnceFileListFilter<String>());
+		sync.setFilter(new AcceptOnceFileListFilter<>());
 		sync.setRemoteDirectory("foo");
 		sync.setBeanFactory(mock(BeanFactory.class));
 		return sync;
 	}
 
-	private class StringSessionFactory implements SessionFactory<String> {
+	private static class StringSessionFactory implements SessionFactory<String> {
 
 		@Override
 		public Session<String> getSession() {
@@ -284,7 +279,7 @@ public class AbstractRemoteFileSynchronizerTests {
 
 	}
 
-	private class StringSession implements Session<String> {
+	private static class StringSession implements Session<String> {
 
 		StringSession() {
 			super();
@@ -357,6 +352,11 @@ public class AbstractRemoteFileSynchronizerTests {
 
 		@Override
 		public Object getClientInstance() {
+			return null;
+		}
+
+		@Override
+		public String getHost() {
 			return null;
 		}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
@@ -73,6 +73,11 @@ public class AbstractRemoteFileSynchronizerTests {
 			}
 
 			@Override
+			protected String protocol() {
+				return "file";
+			}
+
+			@Override
 			protected boolean copyFileToLocalDirectory(String remoteDirectoryPath, String remoteFile,
 					File localDirectory, Session<String> session) throws IOException {
 				if ("bar".equals(remoteFile) && failWhenCopyingBar.getAndSet(false)) {
@@ -254,6 +259,11 @@ public class AbstractRemoteFileSynchronizerTests {
 			@Override
 			protected long getModified(String file) {
 				return 0;
+			}
+
+			@Override
+			protected String protocol() {
+				return "file";
 			}
 
 			@Override

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
@@ -366,7 +366,7 @@ public class AbstractRemoteFileSynchronizerTests {
 		}
 
 		@Override
-		public String getHost() {
+		public String getHostPort() {
 			return null;
 		}
 

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
@@ -32,6 +32,7 @@ import org.springframework.integration.metadata.SimpleMetadataStore;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 2.0
  */
 public class FtpInboundFileSynchronizer extends AbstractInboundFileSynchronizer<FTPFile> {
@@ -60,6 +61,11 @@ public class FtpInboundFileSynchronizer extends AbstractInboundFileSynchronizer<
 	@Override
 	protected long getModified(FTPFile file) {
 		return file.getTimestamp().getTimeInMillis();
+	}
+
+	@Override
+	protected String protocol() {
+		return "ftp";
 	}
 
 }

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
@@ -38,13 +38,14 @@ import org.springframework.util.ObjectUtils;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class FtpSession implements Session<FTPFile> {
 
-	private static final String SERVER_REPLIED_WITH = "'. Server replied with: ";
+	private static final Log LOGGER = LogFactory.getLog(FtpSession.class);
 
-	private final Log logger = LogFactory.getLog(this.getClass());
+	private static final String SERVER_REPLIED_WITH = "'. Server replied with: ";
 
 	private final FTPClient client;
 
@@ -86,7 +87,9 @@ public class FtpSession implements Session<FTPFile> {
 			throw new IOException("Failed to copy '" + path +
 					SERVER_REPLIED_WITH + this.client.getReplyString());
 		}
-		this.logger.info("File has been successfully transferred from: " + path);
+		if (LOGGER.isInfoEnabled()) {
+			LOGGER.info("File has been successfully transferred from: " + path);
+		}
 	}
 
 	@Override
@@ -109,8 +112,8 @@ public class FtpSession implements Session<FTPFile> {
 		}
 		if (this.client.completePendingCommand()) {
 			int replyCode = this.client.getReplyCode();
-			if (this.logger.isDebugEnabled()) {
-				this.logger.debug(this + " finalizeRaw - reply code: " + replyCode);
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug(this + " finalizeRaw - reply code: " + replyCode);
 			}
 			return FTPReply.isPositiveCompletion(replyCode);
 		}
@@ -126,8 +129,8 @@ public class FtpSession implements Session<FTPFile> {
 			throw new IOException("Failed to write to '" + path
 					+ SERVER_REPLIED_WITH + this.client.getReplyString());
 		}
-		if (this.logger.isInfoEnabled()) {
-			this.logger.info("File has been successfully transferred to: " + path);
+		if (LOGGER.isInfoEnabled()) {
+			LOGGER.info("File has been successfully transferred to: " + path);
 		}
 	}
 
@@ -140,8 +143,8 @@ public class FtpSession implements Session<FTPFile> {
 			throw new IOException("Failed to append to '" + path
 					+ SERVER_REPLIED_WITH + this.client.getReplyString());
 		}
-		if (this.logger.isInfoEnabled()) {
-			this.logger.info("File has been successfully appended to: " + path);
+		if (LOGGER.isInfoEnabled()) {
+			LOGGER.info("File has been successfully appended to: " + path);
 		}
 	}
 
@@ -150,17 +153,15 @@ public class FtpSession implements Session<FTPFile> {
 		try {
 			if (this.readingRaw.get()) {
 				if (!finalizeRaw()) {
-					if (this.logger.isWarnEnabled()) {
-						this.logger.warn("Finalize on readRaw() returned false for " + this);
+					if (LOGGER.isWarnEnabled()) {
+						LOGGER.warn("Finalize on readRaw() returned false for " + this);
 					}
 				}
 			}
 			this.client.disconnect();
 		}
 		catch (Exception e) {
-			if (this.logger.isWarnEnabled()) {
-				this.logger.warn("failed to disconnect FTPClient", e);
-			}
+			LOGGER.warn("failed to disconnect FTPClient", e);
 		}
 	}
 
@@ -183,8 +184,8 @@ public class FtpSession implements Session<FTPFile> {
 			throw new IOException("Failed to rename '" + pathFrom +
 					"' to " + pathTo + SERVER_REPLIED_WITH + this.client.getReplyString());
 		}
-		if (this.logger.isInfoEnabled()) {
-			this.logger.info("File has been successfully renamed from: " + pathFrom + " to " + pathTo);
+		if (LOGGER.isInfoEnabled()) {
+			LOGGER.info("File has been successfully renamed from: " + pathFrom + " to " + pathTo);
 		}
 	}
 
@@ -228,6 +229,10 @@ public class FtpSession implements Session<FTPFile> {
 		return this.client;
 	}
 
+	@Override
+	public String getHost() {
+		return this.client.getRemoteAddress().getHostName() + ':' + this.client.getRemotePort();
+	}
 
 	@Override
 	public boolean test() {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
@@ -230,7 +230,7 @@ public class FtpSession implements Session<FTPFile> {
 	}
 
 	@Override
-	public String getHost() {
+	public String getHostPort() {
 		return this.client.getRemoteAddress().getHostName() + ':' + this.client.getRemotePort();
 	}
 

--- a/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-5.2.xsd
+++ b/spring-integration-ftp/src/main/resources/org/springframework/integration/ftp/config/spring-integration-ftp-5.2.xsd
@@ -177,6 +177,29 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="remote-file-metadata-store" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+											type="org.springframework.integration.metadata.MetadataStore" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Reference to a MetadataStore for saving remote files information between
+								synchronization and polling.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="metadata-store-prefix" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify a prefix for metadata store to distinguish keys from another places
+								where the same shared store is used.
+								By default, the remote a component name is used.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attributeGroup ref="tempSuffixGroup" />
 				</xsd:extension>
 			</xsd:complexContent>

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests-context.xml
@@ -30,11 +30,15 @@
 				temporary-file-suffix=".foo"
 				max-fetch-size="42"
 				local-filter="acceptAllFilter"
-				remote-directory-expression="'foo/bar'">
+				remote-directory-expression="'foo/bar'"
+				remote-file-metadata-store="metadataStore"
+				metadata-store-prefix="testPrefix">
 			<int:poller fixed-rate="1000">
 				<int:transactional synchronization-factory="syncFactory"/>
 			</int:poller>
 	</int-ftp:inbound-channel-adapter>
+
+	<bean id="metadataStore" class="org.springframework.integration.metadata.SimpleMetadataStore"/>
 
 	<bean id="dirScanner" class="org.springframework.integration.file.HeadDirectoryScanner">
 		<constructor-arg value="1" />

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
@@ -99,7 +99,7 @@ public class FtpTests extends FtpTestSupport {
 		Message<?> message = out.receive(10_000);
 		assertThat(message).isNotNull();
 		assertThat(message.getHeaders())
-				.containsKeys(FileHeaders.REMOTE_HOST, FileHeaders.REMOTE_DIRECTORY, FileHeaders.REMOTE_FILE);
+				.containsKeys(FileHeaders.REMOTE_HOST_PORT, FileHeaders.REMOTE_DIRECTORY, FileHeaders.REMOTE_FILE);
 		Object payload = message.getPayload();
 		assertThat(payload).isInstanceOf(File.class);
 		File file = (File) payload;
@@ -155,7 +155,7 @@ public class FtpTests extends FtpTestSupport {
 		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isInstanceOf(InputStream.class);
 		assertThat(message.getHeaders().get(FileHeaders.REMOTE_FILE)).isIn(" ftpSource1.txt", "ftpSource2.txt");
-		assertThat(message.getHeaders().get(FileHeaders.REMOTE_HOST, String.class)).contains("localhost:");
+		assertThat(message.getHeaders().get(FileHeaders.REMOTE_HOST_PORT, String.class)).contains("localhost:");
 		new IntegrationMessageHeaderAccessor(message).getCloseableResource().close();
 
 		message = out.receive(10_000);

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
@@ -98,6 +98,8 @@ public class FtpTests extends FtpTestSupport {
 		IntegrationFlowRegistration registration = this.flowContext.registration(flow).register();
 		Message<?> message = out.receive(10_000);
 		assertThat(message).isNotNull();
+		assertThat(message.getHeaders())
+				.containsKeys(FileHeaders.REMOTE_HOST, FileHeaders.REMOTE_DIRECTORY, FileHeaders.REMOTE_FILE);
 		Object payload = message.getPayload();
 		assertThat(payload).isInstanceOf(File.class);
 		File file = (File) payload;

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
@@ -153,6 +153,7 @@ public class FtpTests extends FtpTestSupport {
 		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isInstanceOf(InputStream.class);
 		assertThat(message.getHeaders().get(FileHeaders.REMOTE_FILE)).isIn(" ftpSource1.txt", "ftpSource2.txt");
+		assertThat(message.getHeaders().get(FileHeaders.REMOTE_HOST, String.class)).contains("localhost:");
 		new IntegrationMessageHeaderAccessor(message).getCloseableResource().close();
 
 		message = out.receive(10_000);

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
@@ -123,6 +123,7 @@ public class FtpStreamingMessageSourceTests extends FtpTestSupport {
 		received = (Message<byte[]>) this.data.receive(10000);
 		assertThat(received).isNotNull();
 		assertThat(received.getHeaders().get(FileHeaders.REMOTE_FILE_INFO)).isInstanceOf(FtpFileInfo.class);
+		assertThat(received.getHeaders().get(FileHeaders.REMOTE_HOST, String.class)).contains("localhost:");
 		assertThat(TestUtils.getPropertyValue(source, "toBeReceived", BlockingQueue.class)).hasSize(1);
 		assertThat(this.metadataMap).hasSize(1);
 		this.adapter.stop();

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
@@ -123,7 +123,7 @@ public class FtpStreamingMessageSourceTests extends FtpTestSupport {
 		received = (Message<byte[]>) this.data.receive(10000);
 		assertThat(received).isNotNull();
 		assertThat(received.getHeaders().get(FileHeaders.REMOTE_FILE_INFO)).isInstanceOf(FtpFileInfo.class);
-		assertThat(received.getHeaders().get(FileHeaders.REMOTE_HOST, String.class)).contains("localhost:");
+		assertThat(received.getHeaders().get(FileHeaders.REMOTE_HOST_PORT, String.class)).contains("localhost:");
 		assertThat(TestUtils.getPropertyValue(source, "toBeReceived", BlockingQueue.class)).hasSize(1);
 		assertThat(this.metadataMap).hasSize(1);
 		this.adapter.stop();

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpOutboundTests.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -88,12 +89,12 @@ public class FtpOutboundTests {
 			file.delete();
 		}
 		assertThat(file.exists()).isFalse();
-		FileTransferringMessageHandler<FTPFile> handler = new FileTransferringMessageHandler<FTPFile>(sessionFactory);
+		FileTransferringMessageHandler<FTPFile> handler = new FileTransferringMessageHandler<>(sessionFactory);
 		handler.setRemoteDirectoryExpression(new LiteralExpression("remote-target-dir"));
 		handler.setFileNameGenerator(message -> "handlerContent.test");
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
-		handler.handleMessage(new GenericMessage<String>("String data"));
+		handler.handleMessage(new GenericMessage<>("String data"));
 		assertThat(file.exists()).isTrue();
 		byte[] inFile = FileCopyUtils.copyToByteArray(file);
 		assertThat(new String(inFile)).isEqualTo("String data");
@@ -107,12 +108,12 @@ public class FtpOutboundTests {
 			file.delete();
 		}
 		assertThat(file.exists()).isFalse();
-		FileTransferringMessageHandler<FTPFile> handler = new FileTransferringMessageHandler<FTPFile>(sessionFactory);
+		FileTransferringMessageHandler<FTPFile> handler = new FileTransferringMessageHandler<>(sessionFactory);
 		handler.setRemoteDirectoryExpression(new LiteralExpression("remote-target-dir"));
 		handler.setFileNameGenerator(message -> "handlerContent.test");
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
-		handler.handleMessage(new GenericMessage<byte[]>("byte[] data".getBytes()));
+		handler.handleMessage(new GenericMessage<>("byte[] data".getBytes()));
 		assertThat(file.exists()).isTrue();
 		byte[] inFile = FileCopyUtils.copyToByteArray(file);
 		assertThat(new String(inFile)).isEqualTo("byte[] data");
@@ -124,7 +125,7 @@ public class FtpOutboundTests {
 		File targetDir = new File("remote-target-dir");
 		assertThat(targetDir.exists()).as("target directory does not exist: " + targetDir.getName()).isTrue();
 
-		FileTransferringMessageHandler<FTPFile> handler = new FileTransferringMessageHandler<FTPFile>(sessionFactory);
+		FileTransferringMessageHandler<FTPFile> handler = new FileTransferringMessageHandler<>(sessionFactory);
 		handler.setRemoteDirectoryExpression(new LiteralExpression(targetDir.getName()));
 		handler.setFileNameGenerator(message -> ((File) message.getPayload()).getName() + ".test");
 		handler.setBeanFactory(mock(BeanFactory.class));
@@ -141,7 +142,7 @@ public class FtpOutboundTests {
 	}
 
 	@Test
-	public void testHandleMissingFileMessage() throws Exception {
+	public void testHandleMissingFileMessage() {
 		File targetDir = new File("remote-target-dir");
 		assertThat(targetDir.exists()).as("target directory does not exist: " + targetDir.getName()).isTrue();
 
@@ -191,7 +192,7 @@ public class FtpOutboundTests {
 	}
 
 	@Test //INT-2275
-	public void testFtpOutboundGatewayInsideChain() throws Exception {
+	public void testFtpOutboundGatewayInsideChain() {
 		ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(
 				"FtpOutboundInsideChainTests-context.xml", getClass());
 
@@ -248,7 +249,9 @@ public class FtpOutboundTests {
 							any(OutputStream.class))).thenReturn(true);
 				}
 				when(ftpClient.listFiles("remote-test-dir/"))
-						.thenReturn(ftpFiles.toArray(new FTPFile[ftpFiles.size()]));
+						.thenReturn(ftpFiles.toArray(new FTPFile[0]));
+				when(ftpClient.getRemoteAddress())
+						.thenReturn(InetAddress.getByName("127.0.0.1"));
 				return ftpClient;
 			}
 			catch (Exception e) {

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpInboundFileSynchronizer.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpInboundFileSynchronizer.java
@@ -59,4 +59,9 @@ public class SftpInboundFileSynchronizer extends AbstractInboundFileSynchronizer
 		return (long) file.getAttrs().getMTime() * 1000;
 	}
 
+	@Override
+	protected String protocol() {
+		return "sftp";
+	}
+
 }

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -303,7 +303,7 @@ public class SftpSession implements Session<LsEntry> {
 	}
 
 	@Override
-	public String getHost() {
+	public String getHostPort() {
 		return this.jschSession.getHost() + ':' + this.jschSession.getPort();
 	}
 

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -46,15 +46,17 @@ import com.jcraft.jsch.SftpException;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class SftpSession implements Session<LsEntry> {
 
+	private static final Log LOGGER = LogFactory.getLog(SftpSession.class);
+
 	private static final String SESSION_IS_NOT_CONNECTED = "session is not connected";
 
 	private static final Duration DEFAULT_CHANNEL_CONNECT_TIMEOUT = Duration.ofSeconds(5);
-
-	private final Log logger = LogFactory.getLog(this.getClass());
 
 	private final com.jcraft.jsch.Session jschSession;
 
@@ -214,14 +216,14 @@ public class SftpSession implements Session<LsEntry> {
 			this.channel.rename(pathFrom, pathTo);
 		}
 		catch (SftpException sftpex) {
-			if (this.logger.isDebugEnabled()) {
-				this.logger.debug("Initial File rename failed, possibly because file already exists. Will attempt to delete file: "
-						+ pathTo + " and execute rename again.");
+			if (LOGGER.isDebugEnabled()) {
+				LOGGER.debug("Initial File rename failed, possibly because file already exists. " +
+						"Will attempt to delete file: " + pathTo + " and execute rename again.");
 			}
 			try {
-				this.remove(pathTo);
-				if (this.logger.isDebugEnabled()) {
-					this.logger.debug("Delete file: " + pathTo + " succeeded. Will attempt rename again");
+				remove(pathTo);
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("Delete file: " + pathTo + " succeeded. Will attempt rename again");
 				}
 			}
 			catch (IOException ioex) {
@@ -240,8 +242,8 @@ public class SftpSession implements Session<LsEntry> {
 				throw exception; // NOSONAR - added to suppressed exceptions
 			}
 		}
-		if (this.logger.isDebugEnabled()) {
-			this.logger.debug("File: " + pathFrom + " was successfully renamed to " + pathTo);
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("File: " + pathFrom + " was successfully renamed to " + pathTo);
 		}
 	}
 
@@ -298,6 +300,11 @@ public class SftpSession implements Session<LsEntry> {
 	@Override
 	public ChannelSftp getClientInstance() {
 		return this.channel;
+	}
+
+	@Override
+	public String getHost() {
+		return this.jschSession.getHost() + ':' + this.jschSession.getPort();
 	}
 
 	@Override

--- a/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-5.2.xsd
+++ b/spring-integration-sftp/src/main/resources/org/springframework/integration/sftp/config/spring-integration-sftp-5.2.xsd
@@ -180,6 +180,29 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="remote-file-metadata-store" type="xsd:string">
+						<xsd:annotation>
+							<xsd:appinfo>
+								<tool:annotation kind="ref">
+									<tool:expected-type
+											type="org.springframework.integration.metadata.MetadataStore" />
+								</tool:annotation>
+							</xsd:appinfo>
+							<xsd:documentation>
+								Reference to a MetadataStore for saving remote files information between
+								synchronization and polling.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="metadata-store-prefix" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								Specify a prefix for metadata store to distinguish keys from another places
+								where the same shared store is used.
+								By default, the remote a component name is used.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
 					<xsd:attributeGroup ref="tempSuffixGroup" />
 				</xsd:extension>
 			</xsd:complexContent>

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests-context.xml
@@ -45,11 +45,15 @@
 								  max-fetch-size="42"
 								  delete-remote-files="${delete.remote.files}"
 								  auto-startup="false"
-								  preserve-timestamp="true">
+								  preserve-timestamp="true"
+								  remote-file-metadata-store="metadataStore"
+								  metadata-store-prefix="testPrefix">
 		<poller fixed-rate="1000">
 			<transactional synchronization-factory="syncFactory"/>
 		</poller>
 	</sftp:inbound-channel-adapter>
+
+	<beans:bean id="metadataStore" class="org.springframework.integration.metadata.SimpleMetadataStore"/>
 
 	<beans:bean id="acceptAllFilter" class="org.springframework.integration.file.filters.AcceptAllFileListFilter"/>
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
@@ -118,6 +118,7 @@ public class SftpTests extends SftpTestSupport {
 		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isInstanceOf(InputStream.class);
 		assertThat(message.getHeaders().get(FileHeaders.REMOTE_FILE)).isIn(" sftpSource1.txt", "sftpSource2.txt");
+		assertThat(message.getHeaders().get(FileHeaders.REMOTE_HOST, String.class)).contains("localhost:");
 		((InputStream) message.getPayload()).close();
 		new IntegrationMessageHeaderAccessor(message).getCloseableResource().close();
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
@@ -118,7 +118,7 @@ public class SftpTests extends SftpTestSupport {
 		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isInstanceOf(InputStream.class);
 		assertThat(message.getHeaders().get(FileHeaders.REMOTE_FILE)).isIn(" sftpSource1.txt", "sftpSource2.txt");
-		assertThat(message.getHeaders().get(FileHeaders.REMOTE_HOST, String.class)).contains("localhost:");
+		assertThat(message.getHeaders().get(FileHeaders.REMOTE_HOST_PORT, String.class)).contains("localhost:");
 		((InputStream) message.getPayload()).close();
 		new IntegrationMessageHeaderAccessor(message).getCloseableResource().close();
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
@@ -126,7 +126,7 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 		assertThat(atestFile.getPayload().lastModified()).isGreaterThan(System.currentTimeMillis());
 
 		assertThat(atestFile.getHeaders())
-				.containsKeys(FileHeaders.REMOTE_HOST, FileHeaders.REMOTE_DIRECTORY, FileHeaders.REMOTE_FILE);
+				.containsKeys(FileHeaders.REMOTE_HOST_PORT, FileHeaders.REMOTE_DIRECTORY, FileHeaders.REMOTE_FILE);
 
 		Message<File> btestFile = ms.receive();
 		assertThat(btestFile).isNotNull();

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
@@ -36,6 +36,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.filters.AcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
@@ -58,6 +59,7 @@ import com.jcraft.jsch.SftpATTRS;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class SftpInboundRemoteFileSystemSynchronizerTests {
@@ -97,7 +99,7 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 		store.afterPropertiesSet();
 		SftpPersistentAcceptOnceFileListFilter persistFilter =
 				new SftpPersistentAcceptOnceFileListFilter(store, "foo");
-		List<FileListFilter<LsEntry>> filters = new ArrayList<FileListFilter<LsEntry>>();
+		List<FileListFilter<LsEntry>> filters = new ArrayList<>();
 		filters.add(persistFilter);
 		filters.add(patternFilter);
 		CompositeFileListFilter<LsEntry> filter = new CompositeFileListFilter<LsEntry>(filters);
@@ -109,27 +111,30 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 		ms.setAutoCreateLocalDirectory(true);
 		ms.setLocalDirectory(localDirectory);
 		ms.setBeanFactory(mock(BeanFactory.class));
-		CompositeFileListFilter<File> localFileListFilter = new CompositeFileListFilter<File>();
+		CompositeFileListFilter<File> localFileListFilter = new CompositeFileListFilter<>();
 		localFileListFilter.addFilter(new RegexPatternFileListFilter(".*\\.test$"));
-		AcceptOnceFileListFilter<File> localAcceptOnceFilter = new AcceptOnceFileListFilter<File>();
+		AcceptOnceFileListFilter<File> localAcceptOnceFilter = new AcceptOnceFileListFilter<>();
 		localFileListFilter.addFilter(localAcceptOnceFilter);
 		ms.setLocalFilter(localFileListFilter);
 		ms.afterPropertiesSet();
 		ms.start();
 
-		Message<File> atestFile =  ms.receive();
+		Message<File> atestFile = ms.receive();
 		assertThat(atestFile).isNotNull();
 		assertThat(atestFile.getPayload().getName()).isEqualTo("a.test");
 		// The test remote files are created with the current timestamp + 1 day.
 		assertThat(atestFile.getPayload().lastModified()).isGreaterThan(System.currentTimeMillis());
 
-		Message<File> btestFile =  ms.receive();
+		assertThat(atestFile.getHeaders())
+				.containsKeys(FileHeaders.REMOTE_HOST, FileHeaders.REMOTE_DIRECTORY, FileHeaders.REMOTE_FILE);
+
+		Message<File> btestFile = ms.receive();
 		assertThat(btestFile).isNotNull();
 		assertThat(btestFile.getPayload().getName()).isEqualTo("b.test");
 		// The test remote files are created with the current timestamp + 1 day.
 		assertThat(atestFile.getPayload().lastModified()).isGreaterThan(System.currentTimeMillis());
 
-		Message<File> nothing =  ms.receive();
+		Message<File> nothing = ms.receive();
 		assertThat(nothing).isNull();
 
 		// two times because on the third receive (above) the internal queue will be empty, so it will attempt
@@ -143,7 +148,7 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 		new File("test/a.test").delete();
 		new File("test/b.test").delete();
 		// the remote filter should prevent a re-fetch
-		nothing =  ms.receive();
+		nothing = ms.receive();
 		assertThat(nothing).isNull();
 
 		ms.stop();
@@ -153,7 +158,7 @@ public class SftpInboundRemoteFileSystemSynchronizerTests {
 
 	public static class TestSftpSessionFactory extends DefaultSftpSessionFactory {
 
-		private final Vector<LsEntry> sftpEntries = new Vector<LsEntry>();
+		private final Vector<LsEntry> sftpEntries = new Vector<>();
 
 		private void init() {
 			String[] files = new File("remote-test-dir").list();

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
@@ -119,6 +119,7 @@ public class SftpStreamingMessageSourceTests extends SftpTestSupport {
 		received = (Message<byte[]>) this.data.receive(10000);
 		assertThat(received).isNotNull();
 		assertThat(received.getHeaders().get(FileHeaders.REMOTE_FILE_INFO)).isInstanceOf(SftpFileInfo.class);
+		assertThat(received.getHeaders().get(FileHeaders.REMOTE_HOST, String.class)).contains("localhost:");
 		this.adapter.stop();
 	}
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSourceTests.java
@@ -119,7 +119,7 @@ public class SftpStreamingMessageSourceTests extends SftpTestSupport {
 		received = (Message<byte[]>) this.data.receive(10000);
 		assertThat(received).isNotNull();
 		assertThat(received.getHeaders().get(FileHeaders.REMOTE_FILE_INFO)).isInstanceOf(SftpFileInfo.class);
-		assertThat(received.getHeaders().get(FileHeaders.REMOTE_HOST, String.class)).contains("localhost:");
+		assertThat(received.getHeaders().get(FileHeaders.REMOTE_HOST_PORT, String.class)).contains("localhost:");
 		this.adapter.stop();
 	}
 

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -444,7 +444,7 @@ the removal of the failed file from the filter:
 <int-ftp:inbound-channel-adapter id="ftpAdapter"
         session-factory="ftpSessionFactory"
         channel="requestChannel"
-        remote-directory-expression="'/sftpSource'"
+        remote-directory-expression="'/ftpSource'"
         local-directory="file:myLocalDir"
         auto-create-local-directory="true"
         filename-pattern="*.txt">
@@ -636,6 +636,7 @@ Starting with version 5.0, the `FileHeaders.REMOTE_FILE_INFO` header provides ad
 If you set the `fileInfoJson` property on the `FtpStreamingMessageSource` to `false`, the header contains an `FtpFileInfo` object.
 The `FTPFile` object provided by the underlying Apache Net library can be accessed by using the `FtpFileInfo.getFileInfo()` method.
 The `fileInfoJson` property is not available when you use XML configuration, but you can set it by injecting the `FtpStreamingMessageSource` into one of your configuration classes.
+See also <<ftp-remote-file-info>>.
 
 Starting with version 5.1, the generic type of the `comparator` is `FTPFile`.
 Previously, it was `AbstractFileInfo<FTPFile>`.
@@ -1575,3 +1576,19 @@ public ApplicationEventListeningMessageProducer eventsAdapter() {
 }
 ----
 ====
+
+[[ftp-remote-file-info]]
+=== Remote File Information
+
+Starting with version 5.2, the `FtpStreamingMessageSource` (<<ftp-streaming>>), `FtpInboundFileSynchronizingMessageSource` (<<ftp-inbound>>) and "read"-commands of the `FtpOutboundGateway` (<<ftp-outbound-gateway>>) provide additional headers in the message to produce with an information about remote file:
+
+* `FileHeaders.REMOTE_HOST` - the host:port pair the remote session has been connected during file transfer operation;
+* `FileHeaders.REMOTE_DIRECTORY` - the remote directory the operation has been performed;
+* `FileHeaders.REMOTE_FILE` - the remote file name; applicable only for single file operations.
+
+Since the `FtpInboundFileSynchronizingMessageSource` doesn't produce messages against remote files, but using a local copy, the `AbstractInboundFileSynchronizer` stores an information about remote file in the `MetadataStore` (can be configured externally) in the URI style (`protocol://host:port/remoteDirectory#remoteFileName`) during synchronization operation.
+This metadata is retrieved by the `FtpInboundFileSynchronizingMessageSource` when local file is polled.
+When local file is deleted, it is recommended to remove its metadata entry.
+The `AbstractInboundFileSynchronizer` provides a `removeRemoteFileMetadata()` callback for this purpose.
+In addition there is a `setMetadataStorePrefix()` to be used in the metadata keys.
+It is recommended to have this prefix different from the one used in the `MetadataStore`-based `FileListFilter` implementations, when the same `MetadataStore` instance is shared between these components, to avoid entry overriding because both filter and `AbstractInboundFileSynchronizer` use the same local file name for the metadata entry key.

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -1580,15 +1580,15 @@ public ApplicationEventListeningMessageProducer eventsAdapter() {
 [[ftp-remote-file-info]]
 === Remote File Information
 
-Starting with version 5.2, the `FtpStreamingMessageSource` (<<ftp-streaming>>), `FtpInboundFileSynchronizingMessageSource` (<<ftp-inbound>>) and "read"-commands of the `FtpOutboundGateway` (<<ftp-outbound-gateway>>) provide additional headers in the message to produce with an information about remote file:
+Starting with version 5.2, the `FtpStreamingMessageSource` (<<ftp-streaming>>), `FtpInboundFileSynchronizingMessageSource` (<<ftp-inbound>>) and "read"-commands of the `FtpOutboundGateway` (<<ftp-outbound-gateway>>) provide additional headers in the message to produce with an information about the remote file:
 
-* `FileHeaders.REMOTE_HOST` - the host:port pair the remote session has been connected during file transfer operation;
+* `FileHeaders.REMOTE_HOST_PORT` - the host:port pair the remote session has been connected to during file transfer operation;
 * `FileHeaders.REMOTE_DIRECTORY` - the remote directory the operation has been performed;
 * `FileHeaders.REMOTE_FILE` - the remote file name; applicable only for single file operations.
 
-Since the `FtpInboundFileSynchronizingMessageSource` doesn't produce messages against remote files, but using a local copy, the `AbstractInboundFileSynchronizer` stores an information about remote file in the `MetadataStore` (can be configured externally) in the URI style (`protocol://host:port/remoteDirectory#remoteFileName`) during synchronization operation.
+Since the `FtpInboundFileSynchronizingMessageSource` doesn't produce messages against remote files, but using a local copy, the `AbstractInboundFileSynchronizer` stores an information about remote file in the `MetadataStore` (which can be configured externally) in the URI style (`protocol://host:port/remoteDirectory#remoteFileName`) during synchronization operation.
 This metadata is retrieved by the `FtpInboundFileSynchronizingMessageSource` when local file is polled.
 When local file is deleted, it is recommended to remove its metadata entry.
 The `AbstractInboundFileSynchronizer` provides a `removeRemoteFileMetadata()` callback for this purpose.
 In addition there is a `setMetadataStorePrefix()` to be used in the metadata keys.
-It is recommended to have this prefix different from the one used in the `MetadataStore`-based `FileListFilter` implementations, when the same `MetadataStore` instance is shared between these components, to avoid entry overriding because both filter and `AbstractInboundFileSynchronizer` use the same local file name for the metadata entry key.
+It is recommended to have this prefix be different from the one used in the `MetadataStore`-based `FileListFilter` implementations, when the same `MetadataStore` instance is shared between these components, to avoid entry overriding because both filter and `AbstractInboundFileSynchronizer` use the same local file name for the metadata entry key.

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -200,7 +200,7 @@ injection, as the following example shows:
 
 Version 4.2 introduced the `DelegatingSessionFactory`, which allows the selection of the actual session factory at
 runtime.
-Prior to invoking the FTP endpoint, you can call `setThreadKey()` on the factory to associate a key with the current thread.
+Prior to invoking the SFTP endpoint, you can call `setThreadKey()` on the factory to associate a key with the current thread.
 That key is then used to look up the actual session factory to be used.
 You can clear the key by calling `clearThreadKey()` after use.
 
@@ -334,7 +334,7 @@ Unlike outbound gateways and adapters, where the root object of the SpEL evaluat
 Consequently, the root object of the SpEL evaluation context is the original name of the remote file (a `String`).
 
 The inbound channel adapter first retrieves the file to a local directory and then emits each file according to the poller configuration.
-Starting with version 5.0, you can limit the number of files fetched from the FTP server when new file retrievals are needed.
+Starting with version 5.0, you can limit the number of files fetched from the SFTP server when new file retrievals are needed.
 This can be beneficial when the target files are large or when running in a clustered system with a persistent file list filter, discussed later in this section.
 Use `max-fetch-size` for this purpose.
 A negative value (the default) means no limit and all matching files are retrieved.
@@ -363,7 +363,7 @@ Since version 4.0, this filter requires a `ConcurrentMetadataStore`.
 When used with a shared data store (such as `Redis` with the `RedisMetadataStore`), this lets filter keys be shared across multiple application or server instances.
 
 Starting with version 5.0, the `SftpPersistentAcceptOnceFileListFilter` with an in-memory `SimpleMetadataStore` is applied by default for the `SftpInboundFileSynchronizer`.
-This filter is also applied, together with the `regex` or `pattern` option in the XML configuration, as well as through `FtpInboundChannelAdapterSpec` in Java DSL.
+This filter is also applied, together with the `regex` or `pattern` option in the XML configuration, as well as through `SftpInboundChannelAdapterSpec` in Java DSL.
 You can handle any other use-cases by using `CompositeFileListFilter` (or `ChainFileListFilter`).
 
 The above discussion refers to filtering the files before retrieving them.
@@ -635,6 +635,7 @@ Starting with version 5.0, the `FileHeaders.REMOTE_FILE_INFO` header provides ad
 If you set the `fileInfoJson` property on the `SftpStreamingMessageSource` to `false`, the header contains an `SftpFileInfo` object.
 You can access the `LsEntry` object provided by the underlying Jsch library by using the `SftpFileInfo.getFileInfo()` method.
 The `fileInfoJson` property is not available when you use XML configuration, but you can set it by injecting the `SftpStreamingMessageSource` into one of your configuration classes.
+See also <<ftp-remote-file-info>>.
 
 Starting with version 5.1, the generic type of the `comparator` is `LsEntry`.
 Previously, it was `AbstractFileInfo<LsEntry>`.
@@ -771,8 +772,8 @@ This allows files retrieved from different directories to be downloaded to simil
 ----
 @Bean
 public IntegrationFlow flow() {
-    return IntegrationFlows.from(Ftp.inboundAdapter(sf())
-                    .filter(new FtpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "rotate"))
+    return IntegrationFlows.from(Sftp.inboundAdapter(sf())
+                    .filter(new SftpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "rotate"))
                     .localDirectory(new File(tmpDir))
                     .localFilenameExpression("#remoteDirectory + T(java.io.File).separator + #root")
                     .remoteDirectory("."),
@@ -1283,7 +1284,7 @@ public class SftpJavaApplication {
 
     @Bean
     public SessionFactory<LsEntry> sftpSessionFactory() {
-        DefaultFtpSessionFactory sf = new DefaultFtpSessionFactory();
+        DefaultSftpSessionFactory sf = new DefaultSftpSessionFactory();
         sf.setHost("localhost");
         sf.setPort(port);
         sf.setUsername("foo");
@@ -1319,8 +1320,7 @@ public class SftpJavaApplication {
 
 When performing operations on multiple files (by using `mget` and `mput`) an exception can occur some time after one or more files have been transferred.
 In this case (starting with version 4.2), a `PartialSuccessException` is thrown.
-As well as the usual `MessagingException` properties (`failedMessage` and `cause`), this exception has two additional
-properties:
+As well as the usual `MessagingException` properties (`failedMessage` and `cause`), this exception has two additional properties:
 
 * `partialResults`: The successful transfer results.
 * `derivedInput`: The list of files generated from the request message (such as local files to transfer for an `mput`).
@@ -1366,7 +1366,7 @@ log4j.category.com.jcraft.jsch=DEBUG
 === MessageSessionCallback
 
 Starting with Spring Integration version 4.2, you can use a `MessageSessionCallback<F, T>` implementation with the `<int-sftp:outbound-gateway/>` (`SftpOutboundGateway`) to perform any operation on the `Session<LsEntry>` with the `requestMessage` context.
-You can use it for any non-standard or low-level FTP operation (or several), such as allowing access from an integration flow definition, or functional interface (lambda) implementation injection.
+You can use it for any non-standard or low-level SFTP operation (or several), such as allowing access from an integration flow definition, or functional interface (lambda) implementation injection.
 The following example uses a lambda:
 
 ====
@@ -1433,3 +1433,19 @@ public ApplicationEventListeningMessageProducer eventsAdapter() {
 }
 ----
 ====
+
+[[sftp-remote-file-info]]
+=== Remote File Information
+
+Starting with version 5.2, the `SftpStreamingMessageSource` (<<sftp-streaming>>), `SftpInboundFileSynchronizingMessageSource` (<<sftp-inbound>>) and "read"-commands of the `SftpOutboundGateway` (<<sftp-outbound-gateway>>) provide additional headers in the message to produce with an information about remote file:
+
+* `FileHeaders.REMOTE_HOST` - the host:port pair the remote session has been connected during file transfer operation;
+* `FileHeaders.REMOTE_DIRECTORY` - the remote directory the operation has been performed;
+* `FileHeaders.REMOTE_FILE` - the remote file name; applicable only for single file operations.
+
+Since the `SftpInboundFileSynchronizingMessageSource` doesn't produce messages against remote files, but using a local copy, the `AbstractInboundFileSynchronizer` stores an information about remote file in the `MetadataStore` (can be configured externally) in the URI style (`protocol://host:port/remoteDirectory#remoteFileName`) during synchronization operation.
+This metadata is retrieved by the `SftpInboundFileSynchronizingMessageSource` when local file is polled.
+When local file is deleted, it is recommended to remove its metadata entry.
+The `AbstractInboundFileSynchronizer` provides a `removeRemoteFileMetadata()` callback for this purpose.
+In addition there is a `setMetadataStorePrefix()` to be used in the metadata keys.
+It is recommended to have this prefix different from the one used in the `MetadataStore`-based `FileListFilter` implementations, when the same `MetadataStore` instance is shared between these components, to avoid entry overriding because both filter and `AbstractInboundFileSynchronizer` use the same local file name for the metadata entry key.

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -1437,15 +1437,15 @@ public ApplicationEventListeningMessageProducer eventsAdapter() {
 [[sftp-remote-file-info]]
 === Remote File Information
 
-Starting with version 5.2, the `SftpStreamingMessageSource` (<<sftp-streaming>>), `SftpInboundFileSynchronizingMessageSource` (<<sftp-inbound>>) and "read"-commands of the `SftpOutboundGateway` (<<sftp-outbound-gateway>>) provide additional headers in the message to produce with an information about remote file:
+Starting with version 5.2, the `SftpStreamingMessageSource` (<<sftp-streaming>>), `SftpInboundFileSynchronizingMessageSource` (<<sftp-inbound>>) and "read"-commands of the `SftpOutboundGateway` (<<sftp-outbound-gateway>>) provide additional headers in the message to produce with an information about the remote file:
 
-* `FileHeaders.REMOTE_HOST` - the host:port pair the remote session has been connected during file transfer operation;
+* `FileHeaders.REMOTE_HOST_PORT` - the host:port pair the remote session has been connected to during file transfer operation;
 * `FileHeaders.REMOTE_DIRECTORY` - the remote directory the operation has been performed;
 * `FileHeaders.REMOTE_FILE` - the remote file name; applicable only for single file operations.
 
-Since the `SftpInboundFileSynchronizingMessageSource` doesn't produce messages against remote files, but using a local copy, the `AbstractInboundFileSynchronizer` stores an information about remote file in the `MetadataStore` (can be configured externally) in the URI style (`protocol://host:port/remoteDirectory#remoteFileName`) during synchronization operation.
+Since the `SftpInboundFileSynchronizingMessageSource` doesn't produce messages against remote files, but using a local copy, the `AbstractInboundFileSynchronizer` stores an information about remote file in the `MetadataStore` (which can be configured externally) in the URI style (`protocol://host:port/remoteDirectory#remoteFileName`) during synchronization operation.
 This metadata is retrieved by the `SftpInboundFileSynchronizingMessageSource` when local file is polled.
 When local file is deleted, it is recommended to remove its metadata entry.
 The `AbstractInboundFileSynchronizer` provides a `removeRemoteFileMetadata()` callback for this purpose.
 In addition there is a `setMetadataStorePrefix()` to be used in the metadata keys.
-It is recommended to have this prefix different from the one used in the `MetadataStore`-based `FileListFilter` implementations, when the same `MetadataStore` instance is shared between these components, to avoid entry overriding because both filter and `AbstractInboundFileSynchronizer` use the same local file name for the metadata entry key.
+It is recommended to have this prefix be different from the one used in the `MetadataStore`-based `FileListFilter` implementations, when the same `MetadataStore` instance is shared between these components, to avoid entry overriding because both filter and `AbstractInboundFileSynchronizer` use the same local file name for the metadata entry key.

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -635,7 +635,7 @@ Starting with version 5.0, the `FileHeaders.REMOTE_FILE_INFO` header provides ad
 If you set the `fileInfoJson` property on the `SftpStreamingMessageSource` to `false`, the header contains an `SftpFileInfo` object.
 You can access the `LsEntry` object provided by the underlying Jsch library by using the `SftpFileInfo.getFileInfo()` method.
 The `fileInfoJson` property is not available when you use XML configuration, but you can set it by injecting the `SftpStreamingMessageSource` into one of your configuration classes.
-See also <<ftp-remote-file-info>>.
+See also <<sftp-remote-file-info>>.
 
 Starting with version 5.1, the generic type of the `comparator` is `LsEntry`.
 Previously, it was `AbstractFileInfo<LsEntry>`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -159,6 +159,6 @@ See <<./router.adoc#dynamic-routers, Dynamic Routers>> for more information.
 The `RotatingServerAdvice` is decoupled now from the `RotationPolicy` and its `StandardRotationPolicy`.
 
 The remote file information, including host/port and directory are included now into message headers in the `AbstractInboundFileSynchronizingMessageSource` and `AbstractRemoteFileStreamingMessageSource` implementations.
-As well as this information is included into headers in the read operations results of the `AbstractRemoteFileOutboundGateway`.
+Also this information is included into headers in the read operations results of the `AbstractRemoteFileOutboundGateway` implementations.
 
 See <<./ftp.adoc#ftp, FTP(S) Support>> and <<./sftp.adoc#sftp, SFTP Support>> for more information.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -157,4 +157,8 @@ See <<./router.adoc#dynamic-routers, Dynamic Routers>> for more information.
 ==== FTP/SFTP Changes
 
 The `RotatingServerAdvice` is decoupled now from the `RotationPolicy` and its `StandardRotationPolicy`.
-See <<./ftp.adoc#ftp-rotating-server-advice, Polling Multiple Servers and Directories>> for more information.
+
+The remote file information, including host/port and directory are included now into message headers in the `AbstractInboundFileSynchronizingMessageSource` and `AbstractRemoteFileStreamingMessageSource` implementations.
+As well as this information is included into headers in the read operations results of the `AbstractRemoteFileOutboundGateway`.
+
+See <<./ftp.adoc#ftp, FTP(S) Support>> and <<./sftp.adoc#sftp, SFTP Support>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3043

* Populate a `FileHeaders.REMOTE_HOST` from the
`AbstractRemoteFileStreamingMessageSource` and "get"-based commands
in the `AbstractRemoteFileOutboundGateway`
* Extract the value from the a `Session.getHost()` contract
* The `AbstractInboundFileSynchronizingMessageSource` cannot be
addressed with this because the real message is already based on the
locally stored file
* Adjust some affected tests according our code style requirements

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
