### PR TITLE
Refinement for gateway Mono processing

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/ExpressionUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/ExpressionUtils.java
@@ -46,6 +46,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ *
  * @since 2.2
  */
 public final class ExpressionUtils {
@@ -81,7 +82,7 @@ public final class ExpressionUtils {
 	 * @param beanFactory The bean factory.
 	 * @return The evaluation context.
 	 */
-	public static StandardEvaluationContext createStandardEvaluationContext(BeanFactory beanFactory) {
+	public static StandardEvaluationContext createStandardEvaluationContext(@Nullable BeanFactory beanFactory) {
 		if (beanFactory == null) {
 			logger.warn("Creating EvaluationContext with no beanFactory", new RuntimeException("No beanFactory"));
 		}
@@ -95,14 +96,14 @@ public final class ExpressionUtils {
 	 * @return The evaluation context.
 	 * @since 4.3.15
 	 */
-	public static SimpleEvaluationContext createSimpleEvaluationContext(BeanFactory beanFactory) {
+	public static SimpleEvaluationContext createSimpleEvaluationContext(@Nullable BeanFactory beanFactory) {
 		if (beanFactory == null) {
 			logger.warn("Creating EvaluationContext with no beanFactory", new RuntimeException("No beanFactory"));
 		}
 		return (SimpleEvaluationContext) doCreateContext(beanFactory, true);
 	}
 
-	private static EvaluationContext doCreateContext(BeanFactory beanFactory, boolean simple) {
+	private static EvaluationContext doCreateContext(@Nullable BeanFactory beanFactory, boolean simple) {
 		ConversionService conversionService = null;
 		EvaluationContext evaluationContext = null;
 		if (beanFactory != null) {
@@ -129,8 +130,8 @@ public final class ExpressionUtils {
 	 * @param simple true if simple.
 	 * @return the evaluation context.
 	 */
-	private static EvaluationContext createEvaluationContext(ConversionService conversionService,
-			BeanFactory beanFactory, boolean simple) {
+	private static EvaluationContext createEvaluationContext(@Nullable ConversionService conversionService,
+			@Nullable BeanFactory beanFactory, boolean simple) {
 
 		if (simple) {
 			Builder ecBuilder = SimpleEvaluationContext.forPropertyAccessors(
@@ -166,6 +167,7 @@ public final class ExpressionUtils {
 	 */
 	public static File expressionToFile(Expression expression, EvaluationContext evaluationContext,
 			@Nullable Message<?> message, String name) {
+
 		File file;
 		Object value = message == null
 				? expression.getValue(evaluationContext)

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMessageHandler.java
@@ -41,7 +41,6 @@ public class GatewayMessageHandler extends AbstractReplyProducingMessageHandler 
 
 	public GatewayMessageHandler() {
 		this.gatewayProxyFactoryBean = new GatewayProxyFactoryBean();
-		this.gatewayProxyFactoryBean.setServiceInterface(RequestReplyExchanger.class);
 	}
 
 	public void setRequestChannel(MessageChannel requestChannel) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
@@ -25,7 +25,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
@@ -50,6 +49,7 @@ import reactor.core.publisher.Mono;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class AsyncGatewayTests {
@@ -58,9 +58,8 @@ public class AsyncGatewayTests {
 	public void futureWithMessageReturned() throws Exception {
 		QueueChannel requestChannel = new QueueChannel();
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.afterPropertiesSet();
@@ -82,9 +81,8 @@ public class AsyncGatewayTests {
 			}
 
 		};
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(channel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.afterPropertiesSet();
@@ -104,16 +102,15 @@ public class AsyncGatewayTests {
 		QueueChannel requestChannel = new QueueChannel();
 		addThreadEnricher(requestChannel);
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = (TestEchoService) proxyFactory.getObject();
 		ListenableFuture<Message<?>> f = service.returnMessageListenable("foo");
 		long start = System.currentTimeMillis();
-		final AtomicReference<Message<?>> result = new AtomicReference<Message<?>>();
+		final AtomicReference<Message<?>> result = new AtomicReference<>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		f.addCallback(new ListenableFutureCallback<Message<?>>() {
 
@@ -141,9 +138,8 @@ public class AsyncGatewayTests {
 		QueueChannel requestChannel = new QueueChannel();
 		addThreadEnricher(requestChannel);
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.afterPropertiesSet();
@@ -159,9 +155,8 @@ public class AsyncGatewayTests {
 		QueueChannel requestChannel = new QueueChannel();
 		addThreadEnricher(requestChannel);
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 
@@ -192,9 +187,8 @@ public class AsyncGatewayTests {
 	public void futureWithPayloadReturned() throws Exception {
 		QueueChannel requestChannel = new QueueChannel();
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.afterPropertiesSet();
@@ -209,9 +203,8 @@ public class AsyncGatewayTests {
 	public void futureWithWildcardReturned() throws Exception {
 		QueueChannel requestChannel = new QueueChannel();
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.afterPropertiesSet();
@@ -224,12 +217,11 @@ public class AsyncGatewayTests {
 
 
 	@Test
-	public void monoWithMessageReturned() throws Exception {
+	public void monoWithMessageReturned() {
 		QueueChannel requestChannel = new QueueChannel();
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.afterPropertiesSet();
@@ -240,12 +232,11 @@ public class AsyncGatewayTests {
 	}
 
 	@Test
-	public void monoWithPayloadReturned() throws Exception {
+	public void monoWithPayloadReturned() {
 		QueueChannel requestChannel = new QueueChannel();
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.afterPropertiesSet();
@@ -256,12 +247,11 @@ public class AsyncGatewayTests {
 	}
 
 	@Test
-	public void monoWithWildcardReturned() throws Exception {
+	public void monoWithWildcardReturned() {
 		QueueChannel requestChannel = new QueueChannel();
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.afterPropertiesSet();
@@ -276,16 +266,15 @@ public class AsyncGatewayTests {
 	public void monoWithConsumer() throws Exception {
 		QueueChannel requestChannel = new QueueChannel();
 		startResponder(requestChannel);
-		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean();
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setServiceInterface(TestEchoService.class);
 		proxyFactory.setBeanFactory(mock(BeanFactory.class));
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = (TestEchoService) proxyFactory.getObject();
 		Mono<String> mono = service.returnStringPromise("foo");
 
-		final AtomicReference<String> result = new AtomicReference<String>();
+		final AtomicReference<String> result = new AtomicReference<>();
 		final CountDownLatch latch = new CountDownLatch(1);
 
 		mono.subscribe(s -> {
@@ -374,14 +363,13 @@ public class AsyncGatewayTests {
 		}
 
 		@Override
-		public String get() throws InterruptedException, ExecutionException {
-			return result;
+		public String get() {
+			return this.result;
 		}
 
 		@Override
-		public String get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException,
-				TimeoutException {
-			return result;
+		public String get(long timeout, TimeUnit unit) {
+			return this.result;
 		}
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyMessageMappingTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyMessageMappingTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,6 +40,7 @@ import org.springframework.messaging.handler.annotation.Payload;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class GatewayProxyMessageMappingTests {
@@ -49,9 +51,8 @@ public class GatewayProxyMessageMappingTests {
 
 
 	@Before
-	public void initializeGateway() throws Exception {
-		GatewayProxyFactoryBean factoryBean = new GatewayProxyFactoryBean();
-		factoryBean.setServiceInterface(TestGateway.class);
+	public void initializeGateway() {
+		GatewayProxyFactoryBean factoryBean = new GatewayProxyFactoryBean(TestGateway.class);
 		factoryBean.setDefaultRequestChannel(channel);
 		factoryBean.setBeanName("testGateway");
 		GenericApplicationContext context = new GenericApplicationContext();
@@ -65,8 +66,8 @@ public class GatewayProxyMessageMappingTests {
 
 
 	@Test
-	public void payloadAndHeaderMapWithoutAnnotations() throws Exception {
-		Map<String, Object> m = new HashMap<String, Object>();
+	public void payloadAndHeaderMapWithoutAnnotations() {
+		Map<String, Object> m = new HashMap<>();
 		m.put("k1", "v1");
 		m.put("k2", "v2");
 		gateway.payloadAndHeaderMapWithoutAnnotations("foo", m);
@@ -78,8 +79,8 @@ public class GatewayProxyMessageMappingTests {
 	}
 
 	@Test
-	public void payloadAndHeaderMapWithAnnotations() throws Exception {
-		Map<String, Object> m = new HashMap<String, Object>();
+	public void payloadAndHeaderMapWithAnnotations() {
+		Map<String, Object> m = new HashMap<>();
 		m.put("k1", "v1");
 		m.put("k2", "v2");
 		gateway.payloadAndHeaderMapWithAnnotations("foo", m);
@@ -91,7 +92,7 @@ public class GatewayProxyMessageMappingTests {
 	}
 
 	@Test
-	public void headerValuesAndPayloadWithAnnotations() throws Exception {
+	public void headerValuesAndPayloadWithAnnotations() {
 		gateway.headerValuesAndPayloadWithAnnotations("headerValue1", "payloadValue", "headerValue2");
 		Message<?> result = channel.receive(0);
 		assertThat(result).isNotNull();
@@ -101,8 +102,8 @@ public class GatewayProxyMessageMappingTests {
 	}
 
 	@Test
-	public void mapOnly() throws Exception {
-		Map<String, Object> map = new HashMap<String, Object>();
+	public void mapOnly() {
+		Map<String, Object> map = new HashMap<>();
 		map.put("k1", "v1");
 		map.put("k2", "v2");
 		gateway.mapOnly(map);
@@ -115,8 +116,8 @@ public class GatewayProxyMessageMappingTests {
 
 	@Test
 	public void twoMapsAndOneAnnotatedWithPayload() {
-		Map<String, Object> map1 = new HashMap<String, Object>();
-		Map<String, Object> map2 = new HashMap<String, Object>();
+		Map<String, Object> map1 = new HashMap<>();
+		Map<String, Object> map2 = new HashMap<>();
 		map1.put("k1", "v1");
 		map2.put("k2", "v2");
 		gateway.twoMapsAndOneAnnotatedWithPayload(map1, map2);
@@ -128,7 +129,7 @@ public class GatewayProxyMessageMappingTests {
 	}
 
 	@Test
-	public void payloadAnnotationAtMethodLevel() throws Exception {
+	public void payloadAnnotationAtMethodLevel() {
 		gateway.payloadAnnotationAtMethodLevel("foo", "bar");
 		Message<?> result = channel.receive(0);
 		assertThat(result).isNotNull();
@@ -136,7 +137,7 @@ public class GatewayProxyMessageMappingTests {
 	}
 
 	@Test
-	public void payloadAnnotationAtMethodLevelUsingBeanResolver() throws Exception {
+	public void payloadAnnotationAtMethodLevelUsingBeanResolver() {
 		GenericApplicationContext context = new GenericApplicationContext();
 		RootBeanDefinition gatewayDefinition = new RootBeanDefinition(GatewayProxyFactoryBean.class);
 		gatewayDefinition.getPropertyValues().add("defaultRequestChannel", channel);
@@ -155,7 +156,7 @@ public class GatewayProxyMessageMappingTests {
 	}
 
 	@Test
-	public void payloadAnnotationWithExpression() throws Exception {
+	public void payloadAnnotationWithExpression() {
 		gateway.payloadAnnotationWithExpression("foo");
 		Message<?> result = channel.receive(0);
 		assertThat(result).isNotNull();
@@ -163,7 +164,7 @@ public class GatewayProxyMessageMappingTests {
 	}
 
 	@Test
-	public void payloadAnnotationWithExpressionUsingBeanResolver() throws Exception {
+	public void payloadAnnotationWithExpressionUsingBeanResolver() {
 		GenericApplicationContext context = new GenericApplicationContext();
 		RootBeanDefinition gatewayDefinition = new RootBeanDefinition(GatewayProxyFactoryBean.class);
 		gatewayDefinition.getPropertyValues().add("defaultRequestChannel", channel);
@@ -186,28 +187,32 @@ public class GatewayProxyMessageMappingTests {
 		context.close();
 	}
 
-	@Test(expected = MessagingException.class)
+	@Test
 	public void twoMapsWithoutAnnotations() {
-		Map<String, Object> map1 = new HashMap<String, Object>();
-		Map<String, Object> map2 = new HashMap<String, Object>();
+		Map<String, Object> map1 = new HashMap<>();
+		Map<String, Object> map2 = new HashMap<>();
 		map1.put("k1", "v1");
 		map2.put("k2", "v2");
-		gateway.twoMapsWithoutAnnotations(map1, map2);
+		assertThatExceptionOfType(MessagingException.class)
+				.isThrownBy(() -> this.gateway.twoMapsWithoutAnnotations(map1, map2));
 	}
 
-	@Test(expected = MessagingException.class)
-	public void twoPayloads() throws Exception {
-		gateway.twoPayloads("won't", "work");
+	@Test
+	public void twoPayloads() {
+		assertThatExceptionOfType(MessagingException.class)
+				.isThrownBy(() -> this.gateway.twoPayloads("won't", "work"));
 	}
 
-	@Test(expected = MessagingException.class)
-	public void payloadAndHeaderAnnotationsOnSameParameter() throws Exception {
-		gateway.payloadAndHeaderAnnotationsOnSameParameter("oops");
+	@Test
+	public void payloadAndHeaderAnnotationsOnSameParameter() {
+		assertThatExceptionOfType(MessagingException.class)
+				.isThrownBy(() -> this.gateway.payloadAndHeaderAnnotationsOnSameParameter("oops"));
 	}
 
-	@Test(expected = MessagingException.class)
-	public void payloadAndHeadersAnnotationsOnSameParameter() throws Exception {
-		gateway.payloadAndHeadersAnnotationsOnSameParameter(new HashMap<String, Object>());
+	@Test
+	public void payloadAndHeadersAnnotationsOnSameParameter() {
+		assertThatExceptionOfType(MessagingException.class)
+				.isThrownBy(() -> this.gateway.payloadAndHeadersAnnotationsOnSameParameter(new HashMap<>()));
 	}
 
 
@@ -261,6 +266,7 @@ public class GatewayProxyMessageMappingTests {
 			}
 			return sum;
 		}
+
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/gatewayAutowiring.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/gatewayAutowiring.xml
@@ -14,7 +14,7 @@
 	<channel id="requestChannel"/>
 
 	<beans:bean id="proxy" class="org.springframework.integration.gateway.GatewayProxyFactoryBean">
-		<beans:property name="serviceInterface" value="org.springframework.integration.gateway.TestService"/>
+		<beans:constructor-arg value="org.springframework.integration.gateway.TestService"/>
 		<beans:property name="defaultRequestChannel" ref="requestChannel"/>
 	</beans:bean>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/gatewayWithRendezvousChannel.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/gatewayWithRendezvousChannel.xml
@@ -12,7 +12,7 @@
 	<service-activator ref="testHandler" input-channel="requestChannel"/>
 
 	<beans:bean id="proxy" class="org.springframework.integration.gateway.GatewayProxyFactoryBean">
-		<beans:property name="serviceInterface" value="org.springframework.integration.gateway.TestService"/>
+		<beans:constructor-arg value="org.springframework.integration.gateway.TestService"/>
 		<beans:property name="defaultRequestChannel" ref="requestChannel"/>
 	</beans:bean>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/gatewayWithResponseCorrelator.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/gatewayWithResponseCorrelator.xml
@@ -19,7 +19,7 @@
 	<service-activator ref="handler" input-channel="requestChannel" output-channel="replyChannel"/>
 
 	<beans:bean id="proxy" class="org.springframework.integration.gateway.GatewayProxyFactoryBean">
-		<beans:property name="serviceInterface" value="org.springframework.integration.gateway.TestService"/>
+		<beans:constructor-arg value="org.springframework.integration.gateway.TestService"/>
 		<beans:property name="defaultRequestChannel" ref="requestChannel"/>
 		<beans:property name="defaultReplyChannel" ref="replyChannel"/>
 		<beans:property name="defaultRequestTimeout" value="10000"/>


### PR DESCRIPTION
* Introduce a `MessagingGatewaySupport.MonoReplyChannel` instead of
`FutureReplyChannel` for better on demand handling and reusing a
`Mono` returned from the target handler
* Refactor `GatewayProxyFactoryBean` to identify a target return type
(including generics for `Function`) during initialization
* Handle a `Mono` return type via
`MessagingGatewaySupport.sendAndReceiveMessageReactive()`
* Some `@Nullable` in the `GatewayProxyFactoryBean` and `ExpressionUtils`
* Add `MonoFunction` test-case into the `FunctionsTests.kt`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
