### PR TITLE
Add Kotlin wrappers for router specs

### DIFF
--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/AbstractKotlinRouterSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/AbstractKotlinRouterSpec.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl
+
+import org.springframework.integration.router.AbstractMessageRouter
+import org.springframework.messaging.MessageChannel
+
+/**
+ * An  [AbstractRouterSpec] wrapped for Kotlin DSL.
+ *
+ * @property delegate the [AbstractRouterSpec] this instance is delegating to.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.3
+ */
+abstract class AbstractKotlinRouterSpec<S : AbstractRouterSpec<S, R>, R : AbstractMessageRouter>(
+		open val delegate: AbstractRouterSpec<S, R>) {
+
+	fun ignoreSendFailures(ignoreSendFailures: Boolean) {
+		this.delegate.ignoreSendFailures(ignoreSendFailures)
+	}
+
+	fun applySequence(applySequence: Boolean) {
+		this.delegate.applySequence(applySequence)
+	}
+
+	fun defaultOutputChannel(channelName: String) {
+		this.delegate.defaultOutputChannel(channelName)
+	}
+
+	fun defaultOutputChannel(channel: MessageChannel) {
+		this.delegate.defaultOutputChannel(channel)
+	}
+
+	fun defaultSubFlowMapping(subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+		this.delegate.defaultSubFlowMapping { subFlow(KotlinIntegrationFlowDefinition(it)) }
+	}
+
+	fun defaultOutputToParentFlow() {
+		this.delegate.defaultOutputToParentFlow()
+	}
+
+}

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
@@ -985,7 +985,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	}
 
 	/**
-	 * Populate a [KotlinRecipientListRouterSpec] to the current integration flow position
+	 * Populate a [ScatterGatherHandler] to the current integration flow position
 	 * based on the provided [KotlinRecipientListRouterSpec] for scattering function
 	 * and [AggregatorSpec] for gathering function.
 	 */

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRecipientListRouterSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRecipientListRouterSpec.kt
@@ -66,7 +66,7 @@ class KotlinRecipientListRouterSpec(override val delegate: RecipientListRouterSp
 		this.delegate.recipient(channel, expression)
 	}
 
-	inline fun <reified P> recipient(channel: MessageChannel, noinline selector: (P) -> Boolean) {
+	inline fun <reified P> recipient(channel: MessageChannel, crossinline selector: (P) -> Boolean) {
 		if (Message::class.java.isAssignableFrom(P::class.java))
 			this.delegate.recipientMessageSelector(channel, MessageSelector { selector(it as P) })
 		else
@@ -74,7 +74,7 @@ class KotlinRecipientListRouterSpec(override val delegate: RecipientListRouterSp
 	}
 
 	inline fun <reified P> recipientFlow(crossinline selector: (P) -> Boolean,
-										 noinline subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+										 crossinline subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
 
 		if (Message::class.java.isAssignableFrom(P::class.java))
 			this.delegate.recipientMessageSelectorFlow({ selector(it as P) })

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRecipientListRouterSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRecipientListRouterSpec.kt
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl
+
+import org.springframework.expression.Expression
+import org.springframework.integration.core.GenericSelector
+import org.springframework.integration.core.MessageSelector
+import org.springframework.integration.router.RecipientListRouter
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+
+/**
+ * A  [RecipientListRouterSpec] wrapped for Kotlin DSL.
+ *
+ * @property delegate the [RecipientListRouterSpec] this instance is delegating to.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.3
+ */
+class KotlinRecipientListRouterSpec(override val delegate: RecipientListRouterSpec)
+	: AbstractKotlinRouterSpec<RecipientListRouterSpec, RecipientListRouter>(delegate) {
+
+	fun recipient(channelName: String) {
+		this.delegate.recipient(channelName)
+	}
+
+	fun recipient(channelName: String, expression: String) {
+		this.delegate.recipient(channelName, expression)
+	}
+
+	fun recipient(channelName: String, expression: Expression) {
+		this.delegate.recipient(channelName, expression)
+	}
+
+	inline fun <reified P> recipient(channelName: String, crossinline selector: (P) -> Boolean) {
+		if (Message::class.java.isAssignableFrom(P::class.java))
+			this.delegate.recipientMessageSelector(channelName) { selector(it as P) }
+		else
+			this.delegate.recipient<P>(channelName) { selector(it) }
+	}
+
+	fun recipient(channel: MessageChannel) {
+		this.delegate.recipient(channel)
+	}
+
+	fun recipient(channel: MessageChannel, expression: String) {
+		this.delegate.recipient(channel, expression)
+	}
+
+	fun recipient(channel: MessageChannel, expression: Expression) {
+		this.delegate.recipient(channel, expression)
+	}
+
+	inline fun <reified P> recipient(channel: MessageChannel, noinline selector: (P) -> Boolean) {
+		if (Message::class.java.isAssignableFrom(P::class.java))
+			this.delegate.recipientMessageSelector(channel, MessageSelector { selector(it as P) })
+		else
+			this.delegate.recipient<P>(channel, GenericSelector { selector(it) })
+	}
+
+	inline fun <reified P> recipientFlow(crossinline selector: (P) -> Boolean,
+										 noinline subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+
+		if (Message::class.java.isAssignableFrom(P::class.java))
+			this.delegate.recipientMessageSelectorFlow({ selector(it as P) })
+			{ subFlow(KotlinIntegrationFlowDefinition(it)) }
+		else
+			this.delegate.recipientFlow<P>({ selector(it) }) { subFlow(KotlinIntegrationFlowDefinition(it)) }
+
+	}
+
+	fun recipientFlow(subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+		this.delegate.recipientFlow { subFlow(KotlinIntegrationFlowDefinition(it)) }
+	}
+
+	fun recipientFlow(expression: String, subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+		this.delegate.recipientFlow(expression) { subFlow(KotlinIntegrationFlowDefinition(it)) }
+	}
+
+	fun recipientFlow(expression: Expression, subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+		this.delegate.recipientFlow(expression) { subFlow(KotlinIntegrationFlowDefinition(it)) }
+	}
+
+}

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRouterSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRouterSpec.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl
+
+import org.springframework.integration.router.AbstractMappingMessageRouter
+import org.springframework.messaging.MessageChannel
+
+/**
+ * A  [RouterSpec] wrapped for Kotlin DSL.
+ *
+ * @property delegate the [RouterSpec] this instance is delegating to.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.3
+ */
+class KotlinRouterSpec<K, R : AbstractMappingMessageRouter>(override val delegate: RouterSpec<K, R>)
+	: AbstractKotlinRouterSpec<RouterSpec<K, R>, R>(delegate) {
+
+	fun resolutionRequired(resolutionRequired: Boolean) {
+		this.delegate.resolutionRequired(resolutionRequired)
+	}
+
+	fun dynamicChannelLimit(dynamicChannelLimit: Int) {
+		this.delegate.dynamicChannelLimit(dynamicChannelLimit)
+	}
+
+	fun prefix(prefix: String) {
+		this.delegate.prefix(prefix)
+	}
+
+	fun suffix(suffix: String) {
+		this.delegate.suffix(suffix)
+	}
+
+	fun noChannelKeyFallback() {
+		this.delegate.noChannelKeyFallback()
+	}
+
+	fun channelMapping(key: K, channelName: String) {
+		this.delegate.channelMapping(key, channelName)
+	}
+
+	fun channelMapping(key: K, channel: MessageChannel) {
+		this.delegate.channelMapping(key, channel)
+	}
+
+	fun subFlowMapping(key: K, subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+		this.delegate.subFlowMapping(key) { subFlow(KotlinIntegrationFlowDefinition(it)) }
+	}
+
+}

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
@@ -315,9 +315,9 @@ class KotlinDslTests {
 					scatterGather(
 							{
 								applySequence(true)
-								recipientFlow(GenericSelector<Any> { true }, integrationFlow { handle<Any> { _, _ -> Math.random() * 10 } })
-								recipientFlow(GenericSelector<Any> { true }, integrationFlow { handle<Any> { _, _ -> Math.random() * 10 } })
-								recipientFlow(GenericSelector<Any> { true }, integrationFlow { handle<Any> { _, _ -> Math.random() * 10 } })
+								recipientFlow<Any>({ true }) { handle<Any> { _, _ -> Math.random() * 10 } }
+								recipientFlow<Any>({ true }) { handle<Any> { _, _ -> Math.random() * 10 } }
+								recipientFlow<Any>({ true }) { handle<Any> { _, _ -> Math.random() * 10 } }
 							},
 							{
 								releaseStrategy {

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/routers/RouterDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/routers/RouterDslTests.kt
@@ -102,8 +102,8 @@ class RouterDslTests {
 				integrationFlow {
 					split()
 					route<Int, Boolean>({ it % 2 == 0 }) {
-						subFlowMapping(true) { sf -> sf.handle<Int> { p, _ -> p * 2 } }
-						subFlowMapping(false) { sf -> sf.handle<Int> { p, _ -> p * 3 } }
+						subFlowMapping(true) { handle<Int> { p, _ -> p * 2 } }
+						subFlowMapping(false) { handle<Int> { p, _ -> p * 3 } }
 					}
 					aggregate()
 					channel { queue("routerTwoSubFlowsOutput") }
@@ -114,8 +114,8 @@ class RouterDslTests {
 				integrationFlow {
 					split()
 					route<Int, Boolean>({ it % 2 == 0 }) {
-						subFlowMapping(true) { sf -> sf.gateway(oddFlow()) }
-						subFlowMapping(false) { sf -> sf.gateway(evenFlow()) }
+						subFlowMapping(true) { gateway(oddFlow().inputChannel) }
+						subFlowMapping(false) { gateway(evenFlow().inputChannel) }
 					}
 					aggregate()
 				}


### PR DESCRIPTION
To avoid casting and extra logic logic in the end-user code,
it is better to provide Kotlin-specific API to let end-users to
do whatever is really dictated by API and don't think about specific types to cast

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
