### PR TITLE
GH-3271: Close session on error in stream source

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -216,6 +216,7 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 									this.fileInfoJson ? file.toJson() : file);
 				}
 				catch (IOException e) {
+					session.close();
 					throw new UncheckedIOException("IOException when retrieving " + remotePath, e);
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3271

When exception happens at `.withPayload(session.readRaw(remotePath))`
in the `AbstractRemoteFileStreamingMessageSource` we don't close session.
The resource leaking happens in the caching session factory

* Add `session.close();` into the `catch (IOException e) {`
in the `AbstractRemoteFileStreamingMessageSource.doReceive()`
to clean up resources properly

**Cherry-pick to 5.2.x, 5.1.x & 4.3.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
