### PR TITLE
Introduce RSocketInteractionModel

### DIFF
--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/IntegrationRSocketEndpoint.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/IntegrationRSocketEndpoint.java
@@ -39,4 +39,15 @@ public interface IntegrationRSocketEndpoint extends ReactiveMessageHandler {
 	 */
 	String[] getPath();
 
+	/**
+	 * Obtain {@link RSocketInteractionModel}s
+	 * this {@link ReactiveMessageHandler} is going to be mapped onto.
+	 * Defaults to all the {@link RSocketInteractionModel}s.
+	 * @return the interaction models for mapping.
+	 * @since 5.2.2
+	 */
+	default RSocketInteractionModel[] getInteractionModels() {
+		return RSocketInteractionModel.values();
+	}
+
 }

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/IntegrationRSocketMessageHandler.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/IntegrationRSocketMessageHandler.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.rsocket;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -79,13 +80,19 @@ class IntegrationRSocketMessageHandler extends RSocketMessageHandler {
 	}
 
 	public void addEndpoint(IntegrationRSocketEndpoint endpoint) {
+		RSocketFrameTypeMessageCondition frameTypeMessageCondition = RSocketFrameTypeMessageCondition.EMPTY_CONDITION;
+
+		RSocketInteractionModel[] interactionModels = endpoint.getInteractionModels();
+		if (interactionModels.length > 0) {
+			frameTypeMessageCondition =
+					new RSocketFrameTypeMessageCondition(
+							Arrays.stream(interactionModels)
+									.map(RSocketInteractionModel::getFrameType)
+									.toArray(FrameType[]::new));
+		}
 		registerHandlerMethod(endpoint, HANDLE_MESSAGE_METHOD,
 				new CompositeMessageCondition(
-						new RSocketFrameTypeMessageCondition(
-								FrameType.REQUEST_FNF,
-								FrameType.REQUEST_RESPONSE,
-								FrameType.REQUEST_STREAM,
-								FrameType.REQUEST_CHANNEL),
+						frameTypeMessageCondition,
 						new DestinationPatternsMessageCondition(endpoint.getPath(), getRouteMatcher()))); // NOSONAR
 	}
 

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/RSocketInteractionModel.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/RSocketInteractionModel.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.rsocket;
+
+import io.rsocket.frame.FrameType;
+
+/**
+ * The RSocket protocol interaction models.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.2.2
+ *
+ * @see <a href="https://rsocket.io/">RSocket protocol official site</a>
+ * @see FrameType
+ */
+public enum RSocketInteractionModel {
+
+	/**
+	 * The model for {@link io.rsocket.RSocket#fireAndForget} operation.
+	 */
+	fireAndForget(FrameType.REQUEST_FNF),
+
+	/**
+	 * The model for {@link io.rsocket.RSocket#requestResponse} operation.
+	 */
+	requestResponse(FrameType.REQUEST_RESPONSE),
+
+	/**
+	 * The model for {@link io.rsocket.RSocket#requestStream} operation.
+	 */
+	requestStream(FrameType.REQUEST_STREAM),
+
+	/**
+	 * The model for {@link io.rsocket.RSocket#requestChannel} operation.
+	 */
+	requestChannel(FrameType.REQUEST_CHANNEL);
+
+	private final FrameType frameType;
+
+	RSocketInteractionModel(FrameType frameType) {
+		this.frameType = frameType;
+	}
+
+	public FrameType getFrameType() {
+		return this.frameType;
+	}
+
+}

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/config/RSocketInboundGatewayParser.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/config/RSocketInboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,13 +29,15 @@ import org.springframework.integration.rsocket.inbound.RSocketInboundGateway;
 /**
  * Parser for the &lt;inbound-gateway/&gt; element of the 'rsocket' namespace.
  *
- * @author Mark Fisher
- * @author Gary Russell
+ * @author Artem Bilan
+ *
+ * @since 5.2
  */
 public class RSocketInboundGatewayParser extends AbstractInboundGatewayParser {
 
 	private static final List<String> NON_ELIGIBLE_ATTRIBUTES =
 			Arrays.asList("path",
+					"interaction-models",
 					"rsocket-strategies",
 					"rsocket-connector",
 					"request-element-type");
@@ -59,6 +61,7 @@ public class RSocketInboundGatewayParser extends AbstractInboundGatewayParser {
 				"rSocketStrategies");
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "rsocket-connector",
 				"RSocketConnector");
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "interaction-models");
 	}
 
 }

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/config/RSocketOutboundGatewayParser.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/config/RSocketOutboundGatewayParser.java
@@ -49,6 +49,7 @@ public class RSocketOutboundGatewayParser extends AbstractConsumerEndpointParser
 		builder.addConstructorArgValue(routeExpression);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "client-rsocket-connector",
 				"clientRSocketConnector");
+		populateValueOrExpressionIfAny(builder, element, parserContext, "interaction-model");
 		populateValueOrExpressionIfAny(builder, element, parserContext, "command");
 		populateValueOrExpressionIfAny(builder, element, parserContext, "publisher-element-type");
 		populateValueOrExpressionIfAny(builder, element, parserContext, "expected-response-type");

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/dsl/RSocketInboundGatewaySpec.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/dsl/RSocketInboundGatewaySpec.java
@@ -19,6 +19,7 @@ package org.springframework.integration.rsocket.dsl;
 import org.springframework.core.ResolvableType;
 import org.springframework.integration.dsl.MessagingGatewaySpec;
 import org.springframework.integration.rsocket.AbstractRSocketConnector;
+import org.springframework.integration.rsocket.RSocketInteractionModel;
 import org.springframework.integration.rsocket.inbound.RSocketInboundGateway;
 import org.springframework.messaging.rsocket.RSocketStrategies;
 
@@ -33,6 +34,18 @@ public class RSocketInboundGatewaySpec extends MessagingGatewaySpec<RSocketInbou
 
 	RSocketInboundGatewaySpec(String... path) {
 		super(new RSocketInboundGateway(path));
+	}
+
+	/**
+	 * Configure a set of {@link RSocketInteractionModel} the endpoint is going to be mapped onto.
+	 * @param interactionModels the {@link RSocketInteractionModel}s for mapping.
+	 * @return the spec.
+	 * @since 5.2.2
+	 * @see RSocketInboundGateway#setInteractionModels(RSocketInteractionModel...)
+	 */
+	public RSocketInboundGatewaySpec interactionModels(RSocketInteractionModel... interactionModels) {
+		this.target.setInteractionModels(interactionModels);
+		return this;
 	}
 
 	/**

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/dsl/RSocketInboundGatewaySpec.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/dsl/RSocketInboundGatewaySpec.java
@@ -49,7 +49,7 @@ public class RSocketInboundGatewaySpec extends MessagingGatewaySpec<RSocketInbou
 	}
 
 	/**
-	 * Configure {@link RSocketStrategies} instead of a default one.
+	 * Configure an {@link RSocketStrategies} instead of a default one.
 	 * @param rsocketStrategies the {@link RSocketStrategies} to use.
 	 * @return the spec
 	 * @see RSocketInboundGateway#setRSocketStrategies(RSocketStrategies)
@@ -71,7 +71,7 @@ public class RSocketInboundGatewaySpec extends MessagingGatewaySpec<RSocketInbou
 	}
 
 	/**
-	 * Specify the type of payload to be generated when the inbound RSocket request
+	 * Specify a type of payload to be generated when the inbound RSocket request
 	 * content is read by the converters/encoders.
 	 * @param requestElementType The payload type.
 	 * @return the spec

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/dsl/RSocketOutboundGatewaySpec.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/dsl/RSocketOutboundGatewaySpec.java
@@ -24,6 +24,7 @@ import org.springframework.integration.dsl.MessageHandlerSpec;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.rsocket.ClientRSocketConnector;
+import org.springframework.integration.rsocket.RSocketInteractionModel;
 import org.springframework.integration.rsocket.outbound.RSocketOutboundGateway;
 import org.springframework.messaging.Message;
 import org.springframework.util.MimeType;
@@ -62,9 +63,22 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	 * @param command the {@link RSocketOutboundGateway.Command} to use.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setCommand(RSocketOutboundGateway.Command)
+	 * @deprecated in favor of {@link #interactionModel(RSocketInteractionModel)}
 	 */
+	@Deprecated
 	public RSocketOutboundGatewaySpec command(RSocketOutboundGateway.Command command) {
-		return command(new ValueExpression<>(command));
+		return interactionModel(new ValueExpression<>(command));
+	}
+
+	/**
+	 * Configure a {@link RSocketInteractionModel} for RSocket request type.
+	 * @param interactionModel the {@link RSocketInteractionModel} to use.
+	 * @return the spec
+	 * @see RSocketOutboundGateway#setInteractionModel(RSocketInteractionModel)
+	 * @since 5.2.2
+	 */
+	public RSocketOutboundGatewaySpec interactionModel(RSocketInteractionModel interactionModel) {
+		return interactionModel(new ValueExpression<>(interactionModel));
 	}
 
 	/**
@@ -73,10 +87,25 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	 * @param commandFunction the {@code Function} to use.
 	 * @param <P> the expected request message payload type.
 	 * @return the spec
-	 * @see RSocketOutboundGateway#setCommandExpression(Expression)
+	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
+	 * @deprecated in favor of {@link #interactionModel(Function)}
 	 */
+	@Deprecated
 	public <P> RSocketOutboundGatewaySpec command(Function<Message<P>, ?> commandFunction) {
-		return command(new FunctionExpression<>(commandFunction));
+		return interactionModel(commandFunction);
+	}
+
+	/**
+	 * Configure a {@code Function} to evaluate a {@link RSocketInteractionModel}
+	 * for RSocket request type at runtime against a request message.
+	 * @param interactionModelFunction the {@code Function} to use.
+	 * @param <P> the expected request message payload type.
+	 * @return the spec
+	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
+	 * @since 5.2.2
+	 */
+	public <P> RSocketOutboundGatewaySpec interactionModel(Function<Message<P>, ?> interactionModelFunction) {
+		return interactionModel(new FunctionExpression<>(interactionModelFunction));
 	}
 
 	/**
@@ -84,10 +113,24 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	 * for RSocket request type at runtime against a request message.
 	 * @param commandExpression the SpEL expression to use.
 	 * @return the spec
-	 * @see RSocketOutboundGateway#setCommandExpression(Expression)
+	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
+	 * @deprecated in favor of {@link #interactionModel(String)}
 	 */
+	@Deprecated
 	public RSocketOutboundGatewaySpec command(String commandExpression) {
-		return command(PARSER.parseExpression(commandExpression));
+		return interactionModel(commandExpression);
+	}
+
+	/**
+	 * Configure a SpEL expression to evaluate a {@link RSocketInteractionModel}
+	 * for RSocket request type at runtime against a request message.
+	 * @param interactionModelExpression the SpEL expression to use.
+	 * @return the spec
+	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
+	 * @since 5.2.2
+	 */
+	public RSocketOutboundGatewaySpec interactionModel(String interactionModelExpression) {
+		return interactionModel(PARSER.parseExpression(interactionModelExpression));
 	}
 
 	/**
@@ -95,10 +138,24 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	 * for RSocket request type at runtime against a request message.
 	 * @param commandExpression the SpEL expression to use.
 	 * @return the spec
-	 * @see RSocketOutboundGateway#setCommandExpression(Expression)
+	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
+	 * @deprecated in favor of {@link #interactionModel(Expression)}
 	 */
+	@Deprecated
 	public RSocketOutboundGatewaySpec command(Expression commandExpression) {
-		this.target.setCommandExpression(commandExpression);
+		return interactionModel(commandExpression);
+	}
+
+	/**
+	 * Configure a SpEL expression to evaluate a {@link RSocketInteractionModel}
+	 * for RSocket request type at runtime against a request message.
+	 * @param interactionModelExpression the SpEL expression to use.
+	 * @return the spec
+	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
+	 * @since 5.2.2
+	 */
+	public RSocketOutboundGatewaySpec interactionModel(Expression interactionModelExpression) {
+		this.target.setInteractionModelExpression(interactionModelExpression);
 		return this;
 	}
 

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/dsl/RSocketOutboundGatewaySpec.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/dsl/RSocketOutboundGatewaySpec.java
@@ -59,7 +59,7 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Configure a {@link RSocketOutboundGateway.Command} for RSocket request type.
+	 * Configure an {@link RSocketOutboundGateway.Command} for the RSocket request type.
 	 * @param command the {@link RSocketOutboundGateway.Command} to use.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setCommand(RSocketOutboundGateway.Command)
@@ -71,7 +71,7 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Configure a {@link RSocketInteractionModel} for RSocket request type.
+	 * Configure an {@link RSocketInteractionModel} for the RSocket request type.
 	 * @param interactionModel the {@link RSocketInteractionModel} to use.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setInteractionModel(RSocketInteractionModel)
@@ -82,8 +82,8 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Configure a {@code Function} to evaluate a {@link RSocketOutboundGateway.Command}
-	 * for RSocket request type at runtime against a request message.
+	 * Configure a {@link Function} to evaluate an {@link RSocketOutboundGateway.Command}
+	 * for the RSocket request type at runtime against a request message.
 	 * @param commandFunction the {@code Function} to use.
 	 * @param <P> the expected request message payload type.
 	 * @return the spec
@@ -96,8 +96,8 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Configure a {@code Function} to evaluate a {@link RSocketInteractionModel}
-	 * for RSocket request type at runtime against a request message.
+	 * Configure a {@link Function} to evaluate an {@link RSocketInteractionModel}
+	 * for the RSocket request type at runtime against a request message.
 	 * @param interactionModelFunction the {@code Function} to use.
 	 * @param <P> the expected request message payload type.
 	 * @return the spec
@@ -109,8 +109,8 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Configure a SpEL expression to evaluate a {@link RSocketOutboundGateway.Command}
-	 * for RSocket request type at runtime against a request message.
+	 * Configure a SpEL expression to evaluate an {@link RSocketOutboundGateway.Command}
+	 * for the RSocket request type at runtime against a request message.
 	 * @param commandExpression the SpEL expression to use.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
@@ -122,8 +122,8 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Configure a SpEL expression to evaluate a {@link RSocketInteractionModel}
-	 * for RSocket request type at runtime against a request message.
+	 * Configure a SpEL expression to evaluate an {@link RSocketInteractionModel}
+	 * for the RSocket request type at runtime against a request message.
 	 * @param interactionModelExpression the SpEL expression to use.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
@@ -134,8 +134,8 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Configure a SpEL expression to evaluate a {@link RSocketOutboundGateway.Command}
-	 * for RSocket request type at runtime against a request message.
+	 * Configure a SpEL expression to evaluate an {@link RSocketOutboundGateway.Command}
+	 * for the RSocket request type at runtime against a request message.
 	 * @param commandExpression the SpEL expression to use.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
@@ -147,8 +147,8 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Configure a SpEL expression to evaluate a {@link RSocketInteractionModel}
-	 * for RSocket request type at runtime against a request message.
+	 * Configure a SpEL expression to evaluate an {@link RSocketInteractionModel}
+	 * for the RSocket request type at runtime against a request message.
 	 * @param interactionModelExpression the SpEL expression to use.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setInteractionModelExpression(Expression)
@@ -170,7 +170,7 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Configure a {@code Function} to evaluate a request {@link org.reactivestreams.Publisher}
+	 * Configure a {@link Function} to evaluate a request {@link org.reactivestreams.Publisher}
 	 * elements type at runtime against a request message.
 	 * @param publisherElementTypeFunction the {@code Function} to evaluate a type for the request
 	 * {@link org.reactivestreams.Publisher} elements.
@@ -218,7 +218,7 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Specify the {@code Function} to determine the type for the RSocket response.
+	 * Specify the {@link Function} to determine the type for the RSocket response.
 	 * @param expectedResponseTypeFunction The expected response type {@code Function}.
 	 * @param <P> the expected request message payload type.
 	 * @return the spec
@@ -239,7 +239,7 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 * Specify the {@link Expression} to determine the type for the RSocket response.
+	 * Specify an {@link Expression} to determine the type for the RSocket response.
 	 * @param expectedResponseTypeExpression The expected response type expression.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setExpectedResponseTypeExpression(Expression)
@@ -262,8 +262,8 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 	}
 
 	/**
-	 Configure a SpEL expression to evaluate a metadata as a {@code Map<Object, MimeType>}
-	 * for RSocket request against request message.
+	 * Configure a SpEL expression to evaluate a metadata as a {@code Map<Object, MimeType>}
+	 * for the RSocket request against request message.
 	 * @param metadataExpression the SpEL expression to use.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setMetadataExpression(Expression)
@@ -274,8 +274,7 @@ public class RSocketOutboundGatewaySpec extends MessageHandlerSpec<RSocketOutbou
 
 	/**
 	 * Configure a SpEL expression to evaluate a metadata as a {@code Map<Object, MimeType>}
-	 * for RSocket request against request message.
-	 * for RSocket request type at runtime against a request message.
+	 * for the RSocket request type at runtime against a request message.
 	 * @param metadataExpression the SpEL expression to use.
 	 * @return the spec
 	 * @see RSocketOutboundGateway#setMetadataExpression(Expression)

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/inbound/RSocketInboundGateway.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/inbound/RSocketInboundGateway.java
@@ -30,6 +30,7 @@ import org.springframework.integration.gateway.MessagingGatewaySupport;
 import org.springframework.integration.rsocket.AbstractRSocketConnector;
 import org.springframework.integration.rsocket.ClientRSocketConnector;
 import org.springframework.integration.rsocket.IntegrationRSocketEndpoint;
+import org.springframework.integration.rsocket.RSocketInteractionModel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
@@ -74,6 +75,8 @@ public class RSocketInboundGateway extends MessagingGatewaySupport implements In
 
 	private final String[] path;
 
+	private RSocketInteractionModel[] interactionModels = RSocketInteractionModel.values();
+
 	private RSocketStrategies rsocketStrategies = RSocketStrategies.create();
 
 	@Nullable
@@ -110,6 +113,21 @@ public class RSocketInboundGateway extends MessagingGatewaySupport implements In
 	public void setRSocketConnector(AbstractRSocketConnector rsocketConnector) {
 		Assert.notNull(rsocketConnector, "'rsocketConnector' must not be null");
 		this.rsocketConnector = rsocketConnector;
+	}
+
+	/**
+	 * Configure a set of {@link RSocketInteractionModel} this endpoint is mapped onto.
+	 * @param interactionModelsArg the {@link RSocketInteractionModel}s for mapping.
+	 * @since 5.2.2
+	 */
+	public void setInteractionModels(RSocketInteractionModel... interactionModelsArg) {
+		Assert.notNull(interactionModelsArg, "'interactionModelsArg' must not be null");
+		this.interactionModels = Arrays.copyOf(interactionModelsArg, interactionModelsArg.length);
+	}
+
+	@Override
+	public RSocketInteractionModel[] getInteractionModels() {
+		return Arrays.copyOf(this.interactionModels, this.interactionModels.length);
 	}
 
 	/**

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/inbound/RSocketInboundGateway.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/inbound/RSocketInboundGateway.java
@@ -95,7 +95,7 @@ public class RSocketInboundGateway extends MessagingGatewaySupport implements In
 	}
 
 	/**
-	 * Configure {@link RSocketStrategies} instead of a default one.
+	 * Configure an {@link RSocketStrategies} instead of a default one.
 	 * Note: if {@link AbstractRSocketConnector} is provided, then its
 	 * {@link RSocketStrategies} have a precedence.
 	 * @param rsocketStrategies the {@link RSocketStrategies} to use.
@@ -139,7 +139,7 @@ public class RSocketInboundGateway extends MessagingGatewaySupport implements In
 	}
 
 	/**
-	 * Specify the type of payload to be generated when the inbound RSocket request
+	 * Specify a type of payload to be generated when the inbound RSocket request
 	 * content is read by the encoders.
 	 * By default this value is null which means at runtime any "text" Content-Type will
 	 * result in String while all others default to {@code byte[].class}.

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGateway.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGateway.java
@@ -131,7 +131,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	/**
-	 * Configure a {@link Command} for RSocket request type.
+	 * Configure a {@link Command} for the RSocket request type.
 	 * @param command the {@link Command} to use.
 	 * @deprecated in favor of {@link #setInteractionModel(RSocketInteractionModel)}
 	 */
@@ -141,7 +141,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	/**
-	 * Configure a {@link RSocketInteractionModel} for RSocket request type.
+	 * Configure an {@link RSocketInteractionModel} for the RSocket request type.
 	 * @param interactionModel the {@link RSocketInteractionModel} to use.
 	 * @since 5.2.2
 	 */
@@ -150,7 +150,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	/**
-	 * Configure a SpEL expression to evaluate a {@link Command} for RSocket request type at runtime
+	 * Configure a SpEL expression to evaluate a {@link Command} for the RSocket request type at runtime
 	 * against a request message.
 	 * @param commandExpression the SpEL expression to use.
 	 * @deprecated in favor of {@link #setInteractionModelExpression(Expression)}
@@ -162,7 +162,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 
 	/**
 	 * Configure a SpEL expression to evaluate an {@link RSocketInteractionModel}
-	 * for RSocket request type at runtime against a request message.
+	 * for the RSocket request type at runtime against a request message.
 	 * @param interactionModelExpression the SpEL expression to use.
 	 * @since 5.2.2
 	 */
@@ -194,7 +194,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	/**
-	 * Specify the expected response type for the RSocket response.
+	 * Specify an response type for the RSocket response.
 	 * @param expectedResponseType The expected type.
 	 * @see #setExpectedResponseTypeExpression(Expression)
 	 * @see RSocketRequester.RequestSpec#retrieveMono
@@ -205,7 +205,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	/**
-	 * Specify the {@link Expression} to determine the type for the RSocket response.
+	 * Specify an {@link Expression} to determine the type for the RSocket response.
 	 * @param expectedResponseTypeExpression The expected response type expression.
 	 * @see RSocketRequester.RequestSpec#retrieveMono
 	 * @see RSocketRequester.RequestSpec#retrieveFlux
@@ -215,8 +215,8 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	/**
-	 * Specify a SpEL expression to evaluate a metadata for RSocket request
-	 * as {@code Map<Object, MimeType>} against request message.
+	 * Specify a SpEL expression to evaluate a metadata for the RSocket request
+	 * as {@code Map<Object, MimeType>} against a request message.
 	 * @param metadataExpression the expression for metadata.
 	 */
 	public void setMetadataExpression(Expression metadataExpression) {

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGateway.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGateway.java
@@ -251,7 +251,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 		return requesterMono
 				.map((rSocketRequester) -> createRequestSpec(rSocketRequester, requestMessage))
 				.map((requestSpec) -> prepareRetrieveSpec(requestSpec, requestMessage))
-				.flatMap((responseSpec) -> performRequest(responseSpec, requestMessage));
+				.flatMap((retrieveSpec) -> performRetrieve(retrieveSpec, requestMessage));
 	}
 
 	@SuppressWarnings("unchecked")
@@ -298,7 +298,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 		}
 	}
 
-	private Mono<?> performRequest(RSocketRequester.RetrieveSpec requestSpec, Message<?> requestMessage) {
+	private Mono<?> performRetrieve(RSocketRequester.RetrieveSpec retrieveSpec, Message<?> requestMessage) {
 		RSocketInteractionModel interactionModel = evaluateInteractionModel(requestMessage);
 		Assert.notNull(interactionModel,
 				() -> "The 'interactionModelExpression' [" + this.interactionModelExpression + "] must not evaluate to null");
@@ -311,21 +311,21 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 
 		switch (interactionModel) {
 			case fireAndForget:
-				return requestSpec.send();
+				return retrieveSpec.send();
 			case requestResponse:
 				if (expectedResponseType instanceof Class<?>) {
-					return requestSpec.retrieveMono((Class<?>) expectedResponseType);
+					return retrieveSpec.retrieveMono((Class<?>) expectedResponseType);
 				}
 				else {
-					return requestSpec.retrieveMono((ParameterizedTypeReference<?>) expectedResponseType);
+					return retrieveSpec.retrieveMono((ParameterizedTypeReference<?>) expectedResponseType);
 				}
 			case requestStream:
 			case requestChannel:
 				if (expectedResponseType instanceof Class<?>) {
-					return Mono.just(requestSpec.retrieveFlux((Class<?>) expectedResponseType));
+					return Mono.just(retrieveSpec.retrieveFlux((Class<?>) expectedResponseType));
 				}
 				else {
-					return Mono.just(requestSpec.retrieveFlux((ParameterizedTypeReference<?>) expectedResponseType));
+					return Mono.just(retrieveSpec.retrieveFlux((ParameterizedTypeReference<?>) expectedResponseType));
 				}
 			default:
 				throw new UnsupportedOperationException("Unsupported interaction model: " + interactionModel);

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGateway.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGateway.java
@@ -28,6 +28,7 @@ import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.rsocket.ClientRSocketConnector;
+import org.springframework.integration.rsocket.RSocketInteractionModel;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.rsocket.RSocketRequester;
@@ -46,9 +47,9 @@ import reactor.core.publisher.Mono;
  * {@link RSocketRequesterMethodArgumentResolver#RSOCKET_REQUESTER_HEADER} request message header
  * on the server side.
  * <p>
- * An RSocket operation is determined by the configured {@link Command} or respective SpEL
+ * An RSocket operation is determined by the configured {@link RSocketInteractionModel} or respective SpEL
  * expression to be evaluated at runtime against the request message.
- * By default the {@link Command#requestResponse} operation is used.
+ * By default the {@link RSocketInteractionModel#requestResponse} operation is used.
  * <p>
  * For a {@link Publisher}-based requests, it must be present in the request message {@code payload}.
  * The flattening via upstream {@link org.springframework.integration.channel.FluxMessageChannel} will work, too,
@@ -65,7 +66,7 @@ import reactor.core.publisher.Mono;
  *
  * @since 5.2
  *
- * @see Command
+ * @see RSocketInteractionModel
  * @see RSocketRequester
  */
 public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler {
@@ -77,7 +78,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	@Nullable
 	private ClientRSocketConnector clientRSocketConnector;
 
-	private Expression commandExpression = new ValueExpression<>(Command.requestResponse);
+	private Expression interactionModelExpression = new ValueExpression<>(RSocketInteractionModel.requestResponse);
 
 	private Expression publisherElementTypeExpression;
 
@@ -132,20 +133,44 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	/**
 	 * Configure a {@link Command} for RSocket request type.
 	 * @param command the {@link Command} to use.
+	 * @deprecated in favor of {@link #setInteractionModel(RSocketInteractionModel)}
 	 */
+	@Deprecated
 	public void setCommand(Command command) {
-		setCommandExpression(new ValueExpression<>(command));
+		setInteractionModelExpression(new ValueExpression<>(command.interactionModel));
+	}
+
+	/**
+	 * Configure a {@link RSocketInteractionModel} for RSocket request type.
+	 * @param interactionModel the {@link RSocketInteractionModel} to use.
+	 * @since 5.2.2
+	 */
+	public void setInteractionModel(RSocketInteractionModel interactionModel) {
+		setInteractionModelExpression(new ValueExpression<>(interactionModel));
 	}
 
 	/**
 	 * Configure a SpEL expression to evaluate a {@link Command} for RSocket request type at runtime
 	 * against a request message.
 	 * @param commandExpression the SpEL expression to use.
+	 * @deprecated in favor of {@link #setInteractionModelExpression(Expression)}
 	 */
+	@Deprecated
 	public void setCommandExpression(Expression commandExpression) {
-		Assert.notNull(commandExpression, "'commandExpression' must not be null");
-		this.commandExpression = commandExpression;
+		setInteractionModelExpression(commandExpression);
 	}
+
+	/**
+	 * Configure a SpEL expression to evaluate an {@link RSocketInteractionModel}
+	 * for RSocket request type at runtime against a request message.
+	 * @param interactionModelExpression the SpEL expression to use.
+	 * @since 5.2.2
+	 */
+	public void setInteractionModelExpression(Expression interactionModelExpression) {
+		Assert.notNull(interactionModelExpression, "'interactionModelExpression' must not be null");
+		this.interactionModelExpression = interactionModelExpression;
+	}
+
 
 	/**
 	 * Configure a type for a request {@link Publisher} elements.
@@ -274,17 +299,17 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	private Mono<?> performRequest(RSocketRequester.RetrieveSpec requestSpec, Message<?> requestMessage) {
-		Command command = this.commandExpression.getValue(this.evaluationContext, requestMessage, Command.class);
-		Assert.notNull(command,
-				() -> "The 'command' [" + this.commandExpression + "] must not evaluate to null");
+		RSocketInteractionModel interactionModel = evaluateInteractionModel(requestMessage);
+		Assert.notNull(interactionModel,
+				() -> "The 'interactionModelExpression' [" + this.interactionModelExpression + "] must not evaluate to null");
 
 		Object expectedResponseType = null;
-		if (!Command.fireAndForget.equals(command)) {
+		if (!RSocketInteractionModel.fireAndForget.equals(interactionModel)) {
 			expectedResponseType = evaluateExpressionForType(requestMessage, this.expectedResponseTypeExpression,
 					"expectedResponseType");
 		}
 
-		switch (command) {
+		switch (interactionModel) {
 			case fireAndForget:
 				return requestSpec.send();
 			case requestResponse:
@@ -294,7 +319,8 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 				else {
 					return requestSpec.retrieveMono((ParameterizedTypeReference<?>) expectedResponseType);
 				}
-			case requestStreamOrChannel:
+			case requestStream:
+			case requestChannel:
 				if (expectedResponseType instanceof Class<?>) {
 					return Mono.just(requestSpec.retrieveFlux((Class<?>) expectedResponseType));
 				}
@@ -302,7 +328,25 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 					return Mono.just(requestSpec.retrieveFlux((ParameterizedTypeReference<?>) expectedResponseType));
 				}
 			default:
-				throw new UnsupportedOperationException("Unsupported command: " + command);
+				throw new UnsupportedOperationException("Unsupported interaction model: " + interactionModel);
+		}
+	}
+
+	private RSocketInteractionModel evaluateInteractionModel(Message<?> requestMessage) {
+		Object value = this.interactionModelExpression.getValue(this.evaluationContext, requestMessage);
+		if (value instanceof RSocketInteractionModel) {
+			return (RSocketInteractionModel) value;
+		}
+		else if (value instanceof Command) {
+			return ((Command) value).interactionModel;
+		}
+		else if (value instanceof String) {
+			return RSocketInteractionModel.valueOf((String) value);
+		}
+		else {
+			throw new IllegalStateException("The 'interactionModelExpression' [" +
+					this.interactionModelExpression +
+					"] must evaluate to 'RSocketInteractionModel' or 'String' type, but not into: '" + value + "'");
 		}
 	}
 
@@ -330,20 +374,22 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 
 	/**
 	 * Enumeration of commands supported by the gateways.
+	 * @deprecated in favor of {@link RSocketInteractionModel}
 	 */
+	@Deprecated
 	public enum Command {
 
 		/**
 		 * Perform {@link io.rsocket.RSocket#fireAndForget fireAndForget}.
 		 * @see RSocketRequester.RequestSpec#send()
 		 */
-		fireAndForget,
+		fireAndForget(RSocketInteractionModel.fireAndForget),
 
 		/**
 		 * Perform {@link io.rsocket.RSocket#requestResponse requestResponse}.
 		 * @see RSocketRequester.RequestSpec#retrieveMono
 		 */
-		requestResponse,
+		requestResponse(RSocketInteractionModel.requestResponse),
 
 		/**
 		 * Perform {@link io.rsocket.RSocket#requestStream requestStream} or
@@ -351,7 +397,13 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 		 * the request input consists of a single or multiple payloads.
 		 * @see RSocketRequester.RequestSpec#retrieveFlux
 		 */
-		requestStreamOrChannel
+		requestStreamOrChannel(RSocketInteractionModel.requestStream);
+
+		private final RSocketInteractionModel interactionModel;
+
+		Command(RSocketInteractionModel interactionModel) {
+			this.interactionModel = interactionModel;
+		}
 
 	}
 

--- a/spring-integration-rsocket/src/main/resources/org/springframework/integration/rsocket/config/spring-integration-rsocket-5.2.xsd
+++ b/spring-integration-rsocket/src/main/resources/org/springframework/integration/rsocket/config/spring-integration-rsocket-5.2.xsd
@@ -145,7 +145,7 @@
 						<xsd:annotation>
 							<xsd:documentation>
 								[DEPRECATED in favor of 'interaction-model']
-								A 'Command' for RSocket request type.
+								A 'Command' for the RSocket request type.
 								Mutually exclusive with 'command-expression'.
 							</xsd:documentation>
 						</xsd:annotation>
@@ -156,7 +156,7 @@
 					<xsd:attribute name="interaction-model" default="requestResponse">
 						<xsd:annotation>
 							<xsd:documentation>
-								An 'RSocketInteractionModel' for RSocket request type.
+								An 'RSocketInteractionModel' for the RSocket request type.
 								Mutually exclusive with 'interaction-model-expression'.
 							</xsd:documentation>
 						</xsd:annotation>
@@ -168,7 +168,7 @@
 						<xsd:annotation>
 							<xsd:documentation>
 								[DEPRECATED in favor of 'interaction-model-expression']
-								A SpEL expression to evaluate a 'command' for RSocket request type at runtime
+								A SpEL expression to evaluate a 'command' for the RSocket request type at runtime
 								against request message.
 								Mutually exclusive with 'command'.
 							</xsd:documentation>
@@ -178,7 +178,7 @@
 						<xsd:annotation>
 							<xsd:documentation>
 								A SpEL expression to evaluate an 'RSocketInteractionModel'
-								for RSocket request type at runtime against request message.
+								for the RSocket request type at runtime against request message.
 								Mutually exclusive with 'interaction-model'.
 							</xsd:documentation>
 						</xsd:annotation>

--- a/spring-integration-rsocket/src/main/resources/org/springframework/integration/rsocket/config/spring-integration-rsocket-5.2.xsd
+++ b/spring-integration-rsocket/src/main/resources/org/springframework/integration/rsocket/config/spring-integration-rsocket-5.2.xsd
@@ -36,6 +36,17 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
+					<xsd:attribute name="interaction-models">
+						<xsd:annotation>
+							<xsd:documentation>
+								Comma-separated interaction models.
+								Determines which types of RSocket frames are allowed with this Endpoint.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="interactionModelType xsd:string" />
+						</xsd:simpleType>
+					</xsd:attribute>
 					<xsd:attribute name="error-channel" type="xsd:string">
 						<xsd:annotation>
 							<xsd:appinfo>
@@ -130,9 +141,10 @@
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
-					<xsd:attribute name="command" default="requestResponse">
+					<xsd:attribute name="command">
 						<xsd:annotation>
 							<xsd:documentation>
+								[DEPRECATED in favor of 'interaction-model']
 								A 'Command' for RSocket request type.
 								Mutually exclusive with 'command-expression'.
 							</xsd:documentation>
@@ -141,12 +153,33 @@
 							<xsd:union memberTypes="commandType xsd:string"/>
 						</xsd:simpleType>
 					</xsd:attribute>
+					<xsd:attribute name="interaction-model" default="requestResponse">
+						<xsd:annotation>
+							<xsd:documentation>
+								An 'RSocketInteractionModel' for RSocket request type.
+								Mutually exclusive with 'interaction-model-expression'.
+							</xsd:documentation>
+						</xsd:annotation>
+						<xsd:simpleType>
+							<xsd:union memberTypes="interactionModelType xsd:string"/>
+						</xsd:simpleType>
+					</xsd:attribute>
 					<xsd:attribute name="command-expression" type="xsd:string">
 						<xsd:annotation>
 							<xsd:documentation>
+								[DEPRECATED in favor of 'interaction-model-expression']
 								A SpEL expression to evaluate a 'command' for RSocket request type at runtime
 								against request message.
 								Mutually exclusive with 'command'.
+							</xsd:documentation>
+						</xsd:annotation>
+					</xsd:attribute>
+					<xsd:attribute name="interaction-model-expression" type="xsd:string">
+						<xsd:annotation>
+							<xsd:documentation>
+								A SpEL expression to evaluate an 'RSocketInteractionModel'
+								for RSocket request type at runtime against request message.
+								Mutually exclusive with 'interaction-model'.
 							</xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
@@ -250,5 +283,13 @@
 		</xsd:restriction>
 	</xsd:simpleType>
 
+	<xsd:simpleType name="interactionModelType">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="fireAndForget"/>
+			<xsd:enumeration value="requestResponse"/>
+			<xsd:enumeration value="requestStream"/>
+			<xsd:enumeration value="requestChannel"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 </xsd:schema>

--- a/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketInboundGatewayParserTests-context.xml
+++ b/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketInboundGatewayParserTests-context.xml
@@ -20,6 +20,7 @@
 
 	<int-rsocket:inbound-gateway id="inboundGateway"
 								 path="testPath"
+								 interaction-models="fireAndForget,requestChannel"
 								 rsocket-connector="clientRSocketConnector"
 								 auto-startup="false"
 								 request-channel="requestChannel"

--- a/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketInboundGatewayParserTests.java
+++ b/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketInboundGatewayParserTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.rsocket.ClientRSocketConnector;
+import org.springframework.integration.rsocket.RSocketInteractionModel;
 import org.springframework.integration.rsocket.inbound.RSocketInboundGateway;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.annotation.DirtiesContext;
@@ -34,7 +35,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @SpringJUnitConfig
 @DirtiesContext
-public class RSocketInboundGatewayParserTests {
+class RSocketInboundGatewayParserTests {
 
 	@Autowired
 	private ClientRSocketConnector clientRSocketConnector;
@@ -48,10 +49,11 @@ public class RSocketInboundGatewayParserTests {
 				.isSameAs(this.clientRSocketConnector);
 		assertThat(TestUtils.getPropertyValue(this.inboundGateway, "rsocketStrategies"))
 				.isSameAs(this.clientRSocketConnector.getRSocketStrategies());
-		assertThat(TestUtils.getPropertyValue(this.inboundGateway, "path"))
-				.isEqualTo(new String[] { "testPath" });
+		assertThat(this.inboundGateway.getPath()).containsExactly("testPath");
 		assertThat(TestUtils.getPropertyValue(this.inboundGateway, "requestElementType.resolved"))
 				.isEqualTo(byte[].class);
+		assertThat(this.inboundGateway.getInteractionModels())
+				.containsExactly(RSocketInteractionModel.fireAndForget, RSocketInteractionModel.requestChannel);
 	}
 
 }

--- a/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketOutboundGatewayParserTests-context.xml
+++ b/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketOutboundGatewayParserTests-context.xml
@@ -17,7 +17,7 @@
 	<int-rsocket:outbound-gateway id="outboundGateway"
 								  client-rsocket-connector="clientRSocketConnector"
 								  auto-startup="false"
-								  command="fireAndForget"
+								  interaction-model="fireAndForget"
 								  route-expression="'testRoute'"
 								  request-channel="requestChannel"
 								  publisher-element-type="byte[]"

--- a/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketOutboundGatewayParserTests.java
+++ b/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketOutboundGatewayParserTests.java
@@ -50,7 +50,7 @@ class RSocketOutboundGatewayParserTests {
 	void testOutboundGatewayParser() {
 		assertThat(TestUtils.getPropertyValue(this.outboundGateway, "clientRSocketConnector"))
 				.isSameAs(this.clientRSocketConnector);
-		assertThat(TestUtils.getPropertyValue(this.outboundGateway, "commandExpression.literalValue"))
+		assertThat(TestUtils.getPropertyValue(this.outboundGateway, "interactionModelExpression.literalValue"))
 				.isEqualTo("fireAndForget");
 		assertThat(TestUtils.getPropertyValue(this.outboundGateway, "routeExpression.expression"))
 				.isEqualTo("'testRoute'");

--- a/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/dsl/RSocketDslTests.java
+++ b/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/dsl/RSocketDslTests.java
@@ -28,8 +28,8 @@ import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.rsocket.ClientRSocketConnector;
+import org.springframework.integration.rsocket.RSocketInteractionModel;
 import org.springframework.integration.rsocket.ServerRSocketConnector;
-import org.springframework.integration.rsocket.outbound.RSocketOutboundGateway;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -80,7 +80,7 @@ public class RSocketDslTests {
 			return IntegrationFlows
 					.from(Function.class)
 					.handle(RSockets.outboundGateway("/uppercase")
-							.command((message) -> RSocketOutboundGateway.Command.requestStreamOrChannel)
+							.interactionModel((message) -> RSocketInteractionModel.requestChannel)
 							.expectedResponseType("T(java.lang.String)")
 							.clientRSocketConnector(clientRSocketConnector))
 					.get();
@@ -89,7 +89,8 @@ public class RSocketDslTests {
 		@Bean
 		public IntegrationFlow rsocketUpperCaseFlow() {
 			return IntegrationFlows
-					.from(RSockets.inboundGateway("/uppercase"))
+					.from(RSockets.inboundGateway("/uppercase")
+							.interactionModels(RSocketInteractionModel.requestChannel))
 					.<Flux<String>, Flux<String>>transform((flux) -> flux.map(String::toUpperCase))
 					.get();
 		}

--- a/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGatewayIntegrationTests.java
+++ b/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGatewayIntegrationTests.java
@@ -38,6 +38,7 @@ import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.rsocket.ClientRSocketConnector;
+import org.springframework.integration.rsocket.RSocketInteractionModel;
 import org.springframework.integration.rsocket.ServerRSocketMessageHandler;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.lang.Nullable;
@@ -80,7 +81,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 
 	private static final String ROUTE_HEADER = "rsocket_route";
 
-	private static final String COMMAND_HEADER = "rsocket_command";
+	private static final String INTERACTION_MODEL_HEADER = "interaction_model";
 
 	private static AnnotationConfigApplicationContext serverContext;
 
@@ -154,7 +155,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload("Hello")
 						.setHeader(ROUTE_HEADER, "receive")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.fireAndForget)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.fireAndForget)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -192,7 +193,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload("Hello")
 						.setHeader(ROUTE_HEADER, "echo")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.requestResponse)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.requestResponse)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -224,7 +225,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload("Hello")
 						.setHeader(ROUTE_HEADER, "echo-async")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.requestResponse)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.requestResponse)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -258,7 +259,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload("Hello")
 						.setHeader(ROUTE_HEADER, "echo-stream")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.requestStreamOrChannel)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.requestStream)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -292,7 +293,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload(Flux.range(1, 10).map(i -> "Hello " + i))
 						.setHeader(ROUTE_HEADER, "echo-channel")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.requestStreamOrChannel)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.requestChannel)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -323,7 +324,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload("Hello")
 						.setHeader(ROUTE_HEADER, "void-return-value")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.requestResponse)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.requestResponse)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -353,7 +354,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload("bad")
 						.setHeader(ROUTE_HEADER, "void-return-value")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.requestResponse)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.requestResponse)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -385,7 +386,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload("a")
 						.setHeader(ROUTE_HEADER, "thrown-exception")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.requestResponse)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.requestResponse)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -417,7 +418,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload("a")
 						.setHeader(ROUTE_HEADER, "error-signal")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.requestResponse)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.requestResponse)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -441,7 +442,7 @@ public class RSocketOutboundGatewayIntegrationTests {
 		inputChannel.send(
 				MessageBuilder.withPayload("anything")
 						.setHeader(ROUTE_HEADER, "invalid")
-						.setHeader(COMMAND_HEADER, RSocketOutboundGateway.Command.requestResponse)
+						.setHeader(INTERACTION_MODEL_HEADER, RSocketInteractionModel.requestResponse)
 						.setHeader(RSocketRequesterMethodArgumentResolver.RSOCKET_REQUESTER_HEADER, rsocketRequester)
 						.build());
 
@@ -471,8 +472,8 @@ public class RSocketOutboundGatewayIntegrationTests {
 					new RSocketOutboundGateway(
 							new FunctionExpression<Message<?>>((m) ->
 									m.getHeaders().get(ROUTE_HEADER)));
-			rsocketOutboundGateway.setCommandExpression(
-					new FunctionExpression<Message<?>>((m) -> m.getHeaders().get(COMMAND_HEADER)));
+			rsocketOutboundGateway.setInteractionModelExpression(
+					new FunctionExpression<Message<?>>((m) -> m.getHeaders().get(INTERACTION_MODEL_HEADER)));
 			return rsocketOutboundGateway;
 		}
 

--- a/src/reference/asciidoc/rsocket.adoc
+++ b/src/reference/asciidoc/rsocket.adoc
@@ -122,6 +122,8 @@ See the next section for more information.
 
 The `RSocketInboundGateway` is responsible for receiving RSocket requests and producing responses (if any).
 It requires an array of `path` mapping which could be as patterns similar to MVC request mapping or `@MessageMapping` semantics.
+In addition (since version 5.2.2), a set of interaction models (see `RSocketInteractionModel`) can be configured on the `RSocketInboundGateway` to restrict RSocket requests to this endpoint by the particular frame type.
+By default all the interaction models are supported.
 Such a bean, according its `IntegrationRSocketEndpoint` implementation (extension of a `ReactiveMessageHandler`), is auto detected either by the `ServerRSocketConnector` or `ClientRSocketConnector` for a routing logic in the internal `IntegrationRSocketMessageHandler` for incoming requests.
 An `AbstractRSocketConnector` can be provided to the `RSocketInboundGateway` for explicit endpoint registration.
 This way, the auto-detection option is disabled on that `AbstractRSocketConnector`.
@@ -132,7 +134,7 @@ In this case, an `RSocketInboundGateway` performs a plain `send` operation into 
 Otherwise a `MonoProcessor` value from the `RSocketPayloadReturnValueHandler.RESPONSE_HEADER` header is used for sending a reply to the RSocket.
 For this purpose, an `RSocketInboundGateway` performs a `sendAndReceiveMessageReactive` operation on the `outputChannel`.
 The `payload` of the message to send downstream is always a `Flux` according to `MessagingRSocket` logic.
-When in a `fireAndForget` RSocket interaction model, the messsage has a plain converted `payload`.
+When in a `fireAndForget` RSocket interaction model, the message has a plain converted `payload`.
 The reply `payload` could be a plain object or a `Publisher` - the `RSocketInboundGateway` converts both of them properly into an RSocket response according to the encoders provided in the `RSocketStrategies`.
 
 See <<rsocket-java-config>> for samples how to configure an `RSocketInboundGateway` endpoint and deal with payloads downstream.
@@ -147,7 +149,7 @@ See  `ServerRSocketConnector` JavaDocs for more information.
 
 The `route` to send request has to be configured explicitly (together with path variables) or via a SpEL expression which is evaluated against request message.
 
-The RSocket communication command can be provided via `RSocketOutboundGateway.Command` option or respective expression setting.
+The RSocket interaction model can be provided via `RSocketInteractionModel` option or respective expression setting.
 By default a `requestResponse` is used for common gateway use-cases.
 
 When request message payload is a `Publisher`, a `publisherElementType` option can be provided to encode its elements according an `RSocketStrategies` supplied in the target `RSocketRequester`.
@@ -158,14 +160,14 @@ An RSocket request can also be enhanced with a `metadata`.
 For this purpose a `metadataExpression` against request message can be configured on the `RSocketOutboundGateway`.
 Such an expression must evaluate to a `Map<Object, MimeType>`.
 
-When `command` is not `fireAndForget`, an `expectedResponseType` must be supplied.
+When `interactionModel` is not `fireAndForget`, an `expectedResponseType` must be supplied.
 It is a `String.class` by default.
 An expression for this option can evaluate to a `ParameterizedTypeReference`.
 See the `RSocketRequester.RequestSpec.retrieveMono()` and `RSocketRequester.RequestSpec.retrieveFlux()` JavaDocs for more information about reply data and its type.
 
-A reply `payload` from the `RSocketOutboundGateway` is always `Mono` (even for a `fireAndForget` command it is `Mono<Void>`) always making this component as `async`.
+A reply `payload` from the `RSocketOutboundGateway` is a `Mono` (even for a `fireAndForget` interaction model it is `Mono<Void>`) always making this component as `async`.
 Such a `Mono` is subscribed before producing into the `outputChannel` for regular channels or processed on demand by the `FluxMessageChannel`.
-A `Flux` response for the `requestStreamOrChannel` command is also wrapped into a reply `Mono`.
+A `Flux` response for the `requestStream` or `requestChannel` interaction model is also wrapped into a reply `Mono`.
 It can be flattened downstream by the `FluxMessageChannel` with a passthrough service activator:
 
 ====
@@ -218,6 +220,7 @@ The following example shows how to configure it:
 ----
 <int-rsocket:inbound-gateway id="inboundGateway"
                              path="testPath"
+                             interaction-models="requestStream,requestChannel"
                              rsocket-connector="clientRSocketConnector"
                              request-channel="requestChannel"
                              rsocket-strategies="rsocketStrategies"
@@ -235,7 +238,7 @@ A `ClientRSocketConnector` and `ServerRSocketConnector` should be configured as 
 <int-rsocket:outbound-gateway id="outboundGateway"
                               client-rsocket-connector="clientRSocketConnector"
                               auto-startup="false"
-                              command="fireAndForget"
+                              interaction-model="fireAndForget"
                               route-expression="'testRoute'"
                               request-channel="requestChannel"
                               publisher-element-type="byte[]"
@@ -279,14 +282,15 @@ The following example shows how to configure a RSocket inbound gateway with the 
 @Bean
 public IntegrationFlow rsocketUpperCaseFlow() {
     return IntegrationFlows
-        .from(RSockets.inboundGateway("/uppercase"))
+        .from(RSockets.inboundGateway("/uppercase")
+                   .interactionModels(RSocketInteractionModel.requestChannel))
         .<Flux<String>, Mono<String>>transform((flux) -> flux.next().map(String::toUpperCase))
         .get();
 }
 ----
 ====
 
-A `ClientRSocketConnector` or `ServerRSocketConnector` is assumed in this configuration with meaning for auto-detection of such an endpoint on the "`/uppercase`" path.
+A `ClientRSocketConnector` or `ServerRSocketConnector` is assumed in this configuration with meaning for auto-detection of such an endpoint on the "`/uppercase`" path and expected interaction model as "`request channel`".
 
 The following example shows how to configure a RSocket outbound gateway with Java:
 
@@ -300,8 +304,8 @@ public RSocketOutboundGateway rsocketOutboundGateway() {
             new RSocketOutboundGateway(
                     new FunctionExpression<Message<?>>((m) ->
                         m.getHeaders().get("route_header")));
-    rsocketOutboundGateway.setCommandExpression(
-            new FunctionExpression<Message<?>>((m) -> m.getHeaders().get("rsocket_command")));
+    rsocketOutboundGateway.setInteractionModelExpression(
+            new FunctionExpression<Message<?>>((m) -> m.getHeaders().get("rsocket_interaction_model")));
     rsocketOutboundGateway.setClientRSocketConnector(clientRSocketConnector());
     return rsocketOutboundGateway;
 }
@@ -322,7 +326,7 @@ public IntegrationFlow rsocketUpperCaseRequestFlow(ClientRSocketConnector client
     return IntegrationFlows
         .from(Function.class)
         .handle(RSockets.outboundGateway("/uppercase")
-            .command(RSocketOutboundGateway.Command.requestResponse)
+            .interactionModel(RSocketInteractionModel.requestResponse)
             .expectedResponseType(String.class)
             .clientRSocketConnector(clientRSocketConnector))
         .get();

--- a/src/reference/asciidoc/rsocket.adoc
+++ b/src/reference/asciidoc/rsocket.adoc
@@ -163,7 +163,7 @@ Such an expression must evaluate to a `Map<Object, MimeType>`.
 When `interactionModel` is not `fireAndForget`, an `expectedResponseType` must be supplied.
 It is a `String.class` by default.
 An expression for this option can evaluate to a `ParameterizedTypeReference`.
-See the `RSocketRequester.RequestSpec.retrieveMono()` and `RSocketRequester.RequestSpec.retrieveFlux()` JavaDocs for more information about reply data and its type.
+See the `RSocketRequester.RetrieveSpec.retrieveMono()` and `RSocketRequester.RetrieveSpec.retrieveFlux()` JavaDocs for more information about reply data and its type.
 
 A reply `payload` from the `RSocketOutboundGateway` is a `Mono` (even for a `fireAndForget` interaction model it is `Mono<Void>`) always making this component as `async`.
 Such a `Mono` is subscribed before producing into the `outputChannel` for regular channels or processed on demand by the `FluxMessageChannel`.


### PR DESCRIPTION
* Deprecate `RSocketOutboundGateway.Command` in favor of newly introduced
top level `RSocketInteractionModel`
* Deprecate setter, DSL and XML configurations for the deprecated
`RSocketOutboundGateway.Command` in favor of newly introduced configurators
for the mentioned `RSocketInteractionModel`
* Add `IntegrationRSocketEndpoint.getInteractionModels()` contract for
inbound endpoints.
This way we can restrict mapped endpoints to the particular interaction
model(s)
* Add DSL and XML configuration for inbound interaction model option
* Document changes

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
