### PR TITLE
Fix for SimplePool.setPoolSize() #3143

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * demand up to the limit.
  *
  * @author Gary Russell
+ * @author Sergey Bogatyrev
  * @since 2.2
  *
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
@@ -102,11 +102,9 @@ public class SimplePool<T> implements Pool<T> {
 					break;
 				}
 				T item = this.available.poll();
-				if (item == null) {
-					this.permits.release();
-					break;
+				if (item != null) {
+					doRemoveItem(item);
 				}
-				doRemoveItem(item);
 				this.poolSize.decrementAndGet();
 				delta++;
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/util/SimplePoolTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/util/SimplePoolTests.java
@@ -16,17 +16,17 @@
 
 package org.springframework.integration.util;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
-
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.junit.Test;
-
 import org.springframework.integration.test.util.TestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Gary Russell
@@ -146,7 +146,27 @@ public class SimplePoolTests {
 		pool.releaseItem(s1);
 		assertThat(permits.availablePermits()).isEqualTo(2);
 	}
+	
+	@Test
+	public void testSizeUpdateIfNotAllocated() {
+		SimplePool<String> pool = stringPool(10, new HashSet<>(), new AtomicBoolean());
+		pool.setPoolSize(5);
+		assertThat(pool.getPoolSize()).isEqualTo(5);
+	}
 
+	@Test
+	public void testSizeUpdateIfAllocated() {
+		SimplePool<String> pool = stringPool(10, new HashSet<>(), new AtomicBoolean());
+		List<String> allocated = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			allocated.add(pool.getItem());
+		}
+		for (int i = 0; i < 10; i++) {
+			pool.releaseItem(allocated.get(i));
+		}
+		pool.setPoolSize(5);
+		assertThat(pool.getPoolSize()).isEqualTo(5);
+	}
 
 	private SimplePool<String> stringPool(int size, final Set<String> strings,
 			final AtomicBoolean stale) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/util/SimplePoolTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/util/SimplePoolTests.java
@@ -149,26 +149,27 @@ public class SimplePoolTests {
 		pool.releaseItem(s1);
 		assertThat(permits.availablePermits()).isEqualTo(2);
 	}
-	
+
 	@Test
 	public void testSizeUpdateIfNotAllocated() {
 		SimplePool<String> pool = stringPool(10, new HashSet<>(), new AtomicBoolean());
 		pool.setWaitTimeout(0);
 		pool.setPoolSize(5);
 		assertThat(pool.getPoolSize()).isEqualTo(5);
-		
+
 		// allocating all available items to check permits
 		Set<String> allocatedItems = new HashSet<>();
 		for (int i = 0; i < 5; i++) {
 			allocatedItems.add(pool.getItem());
 		}
 		assertThat(allocatedItems).hasSize(5);
-		
+
 		// no more items can be allocated (indirect check of permits)
 		try {
 			pool.getItem();
 			fail("No more items should be allocated");
-		} catch (PoolItemNotAvailableException e) {
+		}
+		catch (PoolItemNotAvailableException e) {
 			// permits state correctly
 		}
 	}
@@ -181,7 +182,7 @@ public class SimplePoolTests {
 		for (int i = 0; i < 10; i++) {
 			allocated.add(pool.getItem());
 		}
-		
+
 		// release only 2 items
 		for (int i = 0; i < 2; i++) {
 			pool.releaseItem(allocated.get(i));
@@ -189,28 +190,29 @@ public class SimplePoolTests {
 
 		// trying to reduce pool size
 		pool.setPoolSize(5);
-		
+
 		// at this moment the actual pool size can be reduced only partially, because
 		// only 2 items have been released, so 8 items are in use
 		assertThat(pool.getPoolSize()).isEqualTo(8);
 		assertThat(pool.getAllocatedCount()).isEqualTo(8);
 		assertThat(pool.getIdleCount()).isEqualTo(0);
-		
+
 		// releasing 3 items
 		for (int i = 2; i < 5; i++) {
 			pool.releaseItem(allocated.get(i));
 		}
-		
+
 		// now pool size should be reduced
 		assertThat(pool.getPoolSize()).isEqualTo(5);
 		assertThat(pool.getAllocatedCount()).isEqualTo(5);
 		assertThat(pool.getIdleCount()).isEqualTo(0);
-		
+
 		// no more items can be allocated (indirect check of permits)
 		try {
 			pool.getItem();
 			fail("No more items should be allocated");
-		} catch (PoolItemNotAvailableException e) {
+		}
+		catch (PoolItemNotAvailableException e) {
 			// permits state correctly
 		}
 	}


### PR DESCRIPTION
Original implementation exits from the loop if "available" collection is empty. That is not correct, because the number of allocated items can be less then pool size. And so it's OK if "item==null". It's just required to perform cleanup if "item!=null". Otherwise it's required to complete the loop until "delta!=0". 

Resolves https://github.com/spring-projects/spring-integration/issues/3143