### PR TITLE
Fix for Issue with AbstractCorrelatingMessageHandler in handling sequences when Message is returned from outputProcessor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-	ext.kotlinVersion = '1.3.60'
+	ext.kotlinVersion = '1.3.61'
 	repositories {
 		maven { url 'https://repo.spring.io/plugins-release' }
 	}
@@ -48,7 +48,7 @@ ext {
 	aspectjVersion = '1.9.5'
 	assertjVersion = '3.14.0'
 	assertkVersion = '0.20'
-	awaitilityVersion = '4.0.1'
+	awaitilityVersion = '4.0.2'
 	boonVersion = '0.34'
 	commonsDbcp2Version = '2.7.0'
 	commonsIoVersion = '2.6'
@@ -59,8 +59,8 @@ ext {
 	googleJsr305Version = '3.0.2'
 	groovyVersion = '2.5.8'
 	hamcrestVersion = '2.2'
-	hazelcastVersion = '3.12.4'
-	hibernateVersion = '5.4.9.Final'
+	hazelcastVersion = '3.12.5'
+	hibernateVersion = '5.4.10.Final'
 	hsqldbVersion = '2.5.0'
 	h2Version = '1.4.200'
 	jacksonVersion = '2.10.1'
@@ -79,23 +79,23 @@ ext {
 	lettuceVersion = '5.2.1.RELEASE'
 	log4jVersion = '2.12.1'
 	micrometerVersion = '1.3.2'
-	mockitoVersion = '3.2.0'
+	mockitoVersion = '3.2.4'
 	mysqlVersion = '8.0.18'
 	pahoMqttClientVersion = '1.2.0'
-	postgresVersion = '42.2.8'
-	reactorVersion = 'Dysprosium-SR1'
+	postgresVersion = '42.2.9'
+	reactorVersion = 'Dysprosium-SR3'
 	resilience4jVersion = '1.1.0'
 	romeToolsVersion = '1.12.2'
 	rsocketVersion = '1.0.0-RC5'
 	servletApiVersion = '4.0.1'
 	smackVersion = '4.3.4'
-	springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '2.2.2.RELEASE'
-	springDataVersion = 'Moore-SR3'
+	springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '2.2.3.RELEASE'
+	springDataVersion = 'Moore-SR4'
 	springSecurityVersion = '5.2.1.RELEASE'
-	springRetryVersion = '1.2.4.RELEASE'
-	springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.2.2.RELEASE'
+	springRetryVersion = '1.2.5.RELEASE'
+	springVersion = project.hasProperty('springVersion') ? project.springVersion : '5.2.3.RELEASE'
 	springWsVersion = '3.0.8.RELEASE'
-	tomcatVersion = "9.0.29"
+	tomcatVersion = "9.0.30"
 	xstreamVersion = '1.4.11.1'
 }
 
@@ -187,7 +187,7 @@ subprojects { subproject ->
 	}
 
 	jacoco {
-		toolVersion = '0.8.4'
+		toolVersion = '0.8.5'
 	}
 
 	// dependencies that are common across all java projects
@@ -333,7 +333,7 @@ subprojects { subproject ->
 
 	checkstyle {
 		configFile = file("$rootDir/src/checkstyle/checkstyle.xml")
-		toolVersion = project.hasProperty('checkstyleVersion') ? project.checkstyleVersion : '8.26'
+		toolVersion = project.hasProperty('checkstyleVersion') ? project.checkstyleVersion : '8.28'
 	}
 
 	artifacts {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=5.2.3.RELEASE
+version=5.2.4.BUILD-SNAPSHOT
 org.gradle.jvmargs=-Xmx1536m -Dfile.encoding=UTF-8

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=5.2.3.BUILD-SNAPSHOT
+version=5.2.3.RELEASE
 org.gradle.jvmargs=-Xmx1536m -Dfile.encoding=UTF-8

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Abstract Message handler that holds a buffer of correlated messages in a
@@ -89,6 +90,7 @@ import org.springframework.util.CollectionUtils;
  * @author David Liu
  * @author Enrique Rodriguez
  * @author Meherzad Lahewala
+ * @author Jayadev Sirimamilla
  *
  * @since 2.0
  */
@@ -841,6 +843,10 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 							.copyHeaders(message.getHeaders());
 				}
 				result = messageBuilder.popSequenceDetails();
+			}
+			else if (this.popSequence && partialSequence == null && result instanceof Message && (ObjectUtils.nullSafeEquals(((Message) result).getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS), message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS)))) {
+				result = getMessageBuilderFactory()
+						.fromMessage((Message) result).popSequenceDetails();
 			}
 		}
 		finally {

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  * demand up to the limit.
  *
  * @author Gary Russell
+ * @author Sergey Bogatyrev
  * @since 2.2
  *
  */
@@ -102,11 +103,9 @@ public class SimplePool<T> implements Pool<T> {
 					break;
 				}
 				T item = this.available.poll();
-				if (item == null) {
-					this.permits.release();
-					break;
+				if (item != null) {
+					doRemoveItem(item);
 				}
-				doRemoveItem(item);
 				this.poolSize.decrementAndGet();
 				delta++;
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,9 +42,11 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.config.EnableMessageHistory;
 import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlowDefinition;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.expression.FunctionExpression;
+import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -62,6 +64,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Jayadev Sirimamilla
  *
  * @since 5.0
  */
@@ -531,7 +534,6 @@ public class RouterTests {
 	private MessageChannel nestedScatterGatherFlowInput;
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testNestedScatterGather() {
 		QueueChannel replyChannel = new QueueChannel();
 		Message<String> request = MessageBuilder.withPayload("this is a test")
@@ -578,7 +580,7 @@ public class RouterTests {
 		assertThat(receive).isNotNull();
 		Object payload = receive.getPayload();
 		assertThat(payload).isInstanceOf(List.class);
-		assertThat(((List) payload).get(1)).isInstanceOf(RuntimeException.class);
+		assertThat(((List<?>) payload).get(1)).isInstanceOf(RuntimeException.class);
 	}
 
 	@Autowired
@@ -590,6 +592,25 @@ public class RouterTests {
 		assertThatExceptionOfType(RuntimeException.class)
 				.isThrownBy(() -> propagateErrorFromGathererGateway.apply("bar"))
 				.withMessage("intentional");
+	}
+
+	@Autowired
+	@Qualifier("scatterGatherInSubFlow.input")
+	MessageChannel scatterGatherInSubFlowChannel;
+
+
+	@Test
+	public void testNestedScatterGatherSuccess() {
+		PollableChannel replyChannel = new QueueChannel();
+		this.scatterGatherInSubFlowChannel.send(
+				org.springframework.integration.support.MessageBuilder.withPayload("baz")
+						.setReplyChannel(replyChannel)
+						.build());
+
+		Message<?> receive = replyChannel.receive(10000);
+		assertThat(receive).isNotNull();
+		assertThat(receive.getPayload()).isEqualTo("baz");
+
 	}
 
 	@Configuration
@@ -896,7 +917,19 @@ public class RouterTests {
 										throw new RuntimeException("intentional");
 									}),
 							sg -> sg.gatherTimeout(100))
+					.transform(m -> "This should not be executed, results must have been propagated to Error Channel")
 					.get();
+		}
+
+		@Bean
+		public IntegrationFlow scatterGatherInSubFlow() {
+			return flow -> flow.scatterGather(s -> s.applySequence(true)
+							.recipientFlow(inflow -> inflow
+									.scatterGather(s1 -> s1.applySequence(true)
+													.recipientFlow(IntegrationFlowDefinition::bridge),
+											g -> g.outputProcessor(MessageGroup::getOne)
+									)),
+					g -> g.outputProcessor(MessageGroup::getOne));
 		}
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/util/SimplePoolTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/util/SimplePoolTests.java
@@ -17,9 +17,12 @@
 package org.springframework.integration.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.fail;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,6 +33,7 @@ import org.springframework.integration.test.util.TestUtils;
 
 /**
  * @author Gary Russell
+ * @author Sergey Bogatyrev
  * @since 2.2
  *
  */
@@ -147,6 +151,105 @@ public class SimplePoolTests {
 		assertThat(permits.availablePermits()).isEqualTo(2);
 	}
 
+	@Test
+	public void testSizeUpdateIfNotAllocated() {
+		SimplePool<String> pool = stringPool(10, new HashSet<>(), new AtomicBoolean());
+		pool.setWaitTimeout(0);
+		pool.setPoolSize(5);
+		assertThat(pool.getPoolSize()).isEqualTo(5);
+
+		// allocating all available items to check permits
+		Set<String> allocatedItems = new HashSet<>();
+		for (int i = 0; i < 5; i++) {
+			allocatedItems.add(pool.getItem());
+		}
+		assertThat(allocatedItems).hasSize(5);
+
+		// no more items can be allocated (indirect check of permits)
+		assertThatExceptionOfType(PoolItemNotAvailableException.class).isThrownBy(() -> pool.getItem());
+	}
+
+	@Test
+	public void testSizeUpdateIfPartiallyAllocated() {
+		SimplePool<String> pool = stringPool(10, new HashSet<>(), new AtomicBoolean());
+		pool.setWaitTimeout(0);
+		List<String> allocated = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			allocated.add(pool.getItem());
+		}
+
+		// release only 2 items
+		for (int i = 0; i < 2; i++) {
+			pool.releaseItem(allocated.get(i));
+		}
+
+		// trying to reduce pool size
+		pool.setPoolSize(5);
+
+		// at this moment the actual pool size can be reduced only partially, because
+		// only 2 items have been released, so 8 items are in use
+		assertThat(pool.getPoolSize()).isEqualTo(8);
+		assertThat(pool.getAllocatedCount()).isEqualTo(8);
+		assertThat(pool.getIdleCount()).isEqualTo(0);
+		assertThat(pool.getActiveCount()).isEqualTo(8);
+
+		// releasing 3 items
+		for (int i = 2; i < 5; i++) {
+			pool.releaseItem(allocated.get(i));
+		}
+
+		// now pool size should be reduced
+		assertThat(pool.getPoolSize()).isEqualTo(5);
+		assertThat(pool.getAllocatedCount()).isEqualTo(5);
+		assertThat(pool.getIdleCount()).isEqualTo(0);
+		assertThat(pool.getActiveCount()).isEqualTo(5);
+
+		// no more items can be allocated (indirect check of permits)
+		assertThatExceptionOfType(PoolItemNotAvailableException.class).isThrownBy(() -> pool.getItem());
+	}
+
+	@Test
+	public void testSizeUpdateIfFullyAllocated() {
+		SimplePool<String> pool = stringPool(10, new HashSet<>(), new AtomicBoolean());
+		pool.setWaitTimeout(0);
+		List<String> allocated = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			allocated.add(pool.getItem());
+		}
+
+		// trying to reduce pool size
+		pool.setPoolSize(5);
+
+		// at this moment the actual pool size cannot be reduced - all in use
+		assertThat(pool.getPoolSize()).isEqualTo(10);
+		assertThat(pool.getAllocatedCount()).isEqualTo(10);
+		assertThat(pool.getIdleCount()).isEqualTo(0);
+		assertThat(pool.getActiveCount()).isEqualTo(10);
+
+		// releasing 5 items
+		for (int i = 0; i < 5; i++) {
+			pool.releaseItem(allocated.get(i));
+		}
+
+		// now pool size should be reduced
+		assertThat(pool.getPoolSize()).isEqualTo(5);
+		assertThat(pool.getAllocatedCount()).isEqualTo(5);
+		assertThat(pool.getIdleCount()).isEqualTo(0);
+		assertThat(pool.getActiveCount()).isEqualTo(5);
+
+		// no more items can be allocated (indirect check of permits)
+		assertThatExceptionOfType(PoolItemNotAvailableException.class).isThrownBy(() -> pool.getItem());
+
+		// releasing remaining items
+		for (int i = 5; i < 10; i++) {
+			pool.releaseItem(allocated.get(i));
+		}
+
+		assertThat(pool.getPoolSize()).isEqualTo(5);
+		assertThat(pool.getAllocatedCount()).isEqualTo(5);
+		assertThat(pool.getIdleCount()).isEqualTo(5);
+		assertThat(pool.getActiveCount()).isEqualTo(0);
+	}
 
 	private SimplePool<String> stringPool(int size, final Set<String> strings,
 			final AtomicBoolean stale) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
In AbstractCorrelatingMessageHandler, while processing the outputProcessor result, sequences are not being popped when result is an instance of Message. 

An additional condition is added to handle such sequences.

			else if (this.popSequence && partialSequence == null && result instanceof Message && (ObjectUtils.nullSafeEquals(((Message) result).getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS), message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS)))) {
				result = getMessageBuilderFactory()
						.fromMessage((Message) result).popSequenceDetails();
			}
		}
