### PR TITLE
Fix RESOLVABLE_TYPE header population

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonToObjectTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonToObjectTransformer.java
@@ -197,7 +197,7 @@ public class JsonToObjectTransformer extends AbstractTransformer implements Bean
 		}
 		catch (Exception ex) {
 			if (ex.getCause() instanceof ClassNotFoundException) {
-				logger.info("Cannot build a ResolvableType from the request message '" + message +
+				logger.debug("Cannot build a ResolvableType from the request message '" + message +
 						"' evaluating expression '" + this.valueTypeExpression.getExpressionString() + "'", ex);
 				return null;
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -277,7 +277,9 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 					if (shouldMapHeader(headerName, headerMatcher)) {
 						Object value = entry.getValue();
 						target.put(headerName, value);
-						if (JsonHeaders.TYPE_ID.equals(headerName) && value != null) {
+						if (this.replyHeaderMatcher == headerMatcher &&
+								JsonHeaders.TYPE_ID.equals(headerName) && value != null) {
+
 							ResolvableType resolvableType =
 									createJsonResolvableTypHeaderInAny(value, source.get(JsonHeaders.CONTENT_TYPE_ID),
 											source.get(JsonHeaders.KEY_TYPE_ID));
@@ -302,11 +304,10 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 			@Nullable Object keyId) {
 
 		try {
-			return JsonHeaders.buildResolvableType(getClassLoader(), typeId,
-					contentId, keyId);
+			return JsonHeaders.buildResolvableType(getClassLoader(), typeId, contentId, keyId);
 		}
 		catch (Exception e) {
-			this.logger.warn("Cannot build a ResolvableType from 'json__TypeId__' header", e);
+			this.logger.debug("Cannot build a ResolvableType from 'json__TypeId__' header", e);
 		}
 		return null;
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests.java
@@ -93,7 +93,7 @@ public class JsonToObjectTransformerParserTests {
 		assertThat(person.getAddress().toString()).isEqualTo("123 Main Street");
 
 		ArgumentCaptor<String> stringArgumentCaptor = ArgumentCaptor.forClass(String.class);
-		verify(logger).info(stringArgumentCaptor.capture(), any(Exception.class));
+		verify(logger).debug(stringArgumentCaptor.capture(), any(Exception.class));
 		String logMessage = stringArgumentCaptor.getValue();
 
 		assertThat(logMessage).startsWith("Cannot build a ResolvableType from the request message");


### PR DESCRIPTION
* We should not build a RESOLVABLE_TYPE header when we map requests.
Only for replies. See: https://github.com/spring-projects/spring-integration-samples/issues/277
* We should log `ClassNotFoundException` only at debug level - to noise with info or warn

**Cherry-pick to 5.2.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
