### PR TITLE
Upgrade to data Neumann and S-D-Mongo 3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ ext {
 	log4jVersion = '2.12.1'
 	micrometerVersion = '1.3.2'
 	mockitoVersion = '3.2.0'
-	mongodbReactiveDriverVersion = '1.12.0'
+	mongoDriverVersion = '4.0.0-SNAPSHOT'
 	mysqlVersion = '8.0.18'
 	pahoMqttClientVersion = '1.2.0'
 	postgresVersion = '42.2.8'
@@ -576,9 +576,8 @@ project('spring-integration-mongodb') {
 		compile('org.springframework.data:spring-data-mongodb:3.0.0.BUILD-SNAPSHOT') {
 			exclude group: 'org.springframework'
 		}
-		compile("org.mongodb:mongodb-driver-reactivestreams:$mongodbReactiveDriverVersion", optional)
-		compile("org.mongodb:mongodb-driver-sync:4.0.0-SNAPSHOT", optional)
-		compile("org.mongodb:mongodb-driver-async:4.0.0-SNAPSHOT", optional)
+		compile("org.mongodb:mongodb-driver-reactivestreams:$mongoDriverVersion", optional)
+		compile("org.mongodb:mongodb-driver-sync:$mongoDriverVersion", optional)
 		testCompile 'io.projectreactor:reactor-test'
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ ext {
 	servletApiVersion = '4.0.1'
 	smackVersion = '4.3.4'
 	springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '2.2.2.RELEASE'
-	springDataVersion = 'Moore-SR3'
+	springDataVersion = 'Neumann-BUILD-SNAPSHOT'
 	springSecurityVersion = '5.2.1.RELEASE'
 	springRetryVersion = '1.2.4.RELEASE'
 	springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.2.2.RELEASE'
@@ -112,6 +112,7 @@ allprojects {
 			maven { url 'https://repo.spring.io/libs-snapshot' }
 			maven { url "https://oss.jfrog.org/artifactory/libs-snapshot" } // RSocket
 		}
+		maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 //		maven { url 'https://repo.spring.io/libs-staging-local' }
 	}
 
@@ -572,10 +573,12 @@ project('spring-integration-mongodb') {
 	description = 'Spring Integration MongoDB Support'
 	dependencies {
 		compile project(':spring-integration-core')
-		compile('org.springframework.data:spring-data-mongodb') {
+		compile('org.springframework.data:spring-data-mongodb:3.0.0.BUILD-SNAPSHOT') {
 			exclude group: 'org.springframework'
 		}
 		compile("org.mongodb:mongodb-driver-reactivestreams:$mongodbReactiveDriverVersion", optional)
+		compile("org.mongodb:mongodb-driver-sync:4.0.0-SNAPSHOT", optional)
+		compile("org.mongodb:mongodb-driver-async:4.0.0-SNAPSHOT", optional)
 		testCompile 'io.projectreactor:reactor-test'
 	}
 }

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDb.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDb.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.mongodb.dsl;
 
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 
@@ -30,13 +30,13 @@ public final class MongoDb {
 
 	/**
 	 * Create a {@link MongoDbOutboundGatewaySpec} builder instance
-	 * based on the provided {@link MongoDbFactory} and {@link MongoConverter}.
-	 * @param mongoDbFactory the {@link MongoDbFactory} to use.
+	 * based on the provided {@link MongoDatabaseFactory} and {@link MongoConverter}.
+	 * @param mongoDbFactory the {@link MongoDatabaseFactory} to use.
 	 * @param mongoConverter the {@link MongoConverter} to use.
 	 * @return the {@link MongoDbOutboundGatewaySpec} instance
 	 */
 	public static MongoDbOutboundGatewaySpec outboundGateway(
-			MongoDbFactory mongoDbFactory, MongoConverter mongoConverter) {
+			MongoDatabaseFactory mongoDbFactory, MongoConverter mongoConverter) {
 
 		return new MongoDbOutboundGatewaySpec(mongoDbFactory, mongoConverter);
 	}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDbOutboundGatewaySpec.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDbOutboundGatewaySpec.java
@@ -18,8 +18,7 @@ package org.springframework.integration.mongodb.dsl;
 
 import java.util.function.Function;
 
-import org.springframework.data.mongodb.MongoDbFactory;
-import org.springframework.data.mongodb.core.CollectionCallback;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Query;
@@ -41,7 +40,7 @@ import org.springframework.messaging.Message;
 public class MongoDbOutboundGatewaySpec
 		extends MessageHandlerSpec<MongoDbOutboundGatewaySpec, MongoDbOutboundGateway> {
 
-	MongoDbOutboundGatewaySpec(MongoDbFactory mongoDbFactory, MongoConverter mongoConverter) {
+	MongoDbOutboundGatewaySpec(MongoDatabaseFactory mongoDbFactory, MongoConverter mongoConverter) {
 		this.target = new MongoDbOutboundGateway(mongoDbFactory, mongoConverter);
 		this.target.setRequiresReply(true);
 	}
@@ -143,20 +142,6 @@ public class MongoDbOutboundGatewaySpec
 	 */
 	public <P> MongoDbOutboundGatewaySpec collectionNameFunction(Function<Message<P>, String> collectionNameFunction) {
 		this.target.setCollectionNameExpression(new FunctionExpression<>(collectionNameFunction));
-		return this;
-	}
-
-	/**
-	 * Reference to an instance of {@link CollectionCallback} which specifies the database operation to execute.
-	 * This property is mutually exclusive with {@link #query} and {@link #queryExpression} properties.
-	 * @param collectionCallback the {@link CollectionCallback} instance
-	 * @param <P> the type of the message payload.
-	 * @return the spec
-	 * @deprecated in favor of {@link #collectionCallback(MessageCollectionCallback)}
-	 */
-	@Deprecated
-	public <P> MongoDbOutboundGatewaySpec collectionCallback(CollectionCallback<P> collectionCallback) {
-		this.target.setCollectionCallback(collectionCallback);
 		return this;
 	}
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSource.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSource.java
@@ -18,7 +18,7 @@ package org.springframework.integration.mongodb.inbound;
 
 import java.util.List;
 
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -75,7 +75,7 @@ public class MongoDbMessageSource extends AbstractMessageSource<Object> {
 
 	private volatile MongoConverter mongoConverter;
 
-	private volatile MongoDbFactory mongoDbFactory;
+	private volatile MongoDatabaseFactory mongoDbFactory;
 
 	private volatile boolean initialized = false;
 
@@ -84,14 +84,14 @@ public class MongoDbMessageSource extends AbstractMessageSource<Object> {
 	private volatile boolean expectSingleResult = false;
 
 	/**
-	 * Creates an instance with the provided {@link MongoDbFactory} and SpEL expression
+	 * Creates an instance with the provided {@link MongoDatabaseFactory} and SpEL expression
 	 * which should resolve to a MongoDb 'query' string
 	 * (see https://www.mongodb.org/display/DOCS/Querying).
 	 * The 'queryExpression' will be evaluated on every call to the {@link #receive()} method.
 	 * @param mongoDbFactory The mongodb factory.
 	 * @param queryExpression The query expression.
 	 */
-	public MongoDbMessageSource(MongoDbFactory mongoDbFactory, Expression queryExpression) {
+	public MongoDbMessageSource(MongoDatabaseFactory mongoDbFactory, Expression queryExpression) {
 		Assert.notNull(mongoDbFactory, "'mongoDbFactory' must not be null");
 		Assert.notNull(queryExpression, "'queryExpression' must not be null");
 
@@ -156,7 +156,7 @@ public class MongoDbMessageSource extends AbstractMessageSource<Object> {
 	/**
 	 * Allows you to provide a custom {@link MongoConverter} used to assist in deserialization
 	 * data read from MongoDb. Only allowed if this instance was constructed with a
-	 * {@link MongoDbFactory}.
+	 * {@link MongoDatabaseFactory}.
 	 * @param mongoConverter The mongo converter.
 	 */
 	public void setMongoConverter(MongoConverter mongoConverter) {

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/metadata/MongoDbMetadataStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/metadata/MongoDbMetadataStore.java
@@ -21,12 +21,13 @@ import java.util.Map;
 
 import org.bson.Document;
 
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
 import org.springframework.util.Assert;
 
@@ -57,21 +58,21 @@ public class MongoDbMetadataStore implements ConcurrentMetadataStore {
 	private final String collectionName;
 
 	/**
-	 * Configure the MongoDbMetadataStore by provided {@link MongoDbFactory} and
+	 * Configure the MongoDbMetadataStore by provided {@link MongoDatabaseFactory} and
 	 * default collection name - {@link #DEFAULT_COLLECTION_NAME}.
 	 * @param factory the mongodb factory
 	 */
-	public MongoDbMetadataStore(MongoDbFactory factory) {
+	public MongoDbMetadataStore(MongoDatabaseFactory factory) {
 		this(factory, DEFAULT_COLLECTION_NAME);
 	}
 
 	/**
-	 * Configure the MongoDbMetadataStore by provided {@link MongoDbFactory} and
+	 * Configure the MongoDbMetadataStore by provided {@link MongoDatabaseFactory} and
 	 * collection name
 	 * @param factory the mongodb factory
 	 * @param collectionName the collection name where it persists the data
 	 */
-	public MongoDbMetadataStore(MongoDbFactory factory, String collectionName) {
+	public MongoDbMetadataStore(MongoDatabaseFactory factory, String collectionName) {
 		this(new MongoTemplate(factory), collectionName);
 	}
 
@@ -105,7 +106,6 @@ public class MongoDbMetadataStore implements ConcurrentMetadataStore {
 	 * @param key the metadata entry key
 	 * @param value the metadata entry value
 	 * @see MongoTemplate#execute(String, org.springframework.data.mongodb.core.CollectionCallback)
-	 * @see com.mongodb.DBCollection#save
 	 */
 	@Override
 	public void put(String key, String value) {
@@ -188,7 +188,7 @@ public class MongoDbMetadataStore implements ConcurrentMetadataStore {
 	 * @param oldValue the metadata entry old value to replace
 	 * @param newValue the metadata entry new value to put
 	 * @return {@code true} if replace was successful, {@code false} otherwise.
-	 * @see MongoTemplate#updateFirst(Query, Update, String)
+	 * @see MongoTemplate#updateFirst(Query, UpdateDefinition, String)
 	 */
 	@Override
 	public boolean replace(String key, String oldValue, String newValue) {

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGateway.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGateway.java
@@ -18,7 +18,7 @@ package org.springframework.integration.mongodb.outbound;
 
 import org.bson.Document;
 
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.CollectionCallback;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -47,7 +47,7 @@ import org.springframework.util.Assert;
  */
 public class MongoDbOutboundGateway extends AbstractReplyProducingMessageHandler {
 
-	private MongoDbFactory mongoDbFactory;
+	private MongoDatabaseFactory mongoDbFactory;
 
 	private MongoConverter mongoConverter;
 
@@ -65,13 +65,13 @@ public class MongoDbOutboundGateway extends AbstractReplyProducingMessageHandler
 
 	private Expression collectionNameExpression;
 
-	public MongoDbOutboundGateway(MongoDbFactory mongoDbFactory) {
+	public MongoDbOutboundGateway(MongoDatabaseFactory mongoDbFactory) {
 		this(mongoDbFactory, new MappingMongoConverter(new DefaultDbRefResolver(mongoDbFactory),
 				new MongoMappingContext()));
 	}
 
-	public MongoDbOutboundGateway(MongoDbFactory mongoDbFactory, MongoConverter mongoConverter) {
-		Assert.notNull(mongoDbFactory, "mongoDbFactory must not be null.");
+	public MongoDbOutboundGateway(MongoDatabaseFactory mongoDbFactory, MongoConverter mongoConverter) {
+		Assert.notNull(mongoDbFactory, "mongoDatabaseFactory must not be null.");
 		Assert.notNull(mongoConverter, "mongoConverter must not be null.");
 		this.mongoDbFactory = mongoDbFactory;
 		this.mongoConverter = mongoConverter;

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandler.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandler.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.mongodb.outbound;
 
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -42,7 +42,7 @@ public class MongoDbStoringMessageHandler extends AbstractMessageHandler {
 
 	private volatile MongoOperations mongoTemplate;
 
-	private volatile MongoDbFactory mongoDbFactory;
+	private volatile MongoDatabaseFactory mongoDbFactory;
 
 	private volatile MongoConverter mongoConverter;
 
@@ -53,11 +53,11 @@ public class MongoDbStoringMessageHandler extends AbstractMessageHandler {
 	private volatile boolean initialized = false;
 
 	/**
-	 * Will construct this instance using provided {@link MongoDbFactory}
+	 * Will construct this instance using provided {@link MongoDatabaseFactory}
 	 *
 	 * @param mongoDbFactory The mongodb factory.
 	 */
-	public MongoDbStoringMessageHandler(MongoDbFactory mongoDbFactory) {
+	public MongoDbStoringMessageHandler(MongoDatabaseFactory mongoDbFactory) {
 		Assert.notNull(mongoDbFactory, "'mongoDbFactory' must not be null");
 
 		this.mongoDbFactory = mongoDbFactory;
@@ -78,7 +78,7 @@ public class MongoDbStoringMessageHandler extends AbstractMessageHandler {
 	/**
 	 * Allows you to provide custom {@link MongoConverter} used to assist in serialization
 	 * of data written to MongoDb. Only allowed if this instance was constructed with a
-	 * {@link MongoDbFactory}.
+	 * {@link MongoDatabaseFactory}.
 	 *
 	 * @param mongoConverter The mongo converter.
 	 */

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandler.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandler.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.mongodb.outbound;
 
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
@@ -77,7 +77,7 @@ public class ReactiveMongoDbStoringMessageHandler extends AbstractReactiveMessag
 	/**
 	 * Provide a custom {@link MongoConverter} used to assist in serialization of
 	 * data written to MongoDb. Only allowed if this instance was constructed with a
-	 * {@link MongoDbFactory}.
+	 * {@link MongoDatabaseFactory}.
 	 * @param mongoConverter The mongo converter.
 	 */
 	public void setMongoConverter(MongoConverter mongoConverter) {

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -32,7 +32,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
@@ -76,7 +76,7 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 
 	protected final String collectionName; // NOSONAR - final
 
-	protected final MongoDbFactory mongoDbFactory; // NOSONAR - final
+	protected final MongoDatabaseFactory mongoDbFactory; // NOSONAR - final
 
 	private MongoTemplate mongoTemplate;
 
@@ -94,11 +94,11 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 		this.mongoDbFactory = null;
 	}
 
-	public AbstractConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory, String collectionName) {
+	public AbstractConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, String collectionName) {
 		this(mongoDbFactory, null, collectionName);
 	}
 
-	public AbstractConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory,
+	public AbstractConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory,
 			MappingMongoConverter mappingMongoConverter, String collectionName) {
 		Assert.notNull(mongoDbFactory, "'mongoDbFactory' must not be null");
 		Assert.hasText(collectionName, "'collectionName' must not be empty");

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -68,19 +68,19 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 		super(mongoTemplate, collectionName);
 	}
 
-	public ConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory) {
+	public ConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory) {
 		this(mongoDbFactory, null, DEFAULT_COLLECTION_NAME);
 	}
 
-	public ConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter) {
+	public ConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter) {
 		this(mongoDbFactory, mappingMongoConverter, DEFAULT_COLLECTION_NAME);
 	}
 
-	public ConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory, String collectionName) {
+	public ConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, String collectionName) {
 		this(mongoDbFactory, null, collectionName);
 	}
 
-	public ConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter,
+	public ConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter,
 			String collectionName) {
 
 		super(mongoDbFactory, mappingMongoConverter, collectionName);

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
@@ -17,7 +17,7 @@
 package org.springframework.integration.mongodb.store;
 
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.index.Index;
@@ -61,19 +61,19 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 		super(mongoTemplate, collectionName);
 	}
 
-	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory) {
+	public MongoDbChannelMessageStore(MongoDatabaseFactory mongoDbFactory) {
 		this(mongoDbFactory, null, DEFAULT_COLLECTION_NAME);
 	}
 
-	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter) {
+	public MongoDbChannelMessageStore(MongoDatabaseFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter) {
 		this(mongoDbFactory, mappingMongoConverter, DEFAULT_COLLECTION_NAME);
 	}
 
-	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory, String collectionName) {
+	public MongoDbChannelMessageStore(MongoDatabaseFactory mongoDbFactory, String collectionName) {
 		this(mongoDbFactory, null, collectionName);
 	}
 
-	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter,
+	public MongoDbChannelMessageStore(MongoDatabaseFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter,
 			String collectionName) {
 		super(mongoDbFactory, mappingMongoConverter, collectionName);
 	}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -47,7 +47,7 @@ import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -141,19 +141,19 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 	private String[] whiteListPatterns;
 
 	/**
-	 * Create a MongoDbMessageStore using the provided {@link MongoDbFactory}.and the default collection name.
+	 * Create a MongoDbMessageStore using the provided {@link MongoDatabaseFactory}.and the default collection name.
 	 * @param mongoDbFactory The mongodb factory.
 	 */
-	public MongoDbMessageStore(MongoDbFactory mongoDbFactory) {
+	public MongoDbMessageStore(MongoDatabaseFactory mongoDbFactory) {
 		this(mongoDbFactory, null);
 	}
 
 	/**
-	 * Create a MongoDbMessageStore using the provided {@link MongoDbFactory} and collection name.
+	 * Create a MongoDbMessageStore using the provided {@link MongoDatabaseFactory} and collection name.
 	 * @param mongoDbFactory The mongodb factory.
 	 * @param collectionName The collection name.
 	 */
-	public MongoDbMessageStore(MongoDbFactory mongoDbFactory, @Nullable String collectionName) {
+	public MongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, @Nullable String collectionName) {
 		Assert.notNull(mongoDbFactory, "mongoDbFactory must not be null");
 		this.converter = new MessageReadingMongoConverter(mongoDbFactory, new MongoMappingContext());
 		this.template = new MongoTemplate(mongoDbFactory, this.converter);
@@ -523,7 +523,7 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 
 		private Object[] customConverters;
 
-		MessageReadingMongoConverter(MongoDbFactory mongoDbFactory,
+		MessageReadingMongoConverter(MongoDatabaseFactory mongoDbFactory,
 				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
 			super(new DefaultDbRefResolver(mongoDbFactory), mappingContext);
 		}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests-context.xml
@@ -8,7 +8,7 @@
 		http://www.springframework.org/schema/integration/mongodb https://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd">
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<int-mongodb:inbound-channel-adapter id="minimalConfig"

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.expression.common.LiteralExpression;
@@ -49,7 +49,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class MongoDbInboundChannelAdapterParserTests {
 
 	@Autowired
-	private MongoDbFactory mongoDbFactory;
+	private MongoDatabaseFactory mongoDbFactory;
 
 	@Autowired
 	private MongoConverter mongoConverter;

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundChannelAdapterIntegrationTests.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
@@ -49,7 +49,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 		Message<Person> message = new GenericMessage<MongoDbAvailableTests.Person>(this.createPerson("Bob"));
 		channel.send(message);
 
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		assertThat(template.find(new BasicQuery("{'name' : 'Bob'}"), Person.class, "data")).isNotNull();
 		context.close();
@@ -58,7 +58,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 	@Test
 	@MongoDbAvailable
 	public void testWithNamedCollection() throws Exception {
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory("foo");
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory("foo");
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
 
@@ -77,7 +77,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 	@Test
 	@MongoDbAvailable
 	public void testWithTemplate() throws Exception {
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory("foo");
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory("foo");
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
 
@@ -100,7 +100,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 
 		BasicDBObject dbObject = BasicDBObject.parse("{'foo' : 'bar'}");
 
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory("foo");
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory("foo");
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
 
@@ -124,7 +124,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 
 		String object = "{'foo' : 'bar'}";
 
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory("foo");
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory("foo");
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
 
@@ -152,7 +152,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 		Message<Person> message = new GenericMessage<MongoDbAvailableTests.Person>(this.createPerson("Bob"));
 		channel.send(message);
 
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		assertThat(template.find(new BasicQuery("{'name' : 'Bob'}"), Person.class, "data")).isNotNull();
 		context.close();

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests-context.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests-context.xml
@@ -62,7 +62,7 @@
 	</bean>
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<bean id="mongoConverter"

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests.java
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.standard.SpelExpression;
@@ -57,7 +57,7 @@ public class MongoDbOutboundGatewayParserTests {
 	private ApplicationContext context;
 
 	@Autowired
-	private MongoDbFactory mongoDbFactory;
+	private MongoDatabaseFactory mongoDbFactory;
 
 	@Autowired
 	private MongoConverter mongoConverter;

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/inbound-adapter-parser-fail-template-converter-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/inbound-adapter-parser-fail-template-converter-config.xml
@@ -10,7 +10,7 @@
 		http://www.springframework.org/schema/integration/mongodb https://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd">
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<int-mongodb:inbound-channel-adapter id="minimalConfig"

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/inbound-adapter-parser-fail-template-factory-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/inbound-adapter-parser-fail-template-factory-config.xml
@@ -10,7 +10,7 @@
 		http://www.springframework.org/schema/integration/mongodb https://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd">
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<int-mongodb:inbound-channel-adapter id="minimalConfig"

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-adapter-parser-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-adapter-parser-config.xml
@@ -10,7 +10,7 @@
 		http://www.springframework.org/schema/integration/mongodb https://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd">
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<int-mongodb:outbound-channel-adapter id="minimalConfig"/>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-adapter-parser-fail-template-converter-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-adapter-parser-fail-template-converter-config.xml
@@ -10,7 +10,7 @@
 		http://www.springframework.org/schema/integration/mongodb https://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd">
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<int-mongodb:outbound-channel-adapter id="fullConfigWithCollectionExpression"

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-adapter-parser-fail-template-factory-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-adapter-parser-fail-template-factory-config.xml
@@ -10,7 +10,7 @@
 		http://www.springframework.org/schema/integration/mongodb https://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd">
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<int-mongodb:outbound-channel-adapter id="fullConfigWithCollectionExpression"

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-gateway-fail-collection-callback-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-gateway-fail-collection-callback-config.xml
@@ -20,7 +20,7 @@
 		reply-channel="out"/>
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<bean id="mongoDbTemplate" class="org.springframework.data.mongodb.core.MongoTemplate">

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-gateway-fail-template-converter-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-gateway-fail-template-converter-config.xml
@@ -19,7 +19,7 @@
 								  reply-channel="out"/>
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<bean id="mongoDbTemplate" class="org.springframework.data.mongodb.core.MongoTemplate">

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-gateway-fail-template-factory-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-gateway-fail-template-factory-config.xml
@@ -19,7 +19,7 @@
 		reply-channel="out"/>
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
 	</bean>
 
 	<bean id="mongoDbTemplate" class="org.springframework.data.mongodb.core.MongoTemplate">

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/dsl/MongoDbTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/dsl/MongoDbTests.java
@@ -30,11 +30,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -325,8 +325,8 @@ public class MongoDbTests extends MongoDbAvailableTests {
 		}
 
 		@Bean
-		public MongoDbFactory mongoDbFactory() {
-			return new SimpleMongoClientDbFactory(MongoClients.create(), "test");
+		public MongoDatabaseFactory mongoDbFactory() {
+			return new SimpleMongoClientDatabaseFactory(MongoClients.create(), "test");
 		}
 
 		@Bean

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSourceTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSourceTests.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -58,7 +58,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	public void withNullMongoDBFactory() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new MongoDbMessageSource((MongoDbFactory) null, mock(Expression.class)));
+				.isThrownBy(() -> new MongoDbMessageSource((MongoDatabaseFactory) null, mock(Expression.class)));
 	}
 
 	@Test
@@ -70,13 +70,13 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	public void withNullQueryExpression() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new MongoDbMessageSource(mock(MongoDbFactory.class), null));
+				.isThrownBy(() -> new MongoDbMessageSource(mock(MongoDatabaseFactory.class), null));
 	}
 
 	@Test
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithSingleElementIfOneInListAsDbObject() {
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson(), "data");
@@ -96,7 +96,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithSingleElementIfOneInList() {
-		MongoDbFactory mongoDbFactory = prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson(), "data");
@@ -117,7 +117,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithSingleElementIfOneInListAndSingleResult() {
-		MongoDbFactory mongoDbFactory = prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson(), "data");
@@ -138,7 +138,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	@MongoDbAvailable
 	public void validateSuccessfulSubObjectQueryWithSingleElementIfOneInList() {
-		MongoDbFactory mongoDbFactory = prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson(), "data");
@@ -180,7 +180,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 
 	@SuppressWarnings("unchecked")
 	private List<Person> queryMultipleElements(Expression queryExpression) {
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson("Manny"), "data");
@@ -198,7 +198,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithNullReturn() {
 
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson("Manny"), "data");
@@ -217,7 +217,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithCustomConverter() {
 
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson("Manny"), "data");
@@ -243,7 +243,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithMongoTemplate() {
 
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MappingMongoConverter converter = new TestMongoConverter(mongoDbFactory, new MongoMappingContext());
 		converter.afterPropertiesSet();
@@ -269,7 +269,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void validatePipelineInModifyOut() {
 
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/metadata/MongoDbMetadataStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/metadata/MongoDbMetadataStoreTests.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.mongodb.rules.MongoDbAvailableTests;
@@ -45,7 +45,7 @@ public class MongoDbMetadataStoreTests extends MongoDbAvailableTests {
 
 	@Before
 	public void configure() {
-		final MongoDbFactory mongoDbFactory = this.prepareMongoFactory(DEFAULT_COLLECTION_NAME);
+		final MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory(DEFAULT_COLLECTION_NAME);
 		this.store = new MongoDbMetadataStore(mongoDbFactory);
 	}
 
@@ -53,7 +53,7 @@ public class MongoDbMetadataStoreTests extends MongoDbAvailableTests {
 	@Test
 	public void testConfigureCustomCollection() {
 		final String collectionName = "testMetadataStore";
-		final MongoDbFactory mongoDbFactory = this.prepareMongoFactory(collectionName);
+		final MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory(collectionName);
 		final MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		store = new MongoDbMetadataStore(template, collectionName);
 		testBasics();
@@ -62,7 +62,7 @@ public class MongoDbMetadataStoreTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	@Test
 	public void testConfigureFactory() {
-		final MongoDbFactory mongoDbFactory = this.prepareMongoFactory(DEFAULT_COLLECTION_NAME);
+		final MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory(DEFAULT_COLLECTION_NAME);
 		store = new MongoDbMetadataStore(mongoDbFactory);
 		testBasics();
 	}
@@ -71,7 +71,7 @@ public class MongoDbMetadataStoreTests extends MongoDbAvailableTests {
 	@Test
 	public void testConfigureFactorCustomCollection() {
 		final String collectionName = "testMetadataStore";
-		final MongoDbFactory mongoDbFactory = this.prepareMongoFactory(collectionName);
+		final MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory(collectionName);
 		store = new MongoDbMetadataStore(mongoDbFactory, collectionName);
 		testBasics();
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayTests.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -74,7 +74,7 @@ public class MongoDbOutboundGatewayTests extends MongoDbAvailableTests {
 	private MongoConverter mongoConverter;
 
 	@Autowired
-	private MongoDbFactory mongoDbFactory;
+	private MongoDatabaseFactory mongoDbFactory;
 
 	@Before
 	public void setUp() {
@@ -97,7 +97,7 @@ public class MongoDbOutboundGatewayTests extends MongoDbAvailableTests {
 	public void testNoFactorySpecified() {
 
 		try {
-			new MongoDbOutboundGateway((MongoDbFactory) null);
+			new MongoDbOutboundGateway((MongoDatabaseFactory) null);
 			fail("Expected the test case to throw an IllegalArgumentException");
 		}
 		catch (IllegalArgumentException e) {

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayXmlTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayXmlTests.java
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
@@ -53,7 +53,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate mongoTemplate = new MongoTemplate(mongoDbFactory);
 
 		mongoTemplate.save(this.createPerson("Artem"), COLLECTION_NAME);
@@ -64,7 +64,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@After
 	public void cleanUp() throws Exception {
-		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate mongoTemplate = new MongoTemplate(mongoDbFactory);
 
 		mongoTemplate.dropCollection(COLLECTION_NAME);

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandlerTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandlerTests.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -53,7 +53,7 @@ public class MongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 
 	private MongoTemplate template;
 
-	private MongoDbFactory mongoDbFactory;
+	private MongoDatabaseFactory mongoDbFactory;
 
 	@Before
 	public void setUp() {
@@ -66,7 +66,7 @@ public class MongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void withNullMongoDBFactory() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new MongoDbStoringMessageHandler((MongoDbFactory) null));
+				.isThrownBy(() -> new MongoDbStoringMessageHandler((MongoDatabaseFactory) null));
 	}
 
 	@Test

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests.java
@@ -25,6 +25,7 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -51,6 +52,7 @@ import reactor.core.publisher.Mono;
  *
  * @since 5.3
  */
+@Ignore
 public class ReactiveMongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 
 	private ReactiveMongoTemplate template;

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests.java
@@ -25,7 +25,6 @@ import java.time.Duration;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -52,7 +51,6 @@ import reactor.core.publisher.Mono;
  *
  * @since 5.3
  */
-@Ignore
 public class ReactiveMongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 
 	private ReactiveMongoTemplate template;

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/rules/MongoDbAvailableTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/rules/MongoDbAvailableTests.java
@@ -24,11 +24,11 @@ import org.junit.Rule;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -59,8 +59,8 @@ public abstract class MongoDbAvailableTests {
 	public MongoDbAvailableRule mongoDbAvailableRule = new MongoDbAvailableRule();
 
 
-	protected MongoDbFactory prepareMongoFactory(String... additionalCollectionsToDrop) {
-		MongoDbFactory mongoDbFactory = new SimpleMongoClientDbFactory(MongoClients.create(), "test");
+	protected MongoDatabaseFactory prepareMongoFactory(String... additionalCollectionsToDrop) {
+		MongoDatabaseFactory mongoDbFactory = new SimpleMongoClientDatabaseFactory(MongoClients.create(), "test");
 		cleanupCollections(mongoDbFactory, additionalCollectionsToDrop);
 		return mongoDbFactory;
 	}
@@ -84,7 +84,7 @@ public abstract class MongoDbAvailableTests {
 		}
 	}
 
-	protected void cleanupCollections(MongoDbFactory mongoDbFactory, String... additionalCollectionsToDrop) {
+	protected void cleanupCollections(MongoDatabaseFactory mongoDbFactory, String... additionalCollectionsToDrop) {
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.dropCollection("messages");
 		template.dropCollection("configurableStoreMessages");
@@ -179,7 +179,7 @@ public abstract class MongoDbAvailableTests {
 	public static class TestMongoConverter extends MappingMongoConverter {
 
 		public TestMongoConverter(
-				MongoDbFactory mongoDbFactory,
+				MongoDatabaseFactory mongoDbFactory,
 				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
 
 			super(new DefaultDbRefResolver(mongoDbFactory), mappingContext);

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.history.MessageHistory;
@@ -59,8 +59,8 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 
 	protected final GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 
-	protected final SimpleMongoClientDbFactory clientDbFactory =
-			new SimpleMongoClientDbFactory(MongoClients.create(), "test");
+	protected final SimpleMongoClientDatabaseFactory clientDbFactory =
+			new SimpleMongoClientDatabaseFactory(MongoClients.create(), "test");
 
 	@Before
 	public void setup() {
@@ -423,7 +423,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 	//	@Test
 	//	@MongoDbAvailable
 	//	public void testConcurrentModifications() throws Exception{
-	//		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
+	//		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
 	//		final MongoDbMessageStore store1 = new MongoDbMessageStore(mongoDbFactory);
 	//		final MongoDbMessageStore store2 = new MongoDbMessageStore(mongoDbFactory);
 	//

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageStoreTests.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.data.annotation.PersistenceConstructor;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.message.AdviceMessage;
@@ -58,8 +58,8 @@ public abstract class AbstractMongoDbMessageStoreTests extends MongoDbAvailableT
 
 	protected final GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 
-	protected final SimpleMongoClientDbFactory clientDbFactory =
-			new SimpleMongoClientDbFactory(MongoClients.create(), "test");
+	protected final SimpleMongoClientDatabaseFactory clientDbFactory =
+			new SimpleMongoClientDatabaseFactory(MongoClients.create(), "test");
 
 	@Before
 	public void setup() {

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationConfigurableTests-context.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationConfigurableTests-context.xml
@@ -1,33 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans:beans xmlns:beans="http://www.springframework.org/schema/beans"
-			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			 xmlns="http://www.springframework.org/schema/integration"
-			 xmlns:mongo="http://www.springframework.org/schema/data/mongo"
-			 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+<beans:beans
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://www.springframework.org/schema/integration"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
 	http://www.springframework.org/schema/data/mongo https://www.springframework.org/schema/data/mongo/spring-mongo.xsd">
 
-	<mongo:auditing/>
+	<mongo:auditing />
 
-    <beans:bean id="mongoConnectionFactory" class="org.springframework.data.mongodb.core.SimpleMongoDbFactory">
-        <beans:constructor-arg>
-            <beans:bean class="com.mongodb.MongoClient"/>
-        </beans:constructor-arg>
-        <beans:constructor-arg value="test"/>
-    </beans:bean>
+	<beans:bean id="mongoConnectionFactory"
+		class="org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory">
+		<beans:constructor-arg>
+			<beans:bean
+				class="org.springframework.data.mongodb.core.MongoClientFactoryBean">
+				<beans:property name="mongoClientSettings">
+					<beans:bean
+						class="org.springframework.data.mongodb.core.MongoClientSettingsFactoryBean" />
+				</beans:property>
+			</beans:bean>
+		</beans:constructor-arg>
+		<beans:constructor-arg value="test" />
+	</beans:bean>
 
-    <beans:bean id="messageStore" class="org.springframework.integration.mongodb.store.ConfigurableMongoDbMessageStore">
-        <beans:constructor-arg ref="mongoConnectionFactory"/>
-    </beans:bean>
+	<beans:bean id="messageStore"
+		class="org.springframework.integration.mongodb.store.ConfigurableMongoDbMessageStore">
+		<beans:constructor-arg
+			ref="mongoConnectionFactory" />
+	</beans:bean>
 
-    <channel id="output">
-		<queue/>
+	<channel id="output">
+		<queue />
 	</channel>
 
-	<delayer id="#{T (org.springframework.integration.mongodb.store.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
-			 input-channel="input"
-			 output-channel="output"
-			 default-delay="10000"
-			 message-store="messageStore"/>
+	<delayer
+		id="#{T (org.springframework.integration.mongodb.store.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
+		input-channel="input" output-channel="output" default-delay="10000"
+		message-store="messageStore" />
 
 </beans:beans>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -1,33 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans:beans xmlns:beans="http://www.springframework.org/schema/beans"
-			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			 xmlns="http://www.springframework.org/schema/integration"
-			 xmlns:mongo="http://www.springframework.org/schema/data/mongo"
-			 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+<beans:beans
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns="http://www.springframework.org/schema/integration"
+	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 	http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
 	http://www.springframework.org/schema/data/mongo https://www.springframework.org/schema/data/mongo/spring-mongo.xsd">
 
-	<mongo:auditing/>
+	<mongo:auditing />
 
-    <beans:bean id="mongoConnectionFactory" class="org.springframework.data.mongodb.core.SimpleMongoDbFactory">
-        <beans:constructor-arg>
-            <beans:bean class="com.mongodb.MongoClient"/>
-        </beans:constructor-arg>
-        <beans:constructor-arg value="test"/>
-    </beans:bean>
+	<beans:bean id="mongoConnectionFactory"
+		class="org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory">
+		<beans:constructor-arg>
+			<beans:bean
+				class="org.springframework.data.mongodb.core.MongoClientFactoryBean">
+				<beans:property name="mongoClientSettings">
+					<beans:bean
+						class="org.springframework.data.mongodb.core.MongoClientSettingsFactoryBean" />
+				</beans:property>
+			</beans:bean>
+		</beans:constructor-arg>
+		<beans:constructor-arg value="test" />
+	</beans:bean>
 
-    <beans:bean id="messageStore" class="org.springframework.integration.mongodb.store.MongoDbMessageStore">
-        <beans:constructor-arg ref="mongoConnectionFactory"/>
-    </beans:bean>
+	<beans:bean id="messageStore"
+		class="org.springframework.integration.mongodb.store.MongoDbMessageStore">
+		<beans:constructor-arg
+			ref="mongoConnectionFactory" />
+	</beans:bean>
 
-    <channel id="output">
-		<queue/>
+	<channel id="output">
+		<queue />
 	</channel>
 
-	<delayer id="#{T (org.springframework.integration.mongodb.store.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
-			 input-channel="input"
-			 output-channel="output"
-			 default-delay="10000"
-			 message-store="messageStore"/>
+	<delayer
+		id="#{T (org.springframework.integration.mongodb.store.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
+		input-channel="input" output-channel="output" default-delay="10000"
+		message-store="messageStore" />
 
 </beans:beans>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreClaimCheckIntegrationTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/MongoDbMessageStoreClaimCheckIntegrationTests.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.springframework.context.support.GenericApplicationContext;
-import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.mongodb.rules.MongoDbAvailableTests;
 import org.springframework.integration.support.MessageBuilder;
@@ -44,8 +44,8 @@ public class MongoDbMessageStoreClaimCheckIntegrationTests extends MongoDbAvaila
 
 	private final GenericApplicationContext testApplicationContext = TestUtils.createTestApplicationContext();
 
-	private final SimpleMongoClientDbFactory clientDbFactory =
-			new SimpleMongoClientDbFactory(MongoClients.create(), "test");
+	private final SimpleMongoClientDatabaseFactory clientDbFactory =
+			new SimpleMongoClientDatabaseFactory(MongoClients.create(), "test");
 
 	@Before
 	public void setup() {

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-config.xml
@@ -20,9 +20,13 @@
 		<constructor-arg ref="mongoConnectionFactory"/>
 	</bean>
 
-	<bean id="mongoConnectionFactory" class="org.springframework.data.mongodb.core.SimpleMongoDbFactory">
+	<bean id="mongoConnectionFactory" class="org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory">
 		<constructor-arg>
-			<bean class="com.mongodb.MongoClient"/>
+			<bean class="org.springframework.data.mongodb.core.MongoClientFactoryBean">
+				<property name="mongoClientSettings">
+					<bean class="org.springframework.data.mongodb.core.MongoClientSettingsFactoryBean"/>
+				</property>
+			</bean>
 		</constructor-arg>
 		<constructor-arg value="test"/>
 	</bean>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-configurable-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/mongo-aggregator-configurable-config.xml
@@ -20,9 +20,13 @@
 		<constructor-arg ref="mongoConnectionFactory"/>
 	</bean>
 
-	<bean id="mongoConnectionFactory" class="org.springframework.data.mongodb.core.SimpleMongoDbFactory">
+	<bean id="mongoConnectionFactory" class="org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory">
 		<constructor-arg>
-			<bean class="com.mongodb.MongoClient"/>
+			<bean class="org.springframework.data.mongodb.core.MongoClientFactoryBean">
+				<property name="mongoClientSettings">
+					<bean class="org.springframework.data.mongodb.core.MongoClientSettingsFactoryBean"/>
+				</property>
+			</bean>
 		</constructor-arg>
 		<constructor-arg value="test"/>
 	</bean>


### PR DESCRIPTION
Note: new reactive tests are Ignored for now

The async client has this code...

```java
SuppressWarnings("deprecation")
public Builder applyConnectionString(final ConnectionString connectionString) {
    credentialList = new ArrayList<MongoCredential>(connectionString.getCredentialList());
    wrappedBuilder.applyConnectionString(connectionString);
    return this;
}
```

... but `ConnectionString` no longer has `getCredentialList()`.

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
