### PR TITLE
GH-3076: Add file existence check

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/locking/NioFileLocker.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/locking/NioFileLocker.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.file.locking;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.FileLock;
 import java.util.concurrent.ConcurrentHashMap;
@@ -36,6 +37,7 @@ import org.springframework.messaging.MessagingException;
  * @author Iwein Fuld
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Emmanuel Roux
  * @since 2.0
  */
 public class NioFileLocker extends AbstractFileLockerFilter {
@@ -49,6 +51,9 @@ public class NioFileLocker extends AbstractFileLockerFilter {
 			FileLock newLock = null;
 			try {
 				newLock = FileChannelCache.tryLockFor(fileToLock);
+			}
+			catch (FileNotFoundException e) {
+				// Consider lock failed
 			}
 			catch (IOException e) {
 				throw new MessagingException("Failed to lock file: " + fileToLock, e);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/locking/NioFileLocker.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/locking/NioFileLocker.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.file.locking;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.channels.FileLock;
 import java.util.concurrent.ConcurrentHashMap;
@@ -37,7 +36,6 @@ import org.springframework.messaging.MessagingException;
  * @author Iwein Fuld
  * @author Mark Fisher
  * @author Gary Russell
- * @author Emmanuel Roux
  * @since 2.0
  */
 public class NioFileLocker extends AbstractFileLockerFilter {
@@ -51,9 +49,6 @@ public class NioFileLocker extends AbstractFileLockerFilter {
 			FileLock newLock = null;
 			try {
 				newLock = FileChannelCache.tryLockFor(fileToLock);
-			}
-			catch (FileNotFoundException e) {
-				// Consider lock failed
 			}
 			catch (IOException e) {
 				throw new MessagingException("Failed to lock file: " + fileToLock, e);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
@@ -28,6 +28,7 @@ import org.junit.rules.TemporaryFolder;
 
 /**
  * @author Emmanuel Roux
+ * @since 4.3.22
  */
 public class FileChannelCacheTests {
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.file.locking;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/**
+ * @author Emmanuel Roux
+ */
+public class FileChannelCacheTests {
+
+	private File workdir;
+
+	@Rule
+	public TemporaryFolder temp = new TemporaryFolder() {
+
+		@Override
+		public void create() throws IOException {
+			super.create();
+			workdir = temp.newFolder(FileChannelCacheTests.class.getSimpleName());
+		}
+	};
+
+	@Test(expected = FileNotFoundException.class)
+	public void throwsExceptionWhenFileNotExists() throws IOException {
+		File testFile = new File(workdir, "test0");
+		assertThat(testFile.exists()).isFalse();
+		FileChannelCache.tryLockFor(testFile);
+	}
+
+	@Test
+	public void fileLocked() throws IOException {
+		File testFile = new File(workdir, "test1");
+		testFile.createNewFile();
+		assertThat(testFile.exists()).isTrue();
+		assertThat(FileChannelCache.tryLockFor(testFile)).isNotNull();
+		FileChannelCache.closeChannelFor(testFile);
+	}
+}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
@@ -43,11 +43,11 @@ public class FileChannelCacheTests {
 		}
 	};
 
-	@Test(expected = FileNotFoundException.class)
+	@Test
 	public void throwsExceptionWhenFileNotExists() throws IOException {
 		File testFile = new File(workdir, "test0");
 		assertThat(testFile.exists()).isFalse();
-		FileChannelCache.tryLockFor(testFile);
+		assertThat(FileChannelCache.tryLockFor(testFile)).isNull();
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
@@ -19,7 +19,6 @@ package org.springframework.integration.file.locking;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.junit.Rule;

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
@@ -32,28 +32,19 @@ import org.junit.rules.TemporaryFolder;
  */
 public class FileChannelCacheTests {
 
-	private File workdir;
-
 	@Rule
-	public TemporaryFolder temp = new TemporaryFolder() {
-
-		@Override
-		public void create() throws IOException {
-			super.create();
-			workdir = temp.newFolder(FileChannelCacheTests.class.getSimpleName());
-		}
-	};
+	public TemporaryFolder temp = new TemporaryFolder();
 
 	@Test
 	public void throwsExceptionWhenFileNotExists() throws IOException {
-		File testFile = new File(workdir, "test0");
+		File testFile = new File(temp.getRoot(), "test0");
 		assertThat(testFile.exists()).isFalse();
 		assertThat(FileChannelCache.tryLockFor(testFile)).isNull();
 	}
 
 	@Test
 	public void fileLocked() throws IOException {
-		File testFile = new File(workdir, "test1");
+		File testFile = temp.newFile("test1");
 		testFile.createNewFile();
 		assertThat(testFile.exists()).isTrue();
 		assertThat(FileChannelCache.tryLockFor(testFile)).isNotNull();

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
@@ -40,6 +40,7 @@ public class FileChannelCacheTests {
 		File testFile = new File(temp.getRoot(), "test0");
 		assertThat(testFile.exists()).isFalse();
 		assertThat(FileChannelCache.tryLockFor(testFile)).isNull();
+		assertThat(testFile.exists()).isFalse();
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileChannelCacheTests.java
@@ -50,4 +50,5 @@ public class FileChannelCacheTests {
 		assertThat(FileChannelCache.tryLockFor(testFile)).isNotNull();
 		FileChannelCache.closeChannelFor(testFile);
 	}
+
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/NioFileLockerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/NioFileLockerTests.java
@@ -93,4 +93,5 @@ public class NioFileLockerTests {
 		assertThat(locker.lock(testFile)).isFalse();
 		assertThat(testFile.exists()).isFalse();
 	}
+
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/NioFileLockerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/NioFileLockerTests.java
@@ -34,6 +34,7 @@ import org.springframework.integration.test.util.TestUtils;
 /**
  * @author Iwein Fuld
  * @author Gary Russell
+ * @author Emmanuel Roux
  */
 public class NioFileLockerTests {
 
@@ -76,4 +77,20 @@ public class NioFileLockerTests {
 		filter1.unlock(testFile);
 	}
 
+	@Test
+	public void fileLockedWhenNotAlreadyLockedAndExists() throws IOException {
+		NioFileLocker locker = new NioFileLocker();
+		File testFile = new File(workdir, "test2");
+		testFile.createNewFile();
+		assertThat(locker.lock(testFile)).isTrue();
+		locker.unlock(testFile);
+	}
+
+	@Test
+	public void fileNotLockedWhenNotExists() throws IOException {
+		NioFileLocker locker = new NioFileLocker();
+		File testFile = new File(workdir, "test3");
+		assertThat(locker.lock(testFile)).isFalse();
+		assertThat(testFile.exists()).isFalse();
+	}
 }


### PR DESCRIPTION
Fixes spring-projects/spring-integration#3076

* Add file existence check: throw a FileNotFoundException when trying to get a lock for a non-existent file