### PR TITLE
Give access to AmqpOutboundEndpoint.RabbitTemplate

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
@@ -360,7 +360,7 @@ public abstract class AbstractAmqpOutboundEndpoint extends AbstractReplyProducin
 		return this.exchangeNameGenerator;
 	}
 
-	protected AmqpHeaderMapper getHeaderMapper() {
+	public AmqpHeaderMapper getHeaderMapper() {
 		return this.headerMapper;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -98,7 +98,7 @@ public class AmqpOutboundEndpoint extends AbstractAmqpOutboundEndpoint
 
 
 	@Override
-	protected RabbitTemplate getRabbitTemplate() {
+	public RabbitTemplate getRabbitTemplate() {
 		return this.rabbitTemplate;
 	}
 


### PR DESCRIPTION
Related to https://github.com/spring-cloud/spring-cloud-stream/pull/1824

There are some use-cases when we would like to further customize a
`RabbitTemplate` encapsulated in the `AmqpOutboundEndpoint`.
For this purpose there is just enough to make its getter as `public`.
Also make a `AmqpHeaderMapper` available same way via `public` getter

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
