### PR TITLE
Infrastructure for ReactiveMessageHandler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -237,6 +237,7 @@ configure(javaProjects) { subproject ->
 
 		testRuntimeOnly 'org.apache.logging.log4j:log4j-core'
 		testRuntimeOnly 'org.apache.logging.log4j:log4j-jcl'
+		testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 	}
 
 	// enable all compiler warnings; individual projects may customize further
@@ -471,7 +472,6 @@ project('spring-integration-gemfire') {
 		api "commons-io:commons-io:$commonsIoVersion"
 
 		testImplementation project(':spring-integration-stream')
-		testRuntimeOnly 'org.apache.logging.log4j:log4j-slf4j-impl'
 	}
 }
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/FluxMessageChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,14 +78,8 @@ public class FluxMessageChannel extends AbstractMessageChannel
 				Flux.from(publisher)
 						.delaySubscription(this.subscribedSignal.filter(Boolean::booleanValue).next())
 						.publishOn(Schedulers.boundedElastic())
-						.doOnNext((message) -> {
-							try {
-								send(message);
-							}
-							catch (Exception e) {
-								logger.warn("Error during processing event: " + message, e);
-							}
-						})
+						.doOnNext(this::send)
+						.onErrorContinue((ex, message) -> logger.warn("Error during processing event: " + message, ex))
 						.subscribe());
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -115,7 +115,7 @@ public class ConsumerEndpointFactoryBean
 	private volatile boolean initialized;
 
 	public void setHandler(Object handler) {
-		Assert.state(handler instanceof MessageHandler || handler instanceof ReactiveMessageHandler,
+		Assert.isTrue(handler instanceof MessageHandler || handler instanceof ReactiveMessageHandler,
 				"'handler' must be an instance of 'MessageHandler' or 'ReactiveMessageHandler'");
 		synchronized (this.handlerMonitor) {
 			Assert.isNull(this.handler, "handler cannot be overridden");
@@ -222,7 +222,7 @@ public class ConsumerEndpointFactoryBean
 			adviceChain();
 		}
 		else {
-			LOGGER.warn("the advice chain cannot be applied for 'ReactiveMessageHandler'");
+			LOGGER.warn("the advice chain cannot be applied to a 'ReactiveMessageHandler'");
 		}
 		if (this.channelResolver == null) {
 			this.channelResolver = ChannelResolverUtils.getChannelResolver(this.beanFactory);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -221,7 +221,7 @@ public class ConsumerEndpointFactoryBean
 		if (!(this.handler instanceof ReactiveMessageHandlerAdapter)) {
 			adviceChain();
 		}
-		else {
+		else if (!CollectionUtils.isEmpty(this.adviceChain)) {
 			LOGGER.warn("the advice chain cannot be applied to a 'ReactiveMessageHandler'");
 		}
 		if (this.channelResolver == null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ReactiveMessageHandlerAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ReactiveMessageHandlerAdapter.java
@@ -27,20 +27,41 @@ import org.springframework.util.Assert;
  * for synchronous invocations.
  * A subscription to the returned reactive type from {@link ReactiveMessageHandler#handleMessage(Message)}
  * call is done directly in the {@link #handleMessage} implementation.
+ * <p>
+ * The framework wraps a target {@link ReactiveMessageHandler} into this instance automatically
+ * for XML and Annotation configuration. For Java DSL it is recommended to wrap for generic usage
+ * ({@code .handle(MessageHandle)}) or it has to be done in the
+ * {@link org.springframework.integration.dsl.MessageHandlerSpec}
+ * implementation for protocol-specif {@link ReactiveMessageHandler}.
+ * <p>
+ * The framework unwraps a delegate {@link ReactiveMessageHandler} whenever it can compose
+ * reactive streams, e.g. {@link org.springframework.integration.endpoint.ReactiveStreamsConsumer}.
  *
  * @author Artem Bilan
  *
  * @since 5.3
+ *
+ * @see org.springframework.integration.endpoint.ReactiveStreamsConsumer
  */
 public class ReactiveMessageHandlerAdapter implements MessageHandler {
 
 	private final ReactiveMessageHandler delegate;
 
+	/**
+	 * Instantiate based on the provided {@link ReactiveMessageHandler}.
+	 * @param reactiveMessageHandler the {@link ReactiveMessageHandler} to delegate to.
+	 */
 	public ReactiveMessageHandlerAdapter(ReactiveMessageHandler reactiveMessageHandler) {
 		Assert.notNull(reactiveMessageHandler, "'reactiveMessageHandler' must not be null");
 		this.delegate = reactiveMessageHandler;
 	}
 
+	/**
+	 * Get access to the delegate {@link ReactiveMessageHandler}.
+	 * Typically used in the framework internally in components which can compose reactive streams internally
+	 * and allow us to avoid an explicit {@code subscribe()} call.
+	 * @return the {@link ReactiveMessageHandler} this instance is delegating to.
+	 */
 	public ReactiveMessageHandler getDelegate() {
 		return this.delegate;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ReactiveMessageHandlerAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ReactiveMessageHandlerAdapter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.ReactiveMessageHandler;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link MessageHandler} implementation to adapt a {@link ReactiveMessageHandler}
+ * for synchronous invocations.
+ * A subscription to the returned reactive type from {@link ReactiveMessageHandler#handleMessage(Message)}
+ * call is done directly in the {@link #handleMessage} implementation.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.3
+ */
+public class ReactiveMessageHandlerAdapter implements MessageHandler {
+
+	private final ReactiveMessageHandler delegate;
+
+	public ReactiveMessageHandlerAdapter(ReactiveMessageHandler reactiveMessageHandler) {
+		Assert.notNull(reactiveMessageHandler, "'reactiveMessageHandler' must not be null");
+		this.delegate = reactiveMessageHandler;
+	}
+
+	public ReactiveMessageHandler getDelegate() {
+		return this.delegate;
+	}
+
+	@Override
+	public void handleMessage(Message<?> message) throws MessagingException {
+		this.delegate.handleMessage(message).subscribe();
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdviceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdviceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@ package org.springframework.integration.handler.advice;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.aopalliance.aop.Advice;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -28,21 +27,22 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.handler.GenericHandler;
 import org.springframework.integration.handler.advice.ExpressionEvaluatingRequestHandlerAdvice.MessageHandlingExpressionEvaluatingAdviceException;
 import org.springframework.integration.message.AdviceMessage;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 public class ExpressionEvaluatingRequestHandlerAdviceTests {
 
 	@Autowired
@@ -70,14 +70,16 @@ public class ExpressionEvaluatingRequestHandlerAdviceTests {
 
 		@Bean
 		public IntegrationFlow advised() {
-			return f -> f.handle((GenericHandler<String>) (payload, headers) -> {
-				if (payload.equals("good")) {
-					return null;
-				}
-				else {
-					throw new RuntimeException("some failure");
-				}
-			}, c -> c.advice(expressionAdvice()));
+			return f -> f
+					.<String>handle((payload, headers) -> {
+								if (payload.equals("good")) {
+									return null;
+								}
+								else {
+									throw new RuntimeException("some failure");
+								}
+							},
+							c -> c.advice(expressionAdvice()));
 		}
 
 		@Bean

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDb.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDb.java
@@ -17,7 +17,9 @@
 package org.springframework.integration.mongodb.dsl;
 
 import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 
 /**
@@ -50,6 +52,30 @@ public final class MongoDb {
 	 */
 	public static MongoDbOutboundGatewaySpec outboundGateway(MongoOperations mongoTemplate) {
 		return new MongoDbOutboundGatewaySpec(mongoTemplate);
+	}
+
+	/**
+	 * Create a {@link ReactiveMongoDbMessageHandlerSpec} builder instance
+	 * based on the provided {@link ReactiveMongoDatabaseFactory}.
+	 * @param mongoDbFactory the {@link ReactiveMongoDatabaseFactory} to use.
+	 * @return the {@link MongoDbOutboundGatewaySpec} instance
+	 * @since 5.3
+	 */
+	public static ReactiveMongoDbMessageHandlerSpec reactiveOutboundChannelAdapter(
+			ReactiveMongoDatabaseFactory mongoDbFactory) {
+
+		return new ReactiveMongoDbMessageHandlerSpec(mongoDbFactory);
+	}
+
+	/**
+	 * Create a {@link ReactiveMongoDbMessageHandlerSpec} builder instance
+	 * based on the provided {@link ReactiveMongoOperations}.
+	 * @param mongoTemplate the {@link ReactiveMongoOperations} to use.
+	 * @return the {@link ReactiveMongoDbMessageHandlerSpec} instance
+	 * @since 5.3
+	 */
+	public static ReactiveMongoDbMessageHandlerSpec reactiveOutboundChannelAdapter(ReactiveMongoOperations mongoTemplate) {
+		return new ReactiveMongoDbMessageHandlerSpec(mongoTemplate);
 	}
 
 	private MongoDb() {

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDbOutboundGatewaySpec.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDbOutboundGatewaySpec.java
@@ -32,7 +32,7 @@ import org.springframework.messaging.Message;
 /**
  * A {@link MessageHandlerSpec} extension for the MongoDb Outbound endpoint {@link MongoDbOutboundGateway}
  *
- * @author Xavier Padr?
+ * @author Xavier Padro
  * @author Artem Bilan
  *
  * @since 5.0

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/ReactiveMongoDbMessageHandlerSpec.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/ReactiveMongoDbMessageHandlerSpec.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mongodb.dsl;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
+import org.springframework.data.mongodb.core.ReactiveMongoOperations;
+import org.springframework.data.mongodb.core.convert.MongoConverter;
+import org.springframework.expression.Expression;
+import org.springframework.expression.common.LiteralExpression;
+import org.springframework.integration.dsl.ComponentsRegistration;
+import org.springframework.integration.dsl.MessageHandlerSpec;
+import org.springframework.integration.expression.FunctionExpression;
+import org.springframework.integration.handler.ReactiveMessageHandlerAdapter;
+import org.springframework.integration.mongodb.outbound.ReactiveMongoDbStoringMessageHandler;
+import org.springframework.messaging.Message;
+
+/**
+ * A {@link MessageHandlerSpec} extension for the Reactive MongoDb Outbound endpoint
+ * {@link ReactiveMongoDbStoringMessageHandler}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.3
+ */
+public class ReactiveMongoDbMessageHandlerSpec
+		extends MessageHandlerSpec<ReactiveMongoDbMessageHandlerSpec, ReactiveMessageHandlerAdapter>
+		implements ComponentsRegistration {
+
+	private final ReactiveMongoDbStoringMessageHandler messageHandler;
+
+	ReactiveMongoDbMessageHandlerSpec(ReactiveMongoDatabaseFactory mongoDbFactory) {
+		this(new ReactiveMongoDbStoringMessageHandler(mongoDbFactory));
+	}
+
+	ReactiveMongoDbMessageHandlerSpec(ReactiveMongoOperations reactiveMongoOperations) {
+		this(new ReactiveMongoDbStoringMessageHandler(reactiveMongoOperations));
+	}
+
+	private ReactiveMongoDbMessageHandlerSpec(ReactiveMongoDbStoringMessageHandler messageHandler) {
+		this.messageHandler = messageHandler;
+		this.target = new ReactiveMessageHandlerAdapter(this.messageHandler);
+	}
+
+	/**
+	 * Configure a {@link MongoConverter}.
+	 * @param mongoConverter the {@link MongoConverter} to use.
+	 * @return the spec
+	 */
+	public ReactiveMongoDbMessageHandlerSpec mongoConverter(MongoConverter mongoConverter) {
+		this.messageHandler.setMongoConverter(mongoConverter);
+		return this;
+	}
+
+	/**
+	 * Configure a collection name to store data.
+	 * @param collectionName the explicit collection name to use.
+	 * @return the spec
+	 */
+	public ReactiveMongoDbMessageHandlerSpec collectionName(String collectionName) {
+		return collectionNameExpression(new LiteralExpression(collectionName));
+	}
+
+	/**
+	 * Configure a {@link Function} for evaluation a collection against request message.
+	 * @param collectionNameFunction the {@link Function} to determine a collection name at runtime.
+	 * @param <P> an expected payload type
+	 * @return the spec
+	 */
+	public <P> ReactiveMongoDbMessageHandlerSpec collectionNameFunction(
+			Function<Message<P>, String> collectionNameFunction) {
+
+		return collectionNameExpression(new FunctionExpression<>(collectionNameFunction));
+	}
+
+	/**
+	 * Configure a SpEL expression to evaluate a collection name against a request message.
+	 * @param collectionNameExpression the SpEL expression to use.
+	 * @return the spec
+	 */
+	public ReactiveMongoDbMessageHandlerSpec collectionNameExpression(Expression collectionNameExpression) {
+		this.messageHandler.setCollectionNameExpression(collectionNameExpression);
+		return this;
+	}
+
+	@Override
+	public Map<Object, String> getComponentsToRegister() {
+		return Collections.singletonMap(this.messageHandler, null);
+	}
+
+}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandler.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandler.java
@@ -36,6 +36,7 @@ import reactor.core.publisher.Mono;
  * collection is identified by evaluation of the {@link #collectionNameExpression}.
  *
  * @author David Turanski
+ * @author Artme Bilan
  *
  * @since 5.3
  */
@@ -104,7 +105,9 @@ public class ReactiveMongoDbStoringMessageHandler extends AbstractReactiveMessag
 		super.onInit();
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 		if (this.mongoTemplate == null) {
-			this.mongoTemplate = new ReactiveMongoTemplate(this.mongoDbFactory, this.mongoConverter);
+			ReactiveMongoTemplate mongoTemplate = new ReactiveMongoTemplate(this.mongoDbFactory, this.mongoConverter);
+			mongoTemplate.setApplicationContext(getApplicationContext());
+			this.mongoTemplate = mongoTemplate;
 		}
 		this.initialized = true;
 	}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandler.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,7 +113,7 @@ public class ReactiveMongoDbStoringMessageHandler extends AbstractReactiveMessag
 	protected Mono<Void> handleMessageInternal(Message<?> message) {
 		Assert.isTrue(this.initialized, "This class is not yet initialized. Invoke its afterPropertiesSet() method");
 
- 		return evaluateCollectionNameExpression(message)
+		return evaluateCollectionNameExpression(message)
 				.flatMap(collection -> this.mongoTemplate.save(message.getPayload(), collection))
 				.then();
 	}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandler.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandler.java
@@ -113,7 +113,7 @@ public class ReactiveMongoDbStoringMessageHandler extends AbstractReactiveMessag
 	protected Mono<Void> handleMessageInternal(Message<?> message) {
 		Assert.isTrue(this.initialized, "This class is not yet initialized. Invoke its afterPropertiesSet() method");
 
-		return evaluateCollectionNameExpression(message)
+ 		return evaluateCollectionNameExpression(message)
 				.flatMap(collection -> this.mongoTemplate.save(message.getPayload(), collection))
 				.then();
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayXmlTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayXmlTests.java
@@ -39,7 +39,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
- * @author Xavier Padr?
+ * @author Xavier Padro
+ * @author Artem Bilan
+ *
  * @since 5.0
  */
 @RunWith(SpringRunner.class)
@@ -52,7 +54,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 	private ApplicationContext context;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate mongoTemplate = new MongoTemplate(mongoDbFactory);
 
@@ -63,7 +65,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 	}
 
 	@After
-	public void cleanUp() throws Exception {
+	public void cleanUp() {
 		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate mongoTemplate = new MongoTemplate(mongoDbFactory);
 
@@ -73,7 +75,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@Test
 	@MongoDbAvailable
-	public void testSingleQuery() throws Exception {
+	public void testSingleQuery() {
 		EventDrivenConsumer consumer = context.getBean("gatewaySingleQuery", EventDrivenConsumer.class);
 		PollableChannel outChannel = context.getBean("out", PollableChannel.class);
 
@@ -87,7 +89,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@Test
 	@MongoDbAvailable
-	public void testSingleQueryWithTemplate() throws Exception {
+	public void testSingleQueryWithTemplate() {
 		EventDrivenConsumer consumer = context.getBean("gatewayWithTemplate", EventDrivenConsumer.class);
 		PollableChannel outChannel = context.getBean("out", PollableChannel.class);
 
@@ -101,7 +103,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@Test
 	@MongoDbAvailable
-	public void testSingleQueryExpression() throws Exception {
+	public void testSingleQueryExpression() {
 		EventDrivenConsumer consumer = context.getBean("gatewaySingleQueryExpression", EventDrivenConsumer.class);
 		PollableChannel outChannel = context.getBean("out", PollableChannel.class);
 
@@ -120,7 +122,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@Test
 	@MongoDbAvailable
-	public void testQueryExpression() throws Exception {
+	public void testQueryExpression() {
 		EventDrivenConsumer consumer = context.getBean("gatewayQueryExpression", EventDrivenConsumer.class);
 		PollableChannel outChannel = context.getBean("out", PollableChannel.class);
 
@@ -139,7 +141,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@Test
 	@MongoDbAvailable
-	public void testQueryExpressionWithLimit() throws Exception {
+	public void testQueryExpressionWithLimit() {
 		EventDrivenConsumer consumer = context.getBean("gatewayQueryExpressionLimit", EventDrivenConsumer.class);
 		PollableChannel outChannel = context.getBean("out", PollableChannel.class);
 
@@ -157,7 +159,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@Test
 	@MongoDbAvailable
-	public void testCollectionCallback() throws Exception {
+	public void testCollectionCallback() {
 		EventDrivenConsumer consumer = context.getBean("gatewayCollectionCallback", EventDrivenConsumer.class);
 		PollableChannel outChannel = context.getBean("out", PollableChannel.class);
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests-context.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests-context.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:int="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<bean id="input" class="org.springframework.integration.channel.FluxMessageChannel"/>
+
+
+	<int:service-activator input-channel="input">
+		<bean class="org.springframework.integration.mongodb.outbound.ReactiveMongoDbStoringMessageHandler">
+			<constructor-arg
+					value="#{T (org.springframework.integration.mongodb.outbound.ReactiveMongoDbStoringMessageHandlerTests).REACTIVE_MONGO_DATABASE_FACTORY}"/>
+		</bean>
+	</int:service-activator>
+
+</beans>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests.java
@@ -18,6 +18,7 @@ package org.springframework.integration.mongodb.outbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
@@ -190,10 +191,11 @@ public class ReactiveMongoDbStoringMessageHandlerTests extends MongoDbAvailableT
 		this.input.send(message);
 
 		Query query = new BasicQuery("{'name' : 'Bob'}");
-		Person person = waitFor(this.template.findOne(query, Person.class, "data"));
 
-		assertThat(person.getName()).isEqualTo("Bob");
-		assertThat(person.getAddress().getState()).isEqualTo("PA");
+		await().untilAsserted(() ->
+				assertThat(waitFor(this.template.findOne(query, Person.class, "data")))
+						.isNotNull()
+						.extracting("name", "address.state").contains("Bob", "PA"));
 	}
 
 	private static <T> T waitFor(Mono<T> mono) {

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/ReactiveMongoDbStoringMessageHandlerTests.java
@@ -28,9 +28,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
@@ -94,6 +96,7 @@ public class ReactiveMongoDbStoringMessageHandlerTests extends MongoDbAvailableT
 	public void validateMessageHandlingWithDefaultCollection() {
 		ReactiveMongoDbStoringMessageHandler handler = new ReactiveMongoDbStoringMessageHandler(this.mongoDbFactory);
 		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
 		handler.afterPropertiesSet();
 		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob")).build();
 		waitFor(handler.handleMessage(message));
@@ -111,6 +114,7 @@ public class ReactiveMongoDbStoringMessageHandlerTests extends MongoDbAvailableT
 		ReactiveMongoDbStoringMessageHandler handler = new ReactiveMongoDbStoringMessageHandler(this.mongoDbFactory);
 		handler.setCollectionNameExpression(new LiteralExpression("foo"));
 		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
 		handler.afterPropertiesSet();
 
 		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob")).build();
@@ -131,6 +135,7 @@ public class ReactiveMongoDbStoringMessageHandlerTests extends MongoDbAvailableT
 		ReactiveMongoDbStoringMessageHandler handler = new ReactiveMongoDbStoringMessageHandler(this.mongoDbFactory);
 		handler.setCollectionNameExpression(new LiteralExpression(null));
 		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
 		handler.afterPropertiesSet();
 
 		Message<Person> message = MessageBuilder.withPayload(createPerson("Bob")).build();
@@ -151,6 +156,7 @@ public class ReactiveMongoDbStoringMessageHandlerTests extends MongoDbAvailableT
 		converter = spy(converter);
 		handler.setMongoConverter(converter);
 		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
 		handler.afterPropertiesSet();
 		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob")).build();
 		waitFor(handler.handleMessage(message));
@@ -173,6 +179,7 @@ public class ReactiveMongoDbStoringMessageHandlerTests extends MongoDbAvailableT
 		ReactiveMongoDbStoringMessageHandler handler = new ReactiveMongoDbStoringMessageHandler(writingTemplate);
 		handler.setCollectionNameExpression(new LiteralExpression("foo"));
 		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
 		handler.afterPropertiesSet();
 		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob")).build();
 		waitFor(handler.handleMessage(message));

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/rules/MongoDbAvailableTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/rules/MongoDbAvailableTests.java
@@ -65,16 +65,20 @@ public abstract class MongoDbAvailableTests {
 							MongoClientSettings.builder().build()),
 					"test");
 
-	protected MongoDbFactory prepareMongoFactory(String... additionalCollectionsToDrop) {
+	public static final ReactiveMongoDatabaseFactory REACTIVE_MONGO_DATABASE_FACTORY =
+			new SimpleReactiveMongoDatabaseFactory(
+					com.mongodb.reactivestreams.client.MongoClients.create(
+							MongoClientSettings.builder().uuidRepresentation(UuidRepresentation.STANDARD).build()),
+					"test");
+
+	protected MongoDatabaseFactory prepareMongoFactory(String... additionalCollectionsToDrop) {
 		cleanupCollections(MONGO_DATABASE_FACTORY, additionalCollectionsToDrop);
 		return MONGO_DATABASE_FACTORY;
 	}
 
 	protected ReactiveMongoDatabaseFactory prepareReactiveMongoFactory(String... additionalCollectionsToDrop) {
-		ReactiveMongoDatabaseFactory mongoDbFactory = new SimpleReactiveMongoDatabaseFactory(
-				com.mongodb.reactivestreams.client.MongoClients.create(), "test");
-		cleanupCollections(mongoDbFactory, additionalCollectionsToDrop);
-		return mongoDbFactory;
+		cleanupCollections(REACTIVE_MONGO_DATABASE_FACTORY, additionalCollectionsToDrop);
+		return REACTIVE_MONGO_DATABASE_FACTORY;
 	}
 
 	protected void cleanupCollections(ReactiveMongoDatabaseFactory mongoDbFactory,

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/rules/MongoDbAvailableTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/rules/MongoDbAvailableTests.java
@@ -68,10 +68,10 @@ public abstract class MongoDbAvailableTests {
 	public static final ReactiveMongoDatabaseFactory REACTIVE_MONGO_DATABASE_FACTORY =
 			new SimpleReactiveMongoDatabaseFactory(
 					com.mongodb.reactivestreams.client.MongoClients.create(
-							MongoClientSettings.builder().uuidRepresentation(UuidRepresentation.STANDARD).build()),
+							MongoClientSettings.builder().build()),
 					"test");
 
-	protected MongoDatabaseFactory prepareMongoFactory(String... additionalCollectionsToDrop) {
+	protected MongoDbFactory prepareMongoFactory(String... additionalCollectionsToDrop) {
 		cleanupCollections(MONGO_DATABASE_FACTORY, additionalCollectionsToDrop);
 		return MONGO_DATABASE_FACTORY;
 	}


### PR DESCRIPTION
We have now a `ReactiveMongoDbStoringMessageHandler` which implements
a `ReactiveMessageHandler`, but not a `MessageHandler` for possible
deferred subscriptions to the returned Reactor type

We don't have a proper application context processing for this
new type of message handlers

* Change a  `ConsumerEndpointFactoryBean` to apply an `MH` and `RMH`
as possible types for handler
* Introduce a `ReactiveMessageHandlerAdapter` to wrap an `RMH`
into a `MH` for synchronous calls in the regular consumer endpoints
* Wrap an `RMH` into a `ReactiveMessageHandlerAdapter` for regular
endpoints and unwrap for `ReactiveStreamsConsumer`
* Add `RMH`-based ctor into `ReactiveStreamsConsumer` for target
reactive streams composition (`flatMap()` on the `RMH`)
* Remove a `DelegatingSubscriber` from the `ReactiveStreamsConsumer`
in favor of direct calls from the `doOnSubscribe()`, `doOnComplete()`
& `doOnNext()`
* Add an `onErrorContinue()` to handle per-message errors, but don't
cancel the whole source `Publisher`
* Use `Disposable` from the `subscribe()` to cancel in the `stop()`
- recommended way in Reactor
* Use `onErrorContinue()` in the `FluxMessageChannel` instead of
`try..catch` in the `doOnNext()` - for possible `onErrorStop()`
in the provided upstream `Publisher`
* Handle `RMH` in the `ServiceActivatorFactoryBean` as a direct handler
as well with wrapping into `ReactiveMessageHandlerAdapter` for return.
The `ConsumerEndpointFactoryBean` extracts an `RMH` from the adapter
for the `ReactiveStreamsConsumer` anyway
* Add XML parsing test for `ReactiveMongoDbStoringMessageHandler`
* Add `log4j-slf4j-impl` for all the test runtime since `slf4j-api`
comes as a transitive dependency from many places

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
