### PR TITLE
GH-3204: Add channel interceptor support to flow definition

### DIFF
--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -594,6 +594,22 @@ When this operator is used at the end of a flow, it is a one-way handler and the
 To make it as a reply-producing flow, you can either use a simple `bridge()` after the `log()` or,  starting with version 5.1, you can use a `logAndReply()` operator instead.
 `logAndReply` can only be used at the end of a flow.
 
+[[java-dsl-intercept]]
+=== Operator intercept()
+
+Starting with version 5.3, the `intercept()` operator allows to register one or more `ChannelInterceptor` instances at the current `MessageChannel` in the flow.
+This is an alternative to creating an explicit `MessageChannel` via the `MessageChannels` API.
+The following example uses a `MessageSelectingInterceptor` to reject certain messages with an exception:
+
+====
+[source,java]
+----
+.transform(...)
+.intercept(new MessageSelectingInterceptor(m -> m.getPayload().isValid()))
+.handle(...)
+----
+====
+
 [[java-dsl-wiretap]]
 === `MessageChannelSpec.wireTap()`
 
@@ -618,7 +634,7 @@ public IntegrationFlow loggingFlow() {
 
 [IMPORTANT]
 ====
-If the `MessageChannel` is an instance of `InterceptableChannel`, the `log()` or `wireTap()` operators are applied to the current `MessageChannel`.
+If the `MessageChannel` is an instance of `InterceptableChannel`, the `log()`, `wireTap()` or `intercept()` operators are applied to the current `MessageChannel`.
 Otherwise, an intermediate `DirectChannel` is injected into the flow for the currently configured endpoint.
 In the following example, the `WireTap` interceptor is added to `myChannel` directly, because `DirectChannel` implements `InterceptableChannel`:
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -66,6 +66,9 @@ Transactional support in Spring Integration now also includes options to configu
 See `TransactionInterceptorBuilder` for more information.
 See also <<./transactions.adoc#reactive-transactions,Reactive Transactions>>.
 
+A new `intercept()` operator to register `ChannelInterceptor` instances without creating explicit channels was added into Java DSL.
+See <<./dsl.adoc#java-dsl-intercept,Operator intercept()>> for more information.
+
 [[x5.3-amqp]]
 === AMQP Changes
 


### PR DESCRIPTION
Adds an `intercept()` builder method to register one or more
channel interceptors at the current flow position.

Issue #3204

* add `intercept(ChannelInterceptor...)` to `BaseIntegrationFlowDefinition`
* refactor to reuse interceptable channel creation from `wireTap`

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
