### PR TITLE
GH-3276: reactive inbound: Fix `onErrorResume`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -643,7 +643,8 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 			sendMessageForReactiveFlow(requestChannel, requestMessage);
 
 			return buildReplyMono(requestMessage, replyChan.replyMono, error, originalReplyChannelHeader,
-					originalErrorChannelHeader);
+					originalErrorChannelHeader)
+					.onErrorResume(t -> error ? Mono.error(t) : handleSendError(requestMessage, t));
 		});
 	}
 
@@ -693,8 +694,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 								.setHeader(MessageHeaders.ERROR_CHANNEL, originalErrorChannelHeader)
 								.build();
 					}
-				})
-				.onErrorResume(t -> error ? Mono.error(t) : handleSendError(requestMessage, t));
+				});
 	}
 
 	private Mono<Message<?>> handleSendError(Message<?> requestMessage, Throwable exception) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3276

The `onErrorResume` for the `MessagingGatewaySupport.doSendAndReceiveMessageReactive()`
was in wrong place: only for the `buildReplyMono` which works only
when an outbound flow is fully based on reactive channels.
With a regular direct channel we can get an exception from the
`sendMessageForReactiveFlow` which is not covered with the mentioned
`onErrorResume` for the error handling on the configured `errorChannel`

Cherry-pick to `5.2.x & 5.1.x`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
