### PR TITLE
Fixed issue with sequences not being poped when Output processor returns Message

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -90,6 +90,7 @@ import org.springframework.util.ObjectUtils;
  * @author David Liu
  * @author Enrique Rodriguez
  * @author Meherzad Lahewala
+ * @author Jayadev Sirimamilla
  *
  * @since 2.0
  */

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
@@ -66,7 +66,6 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Jayadev Sirimamilla
- *
  * @since 5.0
  */
 @SpringJUnitConfig
@@ -633,8 +632,9 @@ public class RouterTests {
 		Message<?> wiretapMessage2 = scatterGatherWireTapChannel.receive(10000);
 		assertThat(wiretapMessage2).isNotNull()
 				.extracting(Message::getHeaders)
-				.isEqualToComparingOnlyGivenFields(headers1, "correlationId",
-						"gatherResultChannel", "sequenceSize", "sequenceNo");
+				.isEqualToComparingOnlyGivenFields(headers1, IntegrationMessageHeaderAccessor.CORRELATION_ID,
+						"gatherResultChannel", IntegrationMessageHeaderAccessor.SEQUENCE_NUMBER,
+						IntegrationMessageHeaderAccessor.SEQUENCE_SIZE);
 		Message<?> receive = replyChannel.receive(10000);
 
 		assertThat(receive).isNotNull();

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
@@ -615,8 +615,8 @@ public class RouterTests {
 	}
 
 	@Autowired
-			@Qualifier("scatterGatherWiretapChannel")
-	PollableChannel scatterGatherWiretapChannel;
+	@Qualifier("scatterGatherWireTapChannel")
+	PollableChannel scatterGatherWireTapChannel;
 
 	@Timeout(11000)
 	@Test
@@ -627,18 +627,18 @@ public class RouterTests {
 						.setReplyChannel(replyChannel)
 						.build());
 
-		Message<?> wiretapMessage1 = scatterGatherWiretapChannel.receive(10000);
+		Message<?> wiretapMessage1 = scatterGatherWireTapChannel.receive(10000);
 		assertThat(wiretapMessage1).isNotNull();
 		MessageHeaders headers1 = wiretapMessage1.getHeaders();
-		Message<?> wiretapMessage2 = scatterGatherWiretapChannel.receive(10000);
+		Message<?> wiretapMessage2 = scatterGatherWireTapChannel.receive(10000);
 		assertThat(wiretapMessage2).isNotNull()
 				.extracting(Message::getHeaders)
-				.isEqualToComparingOnlyGivenFields(headers1, "correlationId", "gatherResultChannel", "sequenceSize", "sequenceNo");
+				.isEqualToComparingOnlyGivenFields(headers1, "correlationId",
+						"gatherResultChannel", "sequenceSize", "sequenceNo");
 		Message<?> receive = replyChannel.receive(10000);
 
 		assertThat(receive).isNotNull();
 		assertThat(receive.getPayload()).isEqualTo("sequencetest");
-
 
 	}
 
@@ -953,18 +953,19 @@ public class RouterTests {
 		}
 
 		@Bean
-		public PollableChannel scatterGatherWiretapChannel() {
+		public PollableChannel scatterGatherWireTapChannel() {
 			return new QueueChannel();
 		}
+
 		@Bean
 		public IntegrationFlow scatterGatherInSubFlow() {
 			return flow -> flow.scatterGather(s -> s.applySequence(true)
-							.recipientFlow(inflow -> inflow.wireTap(scatterGatherWiretapChannel())
+							.recipientFlow(inflow -> inflow.wireTap(scatterGatherWireTapChannel())
 									.scatterGather(s1 -> s1.applySequence(true)
 													.recipientFlow(IntegrationFlowDefinition::bridge)
 													.recipientFlow("sequencetest"::equals, IntegrationFlowDefinition::bridge),
 											g -> g.outputProcessor(MessageGroup::getOne)
-									).wireTap(scatterGatherWiretapChannel()).bridge()),
+									).wireTap(scatterGatherWireTapChannel()).bridge()),
 					g -> g.outputProcessor(MessageGroup::getOne));
 		}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/routers/RouterTests.java
@@ -27,8 +27,8 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.api.Timeout;
+
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;

--- a/src/reference/asciidoc/aggregator.adoc
+++ b/src/reference/asciidoc/aggregator.adoc
@@ -114,17 +114,15 @@ This method is invoked for aggregating messages as follows:
 
 NOTE: In the interest of code simplicity and promoting best practices such as low coupling, testability, and others, the preferred way of implementing the aggregation logic is through a POJO and using the XML or annotation support for configuring it in the application.
 
-Starting with version 5.1, after processing message group, an `AbstractCorrelatingMessageHandler` performs a `MessageBuilder.popSequenceDetails()` message headers modification for the proper splitter-aggregator scenario with several nested levels.
-It is done only if the message group release result is not a message or collection of messages.
+Starting with version 5.3, after processing message group, an `AbstractCorrelatingMessageHandler` performs a `MessageBuilder.popSequenceDetails()` message headers modification for the proper splitter-aggregator scenario with several nested levels.
+It is done only if the message group release result is not a collection of messages.
 In that case a target `MessageGroupProcessor` is responsible for the `MessageBuilder.popSequenceDetails()` call while building those messages.
 
-Additionally, Starting with version 5.3, if `MessageGroupProcessor` returns a Message, `MessageBuilder.popSequenceDetails()` will be performed on the `outputMessage`  if the sequenceDetails matches with first message of group.
+If `MessageGroupProcessor` returns a Message, `MessageBuilder.popSequenceDetails()` will be performed on the `outputMessage` only if the `sequenceDetails` matches with first message of group.
 
 This functionality can be controlled by a new `popSequence` `boolean` property, so the `MessageBuilder.popSequenceDetails()` can be disabled in some scenarios when correlation details have not been populated by the standard splitter.
 This property, essentially, undoes what has been done by the nearest upstream `applySequence = true` in the `AbstractMessageSplitter`.
 See <<./splitter.adoc#splitter,Splitter>> for more information.
-
-
 
 [[agg-message-collection]]
 IMPORTANT: The `SimpleMessageGroup.getMessages()` method returns an `unmodifiableCollection`.

--- a/src/reference/asciidoc/aggregator.adoc
+++ b/src/reference/asciidoc/aggregator.adoc
@@ -117,6 +117,7 @@ NOTE: In the interest of code simplicity and promoting best practices such as lo
 Starting with version 5.1, after processing message group, an `AbstractCorrelatingMessageHandler` performs a `MessageBuilder.popSequenceDetails()` message headers modification for the proper splitter-aggregator scenario with several nested levels.
 It is done only if the message group release result is not a message or collection of messages.
 In that case a target `MessageGroupProcessor` is responsible for the `MessageBuilder.popSequenceDetails()` call while building those messages.
+Strting with version 5.3 if sequenceDetails of the outputMessage matches with first message of group, `MessageBuilder.popSequenceDetails()` will be performed.
 This functionality can be controlled by a new `popSequence` `boolean` property, so the `MessageBuilder.popSequenceDetails()` can be disabled in some scenarios when correlation details have not been populated by the standard splitter.
 This property, essentially, undoes what has been done by the nearest upstream `applySequence = true` in the `AbstractMessageSplitter`.
 See <<./splitter.adoc#splitter,Splitter>> for more information.

--- a/src/reference/asciidoc/aggregator.adoc
+++ b/src/reference/asciidoc/aggregator.adoc
@@ -117,10 +117,14 @@ NOTE: In the interest of code simplicity and promoting best practices such as lo
 Starting with version 5.1, after processing message group, an `AbstractCorrelatingMessageHandler` performs a `MessageBuilder.popSequenceDetails()` message headers modification for the proper splitter-aggregator scenario with several nested levels.
 It is done only if the message group release result is not a message or collection of messages.
 In that case a target `MessageGroupProcessor` is responsible for the `MessageBuilder.popSequenceDetails()` call while building those messages.
-Strting with version 5.3 if sequenceDetails of the outputMessage matches with first message of group, `MessageBuilder.popSequenceDetails()` will be performed.
+
+Additionally, Starting with version 5.3, if `MessageGroupProcessor` returns a Message, `MessageBuilder.popSequenceDetails()` will be performed on the `outputMessage`  if the sequenceDetails matches with first message of group.
+
 This functionality can be controlled by a new `popSequence` `boolean` property, so the `MessageBuilder.popSequenceDetails()` can be disabled in some scenarios when correlation details have not been populated by the standard splitter.
 This property, essentially, undoes what has been done by the nearest upstream `applySequence = true` in the `AbstractMessageSplitter`.
 See <<./splitter.adoc#splitter,Splitter>> for more information.
+
+
 
 [[agg-message-collection]]
 IMPORTANT: The `SimpleMessageGroup.getMessages()` method returns an `unmodifiableCollection`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -33,6 +33,10 @@ See <<./reactive-streams.adoc/reactive-message-handler,ReactiveMessageHandler>> 
 `spring-integration-mongodb` module now provides channel adapter implementations for Reactive MongoDB driver support in Spring Data.
 See <<./mongodb.adoc#mongodb-reactive-channel-adapters,MongoDB Reactive Channel Adapters>> for more information.
 
+[[x5.3-AbstractCorrelatingMessageHandler]]
+==== AbstractCorrelatingMessageHandler(Splitter/ScatterGather)
+Starting with version 5.3, if `MessageGroupProcessor` returns a Message, `MessageBuilder.popSequenceDetails()` will be performed on the `outputMessage`  if the sequenceDetails matches with first message of group.
+
 [[x5.3-general]]
 === General Changes
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -34,8 +34,9 @@ See <<./reactive-streams.adoc/reactive-message-handler,ReactiveMessageHandler>> 
 See <<./mongodb.adoc#mongodb-reactive-channel-adapters,MongoDB Reactive Channel Adapters>> for more information.
 
 [[x5.3-AbstractCorrelatingMessageHandler]]
-==== AbstractCorrelatingMessageHandler(Splitter/ScatterGather)
-Starting with version 5.3, if `MessageGroupProcessor` returns a Message, `MessageBuilder.popSequenceDetails()` will be performed on the `outputMessage`  if the sequenceDetails matches with first message of group.
+==== Aggregator Changes (Splitter/ScatterGather)
+
+Starting with version 5.3, if `MessageGroupProcessor` returns a Message, `MessageBuilder.popSequenceDetails()` will be performed on the `outputMessage`  if the `sequenceDetails` matches with first message of group.
 
 [[x5.3-general]]
 === General Changes


### PR DESCRIPTION

In AbstractCorrelatingMessageHandler, while processing the outputProcessor result, sequences are not being popped when result is an instance of Message.

#3157

An additional condition is added to handle such sequences.

else if (!(result instanceof Message<?>)) {
					messageBuilder = getMessageBuilderFactory()
							.withPayload(result)
							.copyHeaders(message.getHeaders());
				}
				else if (compareSequences((Message) result, message)) {
					messageBuilder = getMessageBuilderFactory()
							.fromMessage((Message) result);
				}

https://github.com/spring-projects/spring-integration/issues/3157

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
