### PR TITLE
Fix for Issue with AbstractCorrelatingMessageHandler in handling sequences when Message is returned from outputProcessor 

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,6 +59,7 @@ import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Abstract Message handler that holds a buffer of correlated messages in a
@@ -89,6 +90,7 @@ import org.springframework.util.CollectionUtils;
  * @author David Liu
  * @author Enrique Rodriguez
  * @author Meherzad Lahewala
+ * @author Jayadev Sirimamilla
  *
  * @since 2.0
  */
@@ -841,6 +843,10 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 							.copyHeaders(message.getHeaders());
 				}
 				result = messageBuilder.popSequenceDetails();
+			}
+			else if (this.popSequence && partialSequence == null && result instanceof Message && (ObjectUtils.nullSafeEquals(((Message) result).getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS), message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS)))) {
+				result = getMessageBuilderFactory()
+						.fromMessage((Message) result).popSequenceDetails();
 			}
 		}
 		finally {


### PR DESCRIPTION
In AbstractCorrelatingMessageHandler, while processing the outputProcessor result, sequences are not being popped when result is an instance of Message.

https://github.com/spring-projects/spring-integration/issues/3157


An additional condition is added to handle such sequences.

			else if (this.popSequence && partialSequence == null && result instanceof Message && (ObjectUtils.nullSafeEquals(((Message) result).getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS), message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_DETAILS)))) {
				result = getMessageBuilderFactory()
						.fromMessage((Message) result).popSequenceDetails();
			}


<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
