### PR TITLE
GH-3079: Use getMostSpecificMethod for SpEL calls

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -417,7 +417,8 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		StandardEvaluationContext context = getEvaluationContext();
 		Class<?> targetType = AopUtils.getTargetClass(this.targetObject);
 		if (this.method != null) {
-			context.registerMethodFilter(targetType, new FixedMethodFilter(this.method));
+			context.registerMethodFilter(targetType,
+					new FixedMethodFilter(ClassUtils.getMostSpecificMethod(this.method, targetType)));
 			if (this.expectedType != null) {
 				Assert.state(context.getTypeConverter()
 								.canConvert(TypeDescriptor.valueOf((this.method).getReturnType()), this.expectedType),

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -55,7 +55,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.MethodParameter;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.SpelCompilerMode;
-import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelParserConfiguration;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -448,18 +447,6 @@ public class MethodInvokingMessageProcessorTests {
 		assertThatExceptionOfType(MessageHandlingException.class)
 				.isThrownBy(() -> processor.processMessage(new GenericMessage<>("foo")))
 				.withRootCauseInstanceOf(CheckedException.class);
-	}
-
-	@Test
-	public void testProcessMessageMethodNotFound() throws Exception {
-		TestDifferentErrorService service = new TestDifferentErrorService();
-		Method method = TestErrorService.class.getMethod("checked", String.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
-		processor.setUseSpelInvoker(true);
-		processor.setBeanFactory(mock(BeanFactory.class));
-		assertThatExceptionOfType(MessageHandlingException.class)
-				.isThrownBy(() -> processor.processMessage(new GenericMessage<>("foo")))
-				.withCauseInstanceOf(SpelEvaluationException.class);
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -42,6 +42,7 @@ import java.util.stream.Collectors;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.aop.framework.ProxyFactory;
@@ -55,6 +56,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.MethodParameter;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.SpelCompilerMode;
+import org.springframework.expression.spel.SpelEvaluationException;
 import org.springframework.expression.spel.SpelParserConfiguration;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -447,6 +449,19 @@ public class MethodInvokingMessageProcessorTests {
 		assertThatExceptionOfType(MessageHandlingException.class)
 				.isThrownBy(() -> processor.processMessage(new GenericMessage<>("foo")))
 				.withRootCauseInstanceOf(CheckedException.class);
+	}
+
+	@Test
+	@Ignore("See https://github.com/spring-projects/spring-framework/issues/23824")
+	public void testProcessMessageMethodNotFound() throws Exception {
+		TestDifferentErrorService service = new TestDifferentErrorService();
+		Method method = TestErrorService.class.getMethod("checked", String.class);
+		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		processor.setUseSpelInvoker(true);
+		processor.setBeanFactory(mock(BeanFactory.class));
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> processor.processMessage(new GenericMessage<>("foo")))
+				.withCauseInstanceOf(SpelEvaluationException.class);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3079

It turns out that we need to use a *most specific* method for the target
to be called reflectively from the SpEL

NOTE: We drop a *Method not found* error in case of wrong method source
since now we find a right source via `ClassUtils.getMostSpecificMethod()`

**Cherry-pick to 5.1.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
