### PR TITLE
GH-3199: Fix fail back with Long.MAX_VALUE

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
@@ -52,6 +52,8 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 
 	private boolean closeOnRefresh;
 
+	private boolean failBack = true;
+
 	private volatile long creationTime;
 
 	/**
@@ -82,6 +84,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 		Assert.isTrue(!this.cachingDelegates,
 				"'refreshSharedInterval' cannot be changed when using 'CachingClientConnectionFactory` delegates");
 		this.refreshSharedInterval = refreshSharedInterval;
+		this.failBack = refreshSharedInterval != Long.MAX_VALUE;
 	}
 
 	/**
@@ -148,7 +151,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 	protected TcpConnectionSupport obtainConnection() throws InterruptedException {
 		FailoverTcpConnection sharedConnection = (FailoverTcpConnection) getTheConnection();
 		boolean shared = !isSingleUse() && !this.cachingDelegates;
-		boolean refreshShared = shared
+		boolean refreshShared = this.failBack && shared
 				&& sharedConnection != null
 				&& System.currentTimeMillis() > this.creationTime + this.refreshSharedInterval;
 		if (sharedConnection != null && sharedConnection.isOpen() && !refreshShared) {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3199

Wheen the `refreshSharedInterval` was `Long.MAX_VALUE` the test for whether
the interval was exceeded always returned true.

Use a boolean instead (already in place on master).

I will backport to 5.1.x, 4.3.x after merge.

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
