### PR TITLE
GH-3192: pub-sub DSL for broker-backed channels

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.amqp.core.FanoutExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
+import org.springframework.integration.channel.BroadcastCapableChannel;
 import org.springframework.integration.dispatcher.AbstractDispatcher;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
 
@@ -35,7 +36,7 @@ import org.springframework.integration.dispatcher.BroadcastingDispatcher;
  *
  * @since 2.1
  */
-public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel {
+public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel implements BroadcastCapableChannel {
 
 	private volatile FanoutExchange exchange;
 
@@ -53,6 +54,7 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 	 */
 	public PublishSubscribeAmqpChannel(String channelName, AbstractMessageListenerContainer container,
 			AmqpTemplate amqpTemplate) {
+
 		super(channelName, container, amqpTemplate, true);
 	}
 
@@ -69,6 +71,7 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 	 */
 	public PublishSubscribeAmqpChannel(String channelName, AbstractMessageListenerContainer container,
 			AmqpTemplate amqpTemplate, AmqpHeaderMapper outboundMapper, AmqpHeaderMapper inboundMapper) {
+
 		super(channelName, container, amqpTemplate, true, outboundMapper, inboundMapper);
 	}
 
@@ -104,7 +107,7 @@ public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel
 	@Override
 	protected AbstractDispatcher createDispatcher() {
 		BroadcastingDispatcher broadcastingDispatcher = new BroadcastingDispatcher(true);
-		broadcastingDispatcher.setBeanFactory(this.getBeanFactory());
+		broadcastingDispatcher.setBeanFactory(getBeanFactory());
 		return broadcastingDispatcher;
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PublishSubscribeAmqpChannel.java
@@ -30,6 +30,8 @@ import org.springframework.integration.dispatcher.AbstractDispatcher;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
 
 /**
+ * The {@link AbstractSubscribableAmqpChannel} extension for pub-sub semantics based on the {@link FanoutExchange}.
+ *
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
@@ -38,9 +40,9 @@ import org.springframework.integration.dispatcher.BroadcastingDispatcher;
  */
 public class PublishSubscribeAmqpChannel extends AbstractSubscribableAmqpChannel implements BroadcastCapableChannel {
 
-	private volatile FanoutExchange exchange;
-
 	private final Queue queue = new AnonymousQueue();
+
+	private volatile FanoutExchange exchange;
 
 	private volatile Binding binding;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/BroadcastCapableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/BroadcastCapableChannel.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.channel;
+
+import org.springframework.messaging.SubscribableChannel;
+
+/**
+ * A {@link SubscribableChannel} variant for implementations with broadcasting capabilities.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.3
+ */
+public interface BroadcastCapableChannel extends SubscribableChannel {
+
+	/**
+	 * Return a state of this channel in regards of broadcasting capabilities.
+	 * @return the state of this channel in regards of broadcasting capabilities.
+	 */
+	default boolean isBroadcast() {
+		return true;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
@@ -35,7 +35,7 @@ import org.springframework.util.ErrorHandler;
  * @author Gary Russell
  * @author Artem Bilan
  */
-public class PublishSubscribeChannel extends AbstractExecutorChannel {
+public class PublishSubscribeChannel extends AbstractExecutorChannel implements BroadcastCapableChannel {
 
 	private ErrorHandler errorHandler;
 
@@ -135,7 +135,7 @@ public class PublishSubscribeChannel extends AbstractExecutorChannel {
 	@Override
 	public final void onInit() {
 		super.onInit();
-		BeanFactory beanFactory = this.getBeanFactory();
+		BeanFactory beanFactory = getBeanFactory();
 		BroadcastingDispatcher dispatcherToUse = getDispatcher();
 		if (this.executor != null) {
 			Assert.state(dispatcherToUse.getHandlerCount() == 0,

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
@@ -46,6 +46,14 @@ public class PublishSubscribeChannel extends AbstractExecutorChannel implements 
 	private int minSubscribers;
 
 	/**
+	 * Create a PublishSubscribeChannel that will invoke the handlers in the
+	 * message sender's thread.
+	 */
+	public PublishSubscribeChannel() {
+		this(null);
+	}
+
+	/**
 	 * Create a PublishSubscribeChannel that will use an {@link Executor}
 	 * to invoke the handlers. If this is null, each invocation will occur in
 	 * the message sender's thread.
@@ -54,14 +62,6 @@ public class PublishSubscribeChannel extends AbstractExecutorChannel implements 
 	public PublishSubscribeChannel(@Nullable Executor executor) {
 		super(executor);
 		this.dispatcher = new BroadcastingDispatcher(executor);
-	}
-
-	/**
-	 * Create a PublishSubscribeChannel that will invoke the handlers in the
-	 * message sender's thread.
-	 */
-	public PublishSubscribeChannel() {
-		this(null);
 	}
 
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.config.DestructionAwareBeanPostProcesso
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.integration.aggregator.AggregatingMessageHandler;
+import org.springframework.integration.channel.BroadcastCapableChannel;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.FixedSubscriberChannel;
 import org.springframework.integration.channel.FluxMessageChannel;
@@ -292,6 +293,25 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 		PublishSubscribeSpec spec = new PublishSubscribeSpec(executor);
 		publishSubscribeChannelConfigurer.accept(spec);
 		return addComponents(spec.getComponentsToRegister()).channel(spec);
+	}
+
+	/**
+	 * The {@link BroadcastCapableChannel} {@link #channel}
+	 * method specific implementation to allow the use of the 'subflow' subscriber capability.
+	 * @param broadcastCapableChannel the {@link BroadcastCapableChannel} to subscriber sub-flows to.
+	 * @param publishSubscribeChannelConfigurer the {@link Consumer} to specify
+	 * {@link BroadcastPublishSubscribeSpec} 'subflow' definitions.
+	 * @return the current {@link BaseIntegrationFlowDefinition}.
+	 * @since 5.3
+	 */
+	public B publishSubscribeChannel(BroadcastCapableChannel broadcastCapableChannel,
+			Consumer<BroadcastPublishSubscribeSpec> publishSubscribeChannelConfigurer) {
+
+		Assert.notNull(publishSubscribeChannelConfigurer, "'publishSubscribeChannelConfigurer' must not be null");
+		BroadcastPublishSubscribeSpec spec = new BroadcastPublishSubscribeSpec(broadcastCapableChannel);
+		publishSubscribeChannelConfigurer.accept(spec);
+		return addComponents(spec.getComponentsToRegister())
+				.channel(broadcastCapableChannel);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BroadcastPublishSubscribeSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BroadcastPublishSubscribeSpec.java
@@ -24,6 +24,9 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.util.Assert;
 
 /**
+ * An {@link IntegrationComponentSpec} for configuring sub-flow subscribers on the
+ * provided {@link BroadcastCapableChannel}.
+ *
  * @author Artem Bilan
  * @author Gary Russell
  *
@@ -44,6 +47,13 @@ public class BroadcastPublishSubscribeSpec
 		this.target = channel;
 	}
 
+	/**
+	 * Configure a {@link IntegrationFlow} to configure as a subscriber
+	 *                   for the current {@link BroadcastCapableChannel}.
+	 * @param subFlow the {@link IntegrationFlow} to configure as a subscriber
+	 *                   for the current {@link BroadcastCapableChannel}.
+	 * @return the current spec
+	 */
 	public BroadcastPublishSubscribeSpec subscribe(IntegrationFlow subFlow) {
 		Assert.notNull(subFlow, "'subFlow' must not be null");
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BroadcastPublishSubscribeSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BroadcastPublishSubscribeSpec.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.springframework.integration.channel.BroadcastCapableChannel;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.util.Assert;
+
+/**
+ * @author Artem Bilan
+ * @author Gary Russell
+ *
+ * @since 5.3
+ */
+public class BroadcastPublishSubscribeSpec
+		extends IntegrationComponentSpec<BroadcastPublishSubscribeSpec, BroadcastCapableChannel>
+		implements ComponentsRegistration {
+
+	private final Map<Object, String> subscriberFlows = new LinkedHashMap<>();
+
+	private int order;
+
+	protected BroadcastPublishSubscribeSpec(BroadcastCapableChannel channel) {
+		Assert.state(channel.isBroadcast(),
+				() -> "the " + channel +
+						" must be in the 'broadcast' state for using from this 'BroadcastPublishSubscribeSpec'");
+		this.target = channel;
+	}
+
+	public BroadcastPublishSubscribeSpec subscribe(IntegrationFlow subFlow) {
+		Assert.notNull(subFlow, "'subFlow' must not be null");
+
+		IntegrationFlowBuilder flowBuilder =
+				IntegrationFlows.from(this.target)
+						.bridge(consumer -> consumer.order(this.order++));
+
+		MessageChannel subFlowInput = subFlow.getInputChannel();
+
+		if (subFlowInput == null) {
+			subFlow.configure(flowBuilder);
+		}
+		else {
+			flowBuilder.channel(subFlowInput);
+		}
+		this.subscriberFlows.put(flowBuilder.get(), null);
+		return _this();
+	}
+
+	@Override
+	public Map<Object, String> getComponentsToRegister() {
+		return this.subscriberFlows;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublishSubscribeSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublishSubscribeSpec.java
@@ -21,8 +21,6 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 
 import org.springframework.lang.Nullable;
-import org.springframework.messaging.MessageChannel;
-import org.springframework.util.Assert;
 
 /**
  * @author Artem Bilan
@@ -32,15 +30,15 @@ import org.springframework.util.Assert;
  */
 public class PublishSubscribeSpec extends PublishSubscribeChannelSpec<PublishSubscribeSpec> {
 
-	private final Map<Object, String> subscriberFlows = new LinkedHashMap<>();
-
-	private int order;
+	private final BroadcastPublishSubscribeSpec delegate;
 
 	protected PublishSubscribeSpec() {
+		this.delegate = new BroadcastPublishSubscribeSpec(this.channel);
 	}
 
 	protected PublishSubscribeSpec(@Nullable Executor executor) {
 		super(executor);
+		this.delegate = new BroadcastPublishSubscribeSpec(this.channel);
 	}
 
 	@Override
@@ -49,21 +47,7 @@ public class PublishSubscribeSpec extends PublishSubscribeChannelSpec<PublishSub
 	}
 
 	public PublishSubscribeSpec subscribe(IntegrationFlow subFlow) {
-		Assert.notNull(subFlow, "'subFlow' must not be null");
-
-		IntegrationFlowBuilder flowBuilder =
-				IntegrationFlows.from(this.channel)
-						.bridge(consumer -> consumer.order(this.order++));
-
-		MessageChannel subFlowInput = subFlow.getInputChannel();
-
-		if (subFlowInput == null) {
-			subFlow.configure(flowBuilder);
-		}
-		else {
-			flowBuilder.channel(subFlowInput);
-		}
-		this.subscriberFlows.put(flowBuilder.get(), null);
+		this.delegate.subscribe(subFlow);
 		return _this();
 	}
 
@@ -71,7 +55,7 @@ public class PublishSubscribeSpec extends PublishSubscribeChannelSpec<PublishSub
 	public Map<Object, String> getComponentsToRegister() {
 		Map<Object, String> objects = new LinkedHashMap<>();
 		objects.putAll(super.getComponentsToRegister());
-		objects.putAll(this.subscriberFlows);
+		objects.putAll(this.delegate.getComponentsToRegister());
 		return objects;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublishSubscribeSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/PublishSubscribeSpec.java
@@ -23,6 +23,9 @@ import java.util.concurrent.Executor;
 import org.springframework.lang.Nullable;
 
 /**
+ * The {@link PublishSubscribeChannelSpec} extension to configure as a general flow callback for sub-flows
+ * as subscribers.
+ *
  * @author Artem Bilan
  * @author Gary Russell
  *

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.context.SmartLifecycle;
 import org.springframework.integration.MessageDispatchingException;
+import org.springframework.integration.channel.BroadcastCapableChannel;
 import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.dispatcher.AbstractDispatcher;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
@@ -37,7 +38,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
-import org.springframework.messaging.SubscribableChannel;
 import org.springframework.util.Assert;
 
 /**
@@ -48,7 +48,7 @@ import org.springframework.util.Assert;
  * @since 2.0
  */
 public class SubscribableJmsChannel extends AbstractJmsChannel
-		implements SubscribableChannel, SmartLifecycle {
+		implements BroadcastCapableChannel, SmartLifecycle {
 
 	private final AbstractMessageListenerContainer container;
 
@@ -88,16 +88,21 @@ public class SubscribableJmsChannel extends AbstractJmsChannel
 	}
 
 	@Override
+	public boolean isBroadcast() {
+		return this.container.isPubSubDomain();
+	}
+
+	@Override
 	public void onInit() {
 		if (this.initialized) {
 			return;
 		}
 		super.onInit();
-		boolean isPubSub = this.container.isPubSubDomain();
-		this.configureDispatcher(isPubSub);
-		MessageListener listener = new DispatchingMessageListener(
-				this.getJmsTemplate(), this.dispatcher,
-				this, isPubSub, this.getMessageBuilderFactory());
+		boolean isPubSub = isBroadcast();
+		configureDispatcher(isPubSub);
+		MessageListener listener =
+				new DispatchingMessageListener(getJmsTemplate(), this.dispatcher, this, isPubSub,
+						getMessageBuilderFactory());
 		this.container.setMessageListener(listener);
 		if (!this.container.isActive()) {
 			this.container.afterPropertiesSet();
@@ -108,7 +113,7 @@ public class SubscribableJmsChannel extends AbstractJmsChannel
 	private void configureDispatcher(boolean isPubSub) {
 		if (isPubSub) {
 			BroadcastingDispatcher broadcastingDispatcher = new BroadcastingDispatcher(true);
-			broadcastingDispatcher.setBeanFactory(this.getBeanFactory());
+			broadcastingDispatcher.setBeanFactory(getBeanFactory());
 			this.dispatcher = broadcastingDispatcher;
 		}
 		else {
@@ -118,8 +123,8 @@ public class SubscribableJmsChannel extends AbstractJmsChannel
 		}
 		if (this.maxSubscribers == null) {
 			this.maxSubscribers = this.getIntegrationProperty(isPubSub ?
-					IntegrationProperties.CHANNELS_MAX_BROADCAST_SUBSCRIBERS :
-					IntegrationProperties.CHANNELS_MAX_UNICAST_SUBSCRIBERS,
+							IntegrationProperties.CHANNELS_MAX_BROADCAST_SUBSCRIBERS :
+							IntegrationProperties.CHANNELS_MAX_UNICAST_SUBSCRIBERS,
 					Integer.class);
 		}
 		this.dispatcher.setMaxSubscribers(this.maxSubscribers);
@@ -194,6 +199,7 @@ public class SubscribableJmsChannel extends AbstractJmsChannel
 		DispatchingMessageListener(JmsTemplate jmsTemplate,
 				MessageDispatcher dispatcher, SubscribableJmsChannel channel, boolean isPubSub,
 				MessageBuilderFactory messageBuilderFactory) {
+
 			this.jmsTemplate = jmsTemplate;
 			this.dispatcher = dispatcher;
 			this.channel = channel;
@@ -212,8 +218,10 @@ public class SubscribableJmsChannel extends AbstractJmsChannel
 					converted = converter.fromMessage(message);
 				}
 				if (converted != null) {
-					messageToSend = (converted instanceof Message<?>) ? (Message<?>) converted
-							: this.messageBuilderFactory.withPayload(converted).build();
+					messageToSend =
+							converted instanceof Message<?>
+									? (Message<?>) converted
+									: this.messageBuilderFactory.withPayload(converted).build();
 					this.dispatcher.dispatch(messageToSend);
 				}
 				else if (this.logger.isWarnEnabled()) {
@@ -231,8 +239,7 @@ public class SubscribableJmsChannel extends AbstractJmsChannel
 					}
 				}
 				else {
-					throw new MessageDeliveryException(
-							messageToSend, exceptionMessage, e);
+					throw new MessageDeliveryException(messageToSend, exceptionMessage, e);
 				}
 			}
 			catch (Exception e) {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
@@ -41,6 +41,10 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 
 /**
+ * An {@link AbstractJmsChannel} implementation for message-driven subscriptions.
+ * Also implements a {@link BroadcastCapableChannel} to represent possible pub-sub semantics
+ * when configured against JMS topic.
+ *
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.channel.AbstractMessageChannel;
+import org.springframework.integration.channel.BroadcastCapableChannel;
 import org.springframework.integration.channel.ChannelUtils;
 import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
@@ -40,7 +41,6 @@ import org.springframework.integration.util.ErrorHandlingTaskExecutor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.util.Assert;
 import org.springframework.util.ErrorHandler;
@@ -55,7 +55,7 @@ import org.springframework.util.StringUtils;
  */
 @SuppressWarnings("rawtypes")
 public class SubscribableRedisChannel extends AbstractMessageChannel
-		implements SubscribableChannel, SmartLifecycle {
+		implements BroadcastCapableChannel, SmartLifecycle {
 
 	private final RedisMessageListenerContainer container = new RedisMessageListenerContainer();
 
@@ -67,16 +67,16 @@ public class SubscribableRedisChannel extends AbstractMessageChannel
 
 	private final BroadcastingDispatcher dispatcher = new BroadcastingDispatcher(true);
 
-	private volatile Integer maxSubscribers;
-
-	private volatile boolean initialized;
-
 	// defaults
 	private Executor taskExecutor = new SimpleAsyncTaskExecutor();
 
 	private RedisSerializer<?> serializer = new StringRedisSerializer();
 
 	private MessageConverter messageConverter = new SimpleMessageConverter();
+
+	private volatile Integer maxSubscribers;
+
+	private volatile boolean initialized;
 
 	public SubscribableRedisChannel(RedisConnectionFactory connectionFactory, String topicName) {
 		Assert.notNull(connectionFactory, "'connectionFactory' must not be null");

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
@@ -47,6 +47,9 @@ import org.springframework.util.ErrorHandler;
 import org.springframework.util.StringUtils;
 
 /**
+ * An {@link AbstractMessageChannel} implementation with {@link BroadcastCapableChannel}
+ * aspect to provide a pub-sub semantics to consume messages fgrom Redis topic.
+ *
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -742,6 +742,32 @@ public IntegrationFlow subscribersFlow() {
 You can achieve the same result with separate `IntegrationFlow` `@Bean` definitions, but we hope you find the sub-flow style of logic composition useful.
 We find that it results in shorter (and so more readable) code.
 
+Starting with version 5.3, a `BroadcastCapableChannel`-based `publishSubscribeChannel()` implementation is provided to configure sub-flow subscribers on the broker-backed message channels.
+For example we now can configure several subscribers as sub-flows on the `Jms.publishSubscribeChannel()`:
+
+====
+[source,java]
+----
+@Bean
+public BroadcastCapableChannel jmsPublishSubscribeChannel() {
+    return Jms.publishSubscribeChannel(jmsConnectionFactory())
+                .destination("pubsub")
+                .get();
+}
+
+@Bean
+public IntegrationFlow pubSubFlow() {
+    return f -> f
+            .publishSubscribeChannel(jmsPublishSubscribeChannel(),
+                    pubsub -> pubsub
+                            .subscribe(subFlow -> subFlow
+                                .channel(c -> c.queue("jmsPubSubBridgeChannel1")))
+                            .subscribe(subFlow -> subFlow
+                                .channel(c -> c.queue("jmsPubSubBridgeChannel2"))));
+}
+----
+====
+
 A similar `publish-subscribe` sub-flow composition provides the `.routeToRecipients()` method.
 
 Another example is using `.discardFlow()` instead of `.discardChannel()` on the `.filter()` method.

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -742,7 +742,7 @@ public IntegrationFlow subscribersFlow() {
 You can achieve the same result with separate `IntegrationFlow` `@Bean` definitions, but we hope you find the sub-flow style of logic composition useful.
 We find that it results in shorter (and so more readable) code.
 
-Starting with version 5.3, a `BroadcastCapableChannel`-based `publishSubscribeChannel()` implementation is provided to configure sub-flow subscribers on the broker-backed message channels.
+Starting with version 5.3, a `BroadcastCapableChannel`-based `publishSubscribeChannel()` implementation is provided to configure sub-flow subscribers on broker-backed message channels.
 For example we now can configure several subscribers as sub-flows on the `Jms.publishSubscribeChannel()`:
 
 ====
@@ -765,6 +765,14 @@ public IntegrationFlow pubSubFlow() {
                             .subscribe(subFlow -> subFlow
                                 .channel(c -> c.queue("jmsPubSubBridgeChannel2"))));
 }
+
+@Bean
+public BroadcastCapableChannel jmsPublishSubscribeChannel(ConnectionFactory jmsConnectionFactory) {
+    return (BroadcastCapableChannel) Jms.publishSubscribeChannel(jmsConnectionFactory)
+            .destination("pubsub")
+            .get();
+}
+
 ----
 ====
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -53,6 +53,10 @@ See <<./graph.adoc#integration-graph,Integration Graph>> for more information.
 In the aggregator, when the `MessageGroupProcessor` returns a `Message`, the `MessageBuilder.popSequenceDetails()` is performed on the output message if the `sequenceDetails` matches the header in the first message of the group.
 See <<./aggregator.adoc#aggregator-api,Aggregator Programming Model>> for more information.
 
+A new `publishSubscribeChannel()` operator, based on the `BroadcastCapableChannel` and `BroadcastPublishSubscribeSpec`, was added into Java DSL.
+This fluent API has its advantage when we configure sub-flows as pub-sub subscribers for broker-backed channels like `SubscribableJmsChannel`, `SubscribableRedisChannel` etc.
+See <<./dsl.adoc#java-dsl-subflows,Sub-flows support>> for more information.
+
 [[x5.3-amqp]]
 === AMQP Changes
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3192

* Introduce a `BroadcastCapableChannel` abstract to indicate those `SubscribableChannel`
implementations which can provide a pub-sub functionality
* Implement a `BroadcastCapableChannel` in broker-baked channels with pub-sub option
* Introduce a `BaseIntegrationFlowDefinition.publishSubscribeChannel()` based
on the `BroadcastCapableChannel` and `BroadcastPublishSubscribeSpec` to let to
configure sub-flow subscribers in fluent manner

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
