### PR TITLE
INT-3494: Resolve dir for writing as a Resource

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/ExpressionUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/ExpressionUtils.java
@@ -165,12 +165,12 @@ public final class ExpressionUtils {
 	 * @param expression the expression.
 	 * @param evaluationContext the evaluation context.
 	 * @param message the message (if available).
-	 * @param name the name of the result of the evaluation.
+	 * @param propertyName the property name the expression is evaluated for.
 	 * @return the File.
 	 * @since 5.0
 	 */
 	public static File expressionToFile(Expression expression, EvaluationContext evaluationContext,
-			@Nullable Message<?> message, String name) {
+			@Nullable Message<?> message, String propertyName) {
 
 		Object value =
 				message == null
@@ -179,14 +179,14 @@ public final class ExpressionUtils {
 
 		Assert.state(value != null, () ->
 				String.format("The provided %s expression (%s) must not evaluate to null.",
-						name, expression.getExpressionString()));
+						propertyName, expression.getExpressionString()));
 
 		if (value instanceof File) {
 			return (File) value;
 		}
 		else if (value instanceof String) {
 			String path = (String) value;
-			Assert.hasText(path, String.format("Unable to resolve %s for the provided Expression '%s'.", name,
+			Assert.hasText(path, String.format("Unable to resolve %s for the provided Expression '%s'.", propertyName,
 					expression.getExpressionString()));
 			try {
 				return ResourceUtils.getFile(path);
@@ -194,7 +194,7 @@ public final class ExpressionUtils {
 			catch (FileNotFoundException ex) {
 				throw new IllegalStateException(
 						String.format("Unable to resolve %s for the provided Expression '%s'.",
-								name, expression.getExpressionString()),
+								propertyName, expression.getExpressionString()),
 						ex);
 			}
 		}
@@ -205,14 +205,14 @@ public final class ExpressionUtils {
 			catch (IOException ex) {
 				throw new IllegalStateException(
 						String.format("Unable to resolve %s for the provided Expression '%s'.",
-								name, expression.getExpressionString()),
+								propertyName, expression.getExpressionString()),
 						ex);
 			}
 		}
 		else {
 			throw new IllegalStateException(String.format(
 					"The provided %s expression (%s) must evaluate to type java.io.File, String " +
-							"or org.springframework.core.io.Resource, not %s.", name,
+							"or org.springframework.core.io.Resource, not %s.", propertyName,
 					expression.getExpressionString(), value.getClass().getName()));
 		}
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/ExpressionUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/ExpressionUtils.java
@@ -17,6 +17,8 @@
 package org.springframework.integration.expression;
 
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -25,6 +27,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.context.expression.MapAccessor;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.core.io.Resource;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionParser;
@@ -39,6 +42,7 @@ import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
+import org.springframework.util.ResourceUtils;
 
 /**
  * Utility class with static methods for helping with evaluation of SpEL expressions.
@@ -53,7 +57,7 @@ public final class ExpressionUtils {
 
 	private static final ExpressionParser EXPRESSION_PARSER = new SpelExpressionParser();
 
-	private static final Log logger = LogFactory.getLog(ExpressionUtils.class);
+	private static final Log LOGGER = LogFactory.getLog(ExpressionUtils.class);
 
 	private ExpressionUtils() {
 		super();
@@ -84,7 +88,7 @@ public final class ExpressionUtils {
 	 */
 	public static StandardEvaluationContext createStandardEvaluationContext(@Nullable BeanFactory beanFactory) {
 		if (beanFactory == null) {
-			logger.warn("Creating EvaluationContext with no beanFactory", new RuntimeException("No beanFactory"));
+			LOGGER.warn("Creating EvaluationContext with no beanFactory", new RuntimeException("No beanFactory"));
 		}
 		return (StandardEvaluationContext) doCreateContext(beanFactory, false);
 	}
@@ -98,7 +102,7 @@ public final class ExpressionUtils {
 	 */
 	public static SimpleEvaluationContext createSimpleEvaluationContext(@Nullable BeanFactory beanFactory) {
 		if (beanFactory == null) {
-			logger.warn("Creating EvaluationContext with no beanFactory", new RuntimeException("No beanFactory"));
+			LOGGER.warn("Creating EvaluationContext with no beanFactory", new RuntimeException("No beanFactory"));
 		}
 		return (SimpleEvaluationContext) doCreateContext(beanFactory, true);
 	}
@@ -168,29 +172,49 @@ public final class ExpressionUtils {
 	public static File expressionToFile(Expression expression, EvaluationContext evaluationContext,
 			@Nullable Message<?> message, String name) {
 
-		File file;
-		Object value = message == null
-				? expression.getValue(evaluationContext)
-				: expression.getValue(evaluationContext, message);
-		if (value == null) {
-			throw new IllegalStateException(String.format("The provided %s expression (%s) must not evaluate to null.",
-					name, expression.getExpressionString()));
-		}
-		else if (value instanceof File) {
-			file = (File) value;
+		Object value =
+				message == null
+						? expression.getValue(evaluationContext)
+						: expression.getValue(evaluationContext, message);
+
+		Assert.state(value != null, () ->
+				String.format("The provided %s expression (%s) must not evaluate to null.",
+						name, expression.getExpressionString()));
+
+		if (value instanceof File) {
+			return (File) value;
 		}
 		else if (value instanceof String) {
 			String path = (String) value;
 			Assert.hasText(path, String.format("Unable to resolve %s for the provided Expression '%s'.", name,
 					expression.getExpressionString()));
-			file = new File(path);
+			try {
+				return ResourceUtils.getFile(path);
+			}
+			catch (FileNotFoundException ex) {
+				throw new IllegalStateException(
+						String.format("Unable to resolve %s for the provided Expression '%s'.",
+								name, expression.getExpressionString()),
+						ex);
+			}
+		}
+		else if (value instanceof Resource) {
+			try {
+				return ((Resource) value).getFile();
+			}
+			catch (IOException ex) {
+				throw new IllegalStateException(
+						String.format("Unable to resolve %s for the provided Expression '%s'.",
+								name, expression.getExpressionString()),
+						ex);
+			}
 		}
 		else {
 			throw new IllegalStateException(String.format(
-					"The provided %s expression (%s) must evaluate to type java.io.File or String, not %s.", name,
+					"The provided %s expression (%s) must evaluate to type java.io.File, String " +
+							"or org.springframework.core.io.Resource, not %s.", name,
 					expression.getExpressionString(), value.getClass().getName()));
 		}
-		return file;
 	}
 
 	/**

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterInsideChainTests-context.xml
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterInsideChainTests-context.xml
@@ -18,7 +18,7 @@
 		<si:header-enricher>
 			<si:header name="#{T(org.springframework.integration.file.FileHeaders).FILENAME}" value="${test.file}"/>
 		</si:header-enricher>
-		<file:outbound-channel-adapter id="file-outbound-channel-adapter-within-chain" directory="${work.dir}"/>
+		<file:outbound-channel-adapter id="file-outbound-channel-adapter-within-chain" directory-expression="${work.dir}"/>
 	</si:chain>
 
 	<bean id="placeholderProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileOutboundChannelAdapterIntegrationTests.java
@@ -17,15 +17,14 @@
 package org.springframework.integration.file;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.File;
 import java.io.FileOutputStream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.support.MessageBuilder;
@@ -33,8 +32,7 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandlingException;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.FileCopyUtils;
 
 /**
@@ -42,9 +40,8 @@ import org.springframework.util.FileCopyUtils;
  * @author Artem Bilan
  * @author Gary Russell
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
-public class FileOutboundChannelAdapterIntegrationTests {
+@SpringJUnitConfig
+class FileOutboundChannelAdapterIntegrationTests {
 
 	static final String DEFAULT_ENCODING = "UTF-8";
 
@@ -78,103 +75,71 @@ public class FileOutboundChannelAdapterIntegrationTests {
 
 	File sourceFile;
 
-	@Before
-	public void setUp() throws Exception {
-		sourceFile = File.createTempFile("anyFile", ".txt");
-		sourceFile.deleteOnExit();
+	@BeforeEach
+	void setUp(@TempDir File tmpDir) throws Exception {
+		sourceFile = new File(tmpDir, "anyFile.txt");
 		FileCopyUtils.copy(SAMPLE_CONTENT.getBytes(DEFAULT_ENCODING),
 				new FileOutputStream(sourceFile, false));
 		message = MessageBuilder.withPayload(sourceFile).build();
 	}
 
-	@After
-	public void tearDown() {
-		sourceFile.delete();
-	}
-
 	@Test
-	public void saveToBaseDir() throws Exception {
-		this.inputChannelSaveToBaseDir.send(message);
-
+	void saveToBaseDir() {
+		this.inputChannelSaveToBaseDir.send(this.message);
 		assertThat(new File("target/base-directory/foo.txt").exists()).isTrue();
-
 	}
 
 	@Test
-	public void saveToBaseDirDeleteSourceFile() throws Exception {
+	void saveToBaseDirDeleteSourceFile() {
 		assertThat(sourceFile.exists()).isTrue();
-		this.inputChannelSaveToBaseDirDeleteSource.send(message);
+		this.inputChannelSaveToBaseDirDeleteSource.send(this.message);
 		assertThat(new File("target/base-directory/foo.txt").exists()).isTrue();
 		assertThat(sourceFile.exists()).isFalse();
 	}
 
 	@Test
-	public void saveToSubDir() throws Exception {
-		this.inputChannelSaveToSubDir.send(message);
+	void saveToSubDir() {
+		this.inputChannelSaveToSubDir.send(this.message);
 		assertThat(new File("target/base-directory/sub-directory/foo.txt").exists()).isTrue();
 	}
 
 	@Test
-	public void saveToSubDirWithWrongExpression() throws Exception {
-
-		try {
-			this.inputChannelSaveToSubDirWrongExpression.send(message);
-		}
-		catch (MessageHandlingException e) {
-			assertThat(e.getCause().getMessage()).isEqualTo(TestUtils
-					.applySystemFileSeparator("Destination path [target/base-directory/sub-directory/foo.txt] does not" +
-							" point to a directory."));
-			return;
-		}
-
-		fail("Was expecting a MessageHandlingException to be thrown");
+	void saveToSubDirWithWrongExpression() {
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> this.inputChannelSaveToSubDirWrongExpression.send(this.message))
+				.withStackTraceContaining(TestUtils.applySystemFileSeparator(
+						"Destination path [target/base-directory/sub-directory/foo.txt] does " +
+								"not point to a directory."));
 	}
 
 	@Test
-	public void saveToSubDirWithEmptyStringExpression() throws Exception {
-
-		try {
-			this.inputChannelSaveToSubDirEmptyStringExpression.send(message);
-		}
-		catch (MessageHandlingException e) {
-			assertThat(e.getCause().getMessage())
-					.isEqualTo("Unable to resolve Destination Directory for the provided Expression ''   ''.");
-			return;
-		}
-
-		fail("Was expecting a MessageHandlingException to be thrown");
+	void saveToSubDirWithEmptyStringExpression() {
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> this.inputChannelSaveToSubDirEmptyStringExpression.send(this.message))
+				.withStackTraceContaining("Unable to resolve Destination Directory for " +
+						"the provided Expression ''   ''.");
 	}
 
 	@Test
-	public void saveToSubDir2() throws Exception {
-
-		final Message<File> message2 = MessageBuilder.fromMessage(message)
-													.setHeader("myFileLocation", "target/base-directory/headerdir")
-													.build();
+	void saveToSubDir2() {
+		Message<File> message2 = MessageBuilder.fromMessage(message)
+				.setHeader("myFileLocation", "target/base-directory/headerdir")
+				.build();
 
 		this.inputChannelSaveToSubDirWithHeader.send(message2);
 		assertThat(new File("target/base-directory/headerdir/foo.txt").exists()).isTrue();
 	}
 
 	@Test
-	public void saveToSubDirAutoCreateOff() throws Exception {
-
-		try {
-			this.inputChannelSaveToSubDirAutoCreateOff.send(message);
-		}
-		catch (MessageHandlingException e) {
-			assertThat(e.getCause().getMessage()).isEqualTo(TestUtils
-					.applySystemFileSeparator("Destination directory [target/base-directory2/sub-directory2] does not " +
-							"exist."));
-			return;
-		}
-
-		fail("Was expecting a MessageHandlingException to be thrown");
+	void saveToSubDirAutoCreateOff() {
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> this.inputChannelSaveToSubDirAutoCreateOff.send(this.message))
+				.withStackTraceContaining(TestUtils.applySystemFileSeparator("Destination directory " +
+						"[target/base-directory2/sub-directory2] does not exist."));
 	}
 
 	@Test
-	public void saveToSubWithFileExpression() throws Exception {
-
+	void saveToSubWithFileExpression() {
 		final File directory = new File("target/base-directory/sub-directory");
 		final Message<File> messageWithFileHeader = MessageBuilder.fromMessage(message)
 				.setHeader("subDirectory", directory)
@@ -184,46 +149,30 @@ public class FileOutboundChannelAdapterIntegrationTests {
 	}
 
 	@Test
-	public void saveToSubWithFileExpressionNull() throws Exception {
-
+	void saveToSubWithFileExpressionNull() {
 		final File directory = null;
 		final Message<File> messageWithFileHeader = MessageBuilder.fromMessage(message)
 				.setHeader("subDirectory", directory)
 				.build();
 
-		try {
-			this.inputChannelSaveToSubDirWithFile.send(messageWithFileHeader);
-		}
-		catch (MessageHandlingException e) {
-			assertThat(e.getCause().getMessage()).isEqualTo("The provided Destination Directory expression " +
-					"(headers['subDirectory']) must not evaluate to null.");
-
-			return;
-		}
-
-		fail("Was expecting a MessageHandlingException to be thrown");
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> this.inputChannelSaveToSubDirWithFile.send(messageWithFileHeader))
+				.withStackTraceContaining("The provided Destination Directory expression " +
+						"(headers['subDirectory']) must not evaluate to null.");
 	}
 
 	@Test
-	public void saveToSubWithFileExpressionUnsupportedObjectType() throws Exception {
-
-		final Integer unsupportedObject = Integer.valueOf(1234);
+	void saveToSubWithFileExpressionUnsupportedObjectType() {
+		final Integer unsupportedObject = 1234;
 		final Message<File> messageWithFileHeader = MessageBuilder.fromMessage(message)
 				.setHeader("subDirectory", unsupportedObject)
 				.build();
 
-		try {
-			this.inputChannelSaveToSubDirWithFile.send(messageWithFileHeader);
-		}
-		catch (MessageHandlingException e) {
-			assertThat(e.getCause().getMessage()).isEqualTo("The provided Destination Directory expression" +
-					" (headers['subDirectory']) must evaluate to type " +
-					"java.io.File or String, not java.lang.Integer.");
-
-			return;
-		}
-
-		fail("Was expecting a MessageHandlingException to be thrown");
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> this.inputChannelSaveToSubDirWithFile.send(messageWithFileHeader))
+				.withStackTraceContaining("The provided Destination Directory expression" +
+						" (headers['subDirectory']) must evaluate to type " +
+						"java.io.File, String or org.springframework.core.io.Resource, not java.lang.Integer.");
 	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/dsl/FileTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/dsl/FileTests.java
@@ -333,7 +333,7 @@ public class FileTests {
 		@Bean
 		public IntegrationFlow fileFlow1() {
 			return IntegrationFlows.from("fileFlow1Input")
-					.handle(Files.outboundAdapter(tmpDir.getRoot())
+					.handle(Files.outboundAdapter("'file://" + tmpDir.getRoot().getAbsolutePath() + '\'')
 									.fileNameGenerator(message -> null)
 									.fileExistsMode(FileExistsMode.APPEND_NO_FLUSH)
 									.flushInterval(60000)

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -688,7 +688,8 @@ If you want to have full SpEL support, you can use the `directory-expression` at
 This attribute accepts a SpEL expression that is evaluated for each message being processed.
 Thus, you have full access to a message's payload and its headers when you dynamically specify the output file directory.
 
-The SpEL expression must resolve to either a `String` or to `java.io.File`.
+The SpEL expression must resolve to either a `String`, `java.io.File` or `org.springframework.core.io.Resource`.
+(The later is evaluated into )
 Furthermore, the resulting `String` or `File` must point to a directory.
 If you do not specify the `directory-expression` attribute, then you must set the `directory` attribute.
 

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -689,7 +689,7 @@ This attribute accepts a SpEL expression that is evaluated for each message bein
 Thus, you have full access to a message's payload and its headers when you dynamically specify the output file directory.
 
 The SpEL expression must resolve to either a `String`, `java.io.File` or `org.springframework.core.io.Resource`.
-(The later is evaluated into )
+(The later is evaluated into a `File` anyway.)
 Furthermore, the resulting `String` or `File` must point to a directory.
 If you do not specify the `directory-expression` attribute, then you must set the `directory` attribute.
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3494

The expression for local directory can be resolved into a `Resource`
or resource location.
* Fix `ExpressionUtils.expressionToFile()` to support `Resource` and
also use `ResourceUtils.getFile(path)` when expression result is a string
* Modify tests to ensure that resource is resolved properly
* Upgrade affected tests to JUnit 5
* Mention an new functionality in docs

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
