### PR TITLE
GH-3180: Add encoding-mode to WS outbound gateway

### DIFF
--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayPars
 
 	@Override
 	protected BeanDefinitionBuilder parseHandler(Element element, ParserContext parserContext) {
-		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(this.getGatewayClassName(element));
+		BeanDefinitionBuilder builder = BeanDefinitionBuilder.genericBeanDefinition(getGatewayClassName(element));
 		String uri = element.getAttribute("uri");
 		String destinationProvider = element.getAttribute("destination-provider");
 		List<Element> uriVariableElements = DomUtils.getChildElementsByTagName(element, "uri-variable");
@@ -70,7 +70,7 @@ public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayPars
 		else {
 			builder.addConstructorArgValue(uri);
 			if (!CollectionUtils.isEmpty(uriVariableElements)) {
-				ManagedMap<String, Object> uriVariableExpressions = new ManagedMap<String, Object>();
+				ManagedMap<String, Object> uriVariableExpressions = new ManagedMap<>();
 				for (Element uriVariableElement : uriVariableElements) {
 					String name = uriVariableElement.getAttribute("name");
 					String expression = uriVariableElement.getAttribute("expression");
@@ -87,9 +87,11 @@ public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayPars
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "requires-reply");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "ignore-empty-responses");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "encode-uri");
-		this.postProcessGateway(builder, element, parserContext);
+		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "encoding-mode");
+		postProcessGateway(builder, element, parserContext);
 
-		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext, DefaultSoapHeaderMapper.class, null);
+		IntegrationNamespaceUtils.configureHeaderMapper(element, builder, parserContext,
+				DefaultSoapHeaderMapper.class, null);
 
 		return builder;
 	}

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
@@ -24,6 +24,7 @@ import org.springframework.integration.dsl.MessageHandlerSpec;
 import org.springframework.integration.util.JavaUtils;
 import org.springframework.integration.ws.AbstractWebServiceOutboundGateway;
 import org.springframework.integration.ws.SoapHeaderMapper;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
@@ -39,6 +40,8 @@ import org.springframework.ws.transport.WebServiceMessageSender;
  * @param <E> the target {@link AbstractWebServiceOutboundGateway} implementation type.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.3
  *
  */
@@ -58,7 +61,7 @@ public abstract class BaseWsOutboundGatewaySpec<
 
 	private SoapHeaderMapper headerMapper;
 
-	private boolean encodeUri = true;
+	private DefaultUriBuilderFactory.EncodingMode encodingMode;
 
 	private boolean ignoreEmptyResponses = true;
 
@@ -114,14 +117,12 @@ public abstract class BaseWsOutboundGatewaySpec<
 	}
 
 	/**
-	 * Specify whether the URI should be encoded after any <code>uriVariables</code>
-	 * are expanded and before sending the request. The default value is <code>true</code>.
-	 * @param encodeUri true if the URI should be encoded.
-	 * @return the spec.
-	 * @see org.springframework.web.util.UriComponentsBuilder
+	 * Specify a {@link DefaultUriBuilderFactory.EncodingMode} for uri construction.
+	 * @param encodingMode to use for uri construction.
+	 * @return the spec
 	 */
-	public S encodeUri(boolean encodeUri) {
-		this.encodeUri = encodeUri;
+	public S encodingMode(DefaultUriBuilderFactory.EncodingMode encodingMode) {
+		this.encodingMode = encodingMode;
 		return _this();
 	}
 
@@ -158,7 +159,7 @@ public abstract class BaseWsOutboundGatewaySpec<
 		gateway.setUriVariableExpressions(this.uriVariableExpressions);
 		JavaUtils.INSTANCE
 			.acceptIfNotNull(this.headerMapper, gateway::setHeaderMapper);
-		gateway.setEncodeUri(this.encodeUri);
+		gateway.setEncodingMode(this.encodingMode);
 		gateway.setIgnoreEmptyResponses(this.ignoreEmptyResponses);
 		gateway.setRequestCallback(this.requestCallback);
 		return gateway;

--- a/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws.xsd
+++ b/spring-integration-ws/src/main/resources/org/springframework/integration/ws/config/spring-integration-ws.xsd
@@ -127,13 +127,24 @@
 			<xsd:attribute name="encode-uri" default="true">
 				<xsd:annotation>
 					<xsd:documentation>
-						When set to "false", the URI won't be encoded before the request is sent. This may be useful
+						[DEPRECATED] When set to "false", the URI won't be encoded before the request is sent. This may be useful
 						in some scenarios as it allows user control over the encoding, if needed. Default is "true".
 						This attribute is ignored, if 'destination-provider' is specified.
+						Deprecated since 5.3 in favor of 'encoding-mode'.
 					</xsd:documentation>
 				</xsd:annotation>
 				<xsd:simpleType>
 					<xsd:union memberTypes="xsd:boolean xsd:string"/>
+				</xsd:simpleType>
+			</xsd:attribute>
+			<xsd:attribute name="encoding-mode" default="TEMPLATE_AND_VALUES">
+				<xsd:annotation>
+					<xsd:documentation>
+						Set the encoding mode during URI building.
+					</xsd:documentation>
+				</xsd:annotation>
+				<xsd:simpleType>
+					<xsd:union memberTypes="encodingModeEnumeration xsd:string"/>
 				</xsd:simpleType>
 			</xsd:attribute>
 			<xsd:attribute name="destination-provider" type="xsd:string">
@@ -530,5 +541,14 @@ this list can also be simple patterns to be matched against the header names (e.
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
+
+	<xsd:simpleType name="encodingModeEnumeration">
+		<xsd:restriction base="xsd:token">
+			<xsd:enumeration value="TEMPLATE_AND_VALUES"/>
+			<xsd:enumeration value="VALUES_ONLY"/>
+			<xsd:enumeration value="URI_COMPONENT"/>
+			<xsd:enumeration value="NONE"/>
+		</xsd:restriction>
+	</xsd:simpleType>
 
 </xsd:schema>

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests-context.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests-context.xml
@@ -42,6 +42,7 @@
 	<!--Email Transport-->
 	<ws:outbound-gateway request-channel="inputEmail"
 						 uri="mailto:{to}?subject={subject}"
+						 encoding-mode="VALUES_ONLY"
 						 interceptor="emailInterceptor"
 						 message-sender="emailMessageSender">
 		<ws:uri-variable name="to" expression="headers.to"/>

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,7 @@ import javax.jms.Session;
 
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.packet.Stanza;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
@@ -52,8 +51,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessagingException;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.ws.client.WebServiceClientException;
 import org.springframework.ws.client.WebServiceIOException;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
@@ -74,8 +72,7 @@ import org.springframework.ws.transport.mail.MailSenderConnection;
  *
  * @since 2.1
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@SpringJUnitConfig
 public class UriVariableTests {
 
 	@Autowired
@@ -134,7 +131,7 @@ public class UriVariableTests {
 		assertThatExceptionOfType(MessagingException.class)
 				.isThrownBy(() -> this.inputHttp.send(message))
 				.withCauseInstanceOf(WebServiceIOException.class); // offline
-		assertThat(uri.get()).isEqualTo("http://localhost/spring-integration?param=test1%20&%20test2");
+		assertThat(uri.get()).isEqualTo("http://localhost/spring-integration?param=test1%20%26%20test2");
 	}
 
 	@Test

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests-context.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests-context.xml
@@ -127,7 +127,7 @@
 
 	<ws:outbound-gateway id="gatewayWithJmsUri"
 	                     request-channel="inputChannel"
-						 encode-uri="false"
+						 encoding-mode="NONE"
 	                     uri="jms:wsQueue" />
 
 	<bean id="sourceExtractor" class="org.springframework.integration.ws.config.StubSourceExtractor"/>

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
@@ -34,6 +34,7 @@ import org.springframework.integration.ws.SimpleWebServiceOutboundGateway;
 import org.springframework.integration.ws.SoapHeaderMapper;
 import org.springframework.oxm.Marshaller;
 import org.springframework.oxm.Unmarshaller;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
 import org.springframework.ws.client.core.SourceExtractor;
@@ -45,6 +46,8 @@ import org.springframework.ws.transport.WebServiceMessageSender;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.3
  *
  */
@@ -93,7 +96,7 @@ public class WsDslTests {
 						.marshaller(marshaller)
 						.unmarshaller(unmarshaller)
 						.messageFactory(messageFactory)
-						.encodeUri(true)
+						.encodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY)
 						.faultMessageResolver(faultMessageResolver)
 						.headerMapper(headerMapper)
 						.ignoreEmptyResponses(true)
@@ -111,7 +114,7 @@ public class WsDslTests {
 		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.interceptors", ClientInterceptor[].class)[0])
 				.isSameAs(interceptor);
 		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageSenders",
-					WebServiceMessageSender[].class)[0])
+				WebServiceMessageSender[].class)[0])
 				.isSameAs(messageSender);
 		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
 		assertThat(TestUtils.getPropertyValue(gateway, "uriVariableExpressions")).isEqualTo(uriVariableExpressions);
@@ -134,7 +137,7 @@ public class WsDslTests {
 						.destinationProvider(destinationProvider)
 						.sourceExtractor(sourceExtractor)
 						.messageFactory(messageFactory)
-						.encodeUri(true)
+						.encodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY)
 						.faultMessageResolver(faultMessageResolver)
 						.headerMapper(headerMapper)
 						.ignoreEmptyResponses(true)
@@ -151,7 +154,7 @@ public class WsDslTests {
 		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.interceptors", ClientInterceptor[].class)[0])
 				.isSameAs(interceptor);
 		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageSenders",
-					WebServiceMessageSender[].class)[0])
+				WebServiceMessageSender[].class)[0])
 				.isSameAs(messageSender);
 		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
 		assertThat(TestUtils.getPropertyValue(gateway, "uriVariableExpressions")).isEqualTo(uriVariableExpressions);
@@ -169,7 +172,7 @@ public class WsDslTests {
 		MarshallingWebServiceOutboundGateway gateway =
 				Ws.marshallingOutboundGateway(template)
 						.uri(uri)
-						.encodeUri(true)
+						.encodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY)
 						.headerMapper(headerMapper)
 						.ignoreEmptyResponses(true)
 						.requestCallback(requestCallback)
@@ -194,7 +197,7 @@ public class WsDslTests {
 				Ws.simpleOutboundGateway(template)
 						.uri(uri)
 						.sourceExtractor(sourceExtractor)
-						.encodeUri(true)
+						.encodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY)
 						.headerMapper(headerMapper)
 						.ignoreEmptyResponses(true)
 						.requestCallback(requestCallback)
@@ -205,6 +208,10 @@ public class WsDslTests {
 		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
 		assertThat(TestUtils.getPropertyValue(gateway, "uriVariableExpressions")).isEqualTo(uriVariableExpressions);
 		assertThat(TestUtils.getPropertyValue(gateway, "extractPayload", Boolean.class)).isFalse();
+		assertThat(
+				TestUtils.getPropertyValue(gateway, "uriFactory.encodingMode",
+						DefaultUriBuilderFactory.EncodingMode.class))
+				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
 	}
 
 	interface Both extends Marshaller, Unmarshaller {

--- a/src/reference/asciidoc/http.adoc
+++ b/src/reference/asciidoc/http.adoc
@@ -724,7 +724,7 @@ If you wish to partially encode some of the URL, use an `expression` within a `<
 ====
 
 With Java DSL this option can be controlled by the `BaseHttpMessageHandlerSpec.encodingMode()` option.
-Same configuration applies for similar outbound components in the <<./webflux.adoc#webflux,WebFlux module>> and <<./ws.adoc#ws,Web Services module>>.
+The same configuration applies for similar outbound components in the <<./webflux.adoc#webflux,WebFlux module>> and <<./ws.adoc#ws,Web Services module>>.
 For much sophisticated scenarios it is recommended to configure an `UriTemplateHandler` on the externally provided `RestTemplate`; or in case of WebFlux - `WebClient` with it `UriBuilderFactory`.
 
 [[http-java-config]]

--- a/src/reference/asciidoc/http.adoc
+++ b/src/reference/asciidoc/http.adoc
@@ -715,7 +715,7 @@ If you wish to partially encode some of the URL, use an `expression` within a `<
 ====
 [source,xml]
 ----
-<http:outbound-gateway url="https://somehost/%2f/fooApps?bar={param}" encode-uri="false">
+<http:outbound-gateway url="https://somehost/%2f/fooApps?bar={param}" encoding-mode="NONE">
           <http:uri-variable name="param"
             expression="T(org.apache.commons.httpclient.util.URIUtil)
                                              .encodeWithinQuery('Hello World!')"/>
@@ -724,7 +724,7 @@ If you wish to partially encode some of the URL, use an `expression` within a `<
 ====
 
 With Java DSL this option can be controlled by the `BaseHttpMessageHandlerSpec.encodingMode()` option.
-Same configuration applies for similar outbound components in the <<./webflux.adoc/[webflux,WebFlux module>>.
+Same configuration applies for similar outbound components in the <<./webflux.adoc#webflux,WebFlux module>> and <<./ws.adoc#ws,Web Services module>>.
 For much sophisticated scenarios it is recommended to configure an `UriTemplateHandler` on the externally provided `RestTemplate`; or in case of WebFlux - `WebClient` with it `UriBuilderFactory`.
 
 [[http-java-config]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -68,7 +68,7 @@ See <<./amqp.adoc#amqp-inbound-channel-adapter,AMQP Inbound Channel Adapter>>
 The `encodeUri` property on the `AbstractHttpRequestExecutingMessageHandler` has been deprecated in favor of newly introduced `encodingMode`.
 See `DefaultUriBuilderFactory.EncodingMode` JavaDocs and <<./http.adoc#http-uri-encoding,Controlling URI Encoding>> for more information.
 This also affects `WebFluxRequestExecutingMessageHandler`, respective Java DSL and XML configuration.
-Same option is added into an `AbstractWebServiceOutboundGateway`.
+The same option is added into an `AbstractWebServiceOutboundGateway`.
 
 [[x5.3-ws]]
 === Web Services Changes

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -68,9 +68,11 @@ See <<./amqp.adoc#amqp-inbound-channel-adapter,AMQP Inbound Channel Adapter>>
 The `encodeUri` property on the `AbstractHttpRequestExecutingMessageHandler` has been deprecated in favor of newly introduced `encodingMode`.
 See `DefaultUriBuilderFactory.EncodingMode` JavaDocs and <<./http.adoc#http-uri-encoding,Controlling URI Encoding>> for more information.
 This also affects `WebFluxRequestExecutingMessageHandler`, respective Java DSL and XML configuration.
+Same option is added into an `AbstractWebServiceOutboundGateway`.
 
 [[x5.3-ws]]
 === Web Services Changes
 
 Java DSL support has been added for Web Service components.
+The `encodeUri` property on the `AbstractWebServiceOutboundGateway` has been deprecated in favor of newly introduced `encodingMode` - similar to HTTP changes above.
 See <<./ws.adoc#ws,Web Services Support>> for more information.

--- a/src/reference/asciidoc/ws.adoc
+++ b/src/reference/asciidoc/ws.adoc
@@ -305,7 +305,7 @@ If you supply a `DestinationProvider`, variable substitution is not supported an
 
 By default, the URL string is encoded (see https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/util/UriComponentsBuilder.html[`UriComponentsBuilder`]) to the URI object before sending the request.
 In some scenarios with a non-standard URI, it is undesirable to perform the encoding.
-The `<ws:outbound-gateway/>` element provides an provide an `encoding-mode` attribute.
+The `<ws:outbound-gateway/>` element provides an `encoding-mode` attribute.
 To disable encoding the URL, set this attribute to `NONE` (by default, it is `TEMPLATE_AND_VALUES`).
 If you wish to partially encode some of the URL, you can do so by using an `expression` within a `<uri-variable/>`, as the following example shows:
 

--- a/src/reference/asciidoc/ws.adoc
+++ b/src/reference/asciidoc/ws.adoc
@@ -233,7 +233,7 @@ Examples:
 .handle(Ws.simpleOutboundGateway(template)
             .uri(uri)
             .sourceExtractor(sourceExtractor)
-            .encodeUri(true)
+            .encodingMode(DefaultUriBuilderFactory.EncodingMode.NONE)
             .headerMapper(headerMapper)
             .ignoreEmptyResponses(true)
             .requestCallback(requestCallback)
@@ -251,7 +251,7 @@ Examples:
             .marshaller(marshaller)
             .unmarshaller(unmarshaller)
             .messageFactory(messageFactory)
-            .encodeUri(true)
+            .encodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY)
             .faultMessageResolver(faultMessageResolver)
             .headerMapper(headerMapper)
             .ignoreEmptyResponses(true)
@@ -267,7 +267,7 @@ Examples:
 ----
 .handle(Ws.marshallingOutboundGateway(template)
             .uri(uri)
-            .encodeUri(true)
+            .encodingMode(DefaultUriBuilderFactory.EncodingMode.URI_COMPONENT)
             .headerMapper(headerMapper)
             .ignoreEmptyResponses(true)
             .requestCallback(requestCallback)
@@ -305,14 +305,14 @@ If you supply a `DestinationProvider`, variable substitution is not supported an
 
 By default, the URL string is encoded (see https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/util/UriComponentsBuilder.html[`UriComponentsBuilder`]) to the URI object before sending the request.
 In some scenarios with a non-standard URI, it is undesirable to perform the encoding.
-Since version 4.1, the `<ws:outbound-gateway/>` element provides an `encode-uri` attribute.
-To disable encoding the URL, set this attribute `false` (it defaults to `true`).
+The `<ws:outbound-gateway/>` element provides an provide an `encoding-mode` attribute.
+To disable encoding the URL, set this attribute to `NONE` (by default, it is `TEMPLATE_AND_VALUES`).
 If you wish to partially encode some of the URL, you can do so by using an `expression` within a `<uri-variable/>`, as the following example shows:
 
 ====
 [source,xml]
 ----
-<ws:outbound-gateway url="https://somehost/%2f/fooApps?bar={param}" encode-uri="false">
+<ws:outbound-gateway url="https://somehost/%2f/fooApps?bar={param}" encoding-mode="NONE">
           <http:uri-variable name="param"
             expression="T(org.apache.commons.httpclient.util.URIUtil)
                                              .encodeWithinQuery('Hello World!')"/>
@@ -320,7 +320,7 @@ If you wish to partially encode some of the URL, you can do so by using an `expr
 ----
 ====
 
-NOTE: If you set `DestinationProvider`, `encode-uri` is ignored.
+NOTE: If you set `DestinationProvider`, `encoding-mode` is ignored.
 
 [[ws-message-headers]]
 === WS Message Headers


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3180

* Deprecate `encode-uri` in favor of newly introduced `encoding-mode`
* Add new property to XML and DSL configurations
* Fix tests according a new behavior
* Document the feature
* Fix docs for deprecated `encode-uri`
* Mention also WS from `http.adoc`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
