### PR TITLE
Ensure that dynamic routes are included into graph

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/graph/IntegrationGraphServerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/graph/IntegrationGraphServerTests.java
@@ -25,8 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.SmartLifecycle;
@@ -71,7 +70,7 @@ import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.support.PeriodicTrigger;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -86,7 +85,7 @@ import net.minidev.json.JSONArray;
  * @since 4.3
  *
  */
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
 public class IntegrationGraphServerTests {
 
@@ -107,7 +106,7 @@ public class IntegrationGraphServerTests {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void test() throws Exception {
+	void test() throws Exception {
 		Graph graph = this.server.getGraph();
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		ObjectMapper objectMapper = new ObjectMapper();
@@ -219,17 +218,17 @@ public class IntegrationGraphServerTests {
 	}
 
 	@Test
-	public void testIncludesDynamic() {
+	void testIncludesDynamic() {
 		Graph graph = this.server.getGraph();
-		assertThat(graph.getNodes().size()).isEqualTo(33);
+		assertThat(graph.getNodes().size()).isEqualTo(34);
 		IntegrationFlow flow = f -> f.handle(m -> {
 		});
 		IntegrationFlowRegistration reg = this.flowContext.registration(flow).register();
 		graph = this.server.rebuild();
-		assertThat(graph.getNodes().size()).isEqualTo(35);
+		assertThat(graph.getNodes().size()).isEqualTo(36);
 		this.flowContext.remove(reg.getId());
 		graph = this.server.rebuild();
-		assertThat(graph.getNodes().size()).isEqualTo(33);
+		assertThat(graph.getNodes().size()).isEqualTo(34);
 	}
 
 	@Configuration


### PR DESCRIPTION
Modify an `IntegrationGraphServerTests` to be sure that dynamic routes
are included into the graph (with links) after sending a message to the
router and rebuilding a graph

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
