### PR TITLE
3213: Provide a mechanism to customize the Candidate Id…

### DIFF
--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CandidateIdProvider.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CandidateIdProvider.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.zookeeper.config;
+
+/**
+ * Provider that can be used to customize the identifier used by the
+ * {@link org.springframework.integration.leader.Candidate Leadership Candidate}.
+ * This can be used to customize the data that is stored in Zookeeper for the specific zknode.
+ *
+ * @since 5.2.5
+ */
+@FunctionalInterface
+public interface CandidateIdProvider {
+	String generate();
+}

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CandidateProvider.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/config/CandidateProvider.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.zookeeper.config;
 
+import org.springframework.integration.leader.Candidate;
+
 /**
  * Provider that can be used to customize the identifier used by the
  * {@link org.springframework.integration.leader.Candidate Leadership Candidate}.
@@ -24,6 +26,6 @@ package org.springframework.integration.zookeeper.config;
  * @since 5.2.5
  */
 @FunctionalInterface
-public interface CandidateIdProvider {
-	String generate();
+public interface CandidateProvider {
+	Candidate generate(String role);
 }

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/leader/LeaderInitiator.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/leader/LeaderInitiator.java
@@ -170,7 +170,7 @@ public class LeaderInitiator implements SmartLifecycle {
 			if (!this.running) {
 				if (this.client.getState() != CuratorFrameworkState.STARTED) {
 					// we want to do curator start here because it needs to
-					// be started before leader selector and it gets a little
+					// be started before leader selector, and it gets a little
 					// complicated to control ordering via beans so that
 					// curator is fully started.
 					this.client.start();
@@ -255,7 +255,7 @@ public class LeaderInitiator implements SmartLifecycle {
 				}
 
 				// when this method exits, the leadership will be revoked;
-				// therefore this thread needs to be held up until the
+				// therefore, this thread needs to be held up until the
 				// candidate is no longer leader
 				Thread.sleep(Long.MAX_VALUE);
 			}

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBeanTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/config/LeaderInitiatorFactoryBeanTests.java
@@ -18,7 +18,6 @@ package org.springframework.integration.zookeeper.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,8 +34,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.integration.leader.AbstractCandidate;
-import org.springframework.integration.leader.Candidate;
 import org.springframework.integration.leader.Context;
 import org.springframework.integration.leader.DefaultCandidate;
 import org.springframework.integration.leader.event.AbstractLeaderEvent;
@@ -45,7 +42,6 @@ import org.springframework.integration.leader.event.OnGrantedEvent;
 import org.springframework.integration.leader.event.OnRevokedEvent;
 import org.springframework.integration.zookeeper.ZookeeperTestSupport;
 import org.springframework.integration.zookeeper.leader.LeaderInitiator;
-import org.springframework.lang.NonNull;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -121,39 +117,13 @@ public class LeaderInitiatorFactoryBeanTests extends ZookeeperTestSupport {
 	}
 
 	@Test
-	public void testCandidateIdProvider() {
+	public void testCandidateProvider() {
 		String expectedClientId = "some-client-id";
-		LeaderInitiatorFactoryBean factoryBean = new LeaderInitiatorFactoryBean(() -> expectedClientId);
+		LeaderInitiatorFactoryBean factoryBean = new LeaderInitiatorFactoryBean((role) -> new DefaultCandidate(expectedClientId, role));
 		factoryBean.setRole("some-role");
 		assertThat(factoryBean.getCandidate().getId()).isEqualTo(expectedClientId);
 
 		assertThatIllegalArgumentException().isThrownBy(() -> new LeaderInitiatorFactoryBean(null));
-	}
-
-	@Test
-	public void testFactoryBeanExtensibility() {
-		LeaderInitiatorFactoryBean factoryBeanWithErrors = new LeaderInitiatorFactoryBean() {
-			@Override
-			protected Candidate newCandidate(String role) {
-				return null;
-			}
-		};
-		assertThatIllegalStateException().isThrownBy(() -> factoryBeanWithErrors.setRole("some-role"));
-
-		String expectedId = "some-id";
-		LeaderInitiatorFactoryBean customFactoryBean = new LeaderInitiatorFactoryBean() {
-			@Override
-			protected Candidate newCandidate(String role) {
-				return new AbstractCandidate(expectedId, role) {
-					@Override
-					public void onGranted(@NonNull Context ctx) { /*no-op*/ }
-					@Override
-					public void onRevoked(@NonNull Context ctx) { /*no-op*/ }
-				};
-			}
-		};
-		customFactoryBean.setRole("role");
-		assertThat(customFactoryBean.getCandidate().getId()).isEqualTo(expectedId);
 	}
 
 	@Configuration


### PR DESCRIPTION
This commits adds a mechanism to customize the identifier, and therefore
data, that is used for a _Leadership Candidate_. This can be used to
facilitate triage since a custom provider can have additional information, e.g. identifier of the node/instance of the application.

![image](https://user-images.githubusercontent.com/134985/76357335-c1aab380-62d4-11ea-8d72-bd354ab8f6c8.png)
