### PR TITLE
GH-3107: Add errorOnTimeout for Inbound Gateways

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/MessagingGatewaySpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/MessagingGatewaySpec.java
@@ -155,6 +155,22 @@ public abstract class MessagingGatewaySpec<S extends MessagingGatewaySpec<S, G>,
 	}
 
 	/**
+	 * If errorOnTimeout is true, construct an instance that will send an
+	 * {@link org.springframework.messaging.support.ErrorMessage} with a
+	 * {@link org.springframework.integration.MessageTimeoutException} payload to the error channel
+	 * if a reply is expected but none is received. If no error channel is configured,
+	 * the {@link org.springframework.integration.MessageTimeoutException} will be thrown.
+	 * @param errorOnTimeout true to create the error message on reply timeout.
+	 * @return the spec
+	 * @since 5.2.2
+	 * @see MessagingGatewaySupport#setErrorOnTimeout
+	 */
+	public S errorOnTimeout(boolean errorOnTimeout) {
+		this.target.setErrorOnTimeout(errorOnTimeout);
+		return _this();
+	}
+
+	/**
 	 * An {@link InboundMessageMapper} to use.
 	 * @param requestMapper the requestMapper.
 	 * @return the spec.

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -88,7 +88,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 
 	private final Object replyMessageCorrelatorMonitor = new Object();
 
-	private final boolean errorOnTimeout;
+	private boolean errorOnTimeout;
 
 	private final AtomicLong messageCount = new AtomicLong();
 
@@ -139,6 +139,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 	 * configured, the {@link MessageTimeoutException} will be thrown.
 	 * @param errorOnTimeout true to create the error message.
 	 * @since 4.2
+	 * @see #setErrorOnTimeout
 	 */
 	public MessagingGatewaySupport(boolean errorOnTimeout) {
 		MessagingTemplate template = new MessagingTemplate();
@@ -149,6 +150,17 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 		this.errorOnTimeout = errorOnTimeout;
 	}
 
+	/**
+	 * If errorOnTimeout is true, construct an instance that will send an
+	 * {@link ErrorMessage} with a {@link MessageTimeoutException} payload to the error
+	 * channel if a reply is expected but none is received. If no error channel is
+	 * configured, the {@link MessageTimeoutException} will be thrown.
+	 * @param errorOnTimeout true to create the error message on reply timeout.
+	 * @since 5.2.2
+	 */
+	public void setErrorOnTimeout(boolean errorOnTimeout) {
+		this.errorOnTimeout = errorOnTimeout;
+	}
 
 	/**
 	 * Set the request channel.

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/Tcp.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/Tcp.java
@@ -95,23 +95,8 @@ public final class Tcp {
 	 * @return the spec.
 	 */
 	public static TcpInboundGatewaySpec inboundGateway(AbstractConnectionFactory connectionFactory) {
-		return inboundGateway(connectionFactory, false);
+		return new TcpInboundGatewaySpec(connectionFactory);
 	}
-
-	/**
-	 * Create an inbound gateway using the supplied connection factory.
-	 * @param connectionFactory the connection factory - must be an existing bean - it
-	 * will not be initialized.
-	 * @param errorOnTimeout true to create the error message on reply timeout.
-	 * @return the spec.
-	 * @since 5.2.2
-	 */
-	public static TcpInboundGatewaySpec inboundGateway(AbstractConnectionFactory connectionFactory,
-			boolean errorOnTimeout) {
-
-		return new TcpInboundGatewaySpec(connectionFactory, errorOnTimeout);
-	}
-
 
 	/**
 	 * Create an inbound gateway using the supplied connection factory.
@@ -119,20 +104,7 @@ public final class Tcp {
 	 * @return the spec.
 	 */
 	public static TcpInboundGatewaySpec inboundGateway(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec) {
-		return inboundGateway(connectionFactorySpec, false);
-	}
-
-	/**
-	 * Create an inbound gateway using the supplied connection factory.
-	 * @param connectionFactorySpec the connection factory spec.
-	 * @param errorOnTimeout true to create the error message on reply timeout.
-	 * @return the spec.
-	 * @since 5.2.2
-	 */
-	public static TcpInboundGatewaySpec inboundGateway(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec,
-			boolean errorOnTimeout) {
-
-		return new TcpInboundGatewaySpec(connectionFactorySpec, errorOnTimeout);
+		return new TcpInboundGatewaySpec(connectionFactorySpec);
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/Tcp.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/Tcp.java
@@ -24,6 +24,8 @@ import org.springframework.integration.ip.tcp.connection.AbstractConnectionFacto
  *
  * @author Gary Russell
  * @author Tim Ysewyn
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
@@ -31,7 +33,6 @@ public final class Tcp {
 
 	/**
 	 * Boolean indicating the connection factory should use NIO.
-	 *
 	 * @deprecated This isn't used anymore within the framework and will be removed in a future release.
 	 */
 	@Deprecated
@@ -40,7 +41,6 @@ public final class Tcp {
 	/**
 	 * Boolean indicating the connection factory should not use NIO
 	 * (default).
-	 *
 	 * @deprecated This isn't used anymore within the framework and will be removed in a future release.
 	 */
 	@Deprecated
@@ -95,8 +95,23 @@ public final class Tcp {
 	 * @return the spec.
 	 */
 	public static TcpInboundGatewaySpec inboundGateway(AbstractConnectionFactory connectionFactory) {
-		return new TcpInboundGatewaySpec(connectionFactory);
+		return inboundGateway(connectionFactory, false);
 	}
+
+	/**
+	 * Create an inbound gateway using the supplied connection factory.
+	 * @param connectionFactory the connection factory - must be an existing bean - it
+	 * will not be initialized.
+	 * @param errorOnTimeout true to create the error message on reply timeout.
+	 * @return the spec.
+	 * @since 5.2.2
+	 */
+	public static TcpInboundGatewaySpec inboundGateway(AbstractConnectionFactory connectionFactory,
+			boolean errorOnTimeout) {
+
+		return new TcpInboundGatewaySpec(connectionFactory, errorOnTimeout);
+	}
+
 
 	/**
 	 * Create an inbound gateway using the supplied connection factory.
@@ -104,7 +119,20 @@ public final class Tcp {
 	 * @return the spec.
 	 */
 	public static TcpInboundGatewaySpec inboundGateway(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec) {
-		return new TcpInboundGatewaySpec(connectionFactorySpec);
+		return inboundGateway(connectionFactorySpec, false);
+	}
+
+	/**
+	 * Create an inbound gateway using the supplied connection factory.
+	 * @param connectionFactorySpec the connection factory spec.
+	 * @param errorOnTimeout true to create the error message on reply timeout.
+	 * @return the spec.
+	 * @since 5.2.2
+	 */
+	public static TcpInboundGatewaySpec inboundGateway(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec,
+			boolean errorOnTimeout) {
+
+		return new TcpInboundGatewaySpec(connectionFactorySpec, errorOnTimeout);
 	}
 
 	/**
@@ -124,6 +152,7 @@ public final class Tcp {
 	 */
 	public static TcpInboundChannelAdapterSpec inboundAdapter(
 			AbstractConnectionFactorySpec<?, ?> connectionFactorySpec) {
+
 		return new TcpInboundChannelAdapterSpec(connectionFactorySpec);
 	}
 
@@ -163,6 +192,7 @@ public final class Tcp {
 	 */
 	public static TcpOutboundChannelAdapterSpec outboundAdapter(
 			AbstractConnectionFactorySpec<?, ?> connectionFactorySpec) {
+
 		return new TcpOutboundChannelAdapterSpec(connectionFactorySpec);
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundGatewaySpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundGatewaySpec.java
@@ -42,10 +42,9 @@ public class TcpInboundGatewaySpec extends MessagingGatewaySpec<TcpInboundGatewa
 	/**
 	 * Construct an instance using an existing spring-managed connection factory.
 	 * @param connectionFactoryBean the spring-managed bean.
-	 * @param errorOnTimeout true to create the error message on reply timeout.
 	 */
-	TcpInboundGatewaySpec(AbstractConnectionFactory connectionFactoryBean, boolean errorOnTimeout) {
-		super(new TcpInboundGateway(errorOnTimeout));
+	TcpInboundGatewaySpec(AbstractConnectionFactory connectionFactoryBean) {
+		super(new TcpInboundGateway());
 		this.connectionFactory = null;
 		this.target.setConnectionFactory(connectionFactoryBean);
 	}
@@ -53,10 +52,9 @@ public class TcpInboundGatewaySpec extends MessagingGatewaySpec<TcpInboundGatewa
 	/**
 	 * Construct an instance using a connection factory spec.
 	 * @param connectionFactorySpec the spec.
-	 * @param errorOnTimeout true to create the error message on reply timeout.
 	 */
-	TcpInboundGatewaySpec(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec, boolean errorOnTimeout) {
-		super(new TcpInboundGateway(errorOnTimeout));
+	TcpInboundGatewaySpec(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec) {
+		super(new TcpInboundGateway());
 		this.connectionFactory = connectionFactorySpec.get();
 		this.target.setConnectionFactory(this.connectionFactory);
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundGatewaySpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundGatewaySpec.java
@@ -42,9 +42,10 @@ public class TcpInboundGatewaySpec extends MessagingGatewaySpec<TcpInboundGatewa
 	/**
 	 * Construct an instance using an existing spring-managed connection factory.
 	 * @param connectionFactoryBean the spring-managed bean.
+	 * @param errorOnTimeout true to create the error message on reply timeout.
 	 */
-	TcpInboundGatewaySpec(AbstractConnectionFactory connectionFactoryBean) {
-		super(new TcpInboundGateway());
+	TcpInboundGatewaySpec(AbstractConnectionFactory connectionFactoryBean, boolean errorOnTimeout) {
+		super(new TcpInboundGateway(errorOnTimeout));
 		this.connectionFactory = null;
 		this.target.setConnectionFactory(connectionFactoryBean);
 	}
@@ -52,9 +53,10 @@ public class TcpInboundGatewaySpec extends MessagingGatewaySpec<TcpInboundGatewa
 	/**
 	 * Construct an instance using a connection factory spec.
 	 * @param connectionFactorySpec the spec.
+	 * @param errorOnTimeout true to create the error message on reply timeout.
 	 */
-	TcpInboundGatewaySpec(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec) {
-		super(new TcpInboundGateway());
+	TcpInboundGatewaySpec(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec, boolean errorOnTimeout) {
+		super(new TcpInboundGateway(errorOnTimeout));
 		this.connectionFactory = connectionFactorySpec.get();
 		this.target.setConnectionFactory(this.connectionFactory);
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
@@ -49,32 +49,54 @@ import org.springframework.util.Assert;
  * inbound / outbound channel adapters should be used.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class TcpInboundGateway extends MessagingGatewaySupport implements
 		TcpListener, TcpSender, ClientModeCapable, OrderlyShutdownCapable {
 
-	private volatile AbstractServerConnectionFactory serverConnectionFactory;
+	/**
+	 * A default retry interval in milliseconds - {@value #DEFAULT_RETRY_INTERVAL}.
+	 */
+	public static final long DEFAULT_RETRY_INTERVAL = 60000;
 
-	private volatile AbstractClientConnectionFactory clientConnectionFactory;
+	private final Map<String, TcpConnection> connections = new ConcurrentHashMap<>();
 
-	private final Map<String, TcpConnection> connections = new ConcurrentHashMap<String, TcpConnection>();
+	private final AtomicInteger activeCount = new AtomicInteger();
 
-	private volatile boolean isClientMode;
+	private AbstractServerConnectionFactory serverConnectionFactory;
 
-	private volatile boolean isSingleUse;
+	private AbstractClientConnectionFactory clientConnectionFactory;
 
-	private volatile long retryInterval = 60000;
+	private boolean isClientMode;
 
-	private volatile ScheduledFuture<?> scheduledFuture;
+	private boolean isSingleUse;
 
-	private volatile ClientModeConnectionManager clientModeConnectionManager;
+	private long retryInterval = DEFAULT_RETRY_INTERVAL;
 
 	private volatile boolean active;
 
+	private volatile ClientModeConnectionManager clientModeConnectionManager;
+
+	private volatile ScheduledFuture<?> scheduledFuture;
+
 	private volatile boolean shuttingDown;
 
-	private final AtomicInteger activeCount = new AtomicInteger();
+	public TcpInboundGateway() {
+		this(false);
+	}
+
+	/**
+	 * Instantiate based on the provided flag to indicate if an {@link ErrorMessage}
+	 * with a {@link org.springframework.integration.MessageTimeoutException} as a payload
+	 * will be sent into an error channel if a reply is expected but none is received.
+	 * @param errorOnTimeout true to create the error message on reply timeout.
+	 * @since 5.2.2
+	 */
+	public TcpInboundGateway(boolean errorOnTimeout) {
+		super(errorOnTimeout);
+	}
 
 	@Override
 	public boolean onMessage(Message<?> message) {
@@ -117,7 +139,7 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 	}
 
 	private boolean doOnMessage(Message<?> message) {
-		Message<?> reply = this.sendAndReceiveMessage(message);
+		Message<?> reply = sendAndReceiveMessage(message);
 		if (reply == null) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("null reply received for " + message + " nothing to send");
@@ -144,13 +166,15 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 	}
 
 	private void publishNoConnectionEvent(Message<?> message, String connectionId) {
-		AbstractConnectionFactory cf = this.serverConnectionFactory != null ? this.serverConnectionFactory
-				: this.clientConnectionFactory;
+		AbstractConnectionFactory cf =
+				this.serverConnectionFactory != null
+						? this.serverConnectionFactory
+						: this.clientConnectionFactory;
 		ApplicationEventPublisher applicationEventPublisher = cf.getApplicationEventPublisher();
 		if (applicationEventPublisher != null) {
 			applicationEventPublisher.publishEvent(
-				new TcpConnectionFailedCorrelationEvent(this, connectionId,
-						new MessagingException(message, "Connection not found to process reply.")));
+					new TcpConnectionFailedCorrelationEvent(this, connectionId,
+							new MessagingException(message, "Connection not found to process reply.")));
 		}
 	}
 
@@ -163,7 +187,6 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 
 	/**
 	 * Must be {@link AbstractClientConnectionFactory} or {@link AbstractServerConnectionFactory}.
-	 *
 	 * @param connectionFactory the Connection Factory
 	 */
 	public void setConnectionFactory(AbstractConnectionFactory connectionFactory) {
@@ -192,6 +215,7 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 	public void removeDeadConnection(TcpConnection connection) {
 		this.connections.remove(connection.getConnectionId());
 	}
+
 	@Override
 	public String getComponentType() {
 		return "ip:tcp-inbound-gateway";
@@ -221,11 +245,11 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 				this.clientConnectionFactory.start();
 			}
 			if (this.isClientMode) {
-				ClientModeConnectionManager manager = new ClientModeConnectionManager(
-						this.clientConnectionFactory);
+				ClientModeConnectionManager manager =
+						new ClientModeConnectionManager(this.clientConnectionFactory);
 				this.clientModeConnectionManager = manager;
-				Assert.state(this.getTaskScheduler() != null, "Client mode requires a task scheduler");
-				this.scheduledFuture = this.getTaskScheduler().scheduleAtFixedRate(manager, this.retryInterval);
+				Assert.state(getTaskScheduler() != null, "Client mode requires a task scheduler");
+				this.scheduledFuture = getTaskScheduler().scheduleAtFixedRate(manager, this.retryInterval);
 			}
 		}
 	}
@@ -272,8 +296,9 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 	}
 
 	/**
-	 * @param retryInterval
-	 *            the retryInterval to set
+	 * Configure a retry interval.
+	 * Defaults to {@link #DEFAULT_RETRY_INTERVAL}.
+	 * @param retryInterval the retryInterval to set
 	 */
 	public void setRetryInterval(long retryInterval) {
 		this.retryInterval = retryInterval;
@@ -307,4 +332,5 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 		this.stop();
 		return this.activeCount.get();
 	}
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
@@ -83,21 +83,6 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 
 	private volatile boolean shuttingDown;
 
-	public TcpInboundGateway() {
-		this(false);
-	}
-
-	/**
-	 * Instantiate based on the provided flag to indicate if an {@link ErrorMessage}
-	 * with a {@link org.springframework.integration.MessageTimeoutException} as a payload
-	 * will be sent into an error channel if a reply is expected but none is received.
-	 * @param errorOnTimeout true to create the error message on reply timeout.
-	 * @since 5.2.2
-	 */
-	public TcpInboundGateway(boolean errorOnTimeout) {
-		super(errorOnTimeout);
-	}
-
 	@Override
 	public boolean onMessage(Message<?> message) {
 		boolean isErrorMessage = message instanceof ErrorMessage;

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
@@ -24,8 +24,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.aopalliance.intercept.MethodInterceptor;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -34,6 +33,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.MessageTimeoutException;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.core.MessagingTemplate;
@@ -60,7 +60,8 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.ReflectionUtils;
 
 /**
  * @author Gary Russell
@@ -69,7 +70,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @since 5.0
  *
  */
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
 public class IpIntegrationTests {
 
@@ -106,7 +107,7 @@ public class IpIntegrationTests {
 	private AtomicBoolean adviceCalled;
 
 	@Test
-	public void testTcpAdapters() {
+	void testTcpAdapters() {
 		ApplicationEventPublisher publisher = e -> { };
 		AbstractServerConnectionFactory server = Tcp.netServer(0).backlog(2).soTimeout(5000).id("server").get();
 		assertThat(server.getComponentName()).isEqualTo("server");
@@ -133,7 +134,7 @@ public class IpIntegrationTests {
 	}
 
 	@Test
-	public void testTcpGateways() {
+	void testTcpGateways() {
 		TestingUtilities.waitListening(this.server1, null);
 		this.client1.stop();
 		this.client1.setPort(this.server1.getPort());
@@ -142,12 +143,12 @@ public class IpIntegrationTests {
 		MessagingTemplate messagingTemplate = new MessagingTemplate(this.clientTcpFlowInput);
 
 		assertThat(messagingTemplate.convertSendAndReceive("foo", String.class)).isEqualTo("FOO");
-
+		assertThat(messagingTemplate.convertSendAndReceive("junk", String.class)).isEqualTo("error:non-convertible");
 		assertThat(this.adviceCalled.get()).isTrue();
 	}
 
 	@Test
-	public void testUdp() throws Exception {
+	void testUdp() throws Exception {
 		assertThat(this.config.listeningLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.serverPort).isEqualTo(this.udpInbound.getPort());
 		Message<String> outMessage = MessageBuilder.withPayload("foo")
@@ -160,7 +161,7 @@ public class IpIntegrationTests {
 	}
 
 	@Test
-	public void testUdpInheritance() {
+	void testUdpInheritance() {
 		UdpMulticastOutboundChannelAdapterSpec udpMulticastOutboundChannelAdapterSpec =
 				Udp.outboundMulticastAdapter("headers['udp_dest']");
 
@@ -174,7 +175,7 @@ public class IpIntegrationTests {
 	}
 
 	@Test
-	public void testCloseStream() throws InterruptedException {
+	void testCloseStream() throws InterruptedException {
 		IntegrationFlow server = IntegrationFlows.from(Tcp.inboundGateway(Tcp.netServer(0)
 				.deserializer(new ByteArrayRawSerializer())))
 				.<byte[], String>transform(p -> "reply:" + new String(p).toUpperCase())
@@ -192,19 +193,19 @@ public class IpIntegrationTests {
 		}
 		this.applicationContext.addApplicationListener(new Listener());
 		this.flowContext.registration(server)
-			.id("streamCloseServer")
-			.register();
+				.id("streamCloseServer")
+				.register();
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		IntegrationFlow client = IntegrationFlows.from(MessageChannels.direct())
-			.handle(Tcp.outboundGateway(Tcp.netClient("localhost", port.get())
-					.singleUseConnections(true)
-					.serializer(new ByteArrayRawSerializer()))
-				.closeStreamAfterSend(true))
-			.transform(Transformers.objectToString())
-			.get();
+				.handle(Tcp.outboundGateway(Tcp.netClient("localhost", port.get())
+						.singleUseConnections(true)
+						.serializer(new ByteArrayRawSerializer()))
+						.closeStreamAfterSend(true))
+				.transform(Transformers.objectToString())
+				.get();
 		IntegrationFlowRegistration clientRegistration = this.flowContext.registration(client)
-			.id("streamCloseClient")
-			.register();
+				.id("streamCloseClient")
+				.register();
 		assertThat(clientRegistration.getMessagingTemplate()
 				.convertSendAndReceive("foo", String.class)).isEqualTo("reply:FOO");
 	}
@@ -227,10 +228,28 @@ public class IpIntegrationTests {
 
 		@Bean
 		public IntegrationFlow inTcpGateway() {
-			return IntegrationFlows.from(Tcp.inboundGateway(server1()))
+			return IntegrationFlows.from(
+					Tcp.inboundGateway(server1(), true)
+							.replyTimeout(1)
+							.errorChannel("inTcpGatewayErrorFlow.input"))
 					.transform(Transformers.objectToString())
+					.<String>filter((payload) -> !"junk".equals(payload))
 					.<String, String>transform(String::toUpperCase)
 					.get();
+		}
+
+		@Bean
+		public IntegrationFlow inTcpGatewayErrorFlow() {
+			return (flow) -> flow
+					.<Exception>handle((payload, headers) -> {
+						if (payload instanceof MessageTimeoutException) {
+							return "error:non-convertible";
+						}
+						else {
+							ReflectionUtils.rethrowRuntimeException(payload);
+							return null;
+						}
+					});
 		}
 
 		@Bean
@@ -252,7 +271,7 @@ public class IpIntegrationTests {
 
 		@Bean
 		public ApplicationListener<UdpServerListeningEvent> events() {
-			return (ApplicationListener<UdpServerListeningEvent>) event -> {
+			return event -> {
 				this.serverPort = event.getPort();
 				this.listeningLatch.countDown();
 			};

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
@@ -229,8 +229,9 @@ public class IpIntegrationTests {
 		@Bean
 		public IntegrationFlow inTcpGateway() {
 			return IntegrationFlows.from(
-					Tcp.inboundGateway(server1(), true)
+					Tcp.inboundGateway(server1())
 							.replyTimeout(1)
+							.errorOnTimeout(true)
 							.errorChannel("inTcpGatewayErrorFlow.input"))
 					.transform(Transformers.objectToString())
 					.<String>filter((payload) -> !"junk".equals(payload))

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
@@ -142,6 +142,10 @@ public class ChannelPublishingJmsMessageListener
 		this.gatewayDelegate.setReplyTimeout(replyTimeout);
 	}
 
+	public void setErrorOnTimeout(boolean errorOnTimeout) {
+		this.gatewayDelegate.setErrorOnTimeout(errorOnTimeout);
+	}
+
 	@Override
 	public void setShouldTrack(boolean shouldTrack) {
 		this.gatewayDelegate.setShouldTrack(shouldTrack);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
@@ -91,6 +91,12 @@ public class JmsInboundGateway extends MessagingGatewaySupport implements Orderl
 	}
 
 	@Override
+	public void setErrorOnTimeout(boolean errorOnTimeout) {
+		super.setErrorOnTimeout(errorOnTimeout);
+		this.endpoint.getListener().setErrorOnTimeout(errorOnTimeout);
+	}
+
+	@Override
 	public void setShouldTrack(boolean shouldTrack) {
 		super.setShouldTrack(shouldTrack);
 		this.endpoint.setShouldTrack(shouldTrack);
@@ -107,6 +113,8 @@ public class JmsInboundGateway extends MessagingGatewaySupport implements Orderl
 	public void setShutdownContainerOnStop(boolean shutdownContainerOnStop) {
 		this.endpoint.setShutdownContainerOnStop(shutdownContainerOnStop);
 	}
+
+
 
 	@Override
 	public String getComponentType() {

--- a/src/reference/asciidoc/endpoint-summary.adoc
+++ b/src/reference/asciidoc/endpoint-summary.adoc
@@ -223,3 +223,6 @@ The `<int:outbound-channel-adapter>` element lets you send data to a `void` meth
 As discussed in <<./gateway.adoc#gateway,Messaging Gateways>>, the `<int:gateway>` element lets any Java program invoke a messaging flow.
 Each of these works without requiring any source-level dependencies on Spring Integration.
 The equivalent of an outbound gateway in this context is using a service activator (see <<./service-activator.adoc#service-activator,Service Activator>>) to invoke a method that returns an `Object` of some kind.
+
+Starting with version `5.2.2`, all the inbound gateway can be configured with an `errorOnTimeout` boolean flag to throw a `MessageTimeoutException` when downstream reply doesn't come back during reply timeout.
+Such an exception can be handled on the `errorChannel`, e.g. producing a compensation reply for requesting client.

--- a/src/reference/asciidoc/endpoint-summary.adoc
+++ b/src/reference/asciidoc/endpoint-summary.adoc
@@ -224,5 +224,6 @@ As discussed in <<./gateway.adoc#gateway,Messaging Gateways>>, the `<int:gateway
 Each of these works without requiring any source-level dependencies on Spring Integration.
 The equivalent of an outbound gateway in this context is using a service activator (see <<./service-activator.adoc#service-activator,Service Activator>>) to invoke a method that returns an `Object` of some kind.
 
-Starting with version `5.2.2`, all the inbound gateway can be configured with an `errorOnTimeout` boolean flag to throw a `MessageTimeoutException` when downstream reply doesn't come back during reply timeout.
+Starting with version `5.2.2`, all the inbound gateways can be configured with an `errorOnTimeout` boolean flag to throw a `MessageTimeoutException` when the downstream flow doesn't return a reply during the reply timeout.
+The timer is not started until the thread returns a control to the gateway back, so usually it is only useful when the downstream flow is asynchronous or it stops because of `null` return from some handler, e.g. <<./filter.adoc#filter,filter>>.
 Such an exception can be handled on the `errorChannel`, e.g. producing a compensation reply for requesting client.

--- a/src/reference/asciidoc/ip.adoc
+++ b/src/reference/asciidoc/ip.adoc
@@ -1895,8 +1895,6 @@ Usually, replies arrive on a temporary reply channel added to the inbound messag
 |
 | The time in milliseconds for which the gateway waits for a reply.
 Default: 1000 (1 second).
-Starting with version `5.2.2`, the `TcpInboundGateway` can be created with an `errorOnTimeout` boolean flag to raise a `MessageTimeoutException` when downstream reply doesn't come back during reply timeout.
-Such an exception can be handled on the `errorChannel`, e.g. producing a compensation reply for client.
 
 | `error-channel`
 |

--- a/src/reference/asciidoc/ip.adoc
+++ b/src/reference/asciidoc/ip.adoc
@@ -778,7 +778,7 @@ Two additional attributes support this mechanism.
 `retry-interval` specifies (in milliseconds) how often the framework tries to reconnect after a connection failure.
 `scheduler` supplies a `TaskScheduler` to schedule the connection attempts and to test that the connection is still active.
 
-If the gateway is started, you may force the gateway to establish a connection by sending a <control-bus /> command: `@adapter_id.retryConnection()` and examine the current state with `@adapter_id.isClientModeConnected()`.
+If the gateway is started, you may force the gateway to establish a connection by sending a `<control-bus/>` command: `@adapter_id.retryConnection()` and examine the current state with `@adapter_id.isClientModeConnected()`.
 
 The outbound gateway, after sending a message over the connection, waits for a response, constructs a response message, and puts it on the reply channel.
 Communications over the connections are single-threaded.
@@ -1895,6 +1895,8 @@ Usually, replies arrive on a temporary reply channel added to the inbound messag
 |
 | The time in milliseconds for which the gateway waits for a reply.
 Default: 1000 (1 second).
+Starting with version `5.2.2`, the `TcpInboundGateway` can be created with an `errorOnTimeout` boolean flag to raise a `MessageTimeoutException` when downstream reply doesn't come back during reply timeout.
+Such an exception can be handled on the `errorChannel`, e.g. producing a compensation reply for client.
 
 | `error-channel`
 |


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3107

The `MessagingGatewaySupport` has an `errorOnTimeout` option to throw
a `MessageTimeoutException` when downstream reply doesn't come back in
time for configured reply timeout

* Expose an `errorOnTimeout` option as a `TcpInboundGateway` ctor
property
* Add new factory methods into a `Tcp` factory for Java DSL
* Ensure a property works as expected in the `IpIntegrationTests`
* Document a new option

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
