### PR TITLE
GH-3299: Fix client connectionId for TCP/NIO

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -142,7 +142,12 @@ public class TcpNioConnectionTests {
 		assertThat(latch.await(10000, TimeUnit.MILLISECONDS)).isTrue();
 		TcpNioClientConnectionFactory factory = new TcpNioClientConnectionFactory("localhost",
 				serverSocket.get().getLocalPort());
-		factory.setApplicationEventPublisher(nullPublisher);
+		AtomicReference<String> connectionId = new AtomicReference<>();
+		factory.setApplicationEventPublisher(event -> {
+			if (event instanceof TcpConnectionOpenEvent) {
+				connectionId.set(((TcpConnectionOpenEvent) event).getConnectionId());
+			}
+		});
 		factory.setSoTimeout(100);
 		factory.start();
 		try {
@@ -157,6 +162,7 @@ public class TcpNioConnectionTests {
 		done.countDown();
 		factory.stop();
 		serverSocket.get().close();
+		assertThat(connectionId.get()).startsWith("localhost");
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3299

Connect before creating the `TcpNioConnection` object and publishing the
`TcpConnectionOpenEvent`.

This was a regression caused by supporting connect timout; which moved
the connect to after the object was created and event published, causing
the `connectionId` to start with `unknown`.

**cherry-pick to 5.3.x, 5.2.x**

