### PR TITLE
Initial Kotlin DSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,13 @@ subprojects { subproject ->
 		targetCompatibility = 1.8
 	}
 
+	compileKotlin {
+		kotlinOptions {
+			jvmTarget = '1.8'
+			freeCompilerArgs = ["-Xjsr305=strict"]
+			allWarningsAsErrors = true
+		}
+	}
 	compileTestKotlin {
 		kotlinOptions {
 			freeCompilerArgs = ['-Xjsr305=strict']
@@ -195,6 +202,9 @@ subprojects { subproject ->
 			}
 		}
 
+		compile ('org.jetbrains.kotlin:kotlin-reflect', optional)
+		compile ('org.jetbrains.kotlin:kotlin-stdlib-jdk8', optional)
+
 		// JSR-305 only used for non-required meta-annotations
 		compileOnly "com.google.code.findbugs:jsr305:$googleJsr305Version"
 		testCompile "com.google.code.findbugs:jsr305:$googleJsr305Version"
@@ -217,10 +227,6 @@ subprojects { subproject ->
 		testRuntime 'org.apache.logging.log4j:log4j-jcl'
 
 		testCompile "com.willowtreeapps.assertk:assertk-jvm:$assertkVersion"
-
-		testCompile 'org.jetbrains.kotlin:kotlin-reflect'
-		testCompile 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-
 	}
 
 	// enable all compiler warnings; individual projects may customize further
@@ -419,9 +425,10 @@ project('spring-integration-core') {
 		compile("io.github.resilience4j:resilience4j-ratelimiter:$resilience4jVersion", optional)
 		compile("org.apache.avro:avro:$avroVersion", optional)
 
-		testCompile ("org.aspectj:aspectjweaver:$aspectjVersion")
+		testCompile "org.aspectj:aspectjweaver:$aspectjVersion"
 		testCompile 'io.projectreactor:reactor-test'
-		testCompile ('com.fasterxml.jackson.datatype:jackson-datatype-jsr310')
+		testCompile 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+		testCompile 'com.fasterxml.jackson.module:jackson-module-kotlin'
 	}
 }
 

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/IntegrationFlowBuilderExtensions.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/IntegrationFlowBuilderExtensions.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl
+
+import org.springframework.integration.transformer.MessageTransformingHandler
+
+/**
+ * Extension for [IntegrationFlowBuilder.convert()] providing a `convert<Foo>()` variant.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.2
+ */
+inline fun <reified T> IntegrationFlowBuilder.convert(
+		crossinline consumer: (GenericEndpointSpec<MessageTransformingHandler>) -> Unit = {}): IntegrationFlowBuilder =
+		convert(T::class.java) { consumer(it) }
+
+/**
+ * Extension for [IntegrationFlowDefinition.convert()] providing a `convert<Foo>()` variant.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.2
+ */
+inline fun <reified T> IntegrationFlowDefinition<*>.convert(
+		crossinline consumer: (GenericEndpointSpec<MessageTransformingHandler>) -> Unit = {}): IntegrationFlowDefinition<*> =
+		convert(T::class.java) { consumer(it) }

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/kotlin/KotlinDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/kotlin/KotlinDslTests.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.kotlin
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.BeanFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.integration.channel.QueueChannel
+import org.springframework.integration.config.EnableIntegration
+import org.springframework.integration.dsl.IntegrationFlow
+import org.springframework.integration.dsl.IntegrationFlows
+import org.springframework.integration.dsl.convert
+import org.springframework.integration.support.MessageBuilder
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.MessageHeaders
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import java.util.*
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.2
+ */
+@SpringJUnitConfig
+@DirtiesContext
+class KotlinDslTests {
+
+	@Autowired
+	private lateinit var beanFactory: BeanFactory
+
+	@Autowired
+	@Qualifier("convertFlow.input")
+	private lateinit var convertFlowInput: MessageChannel
+
+	@Autowired
+	private lateinit var convertFlowBuilderInput: MessageChannel
+
+	@Test
+	fun `test convert extension`() {
+		assertThat(this.beanFactory.containsBean("kotlinConverter"))
+
+		val replyChannel = QueueChannel()
+		val date = Date()
+		val testMessage =
+				MessageBuilder.withPayload("{\"name\": \"Baz\",\"date\": " + date.time + "}")
+						.setHeader(MessageHeaders.CONTENT_TYPE, "application/json")
+						.setReplyChannel(replyChannel)
+						.build()
+		this.convertFlowInput.send(testMessage)
+
+		var receive = replyChannel.receive(10000)
+
+		var payload = receive?.payload
+
+		assertThat(payload)
+				.isNotNull()
+				.isInstanceOf(TestPojo::class.java)
+				.isEqualTo(TestPojo("Baz", date))
+
+		this.convertFlowBuilderInput.send(testMessage)
+
+		receive = replyChannel.receive(10000)
+
+		payload = receive?.payload
+
+		assertThat(payload)
+				.isNotNull()
+				.isInstanceOf(TestPojo::class.java)
+				.isEqualTo(TestPojo("Baz", date))
+	}
+
+	@Configuration
+	@EnableIntegration
+	class Config {
+
+		@Bean
+		fun convertFlow() =
+				IntegrationFlow {
+					it.convert<TestPojo> { it.id("kotlinConverter") }
+				}
+
+		@Bean
+		fun convertFlowBuilder() =
+				IntegrationFlows.from("convertFlowBuilderInput")
+						.convert<TestPojo>()
+						.get()
+
+	}
+
+	data class TestPojo(val name: String?, val date: Date?)
+
+}


### PR DESCRIPTION
Kotlin is good with reifying generics types into the target `Class`
arguments.

* Introduce an `IntegrationFlowBuilderExtensions.kt` and implement inline
functions for reifying types for the `IntegrationFlowBuilder.convert()`
operator
* Add `KotlinDslTests.kt` to demonstrate a new Kotlin API
* Move Kotlin dependencies to `compile` scope

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
