### PR TITLE
GH-3154: Support `UriBuilderFactory.EncodingMode`

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
@@ -25,6 +25,7 @@ import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.xml.AbstractOutboundChannelAdapterParser;
 import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandler;
+import org.springframework.integration.http.support.DefaultHttpHeaderMapper;
 import org.springframework.util.StringUtils;
 
 /**
@@ -59,8 +60,8 @@ public class HttpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 			builder.addPropertyReference("headerMapper", headerMapper);
 		}
 		else if (StringUtils.hasText(mappedRequestHeaders)) {
-			BeanDefinitionBuilder headerMapperBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-					"org.springframework.integration.http.support.DefaultHttpHeaderMapper");
+			BeanDefinitionBuilder headerMapperBuilder =
+					BeanDefinitionBuilder.genericBeanDefinition(DefaultHttpHeaderMapper.class);
 			IntegrationNamespaceUtils.setValueIfAttributeDefined(headerMapperBuilder, element,
 					"mapped-request-headers", "outboundHeaderNames");
 			builder.addPropertyValue("headerMapper", headerMapperBuilder.getBeanDefinition());

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ public class HttpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 
 		builder.addPropertyValue("expectReply", false);
 		HttpAdapterParsingUtils.configureUrlConstructorArg(element, parserContext, builder);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "encode-uri");
 		HttpAdapterParsingUtils.setHttpMethodOrExpression(element, parserContext, builder);
 
 		String headerMapper = element.getAttribute("header-mapper");
@@ -90,6 +89,8 @@ public class HttpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 			for (String referenceAttributeName : HttpAdapterParsingUtils.SYNC_REST_TEMPLATE_REFERENCE_ATTRIBUTES) {
 				IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, referenceAttributeName);
 			}
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "encode-uri");
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "encoding-mode");
 		}
 		return builder;
 	}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,6 @@ public class HttpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 		BeanDefinitionBuilder builder = getBuilder(element, parserContext);
 
 		HttpAdapterParsingUtils.configureUrlConstructorArg(element, parserContext, builder);
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "encode-uri");
 		HttpAdapterParsingUtils.setHttpMethodOrExpression(element, parserContext, builder);
 
 		String headerMapper = element.getAttribute("header-mapper");
@@ -103,6 +102,8 @@ public class HttpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 			for (String referenceAttributeName : HttpAdapterParsingUtils.SYNC_REST_TEMPLATE_REFERENCE_ATTRIBUTES) {
 				IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, referenceAttributeName);
 			}
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "encode-uri");
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "encoding-mode");
 		}
 		return builder;
 	}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/BaseHttpMessageHandlerSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/BaseHttpMessageHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,7 @@ import org.springframework.integration.http.support.DefaultHttpHeaderMapper;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
 /**
  * The base {@link MessageHandlerSpec} for {@link AbstractHttpRequestExecutingMessageHandler}s.
@@ -71,9 +72,22 @@ public abstract class BaseHttpMessageHandlerSpec<S extends BaseHttpMessageHandle
 	 * expanding and before send request via underlying implementation. The default value is <code>true</code>.
 	 * @param encodeUri true if the URI should be encoded.
 	 * @return the spec
+	 * @deprecated since 5.3 in favor of {@link #encodingMode}
 	 */
+	@Deprecated
 	public S encodeUri(boolean encodeUri) {
 		this.target.setEncodeUri(encodeUri);
+		return _this();
+	}
+
+	/**
+	 * Specify a {@link DefaultUriBuilderFactory.EncodingMode} for uri construction.
+	 * @param encodingMode to use for uri construction.
+	 * @return the spec
+	 * @since 5.3
+	 */
+	public S encodingMode(DefaultUriBuilderFactory.EncodingMode encodingMode) {
+		this.target.setEncodingMode(encodingMode);
 		return _this();
 	}
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
@@ -82,7 +82,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	private static final List<HttpMethod> NO_BODY_HTTP_METHODS =
 			Arrays.asList(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.TRACE);
 
-	DefaultUriBuilderFactory uriFactory = new DefaultUriBuilderFactory();
+	protected final DefaultUriBuilderFactory uriFactory = new DefaultUriBuilderFactory(); // NOSONAR - final
 
 	private final Map<String, Expression> uriVariableExpressions = new HashMap<>();
 
@@ -115,7 +115,6 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	public AbstractHttpRequestExecutingMessageHandler(Expression uriExpression) {
 		Assert.notNull(uriExpression, "URI Expression is required");
 		this.uriExpression = uriExpression;
-		this.uriFactory.setEncodingMode(DefaultUriBuilderFactory.EncodingMode.TEMPLATE_AND_VALUES);
 	}
 
 	/**
@@ -138,6 +137,8 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	/**
 	 * Set the encoding mode to use.
 	 * By default this is set to {@link DefaultUriBuilderFactory.EncodingMode#TEMPLATE_AND_VALUES}.
+	 * For more complicated scenarios consider to configure an {@link org.springframework.web.util.UriTemplateHandler}
+	 * on an externally provided {@link org.springframework.web.client.RestTemplate}.
 	 * @param encodingMode the mode to use for uri encoding
 	 * @since 5.3
 	 */

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -117,6 +117,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 		super(uriExpression);
 		this.restTemplateExplicitlySet = restTemplate != null;
 		this.restTemplate = (this.restTemplateExplicitlySet ? restTemplate : new RestTemplate());
+		if (!this.restTemplateExplicitlySet) {
+			this.restTemplate.setUriTemplateHandler(this.uriFactory);
+		}
 	}
 
 	@Override

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http.xsd
@@ -844,11 +844,22 @@
 		<xsd:attribute name="encode-uri" type="xsd:string" default="true">
 			<xsd:annotation>
 				<xsd:documentation>
-					When set to "false", the real URI won't be encoded before the request is sent. This may be useful
-					in some scenarios as it allows user control over the encoding, if needed,
+					[DEPRECATED] When set to "false", the real URI won't be encoded before the request is sent.
+					This may be useful in some scenarios as it allows user control over the encoding, if needed,
 					for example by using the "url-expression". Default is "true".
+					Deprecated since 5.3 in favor of 'encoding-mode'.
 				</xsd:documentation>
 			</xsd:annotation>
+		</xsd:attribute>
+		<xsd:attribute name="encoding-mode" default="TEMPLATE_AND_VALUES">
+			<xsd:annotation>
+				<xsd:documentation>
+					Set the encoding mode during URI building.
+				</xsd:documentation>
+			</xsd:annotation>
+			<xsd:simpleType>
+				<xsd:union memberTypes="encodingModeEnumeration xsd:string"/>
+			</xsd:simpleType>
 		</xsd:attribute>
 		<xsd:attribute name="http-method">
 			<xsd:annotation>
@@ -942,5 +953,14 @@
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:attributeGroup>
+
+	<xsd:simpleType name="encodingModeEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="TEMPLATE_AND_VALUES"/>
+			<xsd:enumeration value="VALUES_ONLY"/>
+			<xsd:enumeration value="URI_COMPONENT"/>
+			<xsd:enumeration value="NONE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 </xsd:schema>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.integration.http;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.isNull;
 
-import java.net.URI;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -27,8 +26,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Locale;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.DirectFieldAccessor;
@@ -47,7 +45,7 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
@@ -64,7 +62,7 @@ import org.springframework.web.servlet.mvc.HttpRequestHandlerAdapter;
  *
  * @since 3.0
  */
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
 public class HttpProxyScenarioTests {
 
@@ -122,8 +120,8 @@ public class HttpProxyScenarioTests {
 		final String contentDispositionValue = "attachment; filename=\"test.txt\"";
 
 		Mockito.doAnswer(invocation -> {
-			URI uri = invocation.getArgument(0);
-			assertThat(uri).isEqualTo(new URI("http://testServer/test?foo=bar&FOO=BAR"));
+			String uri = invocation.getArgument(0);
+			assertThat(uri).isEqualTo("http://testServer/test?foo=bar&FOO=BAR");
 			HttpEntity<?> httpEntity = (HttpEntity<?>) invocation.getArguments()[2];
 			HttpHeaders httpHeaders = httpEntity.getHeaders();
 			assertThat(httpHeaders.getIfModifiedSince()).isEqualTo(ifModifiedSince);
@@ -134,8 +132,9 @@ public class HttpProxyScenarioTests {
 			responseHeaders.set("Connection", "close");
 			responseHeaders.set("Content-Disposition", contentDispositionValue);
 			return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
-		}).when(template).exchange(Mockito.any(URI.class), Mockito.any(HttpMethod.class),
-				Mockito.any(HttpEntity.class), (Class<?>) isNull());
+		}).when(template)
+				.exchange(Mockito.anyString(), Mockito.any(HttpMethod.class),
+						Mockito.any(HttpEntity.class), (Class<?>) isNull(), Mockito.anyMap());
 
 		PropertyAccessor dfa = new DirectFieldAccessor(this.handler);
 		dfa.setPropertyValue("restTemplate", template);
@@ -175,8 +174,8 @@ public class HttpProxyScenarioTests {
 
 		RestTemplate template = Mockito.spy(new RestTemplate());
 		Mockito.doAnswer(invocation -> {
-			URI uri = invocation.getArgument(0);
-			assertThat(uri).isEqualTo(new URI("http://testServer/testmp"));
+			String uri = invocation.getArgument(0);
+			assertThat(uri).isEqualTo("http://testServer/testmp");
 			HttpEntity<?> httpEntity = (HttpEntity<?>) invocation.getArguments()[2];
 			HttpHeaders httpHeaders = httpEntity.getHeaders();
 			assertThat(httpHeaders.getFirst("Connection")).isEqualTo("Keep-Alive");
@@ -191,8 +190,9 @@ public class HttpProxyScenarioTests {
 			responseHeaders.set("Connection", "close");
 			responseHeaders.set("Content-Type", "text/plain");
 			return new ResponseEntity<>(responseHeaders, HttpStatus.OK);
-		}).when(template).exchange(Mockito.any(URI.class), Mockito.any(HttpMethod.class),
-				Mockito.any(HttpEntity.class), (Class<?>) isNull());
+		}).when(template)
+				.exchange(Mockito.anyString(), Mockito.any(HttpMethod.class),
+						Mockito.any(HttpEntity.class), (Class<?>) isNull(), Mockito.anyMap());
 
 		PropertyAccessor dfa = new DirectFieldAccessor(this.handlermp);
 		dfa.setPropertyValue("restTemplate", template);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-context.xml
@@ -31,6 +31,7 @@
 							  request-factory="testRequestFactory"
 							  error-handler="testErrorHandler"
 							  order="77"
+							  encoding-mode="VALUES_ONLY"
 							  auto-startup="false">
 		<uri-variable name="foo" expression="headers.bar"/>
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.integration.http.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -117,8 +118,8 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(endpointAccessor.getPropertyValue("inputChannel"))
 				.isEqualTo(this.applicationContext.getBean("requests"));
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
-		));
+		DirectFieldAccessor templateAccessor =
+				new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
@@ -126,7 +127,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test1");
 		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
-		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(Charset.forName("UTF-8"));
+		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
 	}
 
@@ -143,8 +144,8 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
 		assertThat(handlerAccessor.getPropertyValue("order")).isEqualTo(77);
 		assertThat(endpointAccessor.getPropertyValue("autoStartup")).isEqualTo(Boolean.FALSE);
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
-		));
+		DirectFieldAccessor templateAccessor =
+				new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(TestUtils.getPropertyValue(handler, "expectedResponseTypeExpression", Expression.class).getValue())
@@ -160,7 +161,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test2/{foo}");
 		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
 				.isEqualTo(HttpMethod.GET.name());
-		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(Charset.forName("UTF-8"));
+		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(false);
 		Map<String, Expression> uriVariableExpressions =
 				(Map<String, Expression>) handlerAccessor.getPropertyValue("uriVariableExpressions");
@@ -207,8 +208,8 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(endpointAccessor.getPropertyValue("inputChannel"))
 				.isEqualTo(this.applicationContext.getBean("requests"));
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
-		));
+		DirectFieldAccessor templateAccessor =
+				new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
@@ -216,7 +217,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test1");
 		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
-		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(Charset.forName("UTF-8"));
+		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
 
 		//INT-3055
@@ -241,8 +242,8 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(endpointAccessor.getPropertyValue("inputChannel"))
 				.isEqualTo(this.applicationContext.getBean("requests"));
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
-		));
+		DirectFieldAccessor templateAccessor =
+				new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
@@ -251,7 +252,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(expression.getExpressionString()).isEqualTo("'http://localhost/test1'");
 		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
-		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(Charset.forName("UTF-8"));
+		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
 	}
 
@@ -276,8 +277,8 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(endpointAccessor.getPropertyValue("inputChannel"))
 				.isEqualTo(this.applicationContext.getBean("requests"));
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
-		));
+		DirectFieldAccessor templateAccessor =
+				new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
@@ -286,7 +287,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(expression.getExpressionString()).isEqualTo("'http://localhost/test1'");
 		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
-		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(Charset.forName("UTF-8"));
+		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
 	}
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
@@ -17,13 +17,12 @@
 package org.springframework.integration.http.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,11 +45,11 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
 /**
  * @author Mark Fisher
@@ -60,8 +59,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Biju Kunjummen
  * @author Shiliang Li
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@SpringJUnitConfig
 @DirtiesContext
 public class HttpOutboundChannelAdapterParserTests {
 
@@ -112,13 +110,15 @@ public class HttpOutboundChannelAdapterParserTests {
 		RestTemplate restTemplate =
 				TestUtils.getPropertyValue(this.minimalConfig, "handler.restTemplate", RestTemplate.class);
 		assertThat(restTemplate).isNotSameAs(customRestTemplate);
-		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor.getPropertyValue("handler");
+		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor
+				.getPropertyValue("handler");
 		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
 		assertThat(handlerAccessor.getPropertyValue("expectReply")).isEqualTo(false);
 		assertThat(endpointAccessor.getPropertyValue("inputChannel"))
 				.isEqualTo(this.applicationContext.getBean("requests"));
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
+		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
+		));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
@@ -134,7 +134,8 @@ public class HttpOutboundChannelAdapterParserTests {
 	@SuppressWarnings("unchecked")
 	public void fullConfig() {
 		DirectFieldAccessor endpointAccessor = new DirectFieldAccessor(this.fullConfig);
-		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor.getPropertyValue("handler");
+		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor
+				.getPropertyValue("handler");
 		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
 		assertThat(handlerAccessor.getPropertyValue("expectReply")).isEqualTo(false);
 		assertThat(endpointAccessor.getPropertyValue("inputChannel"))
@@ -142,7 +143,8 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
 		assertThat(handlerAccessor.getPropertyValue("order")).isEqualTo(77);
 		assertThat(endpointAccessor.getPropertyValue("autoStartup")).isEqualTo(Boolean.FALSE);
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
+		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
+		));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(TestUtils.getPropertyValue(handler, "expectedResponseTypeExpression", Expression.class).getValue())
@@ -171,6 +173,10 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(mappedResponseHeaders.length).isEqualTo(0);
 		assertThat(ObjectUtils.containsElement(mappedRequestHeaders, "requestHeader1")).isTrue();
 		assertThat(ObjectUtils.containsElement(mappedRequestHeaders, "requestHeader2")).isTrue();
+		assertThat(
+				TestUtils.getPropertyValue(handler,
+						"restTemplate.uriTemplateHandler.encodingMode", DefaultUriBuilderFactory.EncodingMode.class))
+				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
 	}
 
 	@Test
@@ -180,10 +186,12 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(restTemplate).isEqualTo(customRestTemplate);
 	}
 
-	@Test(expected = BeanDefinitionParsingException.class)
+	@Test
 	public void failWithRestTemplateAndRestAttributes() {
-		new ClassPathXmlApplicationContext("HttpOutboundChannelAdapterParserTests-fail-context.xml", this.getClass())
-				.close();
+		assertThatExceptionOfType(BeanDefinitionParsingException.class)
+				.isThrownBy(() ->
+						new ClassPathXmlApplicationContext("HttpOutboundChannelAdapterParserTests-fail-context.xml",
+								getClass()));
 	}
 
 	@Test
@@ -192,13 +200,15 @@ public class HttpOutboundChannelAdapterParserTests {
 		RestTemplate restTemplate =
 				TestUtils.getPropertyValue(this.withUrlAndTemplate, "handler.restTemplate", RestTemplate.class);
 		assertThat(restTemplate).isSameAs(customRestTemplate);
-		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor.getPropertyValue("handler");
+		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor
+				.getPropertyValue("handler");
 		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
 		assertThat(handlerAccessor.getPropertyValue("expectReply")).isEqualTo(false);
 		assertThat(endpointAccessor.getPropertyValue("inputChannel"))
 				.isEqualTo(this.applicationContext.getBean("requests"));
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
+		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
+		));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
@@ -224,13 +234,15 @@ public class HttpOutboundChannelAdapterParserTests {
 		RestTemplate restTemplate =
 				TestUtils.getPropertyValue(this.withUrlExpression, "handler.restTemplate", RestTemplate.class);
 		assertThat(restTemplate).isNotSameAs(customRestTemplate);
-		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor.getPropertyValue("handler");
+		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor
+				.getPropertyValue("handler");
 		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
 		assertThat(handlerAccessor.getPropertyValue("expectReply")).isEqualTo(false);
 		assertThat(endpointAccessor.getPropertyValue("inputChannel"))
 				.isEqualTo(this.applicationContext.getBean("requests"));
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
+		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
+		));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
@@ -257,13 +269,15 @@ public class HttpOutboundChannelAdapterParserTests {
 				TestUtils.getPropertyValue(this.withUrlExpressionAndTemplate, "handler.restTemplate",
 						RestTemplate.class);
 		assertThat(restTemplate).isSameAs(customRestTemplate);
-		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor.getPropertyValue("handler");
+		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor
+				.getPropertyValue("handler");
 		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
 		assertThat(handlerAccessor.getPropertyValue("expectReply")).isEqualTo(false);
 		assertThat(endpointAccessor.getPropertyValue("inputChannel"))
 				.isEqualTo(this.applicationContext.getBean("requests"));
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
-		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
+		DirectFieldAccessor templateAccessor = new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"
+		));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
@@ -281,21 +295,23 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(this.withPoller1).isInstanceOf(PollingConsumer.class);
 	}
 
-	@Test(expected = BeanDefinitionParsingException.class)
+	@Test
 	public void failWithUrlAndExpression() {
-		new ClassPathXmlApplicationContext("HttpOutboundChannelAdapterParserTests-url-fail-context.xml",
-				this.getClass()).close();
+		assertThatExceptionOfType(BeanDefinitionParsingException.class)
+				.isThrownBy(() ->
+						new ClassPathXmlApplicationContext("HttpOutboundChannelAdapterParserTests-url-fail-context.xml",
+								getClass()));
 	}
 
 	public static class StubErrorHandler implements ResponseErrorHandler {
 
 		@Override
-		public boolean hasError(ClientHttpResponse response) throws IOException {
+		public boolean hasError(ClientHttpResponse response) {
 			return false;
 		}
 
 		@Override
-		public void handleError(ClientHttpResponse response) throws IOException {
+		public void handleError(ClientHttpResponse response) {
 		}
 
 	}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpOutboundWithinChainTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpOutboundWithinChainTests-context.xml
@@ -9,20 +9,16 @@
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<si:chain id="chain" input-channel="httpOutboundChannelAdapterWithinChain">
-		<outbound-channel-adapter id="adapter" url="http://localhost/test1/%2f" encode-uri="false" rest-template="restTemplate"
+		<outbound-channel-adapter id="adapter" url="http://localhost/test1/%2f" rest-template="restTemplate"
 			trusted-spel="true" />
 	</si:chain>
 
-	<beans:bean id="restTemplate" class="org.mockito.Mockito" factory-method="spy">
-		<beans:constructor-arg>
-			<beans:bean class="org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandlerTests$MockRestTemplate2"/>
-		</beans:constructor-arg>
-	</beans:bean>
+	<beans:bean id="restTemplate"
+				class="org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandlerTests$MockRestTemplate2"/>
 
 	<si:chain input-channel="httpOutboundGatewayWithinChain" output-channel="replyChannel">
 		<outbound-gateway url="http://localhost:51235/%2f/testApps?param={param}"
 						  rest-template="restTemplate"
-						  encode-uri="false"
 						  trusted-spel="true"
 						  expected-response-type-expression="T (org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandlerTests).testParameterizedTypeReference()">
 			<uri-variable name="param" expression="T(java.net.URLEncoder).encode('http Outbound Gateway Within Chain', 'UTF-8')"/>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -17,7 +17,7 @@
 package org.springframework.integration.http.outbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -103,14 +103,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Message<?> message = MessageBuilder.withPayload(form).build();
 		QueueChannel replyChannel = new QueueChannel();
 		handler.setOutputChannel(replyChannel);
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(request.getHeaders().getContentType()).isNotNull();
@@ -138,14 +135,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Message<?> message = MessageBuilder.withPayload(form).build();
 		QueueChannel replyChannel = new QueueChannel();
 		handler.setOutputChannel(replyChannel);
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof MultiValueMap<?, ?>).isTrue();
@@ -172,14 +166,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		Message<?> message = MessageBuilder.withPayload(form).build();
 		QueueChannel replyChannel = new QueueChannel();
 		handler.setOutputChannel(replyChannel);
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof Map<?, ?>).isTrue();
@@ -206,14 +197,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		form.put("c", new String[] { "5" });
 		form.put("d", "6");
 		Message<?> message = MessageBuilder.withPayload(form).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof MultiValueMap<?, ?>).isTrue();
@@ -254,14 +242,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		form.put("c", new String[] { "5" });
 		form.put("d", "6");
 		Message<?> message = MessageBuilder.withPayload(form).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof MultiValueMap<?, ?>).isTrue();
@@ -303,14 +288,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		form.put("a", new Object[] { null, 4, null });
 		form.put("b", "4");
 		Message<?> message = MessageBuilder.withPayload(form).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof MultiValueMap<?, ?>).isTrue();
@@ -351,14 +333,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		form.put("a", list);
 		form.put("b", "4");
 		Message<?> message = MessageBuilder.withPayload(form).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof MultiValueMap<?, ?>).isTrue();
@@ -398,14 +377,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		form.put("a", list);
 		form.put("b", "4");
 		Message<?> message = MessageBuilder.withPayload(form).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof MultiValueMap<?, ?>).isTrue();
@@ -441,14 +417,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		form.put("b", Collections.EMPTY_LIST);
 		form.put("c", Collections.singletonList("3"));
 		Message<?> message = MessageBuilder.withPayload(form).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof MultiValueMap<?, ?>).isTrue();
@@ -486,14 +459,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		form.put("b", Collections.EMPTY_LIST);
 		form.put("c", Collections.singletonList(new City("Mohnton")));
 		Message<?> message = MessageBuilder.withPayload(form).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof MultiValueMap<?, ?>).isTrue();
@@ -528,14 +498,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		form.put("b", "foo");
 		form.put("c", null);
 		Message<?> message = MessageBuilder.withPayload(form).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof MultiValueMap<?, ?>).isTrue();
@@ -564,14 +531,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 
 		byte[] bytes = "Hello World".getBytes();
 		Message<?> message = MessageBuilder.withPayload(bytes).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof byte[]).isTrue();
@@ -590,14 +554,11 @@ public class HttpRequestExecutingMessageHandlerTests {
 		handler.afterPropertiesSet();
 
 		Message<?> message = MessageBuilder.withPayload(mock(Source.class)).build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
-		assertThat(exception.getCause().getMessage()).isEqualTo("intentional");
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("intentional");
+
 		HttpEntity<?> request = template.lastRequestEntity.get();
 		Object body = request.getBody();
 		assertThat(body instanceof Source).isTrue();
@@ -648,55 +609,39 @@ public class HttpRequestExecutingMessageHandlerTests {
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
 
-		Message<?> message = MessageBuilder.withPayload(mock(Source.class)).build();
-		try {
-			handler.handleMessage(message);
-			fail("An Exception expected");
-		}
-		catch (Exception e) {
-			assertThat(e.getCause().getMessage()).isEqualTo("intentional");
-			assertThat(template.lastRequestEntity.get().getHeaders().getContentType()).isNull();
-		}
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(MessageBuilder.withPayload(mock(Source.class)).build()))
+				.withStackTraceContaining("intentional");
+
+		assertThat(template.lastRequestEntity.get().getHeaders().getContentType()).isNull();
 
 		//HEAD
 		handler.setHttpMethod(HttpMethod.HEAD);
 
-		message = MessageBuilder.withPayload(mock(Source.class)).build();
-		try {
-			handler.handleMessage(message);
-			fail("An Exception expected");
-		}
-		catch (Exception e) {
-			assertThat(e.getCause().getMessage()).isEqualTo("intentional");
-			assertThat(template.lastRequestEntity.get().getHeaders().getContentType()).isNull();
-		}
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(MessageBuilder.withPayload(mock(Source.class)).build()))
+				.withStackTraceContaining("intentional");
+
+		assertThat(template.lastRequestEntity.get().getHeaders().getContentType()).isNull();
 
 
 		//DELETE
 		handler.setHttpMethod(HttpMethod.DELETE);
 
-		message = MessageBuilder.withPayload(mock(Source.class)).build();
-		try {
-			handler.handleMessage(message);
-			fail("An Exception expected");
-		}
-		catch (Exception e) {
-			assertThat(e.getCause().getMessage()).isEqualTo("intentional");
-			assertThat(template.lastRequestEntity.get().getHeaders().getContentType()).isEqualTo(MediaType.TEXT_XML);
-		}
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(MessageBuilder.withPayload(mock(Source.class)).build()))
+				.withStackTraceContaining("intentional");
+
+		assertThat(template.lastRequestEntity.get().getHeaders().getContentType()).isEqualTo(MediaType.TEXT_XML);
 
 		//TRACE
 		handler.setHttpMethod(HttpMethod.TRACE);
 
-		message = MessageBuilder.withPayload(mock(Source.class)).build();
-		try {
-			handler.handleMessage(message);
-			fail("An Exception expected");
-		}
-		catch (Exception e) {
-			assertThat(e.getCause().getMessage()).isEqualTo("intentional");
-			assertThat(template.lastRequestEntity.get().getHeaders().getContentType()).isNull();
-		}
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(MessageBuilder.withPayload(mock(Source.class)).build()))
+				.withStackTraceContaining("intentional");
+
+		assertThat(template.lastRequestEntity.get().getHeaders().getContentType()).isNull();
 	}
 
 	@Test
@@ -743,11 +688,10 @@ public class HttpRequestExecutingMessageHandlerTests {
 		handler.afterPropertiesSet();
 		String theURL = "https://bar/baz?foo#bar";
 		Message<?> message = MessageBuilder.withPayload("").setHeader("foo", theURL).build();
-		try {
-			handler.handleRequestMessage(message);
-		}
-		catch (Exception e) {
-		}
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(message));
+
 		assertThat(restTemplate.actualUrl.get()).isEqualTo(theURL);
 	}
 
@@ -764,12 +708,10 @@ public class HttpRequestExecutingMessageHandlerTests {
 		handler.setUriVariableExpressions(Collections.singletonMap("query", parser.parseExpression("payload")));
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
-		Message<?> message = new GenericMessage<>("test-äöü&%");
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception ignored) {
-		}
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("test-äöü&%")));
+
 		assertThat(restTemplate.actualUrl.get()).isEqualTo("https://example.com?query=test-%C3%A4%C3%B6%C3%BC%26%25");
 	}
 
@@ -789,12 +731,10 @@ public class HttpRequestExecutingMessageHandlerTests {
 		handler.setUriVariableExpressions(Collections.singletonMap("query", parser.parseExpression("payload")));
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
-		Message<?> message = new GenericMessage<>("test-äöü");
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception ignored) {
-		}
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("test-äöü")));
+
 		assertThat(restTemplate.actualUrl.get()).isEqualTo("https://example.com?query=test-äöü");
 	}
 
@@ -809,12 +749,10 @@ public class HttpRequestExecutingMessageHandlerTests {
 				new SpelExpressionParser().parseExpression("'https://my.RabbitMQ.com/api/' + payload"), restTemplate);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
-		Message<?> message = MessageBuilder.withPayload("queues/%2f/si.test.queue?foo#bar").build();
-		try {
-			handler.handleRequestMessage(message);
-		}
-		catch (Exception e) {
-		}
+
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("queues/%2f/si.test.queue?foo#bar")));
+
 		assertThat(restTemplate.actualUrl.get())
 				.isEqualTo("https://my.RabbitMQ.com/api/queues/%2f/si.test.queue?foo#bar");
 	}
@@ -836,17 +774,12 @@ public class HttpRequestExecutingMessageHandlerTests {
 
 		HttpHeaders requestHeaders = setUpMocksToCaptureSentHeaders(restTemplate);
 
-		Message<?> message = MessageBuilder.withPayload("foo").build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("foo")))
+				.withStackTraceContaining("404 Not Found");
+
 		assertThat(requestHeaders.getAccept()).isNotNull();
 		assertThat(requestHeaders.getAccept().size() > 0).isTrue();
-		assertThat(exception.getCause().getMessage()).contains("404 Not Found");
 		List<MediaType> accept = requestHeaders.getAccept();
 		assertThat(accept.size() > 0).isTrue();
 		assertThat(accept.get(0).getType()).isEqualTo("application");
@@ -872,17 +805,12 @@ public class HttpRequestExecutingMessageHandlerTests {
 
 		HttpHeaders requestHeaders = setUpMocksToCaptureSentHeaders(restTemplate);
 
-		Message<?> message = MessageBuilder.withPayload("foo").build();
-		Exception exception = null;
-		try {
-			handler.handleMessage(message);
-		}
-		catch (Exception e) {
-			exception = e;
-		}
+		assertThatExceptionOfType(Exception.class)
+				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("foo")))
+				.withStackTraceContaining("404 Not Found");
+
 		assertThat(requestHeaders.getAccept()).isNotNull();
 		assertThat(requestHeaders.getAccept().size() > 0).isTrue();
-		assertThat(exception.getCause().getMessage()).contains("404 Not Found");
 		List<MediaType> accept = requestHeaders.getAccept();
 		assertThat(accept.size() > 0).isTrue();
 		assertThat(accept.get(0).getType()).isEqualTo("application");

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParser.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.config.RuntimeBeanReference;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ExpressionFactoryBean;
+import org.springframework.integration.config.xml.IntegrationNamespaceUtils;
 import org.springframework.integration.http.config.HttpOutboundChannelAdapterParser;
 import org.springframework.integration.webflux.outbound.WebFluxRequestExecutingMessageHandler;
 import org.springframework.util.StringUtils;
@@ -51,6 +52,9 @@ public class WebFluxOutboundChannelAdapterParser extends HttpOutboundChannelAdap
 			builder.getBeanDefinition()
 					.getConstructorArgumentValues()
 					.addIndexedArgumentValue(1, new RuntimeBeanReference(webClientRef));
+		}
+		else {
+			IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "encoding-mode");
 		}
 
 		String type = element.getAttribute("publisher-element-type");

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests-context.xml
@@ -10,7 +10,8 @@
 
 	<si:channel id="requests"/>
 
-	<outbound-channel-adapter id="reactiveMinimalConfig" url="http://localhost/test1" channel="requests"/>
+	<outbound-channel-adapter id="reactiveMinimalConfig" url="http://localhost/test1" channel="requests"
+							  encoding-mode="VALUES_ONLY"/>
 
 	<outbound-channel-adapter id="reactiveWebClientConfig" url="http://localhost/test1" channel="requests"
 							  web-client="webClient"

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,11 +18,10 @@ package org.springframework.integration.webflux.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -33,15 +32,16 @@ import org.springframework.http.HttpMethod;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
 /**
  * @author Artem Bilan
  *
  * @since 5.0
  */
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
 public class WebFluxOutboundChannelAdapterParserTests {
 
@@ -75,8 +75,12 @@ public class WebFluxOutboundChannelAdapterParserTests {
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test1");
 		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
-		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(Charset.forName("UTF-8"));
+		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
+		assertThat(
+				TestUtils.getPropertyValue(handler, "webClient.uriBuilderFactory.encodingMode",
+						DefaultUriBuilderFactory.EncodingMode.class))
+				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
 	}
 
 	@Test

--- a/src/reference/asciidoc/http.adoc
+++ b/src/reference/asciidoc/http.adoc
@@ -703,12 +703,13 @@ List<NameValuePair> nameValuePairs =
 ----
 ====
 
+[[http-uri-encoding]]
 ==== Controlling URI Encoding
 
 By default, the URL string is encoded (see https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/util/UriComponentsBuilder.html[`UriComponentsBuilder`]) to the URI object before sending the request.
 In some scenarios with a non-standard URI (such as the RabbitMQ REST API), it is undesirable to perform the encoding.
-The `<http:outbound-gateway/>` and `<http:outbound-channel-adapter/>` provide an `encode-uri` attribute.
-To disable encoding the URL, set this attribute to `false` (by default, it is `true`).
+The `<http:outbound-gateway/>` and `<http:outbound-channel-adapter/>` provide an `encoding-mode` attribute.
+To disable encoding the URL, set this attribute to `NONE` (by default, it is `TEMPLATE_AND_VALUES`).
 If you wish to partially encode some of the URL, use an `expression` within a `<uri-variable/>`, as the following example shows:
 
 ====
@@ -721,6 +722,10 @@ If you wish to partially encode some of the URL, use an `expression` within a `<
 </http:outbound-gateway>
 ----
 ====
+
+With Java DSL this option can be controlled by the `BaseHttpMessageHandlerSpec.encodingMode()` option.
+Same configuration applies for similar outbound components in the <<./webflux.adoc/[webflux,WebFlux module>>.
+For much sophisticated scenarios it is recommended to configure an `UriTemplateHandler` on the externally provided `RestTemplate`; or in case of WebFlux - `WebClient` with it `UriBuilderFactory`.
 
 [[http-java-config]]
 === Configuring HTTP Endpoints with Java

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -41,3 +41,10 @@ See <<./gateway.adoc/gateway-calling-default-methods,Invoking `default` Methods>
 
 Internal components (such as `_org.springframework.integration.errorLogger`) now have a shortened name when they are represented in the integration graph.
 See <<./graph.adoc#integration-graph,Integration Graph>> for more information.
+
+[[x5.3-http]]
+=== HTTP Changes
+
+The `encodeUri` property on the `AbstractHttpRequestExecutingMessageHandler` has been deprecated in favor of newly introduced `encodingMode`.
+See `DefaultUriBuilderFactory.EncodingMode` JavaDocs and <<./http.adoc/http-uri-encoding,Controlling URI Encoding>> for more information.
+This also effects `WebFluxRequestExecutingMessageHandler`, respective Java DSL and XML configuration.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3154

Spring Framework now provides a `DefaultUriBuilderFactory.EncodingMode`
for encoding URIs in the `RestTemplate` before and after uri template
enrichment with uri variables.
Therefore `encodeUri` and manual uri variables substitution is not necessary
in Spring Integration HTTP components

* Deprecate `AbstractHttpRequestExecutingMessageHandler.encodeUri` in favor of
`DefaultUriBuilderFactory.EncodingMode` and respective configuration
on the `RestTemplate` in HTTP module and `WebClient` in WebFlux module

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
