### PR TITLE
GH-3266: Don't override props in AnnGWProxyFB

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -139,6 +139,8 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 
 	private AsyncTaskExecutor asyncExecutor = new SimpleAsyncTaskExecutor();
 
+	private boolean asyncExecutorExplicitlySet;
+
 	private Class<?> asyncSubmitType;
 
 	private Class<?> asyncSubmitListenableType;
@@ -189,6 +191,16 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		this.defaultRequestChannelName = defaultRequestChannelName;
 	}
 
+	@Nullable
+	protected MessageChannel getDefaultRequestChannel() {
+		return this.defaultRequestChannel;
+	}
+
+	@Nullable
+	protected String getDefaultRequestChannelName() {
+		return this.defaultRequestChannelName;
+	}
+
 	/**
 	 * Set the default reply channel. If no default reply channel is provided,
 	 * and no reply channel is configured with annotations, an anonymous,
@@ -212,6 +224,16 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		this.defaultReplyChannelName = defaultReplyChannelName;
 	}
 
+	@Nullable
+	protected MessageChannel getDefaultReplyChannel() {
+		return this.defaultReplyChannel;
+	}
+
+	@Nullable
+	protected String getDefaultReplyChannelName() {
+		return this.defaultReplyChannelName;
+	}
+
 	/**
 	 * Set the error channel. If no error channel is provided, this gateway will
 	 * propagate Exceptions to the caller. To completely suppress Exceptions, provide
@@ -231,6 +253,16 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 	 */
 	public void setErrorChannelName(String errorChannelName) {
 		this.errorChannelName = errorChannelName;
+	}
+
+	@Nullable
+	protected MessageChannel getErrorChannel() {
+		return this.errorChannel;
+	}
+
+	@Nullable
+	protected String getErrorChannelName() {
+		return this.errorChannelName;
 	}
 
 	/**
@@ -266,6 +298,11 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		}
 	}
 
+	@Nullable
+	protected Expression getDefaultRequestTimeout() {
+		return this.defaultRequestTimeout;
+	}
+
 	/**
 	 * Set the default timeout value for receiving reply messages. If not explicitly
 	 * configured with an annotation, or on a method element, this value will be used.
@@ -299,6 +336,11 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		}
 	}
 
+	@Nullable
+	protected Expression getDefaultReplyTimeout() {
+		return this.defaultReplyTimeout;
+	}
+
 	@Override
 	public void setShouldTrack(boolean shouldTrack) {
 		this.shouldTrack = shouldTrack;
@@ -317,12 +359,15 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 	 * @param executor The executor.
 	 */
 	public void setAsyncExecutor(@Nullable Executor executor) {
-		if (executor == null && logger.isInfoEnabled()) {
+		if (executor == null) {
 			logger.info("A null executor disables the async gateway; " +
 					"methods returning Future<?> will run on the calling thread");
 		}
-		this.asyncExecutor = (executor instanceof AsyncTaskExecutor || executor == null) ? (AsyncTaskExecutor) executor
-				: new TaskExecutorAdapter(executor);
+		this.asyncExecutor =
+				(executor instanceof AsyncTaskExecutor || executor == null)
+						? (AsyncTaskExecutor) executor
+						: new TaskExecutorAdapter(executor);
+		this.asyncExecutorExplicitlySet = true;
 	}
 
 	public void setTypeConverter(TypeConverter typeConverter) {
@@ -336,6 +381,11 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 
 	public void setGlobalMethodMetadata(GatewayMethodMetadata globalMethodMetadata) {
 		this.globalMethodMetadata = globalMethodMetadata;
+	}
+
+	@Nullable
+	protected GatewayMethodMetadata getGlobalMethodMetadata() {
+		return this.globalMethodMetadata;
 	}
 
 	@Override
@@ -352,6 +402,11 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		this.argsMapper = mapper;
 	}
 
+	@Nullable
+	protected MethodArgsMessageMapper getMapper() {
+		return this.argsMapper;
+	}
+
 	/**
 	 * Indicate if {@code default} methods on the interface should be proxied as well.
 	 * If an explicit {@link Gateway} annotation is present on method it is proxied
@@ -365,8 +420,13 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		this.proxyDefaultMethods = proxyDefaultMethods;
 	}
 
+	@Nullable
 	protected AsyncTaskExecutor getAsyncExecutor() {
 		return this.asyncExecutor;
+	}
+
+	protected boolean isAsyncExecutorExplicitlySet() {
+		return this.asyncExecutorExplicitlySet;
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3266

It turns out that `AnnotationGatewayProxyFactoryBean.onInit()` implementation
parses a `@MessagingGateway` attributes ignoring possible properties
population by setters.
This way a Java DSL `GatewayProxySpec` becomes useless since all
its options are overridden by default values from a synthesized
`@MessagingGateway`.
Also it is inconsistency when we declare an `AnnotationGatewayProxyFactoryBean`
as regular bean, but then called setters are ignored

* Add `protected` getters into `GatewayProxyFactoryBean` for all
the properties which can be overridden by annotation attributes
* Fix `AnnotationGatewayProxyFactoryBean` to consult with those getters
before populating a property with value from the annotation

**Cherry-pick to 5.2.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
