### PR TITLE
GH-3247: Fix `SftpSession.exists` for error code

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,16 +127,15 @@ public class SftpSession implements Session<LsEntry> {
 	@Override
 	public String[] listNames(String path) throws IOException {
 		LsEntry[] entries = this.list(path);
-		List<String> names = new ArrayList<String>();
-		for (int i = 0; i < entries.length; i++) {
-			String fileName = entries[i].getFilename();
-			SftpATTRS attrs = entries[i].getAttrs();
+		List<String> names = new ArrayList<>();
+		for (LsEntry entry : entries) {
+			String fileName = entry.getFilename();
+			SftpATTRS attrs = entry.getAttrs();
 			if (!attrs.isDir() && !attrs.isLink()) {
 				names.add(fileName);
 			}
 		}
-		String[] fileNames = new String[names.size()];
-		return names.toArray(fileNames);
+		return names.toArray(new String[0]);
 	}
 
 
@@ -270,15 +269,19 @@ public class SftpSession implements Session<LsEntry> {
 	}
 
 	@Override
-	public boolean exists(String path) {
+	public boolean exists(String path) throws IOException {
 		try {
 			this.channel.lstat(path);
 			return true;
 		}
-		catch (@SuppressWarnings("unused") SftpException e) {
-			// ignore
+		catch (SftpException ex) {
+			if (ex.id == ChannelSftp.SSH_FX_NO_SUCH_FILE) {
+				return false;
+			}
+			else {
+				throw new NestedIOException("Cannot check 'lstat' for path " + path, ex);
+			}
 		}
-		return false;
 	}
 
 	void connect() {

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -84,6 +84,7 @@
 				org.mockito.BDDMockito.*,
 				org.mockito.AdditionalAnswers.*,
 				org.mockito.ArgumentMatchers.*,
+				org.mockito.AdditionalMatchers.*,
 				org.springframework.integration.gemfire.config.xml.ParserTestUtil.*,
 				org.springframework.integration.test.mock.MockIntegration.*,
 				org.springframework.integration.test.util.TestUtils.*,


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3247

When there is no path on the SFTP server, a `ChannelSftp.SSH_FX_NO_SUCH_FILE`
error is returned in the thrown `SftpException`.

* Fix `SftpSession.exists()` to check for the `SSH_FX_NO_SUCH_FILE` to
return `false` and re-throw an exception otherwise
* Add mock test for `SftpSession.exists()`
* Add `org.mockito.AdditionalMatchers` to `checkstyle.xml` exclusions

**Cherry-pick to 5.2.x & 5.1.x**

<!--
Thanks for contributing to Spring Integration. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
