### PR TITLE
Fix NPE for component name after FactoryBeans

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractSimpleMessageHandlerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractSimpleMessageHandlerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -204,7 +204,7 @@ public abstract class AbstractSimpleMessageHandlerFactoryBean<H extends MessageH
 					getBeanFactory(),
 					factory -> ((BeanFactoryAware) this.handler).setBeanFactory(factory))
 				.acceptIfCondition(this.handler instanceof BeanNameAware && this.beanName != null, this.beanName,
-					namne -> ((BeanNameAware) this.handler).setBeanName(this.beanName))
+					name -> ((BeanNameAware) this.handler).setBeanName(this.beanName))
 				.acceptIfCondition(this.handler instanceof ApplicationEventPublisherAware
 										&& this.applicationEventPublisher != null,
 					this.applicationEventPublisher,

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileReadingMessageSourceFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileReadingMessageSourceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.integration.file.DirectoryScanner;
 import org.springframework.integration.file.FileReadingMessageSource;
@@ -37,7 +38,8 @@ import org.springframework.util.Assert;
  *
  * @since 1.0.3
  */
-public class FileReadingMessageSourceFactoryBean extends AbstractFactoryBean<FileReadingMessageSource> {
+public class FileReadingMessageSourceFactoryBean extends AbstractFactoryBean<FileReadingMessageSource>
+		implements BeanNameAware {
 
 	private FileReadingMessageSource source;
 
@@ -60,6 +62,13 @@ public class FileReadingMessageSourceFactoryBean extends AbstractFactoryBean<Fil
 	private Boolean autoCreateDirectory;
 
 	private Integer queueSize;
+
+	private String name;
+
+	@Override
+	public void setBeanName(String name) {
+		this.name = name;
+	}
 
 	public void setDirectory(File directory) {
 		this.directory = directory;
@@ -154,6 +163,7 @@ public class FileReadingMessageSourceFactoryBean extends AbstractFactoryBean<Fil
 		if (beanFactory != null) {
 			this.source.setBeanFactory(beanFactory);
 		}
+		this.source.setBeanName(this.name);
 		this.source.afterPropertiesSet();
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,8 @@ import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.PriorityBlockingQueue;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,8 +39,7 @@ import org.springframework.integration.file.filters.FileListFilter;
 import org.springframework.integration.file.filters.IgnoreHiddenFileListFilter;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Iwein Fuld
@@ -50,8 +48,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  * @author Gunnar Hillert
  * @author Artem Bilan
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
 public class FileInboundChannelAdapterParserTests {
 
@@ -71,7 +68,7 @@ public class FileInboundChannelAdapterParserTests {
 
 	private DirectFieldAccessor accessor;
 
-	@Before
+	@BeforeEach
 	public void init() {
 		this.accessor = new DirectFieldAccessor(inputDirPollerSource);
 	}
@@ -97,10 +94,11 @@ public class FileInboundChannelAdapterParserTests {
 		File actual = (File) this.accessor.getPropertyValue("directory");
 		assertThat(actual).as("'directory' should be set").isEqualTo(expected);
 		assertThat(this.accessor.getPropertyValue("scanEachPoll")).isEqualTo(Boolean.TRUE);
+		assertThat(this.inputDirPollerSource.getComponentName()).isEqualTo("inputDirPoller.adapter.source");
 	}
 
 	@Test
-	public void filter() throws Exception {
+	public void filter() {
 		DefaultDirectoryScanner scanner = (DefaultDirectoryScanner) accessor.getPropertyValue("scanner");
 		DirectFieldAccessor scannerAccessor = new DirectFieldAccessor(scanner);
 		Object filter = scannerAccessor.getPropertyValue("filter");

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,9 @@
 
 package org.springframework.integration.jpa.outbound;
 
-import java.util.List;
-
-import org.aopalliance.aop.Advice;
-
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.integration.config.AbstractSimpleMessageHandlerFactoryBean;
 import org.springframework.integration.jpa.core.JpaExecutor;
 import org.springframework.integration.jpa.support.OutboundGatewayType;
-import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessageHandler;
 
 /**
  * The {@link JpaOutboundGatewayFactoryBean} creates instances of the
@@ -38,34 +31,21 @@ import org.springframework.messaging.MessageHandler;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.2
  *
  */
-public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<JpaOutboundGateway> {
+public class JpaOutboundGatewayFactoryBean extends AbstractSimpleMessageHandlerFactoryBean<JpaOutboundGateway> {
 
 	private JpaExecutor jpaExecutor;
 
 	private OutboundGatewayType gatewayType = OutboundGatewayType.UPDATING;
 
-	/**
-	 * &lt;request-handler-advice-chain /&gt; only applies to the handleRequestMessage.
-	 */
-	private List<Advice> adviceChain;
-
 	private boolean producesReply = true;
-
-	private MessageChannel outputChannel;
-
-	private int order;
 
 	private long replyTimeout;
 
 	private boolean requiresReply = false;
-
-	private String componentName;
-
-	public JpaOutboundGatewayFactoryBean() {
-	}
 
 	public void setJpaExecutor(JpaExecutor jpaExecutor) {
 		this.jpaExecutor = jpaExecutor;
@@ -75,20 +55,8 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<JpaOutbou
 		this.gatewayType = gatewayType;
 	}
 
-	public void setAdviceChain(List<Advice> adviceChain) {
-		this.adviceChain = adviceChain;
-	}
-
 	public void setProducesReply(boolean producesReply) {
 		this.producesReply = producesReply;
-	}
-
-	public void setOutputChannel(MessageChannel outputChannel) {
-		this.outputChannel = outputChannel;
-	}
-
-	public void setOrder(int order) {
-		this.order = order;
 	}
 
 	/**
@@ -106,37 +74,13 @@ public class JpaOutboundGatewayFactoryBean extends AbstractFactoryBean<JpaOutbou
 		this.requiresReply = requiresReply;
 	}
 
-	/**
-	 * Sets the name of the handler component.
-	 * @param componentName The component name.
-	 */
-	public void setComponentName(String componentName) {
-		this.componentName = componentName;
-	}
-
 	@Override
-	public Class<?> getObjectType() {
-		return MessageHandler.class;
-	}
-
-	@Override
-	protected JpaOutboundGateway createInstance() {
+	protected JpaOutboundGateway createHandler() {
 		JpaOutboundGateway jpaOutboundGateway = new JpaOutboundGateway(this.jpaExecutor);
 		jpaOutboundGateway.setGatewayType(this.gatewayType);
 		jpaOutboundGateway.setProducesReply(this.producesReply);
-		jpaOutboundGateway.setOutputChannel(this.outputChannel);
-		jpaOutboundGateway.setOrder(this.order);
 		jpaOutboundGateway.setSendTimeout(this.replyTimeout);
 		jpaOutboundGateway.setRequiresReply(this.requiresReply);
-		jpaOutboundGateway.setComponentName(this.componentName);
-		if (this.adviceChain != null) {
-			jpaOutboundGateway.setAdviceChain(this.adviceChain);
-		}
-		BeanFactory beanFactory = getBeanFactory();
-		if (beanFactory != null) {
-			jpaOutboundGateway.setBeanFactory(beanFactory);
-		}
-		jpaOutboundGateway.afterPropertiesSet();
 		return jpaOutboundGateway;
 	}
 


### PR DESCRIPTION
SO: https://stackoverflow.com/questions/62190244/spring-integration-upgrade-from-5-2-x-to-5-3-problem

When the component is populated to the application context via `FactoryBean`,
all its `BeanFactory` callbacks should be propagated from that `FactoryBean` -
only lifecycle control for this component we have through its `FactoryBean`

**Cherry-pick to 5.3.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
