### PR TITLE
Use a SimpleJsonSerializer in the FileSplitter

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/SimpleJsonSerializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/SimpleJsonSerializer.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -99,7 +100,7 @@ public final class SimpleJsonSerializer {
 			return result.toString();
 		}
 		else {
-			return "\"" + (result == null ? "null" : result.toString()) + "\"";
+			return "\"" + (result == null ? "null" : Matcher.quoteReplacement(result.toString())) + "\"";
 		}
 	}
 

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -1016,7 +1016,7 @@ The default is `false`.
 When `true`, `apply-sequence` is `false` by default.
 See also `markers-json` (the next attribute).
 <4> When `markers` is true, set this to `true` to have the `FileMarker` objects be converted to a JSON string.
-Requires a supported JSON processor library (e.g. Jackson) on the classpath.
+(Uses a `SimpleJsonSerializer` underneath).
 <5> Set to `false` to disable the inclusion of `sequenceSize` and `sequenceNumber` headers in messages.
 The default is `true`, unless `markers` is `true`.
 When `true` and `markers` is `true`, the markers are included in the sequencing.
@@ -1050,7 +1050,7 @@ public FileSplitter(boolean iterator, boolean markers, boolean markersJson)
 ----
 ====
 
-When `markersJson` is true, the markers are represented as a JSON string, as long as a suitable JSON processor library (e.g Jackson) is on the classpath.
+When `markersJson` is true, the markers are represented as a JSON string (using a `SimpleJsonSerializer`).
 
 Version 5.0 introduced the `firstLineAsHeader` option to specify that the first line of content is a header (such as column names in a CSV file).
 The argument passed to this property is the header name under which the first line is carried as a header in the messages emitted for the remaining lines.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -158,3 +158,10 @@ See <<./mqtt.adoc#mqtt-events,MQTT Events>>.
 
 The `FileTransferringMessageHandler` (for FTP and SFTP, for example) in addition to `File`, `byte[]`, `String` and `InputStream` now also supports an `org.springframework.core.io.Resource`.
 See <<./sftp.adoc#sftp,SFTP Support>> and <<./ftp.adoc#ftp,FTP Support>> for more information.
+
+[[x5.3-file]]
+=== File Changes
+
+The `FileSplitter` doesn't require a Jackson processor (or similar) dependency any more for the `markersJson` mode.
+It uses a `SimpleJsonSerializer` for a straightforward string representation of the `FileSplitter.FileMarker` instances.
+See <<./file.adoc#file-splitter,FileSplitter>> for more information.


### PR DESCRIPTION
* To avoid extra dependency for Jackson when we
serialize `FileSplitter.FileMarker` to JSON, use
a `SimpleJsonSerializer` instead.
* Fix `SimpleJsonSerializer` to escape a `\` symbol from property values
since it is used for quoting string values in the final JSON

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
