### PR TITLE
Revert MongoDb driver 4 changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ ext {
 	log4jVersion = '2.13.0'
 	micrometerVersion = '1.3.2'
 	mockitoVersion = '3.2.4'
-	mongoDriverVersion = '4.0.0-SNAPSHOT'
+	mongoDriverVersion = '1.12.0'
 	mysqlVersion = '8.0.18'
 	pahoMqttClientVersion = '1.2.0'
 	postgresVersion = '42.2.9'
@@ -93,7 +93,7 @@ ext {
 	smackVersion = '4.3.4'
 	springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '2.2.3.BUILD-SNAPSHOT'
 	springDataVersion = project.hasProperty('springDataVersion') ? project.springDataVersion : 'Neumann-BUILD-SNAPSHOT'
-	springSecurityVersion = project.hasProperty('springSecurityVersion') ? project.springSecurityVersion : '5.3.0.BUILD-SNAPSHOT'
+	springSecurityVersion = project.hasProperty('springSecurityVersion') ? project.springSecurityVersion : '5.3.0.M1'
 	springRetryVersion = '1.2.5.RELEASE'
 	springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.2.3.BUILD-SNAPSHOT'
 	springWsVersion = '3.0.8.RELEASE'
@@ -591,11 +591,10 @@ project('spring-integration-mongodb') {
 	description = 'Spring Integration MongoDB Support'
 	dependencies {
 		api project(':spring-integration-core')
-		api ('org.springframework.data:spring-data-mongodb:3.0.0.BUILD-SNAPSHOT') {
+		api ('org.springframework.data:spring-data-mongodb') {
 			exclude group: 'org.springframework'
 		}
 		optionalApi "org.mongodb:mongodb-driver-reactivestreams:$mongoDriverVersion"
-		optionalApi "org.mongodb:mongodb-driver-sync:$mongoDriverVersion"
 	}
 }
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDb.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDb.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.mongodb.dsl;
 
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 
@@ -31,13 +31,13 @@ public final class MongoDb {
 
 	/**
 	 * Create a {@link MongoDbOutboundGatewaySpec} builder instance
-	 * based on the provided {@link MongoDatabaseFactory} and {@link MongoConverter}.
-	 * @param mongoDbFactory the {@link MongoDatabaseFactory} to use.
+	 * based on the provided {@link MongoDbFactory} and {@link MongoConverter}.
+	 * @param mongoDbFactory the {@link MongoDbFactory} to use.
 	 * @param mongoConverter the {@link MongoConverter} to use.
 	 * @return the {@link MongoDbOutboundGatewaySpec} instance
 	 */
 	public static MongoDbOutboundGatewaySpec outboundGateway(
-			MongoDatabaseFactory mongoDbFactory, MongoConverter mongoConverter) {
+			MongoDbFactory mongoDbFactory, MongoConverter mongoConverter) {
 
 		return new MongoDbOutboundGatewaySpec(mongoDbFactory, mongoConverter);
 	}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDbOutboundGatewaySpec.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/dsl/MongoDbOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.integration.mongodb.dsl;
 
 import java.util.function.Function;
 
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Query;
@@ -40,7 +40,7 @@ import org.springframework.messaging.Message;
 public class MongoDbOutboundGatewaySpec
 		extends MessageHandlerSpec<MongoDbOutboundGatewaySpec, MongoDbOutboundGateway> {
 
-	MongoDbOutboundGatewaySpec(MongoDatabaseFactory mongoDbFactory, MongoConverter mongoConverter) {
+	MongoDbOutboundGatewaySpec(MongoDbFactory mongoDbFactory, MongoConverter mongoConverter) {
 		this.target = new MongoDbOutboundGateway(mongoDbFactory, mongoConverter);
 		this.target.setRequiresReply(true);
 	}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSource.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2019 the original author or authors.
+ * Copyright 2007-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.integration.mongodb.inbound;
 
 import java.util.List;
 
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -75,7 +75,7 @@ public class MongoDbMessageSource extends AbstractMessageSource<Object> {
 
 	private volatile MongoConverter mongoConverter;
 
-	private volatile MongoDatabaseFactory mongoDbFactory;
+	private volatile MongoDbFactory mongoDbFactory;
 
 	private volatile boolean initialized = false;
 
@@ -84,14 +84,14 @@ public class MongoDbMessageSource extends AbstractMessageSource<Object> {
 	private volatile boolean expectSingleResult = false;
 
 	/**
-	 * Creates an instance with the provided {@link MongoDatabaseFactory} and SpEL expression
+	 * Creates an instance with the provided {@link MongoDbFactory} and SpEL expression
 	 * which should resolve to a MongoDb 'query' string
 	 * (see https://www.mongodb.org/display/DOCS/Querying).
 	 * The 'queryExpression' will be evaluated on every call to the {@link #receive()} method.
 	 * @param mongoDbFactory The mongodb factory.
 	 * @param queryExpression The query expression.
 	 */
-	public MongoDbMessageSource(MongoDatabaseFactory mongoDbFactory, Expression queryExpression) {
+	public MongoDbMessageSource(MongoDbFactory mongoDbFactory, Expression queryExpression) {
 		Assert.notNull(mongoDbFactory, "'mongoDbFactory' must not be null");
 		Assert.notNull(queryExpression, "'queryExpression' must not be null");
 
@@ -156,7 +156,7 @@ public class MongoDbMessageSource extends AbstractMessageSource<Object> {
 	/**
 	 * Allows you to provide a custom {@link MongoConverter} used to assist in deserialization
 	 * data read from MongoDb. Only allowed if this instance was constructed with a
-	 * {@link MongoDatabaseFactory}.
+	 * {@link MongoDbFactory}.
 	 * @param mongoConverter The mongo converter.
 	 */
 	public void setMongoConverter(MongoConverter mongoConverter) {

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/metadata/MongoDbMetadataStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/metadata/MongoDbMetadataStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import java.util.Map;
 
 import org.bson.Document;
 
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -58,21 +58,21 @@ public class MongoDbMetadataStore implements ConcurrentMetadataStore {
 	private final String collectionName;
 
 	/**
-	 * Configure the MongoDbMetadataStore by provided {@link MongoDatabaseFactory} and
+	 * Configure the MongoDbMetadataStore by provided {@link MongoDbFactory} and
 	 * default collection name - {@link #DEFAULT_COLLECTION_NAME}.
 	 * @param factory the mongodb factory
 	 */
-	public MongoDbMetadataStore(MongoDatabaseFactory factory) {
+	public MongoDbMetadataStore(MongoDbFactory factory) {
 		this(factory, DEFAULT_COLLECTION_NAME);
 	}
 
 	/**
-	 * Configure the MongoDbMetadataStore by provided {@link MongoDatabaseFactory} and
+	 * Configure the MongoDbMetadataStore by provided {@link MongoDbFactory} and
 	 * collection name
 	 * @param factory the mongodb factory
 	 * @param collectionName the collection name where it persists the data
 	 */
-	public MongoDbMetadataStore(MongoDatabaseFactory factory, String collectionName) {
+	public MongoDbMetadataStore(MongoDbFactory factory, String collectionName) {
 		this(new MongoTemplate(factory), collectionName);
 	}
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGateway.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.integration.mongodb.outbound;
 
 import org.bson.Document;
 
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.CollectionCallback;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -47,7 +47,7 @@ import org.springframework.util.Assert;
  */
 public class MongoDbOutboundGateway extends AbstractReplyProducingMessageHandler {
 
-	private MongoDatabaseFactory mongoDbFactory;
+	private MongoDbFactory mongoDbFactory;
 
 	private MongoConverter mongoConverter;
 
@@ -65,12 +65,12 @@ public class MongoDbOutboundGateway extends AbstractReplyProducingMessageHandler
 
 	private Expression collectionNameExpression;
 
-	public MongoDbOutboundGateway(MongoDatabaseFactory mongoDbFactory) {
+	public MongoDbOutboundGateway(MongoDbFactory mongoDbFactory) {
 		this(mongoDbFactory, new MappingMongoConverter(new DefaultDbRefResolver(mongoDbFactory),
 				new MongoMappingContext()));
 	}
 
-	public MongoDbOutboundGateway(MongoDatabaseFactory mongoDbFactory, MongoConverter mongoConverter) {
+	public MongoDbOutboundGateway(MongoDbFactory mongoDbFactory, MongoConverter mongoConverter) {
 		Assert.notNull(mongoDbFactory, "mongoDatabaseFactory must not be null.");
 		Assert.notNull(mongoConverter, "mongoConverter must not be null.");
 		this.mongoDbFactory = mongoDbFactory;

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandler.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2019 the original author or authors.
+ * Copyright 2007-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.mongodb.outbound;
 
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
@@ -42,7 +42,7 @@ public class MongoDbStoringMessageHandler extends AbstractMessageHandler {
 
 	private volatile MongoOperations mongoTemplate;
 
-	private volatile MongoDatabaseFactory mongoDbFactory;
+	private volatile MongoDbFactory mongoDbFactory;
 
 	private volatile MongoConverter mongoConverter;
 
@@ -53,11 +53,11 @@ public class MongoDbStoringMessageHandler extends AbstractMessageHandler {
 	private volatile boolean initialized = false;
 
 	/**
-	 * Will construct this instance using provided {@link MongoDatabaseFactory}
+	 * Will construct this instance using provided {@link MongoDbFactory}
 	 *
 	 * @param mongoDbFactory The mongodb factory.
 	 */
-	public MongoDbStoringMessageHandler(MongoDatabaseFactory mongoDbFactory) {
+	public MongoDbStoringMessageHandler(MongoDbFactory mongoDbFactory) {
 		Assert.notNull(mongoDbFactory, "'mongoDbFactory' must not be null");
 
 		this.mongoDbFactory = mongoDbFactory;
@@ -78,7 +78,7 @@ public class MongoDbStoringMessageHandler extends AbstractMessageHandler {
 	/**
 	 * Allows you to provide custom {@link MongoConverter} used to assist in serialization
 	 * of data written to MongoDb. Only allowed if this instance was constructed with a
-	 * {@link MongoDatabaseFactory}.
+	 * {@link MongoDbFactory}.
 	 *
 	 * @param mongoConverter The mongo converter.
 	 */

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
@@ -76,7 +76,7 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 
 	protected final String collectionName; // NOSONAR - final
 
-	protected final MongoDatabaseFactory mongoDbFactory; // NOSONAR - final
+	protected final MongoDbFactory mongoDbFactory; // NOSONAR - final
 
 	private MongoTemplate mongoTemplate;
 
@@ -94,11 +94,11 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 		this.mongoDbFactory = null;
 	}
 
-	public AbstractConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, String collectionName) {
+	public AbstractConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory, String collectionName) {
 		this(mongoDbFactory, null, collectionName);
 	}
 
-	public AbstractConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory,
+	public AbstractConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory,
 			MappingMongoConverter mappingMongoConverter, String collectionName) {
 		Assert.notNull(mongoDbFactory, "'mongoDbFactory' must not be null");
 		Assert.hasText(collectionName, "'collectionName' must not be empty");

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -68,19 +68,19 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 		super(mongoTemplate, collectionName);
 	}
 
-	public ConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory) {
+	public ConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory) {
 		this(mongoDbFactory, null, DEFAULT_COLLECTION_NAME);
 	}
 
-	public ConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter) {
+	public ConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter) {
 		this(mongoDbFactory, mappingMongoConverter, DEFAULT_COLLECTION_NAME);
 	}
 
-	public ConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, String collectionName) {
+	public ConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory, String collectionName) {
 		this(mongoDbFactory, null, collectionName);
 	}
 
-	public ConfigurableMongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter,
+	public ConfigurableMongoDbMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter,
 			String collectionName) {
 
 		super(mongoDbFactory, mappingMongoConverter, collectionName);

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@
 package org.springframework.integration.mongodb.store;
 
 import org.springframework.data.domain.Sort;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.index.Index;
@@ -61,19 +61,19 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 		super(mongoTemplate, collectionName);
 	}
 
-	public MongoDbChannelMessageStore(MongoDatabaseFactory mongoDbFactory) {
+	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory) {
 		this(mongoDbFactory, null, DEFAULT_COLLECTION_NAME);
 	}
 
-	public MongoDbChannelMessageStore(MongoDatabaseFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter) {
+	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter) {
 		this(mongoDbFactory, mappingMongoConverter, DEFAULT_COLLECTION_NAME);
 	}
 
-	public MongoDbChannelMessageStore(MongoDatabaseFactory mongoDbFactory, String collectionName) {
+	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory, String collectionName) {
 		this(mongoDbFactory, null, collectionName);
 	}
 
-	public MongoDbChannelMessageStore(MongoDatabaseFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter,
+	public MongoDbChannelMessageStore(MongoDbFactory mongoDbFactory, MappingMongoConverter mappingMongoConverter,
 			String collectionName) {
 		super(mongoDbFactory, mappingMongoConverter, collectionName);
 	}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -141,19 +141,19 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 	private String[] whiteListPatterns;
 
 	/**
-	 * Create a MongoDbMessageStore using the provided {@link MongoDatabaseFactory}.and the default collection name.
+	 * Create a MongoDbMessageStore using the provided {@link MongoDbFactory}.and the default collection name.
 	 * @param mongoDbFactory The mongodb factory.
 	 */
-	public MongoDbMessageStore(MongoDatabaseFactory mongoDbFactory) {
+	public MongoDbMessageStore(MongoDbFactory mongoDbFactory) {
 		this(mongoDbFactory, null);
 	}
 
 	/**
-	 * Create a MongoDbMessageStore using the provided {@link MongoDatabaseFactory} and collection name.
+	 * Create a MongoDbMessageStore using the provided {@link MongoDbFactory} and collection name.
 	 * @param mongoDbFactory The mongodb factory.
 	 * @param collectionName The collection name.
 	 */
-	public MongoDbMessageStore(MongoDatabaseFactory mongoDbFactory, @Nullable String collectionName) {
+	public MongoDbMessageStore(MongoDbFactory mongoDbFactory, @Nullable String collectionName) {
 		Assert.notNull(mongoDbFactory, "mongoDbFactory must not be null");
 		this.converter = new MessageReadingMongoConverter(mongoDbFactory, new MongoMappingContext());
 		this.template = new MongoTemplate(mongoDbFactory, this.converter);
@@ -523,7 +523,7 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 
 		private Object[] customConverters;
 
-		MessageReadingMongoConverter(MongoDatabaseFactory mongoDbFactory,
+		MessageReadingMongoConverter(MongoDbFactory mongoDbFactory,
 				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
 			super(new DefaultDbRefResolver(mongoDbFactory), mappingContext);
 		}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests-context.xml
@@ -8,7 +8,7 @@
 		http://www.springframework.org/schema/integration/mongodb https://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd">
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
 	</bean>
 
 	<int-mongodb:inbound-channel-adapter id="minimalConfig"

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.expression.common.LiteralExpression;
@@ -49,7 +49,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 public class MongoDbInboundChannelAdapterParserTests {
 
 	@Autowired
-	private MongoDatabaseFactory mongoDbFactory;
+	private MongoDbFactory mongoDbFactory;
 
 	@Autowired
 	private MongoConverter mongoConverter;

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundChannelAdapterIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
@@ -49,7 +49,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 		Message<Person> message = new GenericMessage<MongoDbAvailableTests.Person>(this.createPerson("Bob"));
 		channel.send(message);
 
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		assertThat(template.find(new BasicQuery("{'name' : 'Bob'}"), Person.class, "data")).isNotNull();
 		context.close();
@@ -58,7 +58,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 	@Test
 	@MongoDbAvailable
 	public void testWithNamedCollection() throws Exception {
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory("foo");
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory("foo");
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
 
@@ -77,7 +77,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 	@Test
 	@MongoDbAvailable
 	public void testWithTemplate() throws Exception {
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory("foo");
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory("foo");
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
 
@@ -100,7 +100,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 
 		BasicDBObject dbObject = BasicDBObject.parse("{'foo' : 'bar'}");
 
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory("foo");
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory("foo");
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
 
@@ -124,7 +124,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 
 		String object = "{'foo' : 'bar'}";
 
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory("foo");
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory("foo");
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("outbound-adapter-config.xml", this.getClass());
 
@@ -152,7 +152,7 @@ public class MongoDbOutboundChannelAdapterIntegrationTests extends MongoDbAvaila
 		Message<Person> message = new GenericMessage<MongoDbAvailableTests.Person>(this.createPerson("Bob"));
 		channel.send(message);
 
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		assertThat(template.find(new BasicQuery("{'name' : 'Bob'}"), Person.class, "data")).isNotNull();
 		context.close();

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests-context.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests-context.xml
@@ -62,7 +62,7 @@
 	</bean>
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
 	</bean>
 
 	<bean id="mongoConverter"

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.standard.SpelExpression;
@@ -57,7 +57,7 @@ public class MongoDbOutboundGatewayParserTests {
 	private ApplicationContext context;
 
 	@Autowired
-	private MongoDatabaseFactory mongoDbFactory;
+	private MongoDbFactory mongoDbFactory;
 
 	@Autowired
 	private MongoConverter mongoConverter;

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-adapter-parser-config.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/outbound-adapter-parser-config.xml
@@ -3,14 +3,12 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:int="http://www.springframework.org/schema/integration"
 	xmlns:int-mongodb="http://www.springframework.org/schema/integration/mongodb"
-	xmlns:mongo="http://www.springframework.org/schema/data/mongo"
-	xsi:schemaLocation="http://www.springframework.org/schema/data/mongo https://www.springframework.org/schema/data/mongo/spring-mongo.xsd
-		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration/mongodb https://www.springframework.org/schema/integration/mongodb/spring-integration-mongodb.xsd">
 
 	<bean id="mongoDbFactory" class="org.mockito.Mockito" factory-method="mock">
-		<constructor-arg value="org.springframework.data.mongodb.MongoDatabaseFactory"/>
+		<constructor-arg value="org.springframework.data.mongodb.MongoDbFactory"/>
 	</bean>
 
 	<int-mongodb:outbound-channel-adapter id="minimalConfig"/>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/dsl/MongoDbTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/dsl/MongoDbTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,11 +30,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -52,8 +51,6 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
-
-import com.mongodb.client.MongoClients;
 
 /**
  * @author Xavier Padro
@@ -107,7 +104,7 @@ public class MongoDbTests extends MongoDbAvailableTests {
 	private MongoOperations mongoTemplate;
 
 	@Before
-	public void setUp() throws Exception {
+	public void setUp() {
 		createPersons();
 	}
 
@@ -325,8 +322,8 @@ public class MongoDbTests extends MongoDbAvailableTests {
 		}
 
 		@Bean
-		public MongoDatabaseFactory mongoDbFactory() {
-			return new SimpleMongoClientDatabaseFactory(MongoClients.create(), "test");
+		public MongoDbFactory mongoDbFactory() {
+			return MONGO_DATABASE_FACTORY;
 		}
 
 		@Bean

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSourceTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/inbound/MongoDbMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2019 the original author or authors.
+ * Copyright 2007-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -58,7 +58,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	public void withNullMongoDBFactory() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new MongoDbMessageSource((MongoDatabaseFactory) null, mock(Expression.class)));
+				.isThrownBy(() -> new MongoDbMessageSource((MongoDbFactory) null, mock(Expression.class)));
 	}
 
 	@Test
@@ -70,13 +70,13 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	public void withNullQueryExpression() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new MongoDbMessageSource(mock(MongoDatabaseFactory.class), null));
+				.isThrownBy(() -> new MongoDbMessageSource(mock(MongoDbFactory.class), null));
 	}
 
 	@Test
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithSingleElementIfOneInListAsDbObject() {
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson(), "data");
@@ -96,7 +96,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithSingleElementIfOneInList() {
-		MongoDatabaseFactory mongoDbFactory = prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson(), "data");
@@ -117,7 +117,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithSingleElementIfOneInListAndSingleResult() {
-		MongoDatabaseFactory mongoDbFactory = prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson(), "data");
@@ -138,7 +138,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@Test
 	@MongoDbAvailable
 	public void validateSuccessfulSubObjectQueryWithSingleElementIfOneInList() {
-		MongoDatabaseFactory mongoDbFactory = prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson(), "data");
@@ -180,7 +180,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 
 	@SuppressWarnings("unchecked")
 	private List<Person> queryMultipleElements(Expression queryExpression) {
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson("Manny"), "data");
@@ -198,7 +198,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithNullReturn() {
 
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson("Manny"), "data");
@@ -217,7 +217,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithCustomConverter() {
 
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.save(this.createPerson("Manny"), "data");
@@ -243,7 +243,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void validateSuccessfulQueryWithMongoTemplate() {
 
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MappingMongoConverter converter = new TestMongoConverter(mongoDbFactory, new MongoMappingContext());
 		converter.afterPropertiesSet();
@@ -269,7 +269,7 @@ public class MongoDbMessageSourceTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void validatePipelineInModifyOut() {
 
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/metadata/MongoDbMetadataStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/metadata/MongoDbMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
 import org.springframework.integration.mongodb.rules.MongoDbAvailableTests;
@@ -45,7 +45,7 @@ public class MongoDbMetadataStoreTests extends MongoDbAvailableTests {
 
 	@Before
 	public void configure() {
-		final MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory(DEFAULT_COLLECTION_NAME);
+		final MongoDbFactory mongoDbFactory = this.prepareMongoFactory(DEFAULT_COLLECTION_NAME);
 		this.store = new MongoDbMetadataStore(mongoDbFactory);
 	}
 
@@ -53,7 +53,7 @@ public class MongoDbMetadataStoreTests extends MongoDbAvailableTests {
 	@Test
 	public void testConfigureCustomCollection() {
 		final String collectionName = "testMetadataStore";
-		final MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory(collectionName);
+		final MongoDbFactory mongoDbFactory = this.prepareMongoFactory(collectionName);
 		final MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		store = new MongoDbMetadataStore(template, collectionName);
 		testBasics();
@@ -62,7 +62,7 @@ public class MongoDbMetadataStoreTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	@Test
 	public void testConfigureFactory() {
-		final MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory(DEFAULT_COLLECTION_NAME);
+		final MongoDbFactory mongoDbFactory = this.prepareMongoFactory(DEFAULT_COLLECTION_NAME);
 		store = new MongoDbMetadataStore(mongoDbFactory);
 		testBasics();
 	}
@@ -71,7 +71,7 @@ public class MongoDbMetadataStoreTests extends MongoDbAvailableTests {
 	@Test
 	public void testConfigureFactorCustomCollection() {
 		final String collectionName = "testMetadataStore";
-		final MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory(collectionName);
+		final MongoDbFactory mongoDbFactory = this.prepareMongoFactory(collectionName);
 		store = new MongoDbMetadataStore(mongoDbFactory, collectionName);
 		testBasics();
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -74,7 +74,7 @@ public class MongoDbOutboundGatewayTests extends MongoDbAvailableTests {
 	private MongoConverter mongoConverter;
 
 	@Autowired
-	private MongoDatabaseFactory mongoDbFactory;
+	private MongoDbFactory mongoDbFactory;
 
 	@Before
 	public void setUp() {
@@ -97,7 +97,7 @@ public class MongoDbOutboundGatewayTests extends MongoDbAvailableTests {
 	public void testNoFactorySpecified() {
 
 		try {
-			new MongoDbOutboundGateway((MongoDatabaseFactory) null);
+			new MongoDbOutboundGateway((MongoDbFactory) null);
 			fail("Expected the test case to throw an IllegalArgumentException");
 		}
 		catch (IllegalArgumentException e) {

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayXmlTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbOutboundGatewayXmlTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.mongodb.rules.MongoDbAvailable;
@@ -53,7 +53,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@Before
 	public void setUp() throws Exception {
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate mongoTemplate = new MongoTemplate(mongoDbFactory);
 
 		mongoTemplate.save(this.createPerson("Artem"), COLLECTION_NAME);
@@ -64,7 +64,7 @@ public class MongoDbOutboundGatewayXmlTests extends MongoDbAvailableTests {
 
 	@After
 	public void cleanUp() throws Exception {
-		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 		MongoTemplate mongoTemplate = new MongoTemplate(mongoDbFactory);
 
 		mongoTemplate.dropCollection(COLLECTION_NAME);

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandlerTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/outbound/MongoDbStoringMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2019 the original author or authors.
+ * Copyright 2007-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.factory.BeanFactory;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.core.MongoOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -53,7 +53,7 @@ public class MongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 
 	private MongoTemplate template;
 
-	private MongoDatabaseFactory mongoDbFactory;
+	private MongoDbFactory mongoDbFactory;
 
 	@Before
 	public void setUp() {
@@ -66,7 +66,7 @@ public class MongoDbStoringMessageHandlerTests extends MongoDbAvailableTests {
 	@MongoDbAvailable
 	public void withNullMongoDBFactory() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new MongoDbStoringMessageHandler((MongoDatabaseFactory) null));
+				.isThrownBy(() -> new MongoDbStoringMessageHandler((MongoDbFactory) null));
 	}
 
 	@Test

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/rules/MongoDbAvailableTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/rules/MongoDbAvailableTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,17 +19,16 @@ package org.springframework.integration.mongodb.rules;
 import java.time.Duration;
 
 import org.bson.Document;
-import org.bson.UuidRepresentation;
 import org.bson.conversions.Bson;
 import org.junit.Rule;
 
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoDbFactory;
 import org.springframework.data.mongodb.ReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.core.SimpleMongoClientDbFactory;
 import org.springframework.data.mongodb.core.SimpleReactiveMongoDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -60,13 +59,13 @@ public abstract class MongoDbAvailableTests {
 	@Rule
 	public MongoDbAvailableRule mongoDbAvailableRule = new MongoDbAvailableRule();
 
-	public static final MongoDatabaseFactory MONGO_DATABASE_FACTORY =
-			new SimpleMongoClientDatabaseFactory(
+	public static final MongoDbFactory MONGO_DATABASE_FACTORY =
+			new SimpleMongoClientDbFactory(
 					MongoClients.create(
-							MongoClientSettings.builder().uuidRepresentation(UuidRepresentation.STANDARD).build()),
+							MongoClientSettings.builder().build()),
 					"test");
 
-	protected MongoDatabaseFactory prepareMongoFactory(String... additionalCollectionsToDrop) {
+	protected MongoDbFactory prepareMongoFactory(String... additionalCollectionsToDrop) {
 		cleanupCollections(MONGO_DATABASE_FACTORY, additionalCollectionsToDrop);
 		return MONGO_DATABASE_FACTORY;
 	}
@@ -90,7 +89,7 @@ public abstract class MongoDbAvailableTests {
 		}
 	}
 
-	protected void cleanupCollections(MongoDatabaseFactory mongoDbFactory, String... additionalCollectionsToDrop) {
+	protected void cleanupCollections(MongoDbFactory mongoDbFactory, String... additionalCollectionsToDrop) {
 		MongoTemplate template = new MongoTemplate(mongoDbFactory);
 		template.dropCollection("messages");
 		template.dropCollection("configurableStoreMessages");
@@ -185,7 +184,7 @@ public abstract class MongoDbAvailableTests {
 	public static class TestMongoConverter extends MappingMongoConverter {
 
 		public TestMongoConverter(
-				MongoDatabaseFactory mongoDbFactory,
+				MongoDbFactory mongoDbFactory,
 				MappingContext<? extends MongoPersistentEntity<?>, MongoPersistentProperty> mappingContext) {
 
 			super(new DefaultDbRefResolver(mongoDbFactory), mappingContext);

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/AbstractMongoDbMessageGroupStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -417,7 +417,7 @@ public abstract class AbstractMongoDbMessageGroupStoreTests extends MongoDbAvail
 	//	@Test
 	//	@MongoDbAvailable
 	//	public void testConcurrentModifications() throws Exception{
-	//		MongoDatabaseFactory mongoDbFactory = this.prepareMongoFactory();
+	//		MongoDbFactory mongoDbFactory = this.prepareMongoFactory();
 	//		final MongoDbMessageStore store1 = new MongoDbMessageStore(mongoDbFactory);
 	//		final MongoDbMessageStore store2 = new MongoDbMessageStore(mongoDbFactory);
 	//


### PR DESCRIPTION
* Bring Spring Data MongoDb back to `2.3`;
essentially rely on Spring Data BOM for dependencies
* Change `mongodb-driver-reactivestreams` driver version back to `1.12.0`
* Upgrade to Spring Security 5.3 M1
* Fix MongoDb module to use `MongoDbFactory` class instead of new (not committed yet)
`MongoDatabaseFactory`
* Remove `uuidRepresentation()` configuration from the `MongoClients` factory usage -
that is going to be MongoDb driver 4 feature

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
