### PR TITLE
Handle possible null management overrides

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
@@ -278,7 +278,7 @@ public class IntegrationManagementConfigurer
 				.getBeansOfType(IntegrationManagement.class);
 		for (Entry<String, IntegrationManagement> entry : managed.entrySet()) {
 			IntegrationManagement bean = entry.getValue();
-			if (!bean.getOverrides().loggingConfigured) {
+			if (!getOverrides(bean).loggingConfigured) {
 				bean.setLoggingEnabled(this.defaultLoggingEnabled);
 			}
 			String name = entry.getKey();
@@ -292,7 +292,7 @@ public class IntegrationManagementConfigurer
 				.getBeansOfType(IntegrationManagement.class);
 		for (Entry<String, IntegrationManagement> entry : managed.entrySet()) {
 			IntegrationManagement bean = entry.getValue();
-			if (!bean.getOverrides().loggingConfigured) {
+			if (!getOverrides(bean).loggingConfigured) {
 				bean.setLoggingEnabled(this.defaultLoggingEnabled);
 			}
 			bean.registerMetricsCaptor(this.metricsCaptor);
@@ -364,7 +364,7 @@ public class IntegrationManagementConfigurer
 			metrics = this.metricsFactory.createChannelMetrics(name);
 		}
 		Assert.state(metrics != null, "'metrics' must not be null");
-		ManagementOverrides overrides = bean.getOverrides();
+		ManagementOverrides overrides = getOverrides(bean);
 		Boolean enabled = PatternMatchUtils.smartMatch(name, this.enabledCountsPatterns);
 		if (enabled != null) {
 			bean.setCountsEnabled(enabled);
@@ -396,7 +396,7 @@ public class IntegrationManagementConfigurer
 			org.springframework.integration.support.management.MessageHandlerMetrics bean) {
 		AbstractMessageHandlerMetrics metrics = this.metricsFactory.createHandlerMetrics(name);
 		Assert.state(metrics != null, "'metrics' must not be null");
-		ManagementOverrides overrides = bean.getOverrides();
+		ManagementOverrides overrides = getOverrides(bean);
 		Boolean enabled = PatternMatchUtils.smartMatch(name, this.enabledCountsPatterns);
 		if (enabled != null) {
 			bean.setCountsEnabled(enabled);
@@ -432,7 +432,7 @@ public class IntegrationManagementConfigurer
 			bean.setCountsEnabled(enabled);
 		}
 		else {
-			if (!bean.getOverrides().countsConfigured) {
+			if (!getOverrides(bean).countsConfigured) {
 				bean.setCountsEnabled(this.defaultCountsEnabled);
 			}
 		}
@@ -504,6 +504,10 @@ public class IntegrationManagementConfigurer
 			LOGGER.debug("No source found for (" + name + ")");
 		}
 		return null;
+	}
+
+	private ManagementOverrides getOverrides(final IntegrationManagement bean) {
+		return bean.getOverrides() != null ? bean.getOverrides() : new ManagementOverrides();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
@@ -54,6 +54,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Meherzad Lahewala
+ * @author Jonathan Pearlin
  *
  * @since 4.2
  *
@@ -506,7 +507,7 @@ public class IntegrationManagementConfigurer
 		return null;
 	}
 
-	private ManagementOverrides getOverrides(final IntegrationManagement bean) {
+	private static ManagementOverrides getOverrides(IntegrationManagement bean) {
 		return bean.getOverrides() != null ? bean.getOverrides() : new ManagementOverrides();
 	}
 


### PR DESCRIPTION
Adds handling for cases where the `ManagementOverrides` retrieved from a bean during auto configuration may be `null`.  I ran into this an a Spring Boot integration test that was loading configuration from my application with the `EnableAutoConfiguration` annotation.  Removing the auto configuration annotation resolved the NPE's in the configurer, but that may not always be possible for tests, especially those that rely on Spring configuration classes with auto configuration enabled that are loaded from a provided library JAR.  This PR attempts to handle that case by returning an empty/un-configured `ManagementOverrides` in the case where the call to the `getOverrides()` method on the bean returns null.
