### PR TITLE
GH-3199: TCP FailoverClientCF fail back default

### DIFF
--- a/src/reference/asciidoc/ip.adoc
+++ b/src/reference/asciidoc/ip.adoc
@@ -536,22 +536,24 @@ The following example shows how to configure a failover client connection factor
 
 NOTE: When using the failover connection factory, the `singleUse` property must be consistent between the factory itself and the list of factories it is configured to use.
 
-The connection factory has two properties when used with a shared connection (`singleUse=false`):
+The connection factory has two properties related to failing back, when used with a shared connection (`singleUse=false`):
 
 * `refreshSharedInterval`
 * `closeOnRefresh`
 
-These are `0` and `false` to retain the same behavior that existed before the properties were added.
-
 Consider the following scenario based on the above configuration:
 Let's say `clientFactory1` cannot establish a connection but `clientFactory2` can.
-Each time the `failCF` `getConnection()` method is called, we will again attempt to connect using `clientFactory1`; if successful, the "old" connection will remain open and may be reused in future if the first factory fails once more.
+When the `failCF` `getConnection()` method is called after the `refreshSharedInterval` has passed, we will again attempt to connect using `clientFactory1`; if successful, the connection to `clientFactory2` will be closed.
+If `closeOnRefresh` is `false`, the "old" connection will remain open and may be reused in future if the first factory fails once more.
 
-Set `refreshSharedInterval` to only attempt to reconnect with the first factory after that time has expired; set it to `Long.MAX_VALUE` if you only want to fail back to the first factory when the current connection fails.
+Set `refreshSharedInterval` to only attempt to reconnect with the first factory after that time has expired; setting it to `Long.MAX_VALUE` (default) if you only want to fail back to the first factory when the current connection fails.
 
 Set `closeOnRefresh` to close the "old" connection after a refresh actually creates a new connection.
 
 IMPORTANT: These properties do not apply if any of the delegate factories is a `CachingClientConnectionFactory` because the connection caching is handled there; in that case the list of connection factories will always be consulted to get a connection.
+
+Starting with version 5.3, these default to `Long.MAX_VALUE` and `true` so the factory only attempts to fail back when the current connection fails.
+To revert to the default behavior of previous versions, set them to `0` and `false`.
 
 [[tcp-affinity-cf]]
 ==== TCP Thread Affinity Connection Factory


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3199

- change the default behavior to not fail back until the current connection fails
- reduce method complexity (Sonar)
- 5.3 only

