### PR TITLE
GH-3280: NullChannel as reply for void gateways

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.gateway;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
@@ -48,7 +49,9 @@ import org.springframework.integration.annotation.Gateway;
 import org.springframework.integration.annotation.GatewayHeader;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
+import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -127,6 +130,32 @@ public class GatewayProxyFactoryBeanTests {
 		Message<?> message = requestChannel.receive(1000);
 		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isEqualTo("test");
+	}
+
+	@Test
+	public void testOneWayIgnoreReply() {
+		DirectChannel requestChannel = new DirectChannel();
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		QueueChannel nullChannel = new QueueChannel();
+		willReturn(nullChannel)
+				.given(beanFactory)
+				.getBean(IntegrationContextUtils.NULL_CHANNEL_BEAN_NAME, MessageChannel.class);
+		BridgeHandler handler = new BridgeHandler();
+		handler.setBeanFactory(beanFactory);
+		handler.afterPropertiesSet();
+		requestChannel.subscribe(handler);
+		GatewayProxyFactoryBean proxyFactory = new GatewayProxyFactoryBean(TestService.class);
+		proxyFactory.setDefaultRequestChannel(requestChannel);
+		proxyFactory.setBeanName("testGateway");
+		proxyFactory.setBeanFactory(beanFactory);
+		proxyFactory.afterPropertiesSet();
+		TestService service = (TestService) proxyFactory.getObject();
+		service.oneWay("test");
+		Message<?> message = nullChannel.receive(1000);
+		assertThat(message)
+				.isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("test");
 	}
 
 	@Test

--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -83,7 +83,7 @@ You might also want to explicitly provide a reply channel for monitoring or audi
 To configure a channel interceptor, you need a named channel.
 
 NOTE: Starting with version 5.4, when gateway method return type is `void`, the framework populates a `replyChannel` header as a `nullChannel` bean reference if such a header is not provided explicitly.
-Such a behavior allows to ignore possible reply from downstream flow meeting a one-way gateway contract.
+This allows any possible reply from the downstream flow to be discarded, meeting the one-way gateway contract.
 
 [[gateway-configuration-annotations]]
 ==== Gateway Configuration with Annotations and XML

--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -82,6 +82,9 @@ The gateway creates a bridge from it to the temporary, anonymous reply channel t
 You might also want to explicitly provide a reply channel for monitoring or auditing through an interceptor (for example, <<./channel.adoc#channel-wiretap,wiretap>>).
 To configure a channel interceptor, you need a named channel.
 
+NOTE: Starting with version 5.4, when gateway method return type is `void`, the framework populates a `replyChannel` header as a `nullChannel` bean reference if such a header is not provided explicitly.
+Such a behavior allows to ignore possible reply from downstream flow meeting a one-way gateway contract.
+
 [[gateway-configuration-annotations]]
 ==== Gateway Configuration with Annotations and XML
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -19,4 +19,4 @@ If you are interested in more details, see the Issue Tracker tickets that were r
 === General Changes
 
 The one-way messaging gateway (the `void` method return type) now sets a `nullChannel` explicitly into the `replyChannel` header to ignore any possible downstream replies.
-See for more information in the <<./gateway.adoc#gateway-default-reply-channel,Setting the Default Reply Channel>>.
+See <<./gateway.adoc#gateway-default-reply-channel,Setting the Default Reply Channel>> for more information.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -12,3 +12,11 @@ If you are interested in the changes and features that were introduced in earlie
 
 If you are interested in more details, see the Issue Tracker tickets that were resolved as part of the 5.4 development process.
 
+[[x5.4-new-components]]
+=== New Components
+
+[[x5.4-general]]
+=== General Changes
+
+The one-way messaging gateway (the `void` method return type) now sets a `nullChannel` explicitly into the `replyChannel` header to ignore any possible downstream replies.
+See for more information in the <<./gateway.adoc#gateway-default-reply-channel,Setting the Default Reply Channel>>.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3280

To properly support a one-way gateway (`void` return type), it is
better to ignore any possible replies from downstream instead of
unexpected `no output-channel or replyChannel header available`
error

* Populate a `nullChannel` into a `replyChannel` header
for `void` gateway methods when `replyChannel` is not set explicitly
* Remove redundant `GatewayProxyFactoryBean.PARSER` in favor of
similar `EXPRESSION_PARSER` in the super class
* Test and document the feature

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
