### PR TITLE
spring-projectsGH-3169: Fix DefaultSessionFactoryLocator addSessionFactory key's type from String to Objec

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/DefaultSessionFactoryLocator.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/session/DefaultSessionFactoryLocator.java
@@ -53,8 +53,20 @@ public class DefaultSessionFactoryLocator<F> implements SessionFactoryLocator<F>
 	 * Add a session factory.
 	 * @param key the lookup key.
 	 * @param factory the factory.
+	 * @deprecated since 5.3 in favor of {@link #addSessionFactory}
 	 */
+	@Deprecated
 	public void addSessionFactory(String key, SessionFactory<F> factory) {
+		addSessionFactory((Object) key, factory);
+	}
+
+	/**
+	 * Add a session factory.
+	 * @param key the lookup key.
+	 * @param factory the factory.
+	 * @since 5.3
+	 */
+	public void addSessionFactory(Object key, SessionFactory<F> factory) {
 		this.factories.put(key, factory);
 	}
 


### PR DESCRIPTION
spring-projectsGH-3169: Fix DefaultSessionFactoryLocator addSessionFactory key's type from String to Object

All other DefaultSessionFactoryLocator contracts are based on the Object, so this addSessionFactory has to be on Object as well.