### PR TITLE
GH-3283: HTTP Inbound handle SpEL errors

### DIFF
--- a/src/reference/asciidoc/http.adoc
+++ b/src/reference/asciidoc/http.adoc
@@ -431,6 +431,12 @@ If the error flow times out after a main flow timeout, `500 Internal Server Erro
 NOTE: Previously, the default status code for a timeout was `200 OK`.
 To restore that behavior, set `reply-timeout-status-code-expression="200"`.
 
+Also starting with version 5.4, the request message preparation error is send to the provided error channel.
+A decision about throwing an appropriate exception should be done over there in error flow.
+Previously those error were always be thrown to the HTTP response as 500 status, but in some cases it is just about a wrong request params, so status 400 should be thrown instead.
+See `ResponseStatusException` for more information.
+The `ErrorMessage` sent to this error channel contains an original exception as a payload for analysis.
+
 ==== URI Template Variables and Expressions
 
 By using the `path` attribute in conjunction with the `payload-expression` attribute and the `header` element, you have a high degree of flexibility for mapping inbound request data.

--- a/src/reference/asciidoc/http.adoc
+++ b/src/reference/asciidoc/http.adoc
@@ -431,12 +431,11 @@ If the error flow times out after a main flow timeout, `500 Internal Server Erro
 NOTE: Previously, the default status code for a timeout was `200 OK`.
 To restore that behavior, set `reply-timeout-status-code-expression="200"`.
 
-Also starting with version 5.4, the request message preparation error is send to the provided error channel.
-A decision about throwing an appropriate exception should be done over there in error flow.
-Previously those error were always be thrown to the HTTP response as 500 status, but in some cases it is just about a wrong request params, so status 400 should be thrown instead.
+Also starting with version 5.4, an error that is encountered while preparing the request message is sent to the error channel (if provided).
+A decision about throwing an appropriate exception should be done in the error flow by examining the exception.
+Previously, any exceptions were simply thrown, causing an HTTP 500 server error response status, but in some cases the problem can be caused by incorrect request params, so a `ResponseStatusException` with a 4xx client error status should be thrown instead.
 See `ResponseStatusException` for more information.
-The `ErrorMessage` sent to this error channel contains an original exception as a payload for analysis.
-
+The `ErrorMessage` sent to this error channel contains the original exception as the payload for analysis.
 ==== URI Template Variables and Expressions
 
 By using the `path` attribute in conjunction with the `payload-expression` attribute and the `header` element, you have a high degree of flexibility for mapping inbound request data.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3283

* Process all the request message preparation exceptions
in the provided error channel to let target application
to make a decision about an appropriate HTTP status instead of
default 500 Server Error

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
