### PR TITLE
Fix Messaging Annotations for ReplyProdMHWrapper

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -54,6 +54,7 @@ import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.config.IntegrationConfigUtils;
+import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.context.Orderable;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.AbstractPollingEndpoint;
@@ -163,6 +164,11 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			if (handler instanceof ReplyProducingMessageHandlerWrapper
 					&& StringUtils.hasText(MessagingAnnotationUtils.endpointIdValue(method))) {
 				handlerBeanName = handlerBeanName + ".wrapper";
+			}
+			if (handler instanceof IntegrationObjectSupport) {
+				((IntegrationObjectSupport) handler).setComponentName(
+						handlerBeanName.substring(0,
+								handlerBeanName.indexOf(IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX)));
 			}
 			this.beanFactory.registerSingleton(handlerBeanName, handler);
 			handler = (MessageHandler) this.beanFactory.initializeBean(handler, handlerBeanName);
@@ -396,11 +402,11 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 			if (StringUtils.hasText(ref)) {
 				Assert.state(!StringUtils.hasText(triggerRef)
-						&& !StringUtils.hasText(executorRef)
-						&& !StringUtils.hasText(cron)
-						&& !StringUtils.hasText(fixedDelayValue)
-						&& !StringUtils.hasText(fixedRateValue)
-						&& !StringUtils.hasText(maxMessagesPerPollValue), // NOSONAR boolean complexity
+								&& !StringUtils.hasText(executorRef)
+								&& !StringUtils.hasText(cron)
+								&& !StringUtils.hasText(fixedDelayValue)
+								&& !StringUtils.hasText(fixedRateValue)
+								&& !StringUtils.hasText(maxMessagesPerPollValue), // NOSONAR boolean complexity
 						"The '@Poller' 'ref' attribute is mutually exclusive with other attributes.");
 				pollerMetadata = this.beanFactory.getBean(ref, PollerMetadata.class);
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/BeanNameTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/BeanNameTests.java
@@ -16,8 +16,9 @@
 
 package org.springframework.integration.endpoint;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -31,20 +32,23 @@ import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.config.EnableIntegrationManagement;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.handler.ReplyProducingMessageHandlerWrapper;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0.4
  *
  */
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
 public class BeanNameTests {
 
@@ -75,6 +79,10 @@ public class BeanNameTests {
 	@Qualifier("eipBean2.handler")
 	private MessageHandler eipBean2Handler;
 
+	@Autowired
+	@Qualifier("eipBean2.handler.wrapper")
+	private ReplyProducingMessageHandlerWrapper eipBean2HandlerWrapper;
+
 	@SuppressWarnings("unused")
 	@Autowired
 	private SourcePollingChannelAdapter eipMethodSource;
@@ -95,7 +103,7 @@ public class BeanNameTests {
 
 	@Test
 	public void contextLoads() {
-
+		assertThat(this.eipBean2HandlerWrapper.getComponentName()).isEqualTo("eipBean2");
 	}
 
 	@Configuration


### PR DESCRIPTION
To ensure advice-chain applicability the provided plain
`MessageHandler` is wrapped into a `ReplyProducingMessageHandlerWrapper`
with its particular `.wrapper` bean name.
When we build a graph for integration components, we use a
`componentName` from the `IntegrationObjectSupport` to represent a
node for endpoint in the graph.
In most cases the component name is an endpoint id around a `MessageHandler`

* Populate the missed component name in a `ReplyProducingMessageHandlerWrapper`
in the `AbstractMethodAnnotationPostProcessor` so nodes in the graph has
a proper name for their endpoint in the application context

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
