### PR TITLE
Add more Kotlin DSL for sub-flows

### DIFF
--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/AbstractKotlinRouterSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/AbstractKotlinRouterSpec.kt
@@ -29,7 +29,8 @@ import org.springframework.messaging.MessageChannel
  * @since 5.3
  */
 abstract class AbstractKotlinRouterSpec<S : AbstractRouterSpec<S, R>, R : AbstractMessageRouter>(
-		open val delegate: AbstractRouterSpec<S, R>) {
+		open val delegate: AbstractRouterSpec<S, R>)
+	: ConsumerEndpointSpec<S, R>(delegate.handler) {
 
 	fun ignoreSendFailures(ignoreSendFailures: Boolean) {
 		this.delegate.ignoreSendFailures(ignoreSendFailures)

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinEnricherSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinEnricherSpec.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl
+
+import org.springframework.integration.transformer.ContentEnricher
+import org.springframework.integration.transformer.support.HeaderValueMessageProcessor
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+
+/**
+ * An  [EnricherSpec] wrapped for Kotlin DSL.
+ *
+ * @property delegate the [EnricherSpec] this instance is delegating to.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.3
+ */
+class KotlinEnricherSpec(val delegate: EnricherSpec)
+	: ConsumerEndpointSpec<EnricherSpec, ContentEnricher>(delegate.handler) {
+
+	fun requestChannel(requestChannel: MessageChannel) {
+		this.delegate.requestChannel(requestChannel)
+	}
+
+	fun requestChannel(requestChannel: String) {
+		this.delegate.requestChannel(requestChannel)
+	}
+
+	fun replyChannel(replyChannel: MessageChannel) {
+		this.delegate.replyChannel(replyChannel)
+	}
+
+	fun replyChannel(replyChannel: String) {
+		this.delegate.replyChannel(replyChannel)
+	}
+
+	fun errorChannel(errorChannel: MessageChannel) {
+		this.delegate.errorChannel(errorChannel)
+	}
+
+	fun errorChannel(errorChannel: String) {
+		this.delegate.errorChannel(errorChannel)
+	}
+
+	fun requestTimeout(requestTimeout: Long) {
+		this.delegate.requestTimeout(requestTimeout)
+	}
+
+	fun replyTimeout(replyTimeout: Long) {
+		this.delegate.replyTimeout(replyTimeout)
+	}
+
+	fun requestPayloadExpression(requestPayloadExpression: String) {
+		this.delegate.requestPayloadExpression(requestPayloadExpression)
+	}
+
+	fun <P> requestPayload(function: (Message<P>) -> Any) {
+		this.delegate.requestPayload(function)
+	}
+
+	fun requestSubFlow(subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+		this.delegate.requestSubFlow { subFlow(KotlinIntegrationFlowDefinition(it)) }
+	}
+
+	fun shouldClonePayload(shouldClonePayload: Boolean) {
+		this.delegate.shouldClonePayload(shouldClonePayload)
+	}
+
+	fun <V> property(key: String, value: V) {
+		this.delegate.property(key, value)
+	}
+
+	fun propertyExpression(key: String, expression: String) {
+		this.delegate.propertyExpression(key, expression)
+	}
+
+	fun <P> propertyFunction(key: String, function: (Message<P>) -> Any) {
+		this.delegate.propertyFunction(key, function)
+	}
+
+	fun <V> header(name: String, value: V, overwrite: Boolean?) {
+		this.delegate.header(name, value, overwrite)
+	}
+
+	fun headerExpression(name: String, expression: String, overwrite: Boolean?) {
+		this.delegate.header(name, expression, overwrite)
+	}
+
+	fun <P> headerFunction(name: String, function: (Message<P>) -> Any, overwrite: Boolean?) {
+		this.delegate.header(name, function, overwrite)
+	}
+
+	fun <V> header(headerName: String, headerValueMessageProcessor: HeaderValueMessageProcessor<V>) {
+		this.delegate.header(headerName, headerValueMessageProcessor)
+	}
+
+}

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinFilterEndpointSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinFilterEndpointSpec.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl
+
+import org.springframework.integration.filter.MessageFilter
+import org.springframework.messaging.MessageChannel
+
+/**
+ * An  [FilterEndpointSpec] wrapped for Kotlin DSL.
+ *
+ * @property delegate the [FilterEndpointSpec] this instance is delegating to.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.3
+ */
+class KotlinFilterEndpointSpec(val delegate: FilterEndpointSpec)
+	: ConsumerEndpointSpec<FilterEndpointSpec, MessageFilter>(delegate.handler) {
+
+	fun throwExceptionOnRejection(throwExceptionOnRejection: Boolean) {
+		this.delegate.throwExceptionOnRejection(throwExceptionOnRejection)
+	}
+
+	fun discardChannel(discardChannel: MessageChannel) {
+		this.delegate.discardChannel(discardChannel)
+	}
+
+	fun discardChannel(discardChannelName: String) {
+		this.delegate.discardChannel(discardChannelName)
+	}
+
+	fun discardWithinAdvice(discardWithinAdvice: Boolean) {
+		this.delegate.discardWithinAdvice(discardWithinAdvice)
+	}
+
+	fun discardFlow(subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+		this.delegate.discardFlow { subFlow(KotlinIntegrationFlowDefinition(it)) }
+	}
+
+}

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinSplitterEndpointSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinSplitterEndpointSpec.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl
+
+import org.springframework.integration.splitter.AbstractMessageSplitter
+import org.springframework.messaging.MessageChannel
+
+/**
+ * An  [SplitterEndpointSpec] wrapped for Kotlin DSL.
+ *
+ * @property delegate the [SplitterEndpointSpec] this instance is delegating to.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.3
+ */
+class KotlinSplitterEndpointSpec<H : AbstractMessageSplitter>(val delegate: SplitterEndpointSpec<H>)
+	: ConsumerEndpointSpec<KotlinSplitterEndpointSpec<H>, H>(delegate.handler) {
+
+	fun applySequence(applySequence: Boolean) {
+		this.delegate.applySequence(applySequence)
+	}
+
+	fun delimiters(delimiters: String) {
+		this.delegate.delimiters(delimiters)
+	}
+
+	fun discardChannel(discardChannel: MessageChannel) {
+		this.delegate.discardChannel(discardChannel)
+	}
+
+	fun discardChannel(discardChannelName: String) {
+		this.delegate.discardChannel(discardChannelName)
+	}
+
+	fun discardFlow(discardFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+		this.delegate.discardFlow { discardFlow(KotlinIntegrationFlowDefinition(it)) }
+	}
+
+}

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
@@ -29,9 +29,9 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.integration.channel.FluxMessageChannel
+import org.springframework.integration.channel.PublishSubscribeChannel
 import org.springframework.integration.channel.QueueChannel
 import org.springframework.integration.config.EnableIntegration
-import org.springframework.integration.core.GenericSelector
 import org.springframework.integration.core.MessagingTemplate
 import org.springframework.integration.dsl.context.IntegrationFlowContext
 import org.springframework.integration.endpoint.MessageProcessorMessageSource
@@ -248,7 +248,13 @@ class KotlinDslTests {
 		fun messageSourceFlow() =
 				integrationFlow(MessageProcessorMessageSource { "testSource" },
 						{ poller { it.trigger(OnlyOnceTrigger()) } }) {
-					channel { queue("fromSupplierQueue") }
+					publishSubscribe(PublishSubscribeChannel(),
+							{
+								channel { queue("fromSupplierQueue") }
+							},
+							{
+								log<Any>(LoggingHandler.Level.WARN) { "From second subscriber: ${it.payload}"}
+							})
 				}
 
 		@Bean

--- a/src/reference/asciidoc/index-single.adoc
+++ b/src/reference/asciidoc/index-single.adoc
@@ -23,6 +23,8 @@ include::./messaging-endpoints.adoc[]
 
 include::./dsl.adoc[]
 
+include::./kotlin-dsl.adoc[]
+
 include::./system-management.adoc[]
 
 include::./endpoint-summary.adoc[]

--- a/src/reference/asciidoc/index.adoc
+++ b/src/reference/asciidoc/index.adoc
@@ -2,8 +2,8 @@
 
 include::./index-header.adoc[]
 
-Welcome to the Spring Integration reference documentation! This documentation is also available
-as single searchable link:index-single.html[html] and link:../pdf/spring-integration-reference.pdf[pdf] documents.
+Welcome to the Spring Integration reference documentation!
+This documentation is also available as single searchable link:index-single.html[html] and link:../pdf/spring-integration-reference.pdf[pdf] documents.
 
 [horizontal]
 <<./preface.adoc#preface,Preface>> ::
@@ -15,6 +15,7 @@ as single searchable link:index-single.html[html] and link:../pdf/spring-integra
 <<./message-transformation.adoc#messaging-transformation-chapter,Message Transformation>> ::
 <<./messaging-endpoints.adoc#messaging-endpoints-chapter,Messaging Endpoints>> ::
 <<./dsl.adoc#java-dsl,Java DSL>> ::
+<<./kotlin-dsl.adoc#kotlin-dsl,Kotlin DSL>> ::
 <<./system-management.adoc#system-management-chapter,System Management>> ::
 <<./reactive-streams.adoc#reactive-streams,Reactive Streams Support>> ::
 


### PR DESCRIPTION
* Introduce `KotlinSplitterEndpointSpec`, `KotlinEnricherSpec` &
`KotlinFilterEndpointSpec` to avoid an explicit use of `IntegrationFlow` usage
from Kotlin DSL
* Fix `AbstractKotlinRouterSpec` to extend `ConsumerEndpointSpec` for access
to more endpoint options as it is with Java DSL for similar specs
* Introduce a `KotlinIntegrationFlowDefinition.publishSubscribe()`
for a `BroadcastCapableChannel` and `vararg` of `KotlinIntegrationFlowDefinition` builders.
This allows us to not introduce a `BroadcastPublishSubscribeSpec` wrapper for Kotlin
and let us to remove `publishSubscribeChannel()` DSL methods for `PublishSubscribeSpec`
since it is covered with the `publishSubscribe(PublishSubscribeChannel())` and
respective set of sub-flows in Kotlin DSL as subscribers
* Use new Kotlin specs in the `KotlinIntegrationFlowDefinition` instead of their
Java variants

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
