### PR TITLE
Populate a JsonHeaders.RESOLVABLE_TYPE on reply

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
+import org.springframework.integration.mapping.AbstractHeaderMapper;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.DefaultErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageStrategy;
@@ -416,6 +417,10 @@ public abstract class AbstractAmqpOutboundEndpoint extends AbstractReplyProducin
 		configureDelayGenerator(beanFactory);
 
 		endpointInit();
+
+		if (this.headerMapper instanceof AbstractHeaderMapper) {
+			((AbstractHeaderMapper<?>) this.headerMapper).setBeanClassLoader(getBeanClassLoader());
+		}
 	}
 
 	private void configureExchangeNameGenerator(BeanFactory beanFactory) {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -109,40 +109,43 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 		Map<String, Object> headers = new HashMap<>();
 		try {
 			JavaUtils.INSTANCE
-				.acceptIfNotNull(AmqpHeaders.APP_ID, amqpMessageProperties.getAppId(), headers::put)
-				.acceptIfNotNull(AmqpHeaders.CLUSTER_ID, amqpMessageProperties.getClusterId(), headers::put)
-				.acceptIfNotNull(AmqpHeaders.CONTENT_ENCODING, amqpMessageProperties.getContentEncoding(),
-						headers::put);
+					.acceptIfNotNull(AmqpHeaders.APP_ID, amqpMessageProperties.getAppId(), headers::put)
+					.acceptIfNotNull(AmqpHeaders.CLUSTER_ID, amqpMessageProperties.getClusterId(), headers::put)
+					.acceptIfNotNull(AmqpHeaders.CONTENT_ENCODING, amqpMessageProperties.getContentEncoding(),
+							headers::put);
 			long contentLength = amqpMessageProperties.getContentLength();
 			JavaUtils.INSTANCE
-				.acceptIfCondition(contentLength > 0, AmqpHeaders.CONTENT_LENGTH, contentLength, headers::put)
-				.acceptIfHasText(AmqpHeaders.CONTENT_TYPE, amqpMessageProperties.getContentType(), headers::put)
-				.acceptIfHasText(AmqpHeaders.CORRELATION_ID, amqpMessageProperties.getCorrelationId(), headers::put)
-				.acceptIfNotNull(AmqpHeaders.RECEIVED_DELIVERY_MODE, amqpMessageProperties.getReceivedDeliveryMode(),
-						headers::put);
+					.acceptIfCondition(contentLength > 0, AmqpHeaders.CONTENT_LENGTH, contentLength, headers::put)
+					.acceptIfHasText(AmqpHeaders.CONTENT_TYPE, amqpMessageProperties.getContentType(), headers::put)
+					.acceptIfHasText(AmqpHeaders.CORRELATION_ID, amqpMessageProperties.getCorrelationId(), headers::put)
+					.acceptIfNotNull(AmqpHeaders.RECEIVED_DELIVERY_MODE,
+							amqpMessageProperties.getReceivedDeliveryMode(),
+							headers::put);
 			long deliveryTag = amqpMessageProperties.getDeliveryTag();
 			JavaUtils.INSTANCE
-				.acceptIfCondition(deliveryTag > 0, AmqpHeaders.DELIVERY_TAG, deliveryTag, headers::put)
-				.acceptIfHasText(AmqpHeaders.EXPIRATION, amqpMessageProperties.getExpiration(), headers::put);
+					.acceptIfCondition(deliveryTag > 0, AmqpHeaders.DELIVERY_TAG, deliveryTag, headers::put)
+					.acceptIfHasText(AmqpHeaders.EXPIRATION, amqpMessageProperties.getExpiration(), headers::put);
 			Integer messageCount = amqpMessageProperties.getMessageCount();
 			JavaUtils.INSTANCE
-				.acceptIfCondition(messageCount != null && messageCount > 0, AmqpHeaders.MESSAGE_COUNT, messageCount,
-				headers::put)
-				.acceptIfHasText(AmqpHeaders.MESSAGE_ID, amqpMessageProperties.getMessageId(), headers::put);
+					.acceptIfCondition(messageCount != null && messageCount > 0, AmqpHeaders.MESSAGE_COUNT,
+							messageCount,
+							headers::put)
+					.acceptIfHasText(AmqpHeaders.MESSAGE_ID, amqpMessageProperties.getMessageId(), headers::put);
 			Integer priority = amqpMessageProperties.getPriority();
 			JavaUtils.INSTANCE
-				.acceptIfCondition(priority != null && priority > 0, IntegrationMessageHeaderAccessor.PRIORITY,
-					priority, headers::put)
-				.acceptIfNotNull(AmqpHeaders.RECEIVED_DELAY, amqpMessageProperties.getReceivedDelay(), headers::put)
-				.acceptIfNotNull(AmqpHeaders.RECEIVED_EXCHANGE, amqpMessageProperties.getReceivedExchange(),
-						headers::put)
-				.acceptIfHasText(AmqpHeaders.RECEIVED_ROUTING_KEY, amqpMessageProperties.getReceivedRoutingKey(),
-						headers::put)
-				.acceptIfNotNull(AmqpHeaders.REDELIVERED, amqpMessageProperties.isRedelivered(), headers::put)
-				.acceptIfNotNull(AmqpHeaders.REPLY_TO, amqpMessageProperties.getReplyTo(), headers::put)
-				.acceptIfNotNull(AmqpHeaders.TIMESTAMP, amqpMessageProperties.getTimestamp(), headers::put)
-				.acceptIfHasText(AmqpHeaders.TYPE, amqpMessageProperties.getType(), headers::put)
-				.acceptIfHasText(AmqpHeaders.RECEIVED_USER_ID, amqpMessageProperties.getReceivedUserId(), headers::put);
+					.acceptIfCondition(priority != null && priority > 0, IntegrationMessageHeaderAccessor.PRIORITY,
+							priority, headers::put)
+					.acceptIfNotNull(AmqpHeaders.RECEIVED_DELAY, amqpMessageProperties.getReceivedDelay(), headers::put)
+					.acceptIfNotNull(AmqpHeaders.RECEIVED_EXCHANGE, amqpMessageProperties.getReceivedExchange(),
+							headers::put)
+					.acceptIfHasText(AmqpHeaders.RECEIVED_ROUTING_KEY, amqpMessageProperties.getReceivedRoutingKey(),
+							headers::put)
+					.acceptIfNotNull(AmqpHeaders.REDELIVERED, amqpMessageProperties.isRedelivered(), headers::put)
+					.acceptIfNotNull(AmqpHeaders.REPLY_TO, amqpMessageProperties.getReplyTo(), headers::put)
+					.acceptIfNotNull(AmqpHeaders.TIMESTAMP, amqpMessageProperties.getTimestamp(), headers::put)
+					.acceptIfHasText(AmqpHeaders.TYPE, amqpMessageProperties.getType(), headers::put)
+					.acceptIfHasText(AmqpHeaders.RECEIVED_USER_ID, amqpMessageProperties
+							.getReceivedUserId(), headers::put);
 
 			for (String jsonHeader : JsonHeaders.HEADERS) {
 				Object value = amqpMessageProperties.getHeaders().get(jsonHeader.replaceFirst(JsonHeaders.PREFIX, ""));
@@ -151,6 +154,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 				}
 			}
 
+			createJsonResolvableTypHeaderInAny(headers);
 		}
 		catch (Exception e) {
 			if (logger.isWarnEnabled()) {
@@ -158,6 +162,15 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 			}
 		}
 		return headers;
+	}
+
+	private void createJsonResolvableTypHeaderInAny(Map<String, Object> headers) {
+		Object typeIdHeader = headers.get(JsonHeaders.TYPE_ID);
+		if (typeIdHeader != null) {
+			headers.put(JsonHeaders.RESOLVABLE_TYPE,
+					JsonHeaders.buildResolvableType(getClassLoader(), typeIdHeader,
+							headers.get(JsonHeaders.CONTENT_TYPE_ID), headers.get(JsonHeaders.KEY_TYPE_ID)));
+		}
 	}
 
 	/**
@@ -186,28 +199,28 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 			MessageProperties amqpMessageProperties) {
 
 		JavaUtils.INSTANCE
-			.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.APP_ID, String.class),
-					amqpMessageProperties::setAppId)
-			.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.CLUSTER_ID, String.class),
-					amqpMessageProperties::setClusterId)
-			.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_ENCODING, String.class),
-					amqpMessageProperties::setContentEncoding)
-			.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_LENGTH, Long.class),
-					amqpMessageProperties::setContentLength)
-			.acceptIfHasText(this.extractContentTypeAsString(headers),
-					amqpMessageProperties::setContentType)
-			.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.CORRELATION_ID, String.class),
-					amqpMessageProperties::setCorrelationId)
-			.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.DELAY, Integer.class),
-					amqpMessageProperties::setDelay)
-			.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_MODE, MessageDeliveryMode.class),
-					amqpMessageProperties::setDeliveryMode)
-			.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_TAG, Long.class),
-					amqpMessageProperties::setDeliveryTag)
-			.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.EXPIRATION, String.class),
-					amqpMessageProperties::setExpiration)
-			.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.MESSAGE_COUNT, Integer.class),
-					amqpMessageProperties::setMessageCount);
+				.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.APP_ID, String.class),
+						amqpMessageProperties::setAppId)
+				.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.CLUSTER_ID, String.class),
+						amqpMessageProperties::setClusterId)
+				.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_ENCODING, String.class),
+						amqpMessageProperties::setContentEncoding)
+				.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.CONTENT_LENGTH, Long.class),
+						amqpMessageProperties::setContentLength)
+				.acceptIfHasText(this.extractContentTypeAsString(headers),
+						amqpMessageProperties::setContentType)
+				.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.CORRELATION_ID, String.class),
+						amqpMessageProperties::setCorrelationId)
+				.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.DELAY, Integer.class),
+						amqpMessageProperties::setDelay)
+				.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_MODE, MessageDeliveryMode.class),
+						amqpMessageProperties::setDeliveryMode)
+				.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.DELIVERY_TAG, Long.class),
+						amqpMessageProperties::setDeliveryTag)
+				.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.EXPIRATION, String.class),
+						amqpMessageProperties::setExpiration)
+				.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.MESSAGE_COUNT, Integer.class),
+						amqpMessageProperties::setMessageCount);
 		String messageId = getHeaderIfAvailable(headers, AmqpHeaders.MESSAGE_ID, String.class);
 		if (StringUtils.hasText(messageId)) {
 			amqpMessageProperties.setMessageId(messageId);
@@ -219,16 +232,17 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 			}
 		}
 		JavaUtils.INSTANCE
-			.acceptIfNotNull(getHeaderIfAvailable(headers, IntegrationMessageHeaderAccessor.PRIORITY, Integer.class),
-					amqpMessageProperties::setPriority)
-			.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_EXCHANGE, String.class),
-					amqpMessageProperties::setReceivedExchange)
-			.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_ROUTING_KEY, String.class),
-					amqpMessageProperties::setReceivedRoutingKey)
-			.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.REDELIVERED, Boolean.class),
-					amqpMessageProperties::setRedelivered)
-			.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.REPLY_TO, String.class),
-					amqpMessageProperties::setReplyTo);
+				.acceptIfNotNull(getHeaderIfAvailable(headers, IntegrationMessageHeaderAccessor.PRIORITY,
+						Integer.class),
+						amqpMessageProperties::setPriority)
+				.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_EXCHANGE, String.class),
+						amqpMessageProperties::setReceivedExchange)
+				.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.RECEIVED_ROUTING_KEY, String.class),
+						amqpMessageProperties::setReceivedRoutingKey)
+				.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.REDELIVERED, Boolean.class),
+						amqpMessageProperties::setRedelivered)
+				.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.REPLY_TO, String.class),
+						amqpMessageProperties::setReplyTo);
 		Date timestamp = getHeaderIfAvailable(headers, AmqpHeaders.TIMESTAMP, Date.class);
 		if (timestamp != null) {
 			amqpMessageProperties.setTimestamp(timestamp);
@@ -240,18 +254,19 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 			}
 		}
 		JavaUtils.INSTANCE
-			.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.TYPE, String.class),
-					amqpMessageProperties::setType)
-			.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.USER_ID, String.class),
-					amqpMessageProperties::setUserId);
+				.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.TYPE, String.class),
+						amqpMessageProperties::setType)
+				.acceptIfNotNull(getHeaderIfAvailable(headers, AmqpHeaders.USER_ID, String.class),
+						amqpMessageProperties::setUserId);
 
 		mapJsonHeaders(headers, amqpMessageProperties);
 
 		JavaUtils.INSTANCE
-			.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.SPRING_REPLY_CORRELATION, String.class),
-					replyCorrelation -> amqpMessageProperties.setHeader("spring_reply_correlation", replyCorrelation))
-			.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.SPRING_REPLY_TO_STACK, String.class),
-					replyToStack -> amqpMessageProperties.setHeader("spring_reply_to", replyToStack));
+				.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.SPRING_REPLY_CORRELATION, String.class),
+						replyCorrelation -> amqpMessageProperties
+								.setHeader("spring_reply_correlation", replyCorrelation))
+				.acceptIfHasText(getHeaderIfAvailable(headers, AmqpHeaders.SPRING_REPLY_TO_STACK, String.class),
+						replyToStack -> amqpMessageProperties.setHeader("spring_reply_to", replyToStack));
 	}
 
 	private void mapJsonHeaders(Map<String, Object> headers, MessageProperties amqpMessageProperties) {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -119,8 +119,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 					.acceptIfHasText(AmqpHeaders.CONTENT_TYPE, amqpMessageProperties.getContentType(), headers::put)
 					.acceptIfHasText(AmqpHeaders.CORRELATION_ID, amqpMessageProperties.getCorrelationId(), headers::put)
 					.acceptIfNotNull(AmqpHeaders.RECEIVED_DELIVERY_MODE,
-							amqpMessageProperties.getReceivedDeliveryMode(),
-							headers::put);
+							amqpMessageProperties.getReceivedDeliveryMode(), headers::put);
 			long deliveryTag = amqpMessageProperties.getDeliveryTag();
 			JavaUtils.INSTANCE
 					.acceptIfCondition(deliveryTag > 0, AmqpHeaders.DELIVERY_TAG, deliveryTag, headers::put)
@@ -128,8 +127,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 			Integer messageCount = amqpMessageProperties.getMessageCount();
 			JavaUtils.INSTANCE
 					.acceptIfCondition(messageCount != null && messageCount > 0, AmqpHeaders.MESSAGE_COUNT,
-							messageCount,
-							headers::put)
+							messageCount, headers::put)
 					.acceptIfHasText(AmqpHeaders.MESSAGE_ID, amqpMessageProperties.getMessageId(), headers::put);
 			Integer priority = amqpMessageProperties.getPriority();
 			JavaUtils.INSTANCE
@@ -144,8 +142,8 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 					.acceptIfNotNull(AmqpHeaders.REPLY_TO, amqpMessageProperties.getReplyTo(), headers::put)
 					.acceptIfNotNull(AmqpHeaders.TIMESTAMP, amqpMessageProperties.getTimestamp(), headers::put)
 					.acceptIfHasText(AmqpHeaders.TYPE, amqpMessageProperties.getType(), headers::put)
-					.acceptIfHasText(AmqpHeaders.RECEIVED_USER_ID, amqpMessageProperties
-							.getReceivedUserId(), headers::put);
+					.acceptIfHasText(AmqpHeaders.RECEIVED_USER_ID,
+							amqpMessageProperties.getReceivedUserId(), headers::put);
 
 			for (String jsonHeader : JsonHeaders.HEADERS) {
 				Object value = amqpMessageProperties.getHeaders().get(jsonHeader.replaceFirst(JsonHeaders.PREFIX, ""));

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,10 +28,12 @@ import java.util.Map.Entry;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.beans.factory.BeanClassLoaderAware;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
@@ -43,9 +45,11 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Stephane Nicoll
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.1
  */
-public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMapper<T> {
+public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMapper<T>, BeanClassLoaderAware {
 
 	/**
 	 * A special pattern that only matches standard request headers.
@@ -74,9 +78,11 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 
 	private final Collection<String> replyHeaderNames;
 
-	private volatile HeaderMatcher requestHeaderMatcher;
+	private HeaderMatcher requestHeaderMatcher;
 
-	private volatile HeaderMatcher replyHeaderMatcher;
+	private HeaderMatcher replyHeaderMatcher;
+
+	private ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
 
 	/**
 	 * Create a new instance.
@@ -94,6 +100,15 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 		this.replyHeaderNames = replyHeaderNames;
 		this.requestHeaderMatcher = createDefaultHeaderMatcher(this.standardHeaderPrefix, this.requestHeaderNames);
 		this.replyHeaderMatcher = createDefaultHeaderMatcher(this.standardHeaderPrefix, this.replyHeaderNames);
+	}
+
+	@Override
+	public void setBeanClassLoader(ClassLoader classLoader) {
+		this.classLoader = classLoader;
+	}
+
+	protected ClassLoader getClassLoader() {
+		return this.classLoader;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/JsonHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/JsonHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,11 @@ package org.springframework.integration.mapping.support;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.lang.Nullable;
+import org.springframework.util.ClassUtils;
 
 /**
  * Pre-defined names and prefixes to be used for setting and/or retrieving JSON
@@ -43,7 +48,7 @@ public final class JsonHeaders {
 	public static final String KEY_TYPE_ID = PREFIX + "__KeyTypeId__";
 
 	/**
-	 * The header to represent a {@link org.springframework.core.ResolvableType}
+	 * The header to represent a {@link ResolvableType}
 	 * for the target deserialized object.
 	 * @since 5.2
 	 */
@@ -51,5 +56,71 @@ public final class JsonHeaders {
 
 	public static final Collection<String> HEADERS =
 			Collections.unmodifiableList(Arrays.asList(TYPE_ID, CONTENT_TYPE_ID, KEY_TYPE_ID, RESOLVABLE_TYPE));
+
+	/**
+	 * Build a {@link ResolvableType} for provided class components.
+	 * @param classLoader a {@link ClassLoader} t load classes for components if needed.
+	 * @param targetClassValue the class representation object.
+	 * @param contentClassValue the collection element (or map value) class representation object.
+	 * @param keyClassValue the map key class representation object.
+	 * @return the {@link ResolvableType} based on provided class components
+	 * @since 5.2.4
+	 */
+	public static ResolvableType buildResolvableType(ClassLoader classLoader, Object targetClassValue,
+			@Nullable Object contentClassValue, @Nullable Object keyClassValue) {
+
+		Class<?> targetClass = getClassForValue(classLoader, targetClassValue);
+		Class<?> keyClass = getClassForValue(classLoader, keyClassValue);
+		Class<?> contentClass = getClassForValue(classLoader, contentClassValue);
+
+		return buildResolvableType(targetClass, contentClass, keyClass);
+	}
+
+	@Nullable
+	private static Class<?> getClassForValue(ClassLoader classLoader, @Nullable Object classValue) {
+		if (classValue instanceof Class<?>) {
+			return (Class<?>) classValue;
+		}
+		else if (classValue != null) {
+			try {
+				return ClassUtils.forName(classValue.toString(), classLoader);
+			}
+			catch (ClassNotFoundException | LinkageError e) {
+				throw new IllegalStateException(e);
+			}
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Build a {@link ResolvableType} for provided class components.
+	 * @param targetClass the class to use.
+	 * @param contentClass the collection element (or map value) class.
+	 * @param keyClass the map key class.
+	 * @return the {@link ResolvableType} based on provided class components
+	 * @since 5.2.4
+	 */
+	public static ResolvableType buildResolvableType(Class<?> targetClass, @Nullable Class<?> contentClass,
+			@Nullable Class<?> keyClass) {
+
+		if (keyClass != null) {
+			return TypeDescriptor
+					.map(targetClass,
+							TypeDescriptor.valueOf(keyClass),
+							TypeDescriptor.valueOf(contentClass))
+					.getResolvableType();
+		}
+		else if (contentClass != null) {
+			return TypeDescriptor
+					.collection(targetClass,
+							TypeDescriptor.valueOf(contentClass))
+					.getResolvableType();
+		}
+		else {
+			return ResolvableType.forClass(targetClass);
+		}
+	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JsonObjectMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,9 +23,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.springframework.core.ResolvableType;
-import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.integration.mapping.support.JsonHeaders;
-import org.springframework.lang.Nullable;
 
 /**
  * Strategy interface to convert an Object to/from the JSON representation.
@@ -102,29 +100,7 @@ public interface JsonObjectMapper<N, P> {
 			}
 		}
 
-
-		map.put(JsonHeaders.RESOLVABLE_TYPE, buildResolvableType(targetClass, contentClass, keyClass));
-	}
-
-	static ResolvableType buildResolvableType(Class<?> targetClass, @Nullable Class<?> contentClass,
-			@Nullable Class<?> keyClass) {
-
-		if (keyClass != null) {
-			return TypeDescriptor
-					.map(targetClass,
-							TypeDescriptor.valueOf(keyClass),
-							TypeDescriptor.valueOf(contentClass))
-					.getResolvableType();
-		}
-		else if (contentClass != null) {
-			return TypeDescriptor
-					.collection(targetClass,
-							TypeDescriptor.valueOf(contentClass))
-					.getResolvableType();
-		}
-		else {
-			return ResolvableType.forClass(targetClass);
-		}
+		map.put(JsonHeaders.RESOLVABLE_TYPE, JsonHeaders.buildResolvableType(targetClass, contentClass, keyClass));
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration-samples/issues/277

In the `AbstractAmqpOutboundEndpoint` the `JsonHeaders.RESOLVABLE_TYPE`
from request message is copied to reply message making inconsistency downstream.
The `JsonToObjectTransformer` consults first a `JsonHeaders.RESOLVABLE_TYPE`
and deserialize payload to wrong type

* Fix `DefaultAmqpHeaderMapper` to populate a `JsonHeaders.RESOLVABLE_TYPE`
alongside with other `JsonHeaders` populated from the reply AMQP message.
This way a `JsonHeaders.RESOLVABLE_TYPE` from request message won't have effect
* To get access to classes, supply `AbstractHeaderMapper` with a bean factory `ClassLoader`
* Introduce a couple utility methods into `JsonHeaders` for building a `ResolvableType`

**Cherry-pick to 5.2.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
