### PR TITLE
Add back-pressure tests for SubscribableChannelPublisherAdapter

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/MessageChannelReactiveUtilsTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/MessageChannelReactiveUtilsTest.java
@@ -16,6 +16,10 @@
 
 package org.springframework.integration.channel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
 import org.junit.Test;
 
 import org.springframework.messaging.SubscribableChannel;
@@ -26,10 +30,6 @@ import reactor.core.Disposables;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.concurrent.Queues;
-
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class MessageChannelReactiveUtilsTest {
 
@@ -57,8 +57,7 @@ public class MessageChannelReactiveUtilsTest {
 					.expectNoEvent(Duration.ofMillis(100))
 					.thenCancel()
 					.verify(Duration.ofSeconds(1));
-		}
-		finally {
+		} finally {
 			compositeDisposable.dispose();
 		}
 	}
@@ -89,8 +88,7 @@ public class MessageChannelReactiveUtilsTest {
 					.thenAwait(Duration.ofMillis(100))
 					.thenCancel()
 					.verify(Duration.ofSeconds(1));
-		}
-		finally {
+		} finally {
 			compositeDisposable.dispose();
 		}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/MessageChannelReactiveUtilsTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/MessageChannelReactiveUtilsTest.java
@@ -57,7 +57,8 @@ public class MessageChannelReactiveUtilsTest {
 					.expectNoEvent(Duration.ofMillis(100))
 					.thenCancel()
 					.verify(Duration.ofSeconds(1));
-		} finally {
+		}
+		finally {
 			compositeDisposable.dispose();
 		}
 	}
@@ -88,7 +89,8 @@ public class MessageChannelReactiveUtilsTest {
 					.thenAwait(Duration.ofMillis(100))
 					.thenCancel()
 					.verify(Duration.ofSeconds(1));
-		} finally {
+		}
+		finally {
 			compositeDisposable.dispose();
 		}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/MessageChannelReactiveUtilsTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/MessageChannelReactiveUtilsTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2002-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.channel;
+
+import org.junit.Test;
+import org.springframework.messaging.SubscribableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import reactor.core.Disposable;
+import reactor.core.Disposables;
+import reactor.core.scheduler.Schedulers;
+import reactor.test.StepVerifier;
+import reactor.util.concurrent.Queues;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MessageChannelReactiveUtilsTest {
+
+	@Test
+	public void testBackpressureWithSubscribableChannel() {
+		Disposable.Composite compositeDisposable = Disposables.composite();
+		try {
+			DirectChannel channel = new DirectChannel();
+			assertThat(channel).isInstanceOf(SubscribableChannel.class);
+			int initialRequest = 10;
+			StepVerifier.create(MessageChannelReactiveUtils.toPublisher(channel), initialRequest)
+					.expectSubscription()
+					.then(() -> {
+						compositeDisposable.add(
+								Schedulers.boundedElastic().schedule(() -> {
+									while (true) {
+										if (channel.getSubscriberCount() > 0) {
+											channel.send(new GenericMessage<>("foo"));
+										}
+									}
+								})
+						);
+					})
+					.expectNextCount(initialRequest)
+					.expectNoEvent(Duration.ofMillis(100))
+					.thenCancel()
+					.verify(Duration.ofSeconds(1));
+		} finally {
+			compositeDisposable.dispose();
+		}
+	}
+
+	@Test
+	public void testOverproducingWithSubscribableChannel() {
+		DirectChannel channel = new DirectChannel();
+		channel.setCountsEnabled(true);
+		assertThat(channel).isInstanceOf(SubscribableChannel.class);
+
+		Disposable.Composite compositeDisposable = Disposables.composite();
+		try {
+			int initialRequest = 10;
+			StepVerifier.create(MessageChannelReactiveUtils.toPublisher(channel), initialRequest)
+					.expectSubscription()
+					.then(() -> {
+						compositeDisposable.add(
+								Schedulers.boundedElastic().schedule(() -> {
+									while (true) {
+										if (channel.getSubscriberCount() > 0) {
+											channel.send(new GenericMessage<>("foo"));
+										}
+									}
+								})
+						);
+					})
+					.expectNextCount(initialRequest)
+					.thenAwait(Duration.ofMillis(100))
+					.thenCancel()
+					.verify(Duration.ofSeconds(1));
+		} finally {
+			compositeDisposable.dispose();
+		}
+
+		assertThat(channel.getMetrics().getSendCountLong())
+				.as("produced")
+				.isLessThanOrEqualTo(Queues.SMALL_BUFFER_SIZE);
+	}
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/MessageChannelReactiveUtilsTest.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/MessageChannelReactiveUtilsTest.java
@@ -17,8 +17,10 @@
 package org.springframework.integration.channel;
 
 import org.junit.Test;
+
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.GenericMessage;
+
 import reactor.core.Disposable;
 import reactor.core.Disposables;
 import reactor.core.scheduler.Schedulers;
@@ -55,7 +57,8 @@ public class MessageChannelReactiveUtilsTest {
 					.expectNoEvent(Duration.ofMillis(100))
 					.thenCancel()
 					.verify(Duration.ofSeconds(1));
-		} finally {
+		}
+		finally {
 			compositeDisposable.dispose();
 		}
 	}
@@ -86,7 +89,8 @@ public class MessageChannelReactiveUtilsTest {
 					.thenAwait(Duration.ofMillis(100))
 					.thenCancel()
 					.verify(Duration.ofSeconds(1));
-		} finally {
+		}
+		finally {
 			compositeDisposable.dispose();
 		}
 


### PR DESCRIPTION
As discovered while pairing with @olegz, `SubscribableChannel` reactive adapter does not respect back-pressure.

There are two problems, actually:
1. The requests are ignored due to the use of `FluxSink.OverflowStrategy.IGNORE`
2. Even if you change it to `FluxSink.OverflowStrategy.BUFFER`, the buffer will be unbounded and eventually lead to OOM (see https://github.com/reactor/reactor-core/issues/1936)

It is highly recommended to use `EmitterProcessor` instead of `Flux.create` in the adapter, so that you push until the buffer is full, and it will block the `SubscribableChannel`'s callback when calling `onNext` until the queue gets more capacity to handle new messages.

See [this gist](https://gist.github.com/bsideup/2a75b8f95096ef74d05546e8cef6a749) if you want to play with `Flux.create` vs `EmitterProcessor`.