### PR TITLE
GH-3230: MMIH: Fix Pausable/Lifecycle Methods

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ import org.springframework.integration.annotation.Payloads;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.UseSpelInvoker;
 import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.core.Pausable;
 import org.springframework.integration.support.MutableMessage;
 import org.springframework.integration.support.NullAwarePayloadArgumentResolver;
 import org.springframework.integration.support.converter.ConfigurableCompositeMessageConverter;
@@ -97,7 +98,6 @@ import org.springframework.messaging.handler.invocation.MethodArgumentResolution
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
@@ -818,14 +818,19 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 	}
 
 	private boolean isMethodEligible(Method methodToProcess) {
-		return !(methodToProcess.isBridge() || // NOSONAR boolean complexity
+		return (!(methodToProcess.isBridge() || // NOSONAR boolean complexity
 				isMethodDefinedOnObjectClass(methodToProcess) ||
 				methodToProcess.getDeclaringClass().equals(Proxy.class) ||
 				(this.requiresReply && void.class.equals(methodToProcess.getReturnType())) ||
-				(this.methodName != null && !this.methodName.equals(methodToProcess.getName())) ||
-				(this.methodName == null &&
-						ObjectUtils.containsElement(new String[] { "start", "stop", "isRunning" },
-								methodToProcess.getName())));
+				(this.methodName != null && !this.methodName.equals(methodToProcess.getName()))))
+			&& !isPausableMethod(methodToProcess);
+	}
+
+	private boolean isPausableMethod(Method pausableMethod) {
+		Class<?> declaringClass = pausableMethod.getDeclaringClass();
+		return (Pausable.class.isAssignableFrom(declaringClass) || Lifecycle.class.isAssignableFrom(declaringClass))
+				&& ReflectionUtils.findMethod(Pausable.class, pausableMethod.getName(),
+						pausableMethod.getParameterTypes()) != null;
 	}
 
 	private void populateHandlerMethod(Map<Class<?>, HandlerMethod> candidateMethods,

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -1176,9 +1176,11 @@ public class MethodInvokingMessageProcessorTests {
 
 	@Test
 	void lifecycleOnlyExplicitMethod() {
-		assertThatIllegalStateException().isThrownBy(() ->
-				new MethodInvokingMessageProcessor(new LifecycleBean(), "start"))
-			.withMessageContaining("no eligible methods");
+		LifecycleBean targetObject = new LifecycleBean();
+		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(targetObject, "start");
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Object result = processor.processMessage(new GenericMessage<>("testing"));
+		assertThat(targetObject.startCalled).isTrue();
 	}
 
 	@Test
@@ -1613,8 +1615,11 @@ public class MethodInvokingMessageProcessorTests {
 
 	public static class LifecycleBean implements Lifecycle {
 
+		boolean startCalled;
+
 		@Override
 		public void start() {
+			this.startCalled = true;
 		}
 
 		@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.handler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -51,6 +52,7 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.Lifecycle;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -1165,6 +1167,29 @@ public class MethodInvokingMessageProcessorTests {
 		assertThat(result).isEqualTo("Foo,Bar");
 	}
 
+	@Test
+	void lifecycleOnly() {
+		assertThatIllegalStateException().isThrownBy(() ->
+				new MethodInvokingMessageProcessor(new LifecycleBean(), (String) null))
+			.withMessageContaining("no eligible methods");
+	}
+
+	@Test
+	void lifecycleOnlyExplicitMethod() {
+		assertThatIllegalStateException().isThrownBy(() ->
+				new MethodInvokingMessageProcessor(new LifecycleBean(), "start"))
+			.withMessageContaining("no eligible methods");
+	}
+
+	@Test
+	void lifecycleWithValidStartMethid() {
+		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new LifeCycleWithCustomStart(),
+				(String) null);
+		processor.setBeanFactory(mock(BeanFactory.class));
+		Object result = processor.processMessage(new GenericMessage<>("testing"));
+		assertThat(result).isEqualTo("TESTING");
+	}
+
 	public static class Employee<T> {
 
 		private T entity;
@@ -1582,6 +1607,31 @@ public class MethodInvokingMessageProcessorTests {
 
 		public Integer getBaz() {
 			return this.baz;
+		}
+
+	}
+
+	public static class LifecycleBean implements Lifecycle {
+
+		@Override
+		public void start() {
+		}
+
+		@Override
+		public void stop() {
+		}
+
+		@Override
+		public boolean isRunning() {
+			return false;
+		}
+
+	}
+
+	public static class LifeCycleWithCustomStart extends LifecycleBean {
+
+		public String start(String in) {
+			return in.toUpperCase();
 		}
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -1184,7 +1184,7 @@ public class MethodInvokingMessageProcessorTests {
 	}
 
 	@Test
-	void lifecycleWithValidStartMethid() {
+	void lifecycleWithValidStartMethod() {
 		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new LifeCycleWithCustomStart(),
 				(String) null);
 		processor.setBeanFactory(mock(BeanFactory.class));


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3230

Previously, methods with the same name as `Lifecycle` methods were unconditionally ignored when no method name provided.

- Use logic similar to `ControlBusMethodFilter` to explicitly compare the candidate Method
  to those on `Paused` and `Lifecycle` and only ignore those.
- Explicitly disallow these methods when named - previously the check was only performed
  if no method name was supplied.

**Consideration for backporting:**

**Behavior change, test `lifecycleOnlyExplicitMethod()` fails on 5.2.x (method explicitly requested works).**