### PR TITLE
INT-3216 documentation fix for outbound file adapter

### DIFF
--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -398,7 +398,7 @@ Generally, instead of using an `AcceptOnceFileListFilter` in this case, you shou
 
 ==== Configuring with Java Configuration
 
-The following Spring Boot application shows an example of how to configure the inbound adapter with Java configuration:
+The following Spring Boot application shows an example of how to configure the outbound adapter with Java configuration:
 
 ====
 [source, java]
@@ -438,7 +438,7 @@ public class FileReadingJavaApplication {
 
 ==== Configuring with the Java DSL
 
-The following Spring Boot application shows an example of how to configure the inbound adapter with the Java DSL:
+The following Spring Boot application shows an example of how to configure the outbound adapter with the Java DSL:
 
 ====
 [source, java]


### PR DESCRIPTION
Reference documentation for configuring an outbound file adapter using java configuration or java dsl incorrectly says inbound adapter instead of outbound adapter.

https://docs.spring.io/spring-integration/docs/5.2.3.RELEASE/reference/html/file.html#configuring-with-java-configuration-2

Current State:

==== Configuring with Java Configuration

The following Spring Boot application shows an example of how to configure the inbound adapter with Java configuration:

==== Configuring with the Java DSL

The following Spring Boot application shows an example of how to configure the inbound adapter with the Java DSL:
Proposed new state:

==== Configuring with Java Configuration

The following Spring Boot application shows an example of how to configure the outbound adapter with Java configuration:

==== Configuring with the Java DSL

The following Spring Boot application shows an example of how to configure the outbound adapter with the Java DSL:
