### PR TITLE
BoundRabbitChannelAdvice - reject invalid config

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/BoundRabbitChannelAdvice.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/BoundRabbitChannelAdvice.java
@@ -75,6 +75,10 @@ public class BoundRabbitChannelAdvice implements HandleMessageAdvice {
 		Assert.notNull(operations, "'operations' cannot be null");
 		this.operations = operations;
 		this.waitForConfirmsTimeout = waitForConfirmsTimeout;
+		if (this.waitForConfirmsTimeout != null) {
+			Assert.isTrue(operations.getConnectionFactory().isSimplePublisherConfirms(),
+					"'waitForConfirmsTimeout' requires a connection factory with simple publisher confirms enabled");
+		}
 	}
 
 	@Override

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/BoundRabbitChannelAdviceTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/BoundRabbitChannelAdviceTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.amqp.support;
 
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -34,6 +35,7 @@ import java.util.concurrent.ExecutorService;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitOperations;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -73,6 +75,15 @@ public class BoundRabbitChannelAdviceTests {
 		verify(this.config.channel).basicPublish(eq(""), eq("rk"), anyBoolean(), any(), eq("B".getBytes()));
 		verify(this.config.channel).basicPublish(eq(""), eq("rk"), anyBoolean(), any(), eq("C".getBytes()));
 		verify(this.config.channel).waitForConfirmsOrDie(10_000L);
+	}
+
+	@Test
+	void validate() {
+		RabbitOperations template = mock(RabbitOperations.class);
+		given(template.getConnectionFactory()).willReturn(
+				mock(org.springframework.amqp.rabbit.connection.ConnectionFactory.class));
+		assertThatIllegalArgumentException().isThrownBy(() ->
+				new BoundRabbitChannelAdvice(template, Duration.ofSeconds(1)));
 	}
 
 	@Configuration


### PR DESCRIPTION
Don't allow a `waitForConfirmsTimeout` if the factory is not configured
for simple publisher confirmations.

Otherwise, a runtime error will occur.

**cherry-pick to 5.2.x, 5.1.x**
