### PR TITLE
Fix typo in CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -97,7 +97,7 @@ As discussed above, when issuing pull requests, please ensure that your commit h
 From the command line you can check this using:
 
 ----
-log --graph --pretty=oneline
+git log --graph --pretty=oneline
 ----
 
 As this may cause lots of typing, we recommend creating a global alias, e.g. `git logg` for this:


### PR DESCRIPTION
Add `git` itself to the standalone (not alias) sample command for checking commit history.