### PR TITLE
GH-3238: Fix Unmarshaller to close File resource

### DIFF
--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/jaxbmarshaling/JaxbMarshallingIntegrationTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/transformer/jaxbmarshaling/JaxbMarshallingIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,68 +17,90 @@
 package org.springframework.integration.xml.transformer.jaxbmarshaling;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import javax.xml.transform.Result;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMResult;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.w3c.dom.Document;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.integration.transformer.MessageTransformationException;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.AbstractJUnit4SpringContextTests;
+import org.springframework.oxm.UnmarshallingFailureException;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.xml.transform.StringSource;
 
 /**
  * @author Jonas Partner
+ * @author Artem Bilan
  */
-@ContextConfiguration
-public class JaxbMarshallingIntegrationTests extends AbstractJUnit4SpringContextTests {
+@SpringJUnitConfig
+public class JaxbMarshallingIntegrationTests {
 
-	@Autowired @Qualifier("marshallIn")
+	@Autowired
+	@Qualifier("marshallIn")
 	MessageChannel marshallIn;
 
-	@Autowired @Qualifier("marshallOut")
+	@Autowired
+	@Qualifier("marshallOut")
 	PollableChannel marshalledOut;
 
-	@Autowired @Qualifier("unmarshallIn")
+	@Autowired
+	@Qualifier("unmarshallIn")
 	MessageChannel unmarshallIn;
 
-	@Autowired @Qualifier("unmarshallOut")
+	@Autowired
+	@Qualifier("unmarshallOut")
 	PollableChannel unmarshallOut;
 
+	@TempDir
+	Path tempDirectory;
 
-	@SuppressWarnings("unchecked")
 	@Test
-	public void testMarshalling() throws Exception {
+	public void testMarshalling() {
 		JaxbAnnotatedPerson person = new JaxbAnnotatedPerson();
 		person.setFirstName("john");
-		marshallIn.send(new GenericMessage<Object>(person));
-		GenericMessage<Result> res = (GenericMessage<Result>) marshalledOut.receive(2000);
-		assertThat(res).as("No response recevied").isNotNull();
+		this.marshallIn.send(new GenericMessage<>(person));
+		Message<?> res = this.marshalledOut.receive(2000);
+		assertThat(res).as("No response received").isNotNull();
 		assertThat(res.getPayload() instanceof DOMResult).as("payload was not a DOMResult").isTrue();
 		Document doc = (Document) ((DOMResult) res.getPayload()).getNode();
 		assertThat(doc.getDocumentElement().getLocalName()).as("Wrong name for root element ").isEqualTo("person");
 	}
 
 
-	@SuppressWarnings("unchecked")
 	@Test
-	public void testUnmarshalling() throws Exception {
+	public void testUnmarshalling() {
 		StringSource source = new StringSource("<person><firstname>bob</firstname></person>");
-		unmarshallIn.send(new GenericMessage<Source>(source));
-		GenericMessage<Object> res = (GenericMessage<Object>) unmarshallOut.receive(2000);
+		this.unmarshallIn.send(new GenericMessage<Source>(source));
+		Message<?> res = this.unmarshallOut.receive(2000);
 		assertThat(res).as("No response").isNotNull();
 		assertThat(res.getPayload() instanceof JaxbAnnotatedPerson).as("Not a Person ").isTrue();
 		JaxbAnnotatedPerson person = (JaxbAnnotatedPerson) res.getPayload();
-		assertThat(person.getFirstName()).as("Worng firstname").isEqualTo("bob");
-
+		assertThat(person.getFirstName()).as("Wrong firstname").isEqualTo("bob");
 	}
 
+	@Test
+	public void testFileUnlockedAfterUnmarshallingFailure() throws IOException {
+		Path tempFile = Files.createTempFile(this.tempDirectory, null, null);
+		Files.write(tempFile, "junk".getBytes());
+		assertThatExceptionOfType(MessageTransformationException.class)
+				.isThrownBy(() -> this.unmarshallIn.send(new GenericMessage<>(tempFile.toFile())))
+				.withCauseInstanceOf(UnmarshallingFailureException.class)
+				.withStackTraceContaining("Content is not allowed in prolog.");
+
+		Files.delete(tempFile);
+	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3238

* Extract an `InputStream` from a `File` payload in the `UnmarshallingTransformer`
before parsing an XML.
Close this `InputStream` in the `finally` block to release the file resource

**Cherry-pick to 5.2.x, 5.1.x & 4.3.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
