### PR TITLE
GH-3118: MessagingGW: Don't proxy default methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ if (System.getenv('TRAVIS') || System.getenv('bamboo_buildKey')) {
 
 	nohttp {
 		whitelistFile = file('src/nohttp/whitelist.lines')
-		source.include '**/src/**'
+		source.include '**/src/**'GatewayDslTests
 		source.exclude '**/*.gif', '**/*.jpg', '**/*.png', '**/*.svg', '**/*.ks'
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ if (System.getenv('TRAVIS') || System.getenv('bamboo_buildKey')) {
 
 	nohttp {
 		whitelistFile = file('src/nohttp/whitelist.lines')
-		source.include '**/src/**'GatewayDslTests
+		source.include '**/src/**'
 		source.exclude '**/*.gif', '**/*.jpg', '**/*.png', '**/*.svg', '**/*.ks'
 	}
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
@@ -132,4 +132,15 @@ public @interface MessagingGateway {
 	 */
 	String mapper() default "";
 
+	/**
+	 * Indicate if {@code default} methods on the interface should be proxied as well.
+	 * If an explicit {@link Gateway} annotation is present on method it is proxied
+	 * independently of this option.
+	 * Note: default methods in JDK classes (such as {@code Function}) can be proxied, but cannot be invoked
+	 * via {@code MethodHandle} by an internal Java security restriction for {@code MethodHandle.Lookup}.
+	 * @return the boolean flag to proxy default methods or invoke via {@code MethodHandle}.
+	 * @since 5.3
+	 */
+	boolean proxyDefaultMethods() default false;
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingGatewayRegistrar.java
@@ -68,8 +68,8 @@ public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar 
 					importingClassMetadata.getAnnotationAttributes(MessagingGateway.class.getName());
 			replaceEmptyOverrides(valuesHierarchy, annotationAttributes); // NOSONAR never null
 			annotationAttributes.put("serviceInterface", importingClassMetadata.getClassName());
-
-			BeanDefinitionReaderUtils.registerBeanDefinition(this.parse(annotationAttributes), registry);
+			annotationAttributes.put("proxyDefaultMethods", "" + annotationAttributes.remove("proxyDefaultMethods"));
+			BeanDefinitionReaderUtils.registerBeanDefinition(parse(annotationAttributes), registry);
 		}
 	}
 
@@ -84,6 +84,7 @@ public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar 
 		String errorChannel = (String) gatewayAttributes.get("errorChannel");
 		String asyncExecutor = (String) gatewayAttributes.get("asyncExecutor");
 		String mapper = (String) gatewayAttributes.get("mapper");
+		String proxyDefaultMethods = (String) gatewayAttributes.get("proxyDefaultMethods");
 
 		boolean hasMapper = StringUtils.hasText(mapper);
 		boolean hasDefaultPayloadExpression = StringUtils.hasText(defaultPayloadExpression);
@@ -151,6 +152,9 @@ public class MessagingGatewayRegistrar implements ImportBeanDefinitionRegistrar 
 		}
 		if (StringUtils.hasText(mapper)) {
 			gatewayProxyBuilder.addPropertyReference("mapper", mapper);
+		}
+		if (StringUtils.hasText(proxyDefaultMethods)) {
+			gatewayProxyBuilder.addPropertyValue("proxyDefaultMethods", proxyDefaultMethods);
 		}
 
 		gatewayProxyBuilder.addPropertyValue("defaultRequestTimeoutExpressionString",

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
@@ -86,6 +86,8 @@ public class GatewayParser implements BeanDefinitionParser {
 
 		gatewayAttributes.put("serviceInterface", element.getAttribute("service-interface"));
 
+		gatewayAttributes.put("proxyDefaultMethods", element.getAttribute("proxy-default-methods"));
+
 		BeanDefinitionHolder gatewayHolder = this.registrar.parse(gatewayAttributes);
 		if (isNested) {
 			return gatewayHolder.getBeanDefinition();

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/GatewayProxySpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/GatewayProxySpec.java
@@ -263,6 +263,18 @@ public class GatewayProxySpec {
 		return this;
 	}
 
+	/**
+	 * Indicate if {@code default} methods on the interface should be proxied as well.
+	 * @param proxyDefaultMethods the boolean flag to proxy default methods or invoke via {@code MethodHandle}.
+	 * @return current {@link GatewayProxySpec}.
+	 * @see GatewayProxyFactoryBean#setProxyDefaultMethods(boolean)
+	 * @since 5.3
+	 */
+	public GatewayProxySpec proxyDefaultMethods(boolean proxyDefaultMethods) {
+		this.gatewayProxyFactoryBean.setProxyDefaultMethods(proxyDefaultMethods);
+		return this;
+	}
+
 	MessageChannel getGatewayRequestChannel() {
 		return this.gatewayRequestChannel;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/AnnotationGatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/AnnotationGatewayProxyFactoryBean.java
@@ -90,7 +90,10 @@ public class AnnotationGatewayProxyFactoryBean extends GatewayProxyFactoryBean {
 		else if (StringUtils.hasText(asyncExecutor)) {
 			setAsyncExecutor(beanFactory.getBean(asyncExecutor, Executor.class));
 		}
-
+		boolean proxyDefaultMethods = this.gatewayAttributes.getBoolean("proxyDefaultMethods");
+		if (proxyDefaultMethods) {
+			setProxyDefaultMethods(proxyDefaultMethods);
+		}
 		super.onInit();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/DefaultMethodInvokingMethodInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/DefaultMethodInvokingMethodInterceptor.java
@@ -43,7 +43,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Mark Paluch
  * @author Artem Bilan
  *
- * @since 5.2.3
+ * @since 5.3
  */
 class DefaultMethodInvokingMethodInterceptor implements MethodInterceptor {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/DefaultMethodInvokingMethodInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/DefaultMethodInvokingMethodInterceptor.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2015-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.gateway;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Map;
+
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
+
+import org.springframework.aop.ProxyMethodInvocation;
+import org.springframework.lang.Nullable;
+import org.springframework.util.ConcurrentReferenceHashMap;
+import org.springframework.util.ConcurrentReferenceHashMap.ReferenceType;
+import org.springframework.util.ReflectionUtils;
+
+/**
+ * Method interceptor to invoke default methods on the repository proxy.
+ *
+ * The copy of {@code DefaultMethodInvokingMethodInterceptor} from Spring Data Commons.
+ *
+ * @author Oliver Gierke
+ * @author Jens Schauder
+ * @author Mark Paluch
+ * @author Artem Bilan
+ *
+ * @since 5.2.3
+ */
+class DefaultMethodInvokingMethodInterceptor implements MethodInterceptor {
+
+	private final MethodHandleLookup methodHandleLookup = MethodHandleLookup.getMethodHandleLookup();
+
+	private final Map<Method, MethodHandle> methodHandleCache =
+			new ConcurrentReferenceHashMap<>(10, ReferenceType.WEAK);
+
+	@Override
+	public Object invoke(MethodInvocation invocation) throws Throwable { // NOSONAR
+		Method method = invocation.getMethod();
+		if (!method.isDefault()) {
+			return invocation.proceed();
+		}
+		Object[] arguments = invocation.getArguments();
+		Object proxy = ((ProxyMethodInvocation) invocation).getProxy();
+		return getMethodHandle(method)
+				.bindTo(proxy)
+				.invokeWithArguments(arguments);
+	}
+
+	private MethodHandle getMethodHandle(Method method) {
+		return this.methodHandleCache.computeIfAbsent(method,
+				(key) -> {
+					try {
+						return this.methodHandleLookup.lookup(key);
+					}
+					catch (ReflectiveOperationException ex) {
+						throw new IllegalStateException(ex);
+					}
+				});
+	}
+
+	enum MethodHandleLookup {
+
+		/**
+		 * Encapsulated {@link MethodHandle} lookup working on Java 9.
+		 */
+		ENCAPSULATED {
+
+			@Nullable
+			private final Method privateLookupIn =
+					ReflectionUtils.findMethod(MethodHandles.class, "privateLookupIn", Class.class, Lookup.class);
+
+			@Override
+			MethodHandle lookup(Method method) throws ReflectiveOperationException {
+				if (this.privateLookupIn == null) {
+					throw new IllegalStateException("Could not obtain MethodHandles.privateLookupIn!");
+				}
+				return doLookup(method, getLookup(method.getDeclaringClass(), this.privateLookupIn));
+			}
+
+			@Override
+			boolean isAvailable() {
+				return this.privateLookupIn != null;
+			}
+
+			private Lookup getLookup(Class<?> declaringClass, Method privateLookupIn) {
+				Lookup lookup = MethodHandles.lookup();
+				try {
+					return (Lookup) privateLookupIn.invoke(MethodHandles.class, declaringClass, lookup);
+				}
+				catch (ReflectiveOperationException e) {
+					return lookup;
+				}
+			}
+
+		},
+
+		/**
+		 * Open (via reflection construction of {@link Lookup}) method handle lookup. Works with Java 8 and
+		 * with Java 9 permitting illegal access.
+		 */
+		OPEN {
+
+			@Nullable
+			private final Constructor<Lookup> constructor;
+
+			{
+				Constructor<Lookup> ctor = null;
+				try {
+					ctor = Lookup.class.getDeclaredConstructor(Class.class);
+					ReflectionUtils.makeAccessible(ctor);
+				}
+				catch (Exception ex) {
+					// this is the signal that we are on Java 9 (encapsulated) and can't use the accessible constructor
+					// approach.
+					if (!ex.getClass().getName().equals("java.lang.reflect.InaccessibleObjectException")) {
+						throw new IllegalStateException(ex);
+					}
+				}
+				this.constructor = ctor;
+			}
+
+			@Override
+			MethodHandle lookup(Method method) throws ReflectiveOperationException {
+				if (!isAvailable()) {
+					throw new IllegalStateException("Could not obtain MethodHandles.lookup constructor!");
+				}
+				return this.constructor.newInstance(method.getDeclaringClass())
+						.unreflectSpecial(method, method.getDeclaringClass());
+			}
+
+			@Override
+			boolean isAvailable() {
+				return this.constructor != null;
+			}
+
+		},
+
+		/**
+		 * Fallback {@link MethodHandle} lookup using {@link MethodHandles#lookup() public lookup}.
+		 */
+		FALLBACK {
+			@Override
+			MethodHandle lookup(Method method) throws ReflectiveOperationException {
+				return doLookup(method, MethodHandles.lookup());
+			}
+
+			@Override
+			boolean isAvailable() {
+				return true;
+			}
+
+		};
+
+		private static MethodHandle doLookup(Method method, Lookup lookup) throws ReflectiveOperationException {
+			MethodType methodType = MethodType.methodType(method.getReturnType(), method.getParameterTypes());
+			return lookup.findSpecial(method.getDeclaringClass(), method.getName(),
+					methodType, method.getDeclaringClass());
+		}
+
+		abstract MethodHandle lookup(Method method) throws ReflectiveOperationException;
+
+		/**
+		 * @return {@literal true} if the lookup is available.
+		 */
+		abstract boolean isAvailable();
+
+		/**
+		 * Obtain the first available {@link MethodHandleLookup}.
+		 * @return the {@link MethodHandleLookup}
+		 * @throws IllegalStateException if no {@link MethodHandleLookup} is available.
+		 */
+		public static MethodHandleLookup getMethodHandleLookup() {
+			for (MethodHandleLookup it : MethodHandleLookup.values()) {
+				if (it.isAvailable()) {
+					return it;
+				}
+			}
+			throw new IllegalStateException("No MethodHandleLookup available!");
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration.xsd
@@ -832,6 +832,19 @@
 					</xsd:appinfo>
 				</xsd:annotation>
 			</xsd:attribute>
+			<xsd:attribute name="proxy-default-methods" default="false">
+				<xsd:annotation>
+					<xsd:documentation>
+						Indicate if default methods on the interface should be proxied as well.
+						If an explicit Gateway annotation is present on method it is proxied independently of this option.
+						Note: default methods in JDK classes (such as 'Function') can be proxied, but cannot be invoked
+						via 'MethodHandle' by an internal Java security restriction for 'MethodHandle.Lookup'.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="xsd:boolean xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
 		</xsd:complexType>
 	</xsd:element>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests-context.xml
@@ -21,7 +21,8 @@
 
 	<gateway id="oneWay"
 			 service-interface="org.springframework.integration.gateway.TestService"
-			 default-request-channel="requestChannel"/>
+			 default-request-channel="requestChannel"
+			 proxy-default-methods="true"/>
 
 	<gateway id="solicitResponse"
 			 service-interface="org.springframework.integration.gateway.TestService"
@@ -84,15 +85,15 @@
 			 async-executor="testExecutor">
 		<default-header name="baz" value="qux"/>
 		<method name="oneWay" request-channel="otherRequestChannel"
-							  request-timeout="456"
-							  reply-timeout="123"
-							  payload-expression="'fiz'"
-							  reply-channel="foo">
+				request-timeout="456"
+				reply-timeout="123"
+				payload-expression="'fiz'"
+				reply-channel="foo">
 			<header name="foo" value="bar"/>
 		</method>
 		<method name="oneWayWithTimeouts" request-channel="otherRequestChannel"
-							  request-timeout="args[1]"
-							  reply-timeout="args[2]">
+				request-timeout="args[1]"
+				reply-timeout="args[2]">
 		</method>
 	</gateway>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/TestService.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/TestService.java
@@ -19,6 +19,7 @@ package org.springframework.integration.gateway;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 
+import org.springframework.integration.annotation.Gateway;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Payload;
 
@@ -64,6 +65,11 @@ public interface TestService {
 	CompletableFuture<Message<?>> completableReturnsMessage(String s);
 
 	MyCompletableMessageFuture customCompletableReturnsMessage(String s);
+
+	@Gateway(requestChannel = "errorChannel")
+	default void defaultMethodGateway(Object payload) {
+		throw new UnsupportedOperationException();
+	}
 
 	class MyCompletableFuture extends CompletableFuture<String> {
 

--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -351,6 +351,12 @@ public interface Cafe {
 
 If a method has no argument and no return value but does contain a payload expression, it is treated as a send-only operation.
 
+[[gateway-calling-default-methods]]
+==== Invoking `default` Methods
+
+An interface for gateway proxy may have `default` methods as well and starting with version 5.2.3, the framework injects a `DefaultMethodInvokingMethodInterceptor` into a proxy for calling `default` methods using a `java.lang.invoke.MethodHandle` approach instead of proxying them improperly.
+The interfaces from JDK, such as `java.util.function.Function`, still can be used for gateway proxy, but their `default` methods cannot be called because of internal Java security reasons for a `MethodHandles.Lookup` instantiation against JDK classes.
+
 [[gateway-error-handling]]
 ==== Error Handling
 
@@ -719,7 +725,7 @@ A `Mono` can be used to retrieve the result later (similar to a `Future<?>`), or
 IMPORTANT: The `Mono` is not immediately flushed by the framework.
 Consequently, the underlying message flow is not started before the gateway method returns (as it is with a `Future<?>` `Executor` task).
 The flow starts when the `Mono` is subscribed to.
-Alternatively, the `Mono` (being a `Composable`) might be a part of Reactor stream, when the `subscribe()` is related to the entire `Flux`.
+Alternatively, the `Mono` (being a "`Composable`") might be a part of Reactor stream, when the `subscribe()` is related to the entire `Flux`.
 The following example shows how to create a gateway with Project Reactor:
 
 ====

--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -354,8 +354,9 @@ If a method has no argument and no return value but does contain a payload expre
 [[gateway-calling-default-methods]]
 ==== Invoking `default` Methods
 
-An interface for gateway proxy may have `default` methods as well and starting with version 5.2.3, the framework injects a `DefaultMethodInvokingMethodInterceptor` into a proxy for calling `default` methods using a `java.lang.invoke.MethodHandle` approach instead of proxying them improperly.
+An interface for gateway proxy may have `default` methods as well and starting with version 5.3, the framework injects a `DefaultMethodInvokingMethodInterceptor` into a proxy for calling `default` methods using a `java.lang.invoke.MethodHandle` approach instead of proxying.
 The interfaces from JDK, such as `java.util.function.Function`, still can be used for gateway proxy, but their `default` methods cannot be called because of internal Java security reasons for a `MethodHandles.Lookup` instantiation against JDK classes.
+These methods also can be proxied (losing their implementation logic and, at the same time, restoring previous gateway proxy behavior) using an explicit `@Gateway` annotation on the method, or `proxyDefaultMethods` on the `@MessagingGateway` annotation or `<gateway>` XML component.
 
 [[gateway-error-handling]]
 ==== Error Handling

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -24,4 +24,5 @@ See its JavaDocs and <<./graph.adoc#integration-graph,Integration Graph>> for mo
 [[x5.3-general]]
 === General Changes
 
-
+The gateway proxy now doesn't proxy `default` methods by default.
+see <<./gateway.adoc/gateway-calling-default-methods,Invoking `default` Methods>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3118

The `GatewayProxyFactoryBean` proxies all the methods in the provided interface,
including `default` and `static`.
This is not what is expected from end-users.

* Proxy only `abstract` methods from the provided interface
* Introduce a `DefaultMethodInvokingMethodInterceptor` to call `default`
method on the interface using a `MethodHandle` approach for those methods
calling

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
