### PR TITLE
Deprecate `IntFlows.from(service, methodName)`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
@@ -179,10 +179,26 @@ public abstract class IntegrationFlowAdapter implements IntegrationFlow, SmartLi
 		return IntegrationFlows.from(inboundGatewaySpec);
 	}
 
+	/**
+	 * @param service service for polling method
+	 * @param methodName method to poll
+	 * @return the IntegrationFlowBuilder
+	 * @deprecated since 5.2 in favor of method reference via {@link #from(Supplier)}
+	 */
+	@Deprecated
 	protected IntegrationFlowBuilder from(Object service, String methodName) {
 		return IntegrationFlows.from(service, methodName);
 	}
 
+	/**
+	 *
+	 * @param service service for polling method
+	 * @param methodName method to poll
+	 * @param endpointConfigurer configurer for {@link SourcePollingChannelAdapterSpec}
+	 * @return the IntegrationFlowBuilder
+	 * @deprecated since 5.2 in favor of method reference via {@link #from(Supplier)}
+	 */
+	@Deprecated
 	protected IntegrationFlowBuilder from(Object service, String methodName,
 			Consumer<SourcePollingChannelAdapterSpec> endpointConfigurer) {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
@@ -139,9 +139,10 @@ public final class IntegrationFlows {
 	 * @param service the service to use.
 	 * @param methodName the method to invoke.
 	 * @return new {@link IntegrationFlowBuilder}.
-	 * @since 1.1
 	 * @see MethodInvokingMessageSource
+	 * @deprecated since 5.2 in favor of method reference via {@link #from(Supplier)}
 	 */
+	@Deprecated
 	public static IntegrationFlowBuilder from(Object service, String methodName) {
 		return from(service, methodName, null);
 	}
@@ -155,7 +156,7 @@ public final class IntegrationFlows {
 	 * @see Supplier
 	 */
 	public static <T> IntegrationFlowBuilder from(Supplier<T> messageSource) {
-		return from(messageSource, "get", null);
+		return from(messageSource, (Consumer<SourcePollingChannelAdapterSpec>) null);
 	}
 
 	/**
@@ -171,7 +172,11 @@ public final class IntegrationFlows {
 	 */
 	public static <T> IntegrationFlowBuilder from(Supplier<T> messageSource,
 			Consumer<SourcePollingChannelAdapterSpec> endpointConfigurer) {
-		return from(messageSource, "get", endpointConfigurer);
+		Assert.notNull(messageSource, "'messageSource' must not be null");
+		MethodInvokingMessageSource methodInvokingMessageSource = new MethodInvokingMessageSource();
+		methodInvokingMessageSource.setObject(messageSource);
+		methodInvokingMessageSource.setMethodName("get");
+		return from(methodInvokingMessageSource, endpointConfigurer);
 	}
 
 	/**
@@ -182,9 +187,10 @@ public final class IntegrationFlows {
 	 * @param endpointConfigurer the {@link Consumer} to provide more options for the
 	 * {@link org.springframework.integration.config.SourcePollingChannelAdapterFactoryBean}.
 	 * @return new {@link IntegrationFlowBuilder}.
-	 * @since 1.1
 	 * @see MethodInvokingMessageSource
+	 * @deprecated since 5.2 in favor of method reference via {@link #from(Supplier)}
 	 */
+	@Deprecated
 	public static IntegrationFlowBuilder from(Object service, String methodName,
 			Consumer<SourcePollingChannelAdapterSpec> endpointConfigurer) {
 		Assert.notNull(service, "'service' must not be null");

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flowservices/FlowServiceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flowservices/FlowServiceTests.java
@@ -24,7 +24,6 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -175,7 +174,7 @@ public class FlowServiceTests {
 
 		@Override
 		protected IntegrationFlowDefinition<?> buildFlow() {
-			return from(this, "messageSource", e -> e.poller(p -> p.trigger(this::nextExecutionTime)))
+			return from(this::messageSource, e -> e.poller(p -> p.trigger(this::nextExecutionTime)))
 					.split(this, null, e -> e.applySequence(false))
 					.transform(this)
 					.aggregate(a -> a.processor(this, null))
@@ -213,7 +212,7 @@ public class FlowServiceTests {
 
 		@Aggregator
 		public String aggregate(List<String> payloads) {
-			return payloads.stream().collect(Collectors.joining());
+			return String.join("", payloads);
 		}
 
 		@Filter


### PR DESCRIPTION
The method reference together with a `IntegrationFlows.frm(Supplier<?>)`
do the trick to avoid a method name resolution and also gives us a code
navigation in the IDE

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
