### PR TITLE
Add Reactive Channel Mono subscribeToUpstream()

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
@@ -221,7 +221,9 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 		if (this.subscribed.compareAndSet(false, true)) {
 			MessageChannel outputChannel = getOutputChannel();
 			if (outputChannel instanceof ReactiveStreamsSubscribableChannel) {
-				((ReactiveStreamsSubscribableChannel) outputChannel).subscribeTo(this.aggregatorFlux);
+				((ReactiveStreamsSubscribableChannel) outputChannel)
+						.subscribeToUpstream(this.aggregatorFlux)
+						.subscribe();
 			}
 			else {
 				this.subscription =

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ReactiveStreamsSubscribableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ReactiveStreamsSubscribableChannel.java
@@ -20,7 +20,12 @@ import org.reactivestreams.Publisher;
 
 import org.springframework.messaging.Message;
 
+import reactor.core.publisher.Mono;
+
 /**
+ * Reactive Streams specific message channel for composing upstream {@link Publisher}s
+ * into an on-demand processing in this channel implementation.
+ *
  * @author Artem Bilan
  * @author Gary Russell
  *
@@ -28,6 +33,26 @@ import org.springframework.messaging.Message;
  */
 public interface ReactiveStreamsSubscribableChannel {
 
+	/**
+	 * Subscribe to the provided {@link Publisher}.
+	 * @param publisher the {@link Publisher} to subscribe to.
+	 * @deprecated in favor of {@link #subscribeToUpstream}.
+	 * Framework doesn't call this method internally any more.
+	 */
+	@Deprecated
 	void subscribeTo(Publisher<? extends Message<?>> publisher);
+
+	/**
+	 * Compose with the provided upstream {@link Publisher} for processing its events in this channel.
+	 * It is recommended to implement this method for possible reactive streams composition.
+	 * @param upstreamPublisher the upstream {@link Publisher} to subscribe to.
+	 * @return the {@link Mono} for reactive streams composition.
+	 * @since 5.2.2
+	 */
+	@SuppressWarnings("deprecagtion")
+	default Mono<Void> subscribeToUpstream(Publisher<? extends Message<?>> upstreamPublisher) {
+		subscribeTo(upstreamPublisher);
+		return Mono.empty();
+	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ReactiveStreamsSubscribableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ReactiveStreamsSubscribableChannel.java
@@ -51,8 +51,11 @@ public interface ReactiveStreamsSubscribableChannel {
 	 */
 	@SuppressWarnings("deprecagtion")
 	default Mono<Void> subscribeToUpstream(Publisher<? extends Message<?>> upstreamPublisher) {
-		subscribeTo(upstreamPublisher);
-		return Mono.empty();
+		return Mono.defer(() -> {
+					subscribeTo(upstreamPublisher);
+					return Mono.empty();
+				}
+		);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -2819,7 +2819,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 		Flux<Message<O>> result = Transformers.transformWithFunction(upstream, fluxFunction);
 
 		FluxMessageChannel downstream = new FluxMessageChannel();
-		downstream.subscribeTo((Flux<Message<?>>) (Flux<?>) result);
+		downstream.subscribeToUpstream((Flux<Message<?>>) (Flux<?>) result).subscribe();
 
 		return currentMessageChannel(downstream)
 				.addComponent(downstream);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
@@ -375,7 +375,7 @@ public final class IntegrationFlows {
 	 */
 	public static IntegrationFlowBuilder from(Publisher<? extends Message<?>> publisher) {
 		FluxMessageChannel reactiveChannel = new FluxMessageChannel();
-		reactiveChannel.subscribeTo(publisher);
+		reactiveChannel.subscribeToUpstream(publisher).subscribe();
 		return from((MessageChannel) reactiveChannel);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -185,7 +185,9 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 		super.doStart();
 
 		if (isReactive()) {
-			((ReactiveStreamsSubscribableChannel) this.outputChannel).subscribeTo(getPollingFlux());
+			((ReactiveStreamsSubscribableChannel) this.outputChannel)
+					.subscribeToUpstream(getPollingFlux())
+					.subscribe();
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -652,12 +652,11 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 							? requestChannel.send(requestMessage, sendTimeout)
 							: requestChannel.send(requestMessage);
 
-			return Mono.just(sent)
-					.filter(Boolean::booleanValue)
-					.switchIfEmpty(Mono.error(new MessageDeliveryException(requestMessage,
+			return sent
+					? Mono.empty()
+					: Mono.error(new MessageDeliveryException(requestMessage,
 							"Failed to send message to channel '" + requestChannel +
-									"' within timeout: " + sendTimeout)))
-					.then();
+									"' within timeout: " + sendTimeout));
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -308,10 +308,11 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 			}
 			else {
 				((ReactiveStreamsSubscribableChannel) messageChannel)
-						.subscribeTo(
+						.subscribeToUpstream(
 								Flux.from((Publisher<?>) reply)
 										.doOnError((ex) -> sendErrorMessage(requestMessage, ex))
-										.map(result -> createOutputMessage(result, requestHeaders)));
+										.map(result -> createOutputMessage(result, requestHeaders)))
+						.subscribe();
 			}
 		}
 		else {


### PR DESCRIPTION
It would be better to let  `ReactiveStreamsSubscribableChannel` to
return some Reactor type for its `subscribeTo` instead of plain `void`.
This way we can compose reactive streams for deferred subscription
instead of intermediate subscribe inside a `FluxMessageChannel`

* Introduce a `Mono<Void> subscribeToUpstream(Publisher)` into the
`ReactiveStreamsSubscribableChannel` as a `default` method to avoid
breaking changes and call existing deprecated now
`void subscribeTo(Publisher)`
* Fix `FluxMessageChannel` to implement a new `subscribeToUpstream`
and call this one from the deprecated `subscribeTo`
* Fix all the `subscribeTo` usage in favor of newly introduced
`subscribeToUpstream`.

The fix doesn't bring too much subscription gain in the framework
(unless `MessagingGatewaySupport.sendAndReceiveMessageReactive()`
changes), but can be useful in target application when reactive streams
composition is important even if we place a `FluxMessageChannel` in
between

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
