### PR TITLE
Fix for Scatter Gather getting hung when Nested Scatter Gathers are used

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
@@ -38,6 +38,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.InterceptableChannel;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -55,10 +56,6 @@ import org.springframework.util.ClassUtils;
 public class ScatterGatherHandler extends AbstractReplyProducingMessageHandler implements Lifecycle {
 
 	private static final String GATHER_RESULT_CHANNEL = "gatherResultChannel";
-
-	private static final String ORIGINAL_REPLY_CHANNEL = "originalReplyChannel";
-
-	private static final String ORIGINAL_ERROR_CHANNEL = "originalErrorChannel";
 
 	private final MessageChannel scatterChannel;
 
@@ -168,9 +165,7 @@ public class ScatterGatherHandler extends AbstractReplyProducingMessageHandler i
 		MessageHeaders headers = message.getHeaders();
 		return getMessageBuilderFactory()
 				.fromMessage(message)
-				.setHeader(MessageHeaders.REPLY_CHANNEL, headers.get(ORIGINAL_REPLY_CHANNEL))
-				.setHeader(MessageHeaders.ERROR_CHANNEL, headers.get(ORIGINAL_ERROR_CHANNEL))
-				.removeHeaders(ORIGINAL_REPLY_CHANNEL, ORIGINAL_ERROR_CHANNEL)
+				.setHeader(MessageHeaders.ERROR_CHANNEL, headers.get(GATHER_RESULT_CHANNEL))
 				.build();
 	}
 
@@ -183,8 +178,6 @@ public class ScatterGatherHandler extends AbstractReplyProducingMessageHandler i
 				getMessageBuilderFactory()
 						.fromMessage(requestMessage)
 						.setHeader(GATHER_RESULT_CHANNEL, gatherResultChannel)
-						.setHeader(ORIGINAL_REPLY_CHANNEL, requestMessageHeaders.getReplyChannel())
-						.setHeader(ORIGINAL_ERROR_CHANNEL, requestMessageHeaders.getErrorChannel())
 						.setReplyChannel(this.gatherChannel)
 						.setErrorChannelName(this.errorChannelName)
 						.build();
@@ -192,16 +185,16 @@ public class ScatterGatherHandler extends AbstractReplyProducingMessageHandler i
 		this.messagingTemplate.send(this.scatterChannel, scatterMessage);
 
 		Message<?> gatherResult = gatherResultChannel.receive(this.gatherTimeout);
-		if (gatherResult != null && (requestMessageHeaders.containsKey(ORIGINAL_REPLY_CHANNEL)
-				|| requestMessageHeaders.containsKey(ORIGINAL_ERROR_CHANNEL)
-				|| requestMessageHeaders.containsKey(GATHER_RESULT_CHANNEL))) {
+
+		if (gatherResult != null) {
+			if (gatherResult instanceof ErrorMessage) {
+				throw (RuntimeException) gatherResult.getPayload();
+			}
 			return getMessageBuilderFactory()
 					.fromMessage(gatherResult)
-					.removeHeader(GATHER_RESULT_CHANNEL)
 					.setHeader(GATHER_RESULT_CHANNEL, requestMessageHeaders.get(GATHER_RESULT_CHANNEL))
-					.setHeader(ORIGINAL_REPLY_CHANNEL, requestMessageHeaders.get(ORIGINAL_REPLY_CHANNEL))
-					.setHeader(ORIGINAL_ERROR_CHANNEL, requestMessageHeaders.get(ORIGINAL_ERROR_CHANNEL))
 					.setHeader(MessageHeaders.REPLY_CHANNEL, requestMessage.getHeaders().getReplyChannel())
+					.setHeader(MessageHeaders.ERROR_CHANNEL, requestMessage.getHeaders().getErrorChannel())
 					.build();
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
@@ -48,6 +48,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Artem Bilan
  * @author Abdul Zaheer
+ * @author Jayadev Sirimamilla
  *
  * @since 4.1
  */

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
@@ -926,10 +926,10 @@ public class RouterTests {
 			return flow -> flow.scatterGather(s -> s.applySequence(true)
 									.recipientFlow(inflow -> inflow
 											.scatterGather(s1 -> s1.applySequence(true)
-															.recipientFlow(IntegrationFlowDefinition::bridge)
-													, g -> g.outputProcessor(MessageGroup::getOne)
-											))
-							, g -> g.outputProcessor(MessageGroup::getOne)
+															.recipientFlow(IntegrationFlowDefinition::bridge),
+													g -> g.outputProcessor(MessageGroup::getOne)
+											)),
+					g -> g.outputProcessor(MessageGroup::getOne)
 					);
 		}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
@@ -918,6 +918,7 @@ public class RouterTests {
 										throw new RuntimeException("intentional");
 									}),
 							sg -> sg.gatherTimeout(100))
+					.transform(m -> "This should not be executed, results must have been propagated to Error Channel")
 					.get();
 		}
 		@Bean


### PR DESCRIPTION
Github Issue: https://github.com/spring-projects/spring-integration/issues/3152

Issue with flow going in hung state when nested scatter gather is used in a flow.

Cause:
In 5.2.3 version, ReplyChannel and ErrorChannel are copied to headers ORIGINAL_REPLY_CHANNEL, ORIGINAL_ERROR_CHANNEL. This process is not taking care of any ORIGINAL_REPLY_CHANNEL, ORIGINAL_ERROR_CHANNEL already available in request headers. if these headers are already present in the headers, they will be overridden without being preserved for the reply path.

This is causing issue in the nested ScatterGather situations.

@Override
	protected Object handleRequestMessage(Message<?> requestMessage) {
		MessageHeaders requestMessageHeaders = requestMessage.getHeaders();
		PollableChannel gatherResultChannel = new QueueChannel();

		Message<?> scatterMessage =
				getMessageBuilderFactory()
						.fromMessage(requestMessage)
						.setHeader(GATHER_RESULT_CHANNEL, gatherResultChannel)
						.setHeader(ORIGINAL_REPLY_CHANNEL, requestMessageHeaders.getReplyChannel())
						.setHeader(ORIGINAL_ERROR_CHANNEL, requestMessageHeaders.getErrorChannel())
						.setReplyChannel(this.gatherChannel)
						.setErrorChannelName(this.errorChannelName)
						.build();

		this.messagingTemplate.send(this.scatterChannel, scatterMessage);

		return gatherResultChannel.receive(this.gatherTimeout);
	}

	private Message<?> enhanceScatterReplyMessage(Message<?> message) {
		MessageHeaders headers = message.getHeaders();
		return getMessageBuilderFactory()
				.fromMessage(message)
				.setHeader(MessageHeaders.REPLY_CHANNEL, headers.get(ORIGINAL_REPLY_CHANNEL))
				.setHeader(MessageHeaders.ERROR_CHANNEL, headers.get(ORIGINAL_ERROR_CHANNEL))
				.removeHeaders(ORIGINAL_REPLY_CHANNEL, ORIGINAL_ERROR_CHANNEL)
				.build();
	}

Possible Solution:
Enhance the reply before responding in handleRequestMessage method. this will let the flow continue in success scenarios

@Override
	protected Object handleRequestMessage(Message<?> requestMessage) {
		MessageHeaders requestMessageHeaders = requestMessage.getHeaders();
		PollableChannel gatherResultChannel = new QueueChannel();

		Message<?> scatterMessage =
				getMessageBuilderFactory()
						.fromMessage(requestMessage)
						.setHeader(GATHER_RESULT_CHANNEL, gatherResultChannel)
						.setHeader(ORIGINAL_REPLY_CHANNEL, requestMessageHeaders.getReplyChannel())
						.setHeader(ORIGINAL_ERROR_CHANNEL, requestMessageHeaders.getErrorChannel())
						.setReplyChannel(this.gatherChannel)
						.setErrorChannelName(this.errorChannelName)
						.build();

		this.messagingTemplate.send(this.scatterChannel, scatterMessage);

		Message<?> gatherResult = gatherResultChannel.receive(this.gatherTimeout);
		if (gatherResult != null && (requestMessageHeaders.containsKey(ORIGINAL_REPLY_CHANNEL)
				|| requestMessageHeaders.containsKey(ORIGINAL_ERROR_CHANNEL)
				|| requestMessageHeaders.containsKey(GATHER_RESULT_CHANNEL))) {
			return getMessageBuilderFactory()
					.fromMessage(gatherResult)
					.removeHeader(GATHER_RESULT_CHANNEL)
					.setHeader(GATHER_RESULT_CHANNEL, requestMessageHeaders.get(GATHER_RESULT_CHANNEL))
					.setHeader(ORIGINAL_REPLY_CHANNEL, requestMessageHeaders.get(ORIGINAL_REPLY_CHANNEL))
					.setHeader(ORIGINAL_ERROR_CHANNEL, requestMessageHeaders.get(ORIGINAL_ERROR_CHANNEL))
					.setHeader(MessageHeaders.REPLY_CHANNEL, requestMessage.getHeaders().getReplyChannel())
					.build();
		}

		return gatherResult;
	}



<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
