### PR TITLE
GH-3090: Add `logout() to `FtpSession.close()`

### DIFF
--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
@@ -154,6 +154,7 @@ public class FtpSession implements Session<FTPFile> {
 			if (this.readingRaw.get() && !finalizeRaw() && LOGGER.isWarnEnabled()) {
 				LOGGER.warn("Finalize on readRaw() returned false for " + this);
 			}
+			this.client.logout();
 			this.client.disconnect();
 		}
 		catch (Exception e) {
@@ -194,7 +195,6 @@ public class FtpSession implements Session<FTPFile> {
 	public boolean rmdir(String directory) throws IOException {
 		return this.client.removeDirectory(directory);
 	}
-
 
 	@Override
 	public boolean exists(String path) throws IOException {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/SessionFactoryTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/SessionFactoryTests.java
@@ -44,6 +44,7 @@ import org.springframework.integration.util.PoolItemNotAvailableException;
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -51,7 +52,7 @@ public class SessionFactoryTests {
 
 
 	@Test
-	public void testTimeouts() throws Exception {
+	public void testFtpClientInteraction() throws Exception {
 		final FTPClient client = mock(FTPClient.class);
 		DefaultFtpSessionFactory sessionFactory = new DefaultFtpSessionFactory() {
 
@@ -66,10 +67,15 @@ public class SessionFactoryTests {
 		sessionFactory.setDataTimeout(789);
 		doReturn(200).when(client).getReplyCode();
 		doReturn(true).when(client).login("foo", null);
-		sessionFactory.getSession();
+		FtpSession session = sessionFactory.getSession();
 		verify(client).setConnectTimeout(123);
 		verify(client).setDefaultTimeout(456);
 		verify(client).setDataTimeout(789);
+
+		session.close();
+
+		verify(client).logout();
+		verify(client).disconnect();
 	}
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3090

Without `logout()` the FTP session is not closed at all,
but just the connection is closed.
Some FTP servers close those sessions eventually anyway, but some just
leak with resources.

**Cherry-pick to 5.1.x & 4.3.x**
