### PR TITLE
Improve RSocket support

### DIFF
--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/AbstractRSocketConnector.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/AbstractRSocketConnector.java
@@ -23,12 +23,10 @@ import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.SmartLifecycle;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.rsocket.RSocketStrategies;
 import org.springframework.util.Assert;
 import org.springframework.util.MimeType;
-import org.springframework.util.MimeTypeUtils;
-
-import io.rsocket.metadata.WellKnownMimeType;
 
 /**
  * A base connector container for common RSocket client and server functionality.
@@ -49,18 +47,12 @@ public abstract class AbstractRSocketConnector
 
 	protected final IntegrationRSocketMessageHandler rSocketMessageHandler; // NOSONAR - final
 
-	private MimeType dataMimeType;
-
-	private MimeType metadataMimeType =
-			MimeTypeUtils.parseMimeType(WellKnownMimeType.MESSAGE_RSOCKET_COMPOSITE_METADATA.toString());
-
-	private RSocketStrategies rsocketStrategies = RSocketStrategies.create();
-
 	private boolean autoStartup = true;
 
 	private volatile boolean running;
 
 	protected AbstractRSocketConnector(IntegrationRSocketMessageHandler rSocketMessageHandler) {
+		Assert.notNull(rSocketMessageHandler, "'rSocketMessageHandler' must not be null");
 		this.rSocketMessageHandler = rSocketMessageHandler;
 	}
 
@@ -68,13 +60,13 @@ public abstract class AbstractRSocketConnector
 	 * Configure a {@link MimeType} for data exchanging.
 	 * @param dataMimeType the {@link MimeType} to use.
 	 */
-	public void setDataMimeType(MimeType dataMimeType) {
-		Assert.notNull(dataMimeType, "'dataMimeType' must not be null");
-		this.dataMimeType = dataMimeType;
+	public void setDataMimeType(@Nullable MimeType dataMimeType) {
+		this.rSocketMessageHandler.setDefaultDataMimeType(dataMimeType);
 	}
 
+	@Nullable
 	protected MimeType getDataMimeType() {
-		return this.dataMimeType;
+		return this.rSocketMessageHandler.getDefaultDataMimeType();
 	}
 
 	/**
@@ -83,12 +75,11 @@ public abstract class AbstractRSocketConnector
 	 * @param metadataMimeType the {@link MimeType} to use.
 	 */
 	public void setMetadataMimeType(MimeType metadataMimeType) {
-		Assert.notNull(metadataMimeType, "'metadataMimeType' must not be null");
-		this.metadataMimeType = metadataMimeType;
+		this.rSocketMessageHandler.setDefaultMetadataMimeType(metadataMimeType);
 	}
 
 	protected MimeType getMetadataMimeType() {
-		return this.metadataMimeType;
+		return this.rSocketMessageHandler.getDefaultMetadataMimeType();
 	}
 
 	/**
@@ -96,12 +87,11 @@ public abstract class AbstractRSocketConnector
 	 * @param rsocketStrategies the {@link RSocketStrategies} to use.
 	 */
 	public void setRSocketStrategies(RSocketStrategies rsocketStrategies) {
-		Assert.notNull(rsocketStrategies, "'rsocketStrategies' must not be null");
-		this.rsocketStrategies = rsocketStrategies;
+		this.rSocketMessageHandler.setRSocketStrategies(rsocketStrategies);
 	}
 
 	public RSocketStrategies getRSocketStrategies() {
-		return this.rsocketStrategies;
+		return this.rSocketMessageHandler.getRSocketStrategies();
 	}
 
 	/**
@@ -131,9 +121,6 @@ public abstract class AbstractRSocketConnector
 
 	@Override
 	public void afterPropertiesSet() {
-		this.rSocketMessageHandler.setDefaultDataMimeType(this.dataMimeType);
-		this.rSocketMessageHandler.setDefaultMetadataMimeType(this.metadataMimeType);
-		this.rSocketMessageHandler.setRSocketStrategies(this.rsocketStrategies);
 		this.rSocketMessageHandler.afterPropertiesSet();
 	}
 

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/ServerRSocketMessageHandler.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/ServerRSocketMessageHandler.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.rsocket;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.handler.CompositeMessageCondition;
+import org.springframework.messaging.handler.DestinationPatternsMessageCondition;
+import org.springframework.messaging.rsocket.RSocketRequester;
+import org.springframework.messaging.rsocket.annotation.support.RSocketFrameTypeMessageCondition;
+import org.springframework.messaging.rsocket.annotation.support.RSocketRequesterMethodArgumentResolver;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * An {@link IntegrationRSocketMessageHandler} extension for RSocket service side.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.2.1
+ */
+public class ServerRSocketMessageHandler extends IntegrationRSocketMessageHandler
+		implements ApplicationEventPublisherAware {
+
+	private static final Method HANDLE_CONNECTION_SETUP_METHOD =
+			ReflectionUtils.findMethod(ServerRSocketMessageHandler.class, "handleConnectionSetup", Message.class);
+
+
+	private final Map<Object, RSocketRequester> clientRSocketRequesters = new HashMap<>();
+
+	private BiFunction<Map<String, Object>, DataBuffer, Object> clientRSocketKeyStrategy =
+			(headers, data) -> data.toString(StandardCharsets.UTF_8);
+
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	public ServerRSocketMessageHandler() {
+		this(false);
+	}
+
+	public ServerRSocketMessageHandler(boolean requestMappingCompatible) {
+		super(requestMappingCompatible);
+	}
+
+
+	public Map<Object, RSocketRequester> getClientRSocketRequesters() {
+		return Collections.unmodifiableMap(this.clientRSocketRequesters);
+	}
+
+	public void setClientRSocketKeyStrategy(
+			BiFunction<Map<String, Object>, DataBuffer, Object> clientRSocketKeyStrategy) {
+
+		Assert.notNull(clientRSocketKeyStrategy, "'clientRSocketKeyStrategy' must not be null");
+		this.clientRSocketKeyStrategy = clientRSocketKeyStrategy;
+	}
+
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+
+	void registerHandleConnectionSetupMethod() {
+		registerHandlerMethod(this, HANDLE_CONNECTION_SETUP_METHOD,
+				new CompositeMessageCondition(
+						RSocketFrameTypeMessageCondition.CONNECT_CONDITION,
+						new DestinationPatternsMessageCondition(new String[] { "*" }, obtainRouteMatcher())));
+	}
+
+	@SuppressWarnings("unused")
+	private void handleConnectionSetup(Message<DataBuffer> connectMessage) {
+		DataBuffer dataBuffer = connectMessage.getPayload();
+		MessageHeaders messageHeaders = connectMessage.getHeaders();
+		Object rsocketRequesterKey = this.clientRSocketKeyStrategy.apply(messageHeaders, dataBuffer);
+		RSocketRequester rsocketRequester =
+				messageHeaders.get(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER,
+						RSocketRequester.class);
+		this.clientRSocketRequesters.put(rsocketRequesterKey, rsocketRequester);
+		RSocketConnectedEvent rSocketConnectedEvent =
+				new RSocketConnectedEvent(this, messageHeaders, dataBuffer, rsocketRequester); // NOSONAR
+		if (this.applicationEventPublisher != null) {
+			this.applicationEventPublisher.publishEvent(rSocketConnectedEvent);
+		}
+		else {
+			if (logger.isInfoEnabled()) {
+				logger.info("The RSocket has been connected: " + rSocketConnectedEvent);
+			}
+		}
+	}
+
+}

--- a/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGatewayIntegrationTests.java
+++ b/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGatewayIntegrationTests.java
@@ -38,6 +38,7 @@ import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.rsocket.ClientRSocketConnector;
+import org.springframework.integration.rsocket.ServerRSocketMessageHandler;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
@@ -531,7 +532,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 
 		@Bean
 		public RSocketMessageHandler messageHandler() {
-			return new RSocketMessageHandler();
+			return new ServerRSocketMessageHandler(true);
 		}
 
 	}


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-boot/issues/18812

* Extract `ServerRSocketMessageHandler` into a `public` class to allow
to configure it as top-level bean and bind it into an existing server
* Change `ServerRSocketConnector` to accept the mentioned external bean
and don't create an internal RSocket server with an assumption that it
is create externally
* Add `IntegrationRSocketMessageHandler.requestMappingCompatible`
option to allow to configure `ServerRSocketMessageHandler` for both
Spring Integration RSocket channel adapters and regular `@MessageMapping`.
This is useful for Spring Boot auto-configuration

These changes give a hook to auto-configure Spring Integration RSocket
channel adapters in Spring Boot

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
