### PR TITLE
DeadlockLoserDataAccessException during JdbcLock.unlock #3294

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -236,14 +236,20 @@ public class JdbcLockRegistry implements ExpirableLockRegistry {
 				this.delegate.unlock();
 				return;
 			}
-			try {
-				this.mutex.delete(this.path);
-			}
-			catch (Exception e) {
-				throw new DataAccessResourceFailureException("Failed to release mutex at " + this.path, e);
-			}
-			finally {
-				this.delegate.unlock();
+			while (true) {
+				try {
+					this.mutex.delete(this.path);
+					return;
+				}
+				catch (TransientDataAccessException e) {
+					// try again
+				}
+				catch (Exception e) {
+					throw new DataAccessResourceFailureException("Failed to release mutex at " + this.path, e);
+				}
+				finally {
+					this.delegate.unlock();
+				}
 			}
 		}
 


### PR DESCRIPTION
A DeadlockLoserDataAccessException can occur during org.springframework.integration.jdbc.lock.JdbcLockRegistry$JdbcLock.unlock()

Like lock(), retry unlock() while TransientDataAccessException occurs