### PR TITLE
GH-3092 Refactor FTP and SFTP outbound specs, handlers

### DIFF
--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/Ftp.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/Ftp.java
@@ -35,6 +35,7 @@ import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Deepak Gunasekaran
+ *
  * @since 5.0
  */
 public final class Ftp {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/Ftp.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/Ftp.java
@@ -111,7 +111,9 @@ public final class Ftp {
 	 * A {@link FtpMessageHandlerSpec} factory for an outbound channel adapter spec.
 	 * @param remoteFileTemplate the remote file template.
 	 * @return the spec.
+	 * @deprecated in favor of {@link #outboundAdapter(FtpRemoteFileTemplate)}
 	 */
+	@Deprecated
 	public static FtpMessageHandlerSpec outboundAdapter(RemoteFileTemplate<FTPFile> remoteFileTemplate) {
 		return new FtpMessageHandlerSpec(remoteFileTemplate);
 	}
@@ -121,11 +123,34 @@ public final class Ftp {
 	 * @param remoteFileTemplate the remote file template.
 	 * @param fileExistsMode the file exists mode.
 	 * @return the spec.
+	 * @deprecated in favor of {@link #outboundAdapter(FtpRemoteFileTemplate, FileExistsMode)}
 	 */
+	@Deprecated
 	public static FtpMessageHandlerSpec outboundAdapter(RemoteFileTemplate<FTPFile> remoteFileTemplate,
 			FileExistsMode fileExistsMode) {
 
 		return new FtpMessageHandlerSpec(remoteFileTemplate, fileExistsMode);
+	}
+
+	/**
+	 * A {@link FtpMessageHandlerSpec} factory for an outbound channel adapter spec.
+	 * @param ftpRemoteFileTemplate the remote file template.
+	 * @return the spec.
+	 */
+	public static FtpMessageHandlerSpec outboundAdapter(FtpRemoteFileTemplate ftpRemoteFileTemplate) {
+		return new FtpMessageHandlerSpec(ftpRemoteFileTemplate);
+	}
+
+	/**
+	 * A {@link FtpMessageHandlerSpec} factory for an outbound channel adapter spec.
+	 * @param ftpRemoteFileTemplate the remote file template.
+	 * @param fileExistsMode the file exists mode.
+	 * @return the spec.
+	 */
+	public static FtpMessageHandlerSpec outboundAdapter(FtpRemoteFileTemplate ftpRemoteFileTemplate,
+			FileExistsMode fileExistsMode) {
+
+		return new FtpMessageHandlerSpec(ftpRemoteFileTemplate, fileExistsMode);
 	}
 
 	/**

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/Ftp.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/Ftp.java
@@ -34,7 +34,7 @@ import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
  *
  * @author Artem Bilan
  * @author Gary Russell
- *
+ * @author Deepak Gunasekaran
  * @since 5.0
  */
 public final class Ftp {
@@ -136,6 +136,7 @@ public final class Ftp {
 	 * A {@link FtpMessageHandlerSpec} factory for an outbound channel adapter spec.
 	 * @param ftpRemoteFileTemplate the remote file template.
 	 * @return the spec.
+	 * @since 5.4
 	 */
 	public static FtpMessageHandlerSpec outboundAdapter(FtpRemoteFileTemplate ftpRemoteFileTemplate) {
 		return new FtpMessageHandlerSpec(ftpRemoteFileTemplate);
@@ -146,6 +147,7 @@ public final class Ftp {
 	 * @param ftpRemoteFileTemplate the remote file template.
 	 * @param fileExistsMode the file exists mode.
 	 * @return the spec.
+	 * @since 5.4
 	 */
 	public static FtpMessageHandlerSpec outboundAdapter(FtpRemoteFileTemplate ftpRemoteFileTemplate,
 			FileExistsMode fileExistsMode) {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/FtpMessageHandlerSpec.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/FtpMessageHandlerSpec.java
@@ -23,6 +23,7 @@ import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.ftp.outbound.FtpMessageHandler;
+import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
 
 /**
  * A {@link FileTransferringMessageHandlerSpec} for FTP.
@@ -38,12 +39,22 @@ public class FtpMessageHandlerSpec extends FileTransferringMessageHandlerSpec<FT
 		this.target = new FtpMessageHandler(sessionFactory);
 	}
 
+	@Deprecated
 	protected FtpMessageHandlerSpec(RemoteFileTemplate<FTPFile> remoteFileTemplate) {
 		this.target = new FtpMessageHandler(remoteFileTemplate.getSessionFactory());
 	}
 
+	@Deprecated
 	protected FtpMessageHandlerSpec(RemoteFileTemplate<FTPFile> remoteFileTemplate, FileExistsMode fileExistsMode) {
 		this.target = new FtpMessageHandler(remoteFileTemplate, fileExistsMode);
+	}
+
+	protected FtpMessageHandlerSpec(FtpRemoteFileTemplate ftpRemoteFileTemplate) {
+		this.target = new FtpMessageHandler(ftpRemoteFileTemplate);
+	}
+
+	protected FtpMessageHandlerSpec(FtpRemoteFileTemplate ftpRemoteFileTemplate, FileExistsMode fileExistsMode) {
+		this.target = new FtpMessageHandler(ftpRemoteFileTemplate, fileExistsMode);
 	}
 
 }

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/FtpMessageHandlerSpec.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/FtpMessageHandlerSpec.java
@@ -30,7 +30,7 @@ import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
  *
  * @author Artem Bilan
  * @author Joaquin Santana
- *
+ * @author Deepak Gunasekaran
  * @since 5.0
  */
 public class FtpMessageHandlerSpec extends FileTransferringMessageHandlerSpec<FTPFile, FtpMessageHandlerSpec> {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/FtpMessageHandlerSpec.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/FtpMessageHandlerSpec.java
@@ -31,6 +31,7 @@ import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
  * @author Artem Bilan
  * @author Joaquin Santana
  * @author Deepak Gunasekaran
+ *
  * @since 5.0
  */
 public class FtpMessageHandlerSpec extends FileTransferringMessageHandlerSpec<FTPFile, FtpMessageHandlerSpec> {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/outbound/FtpMessageHandler.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/outbound/FtpMessageHandler.java
@@ -35,6 +35,7 @@ import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
  *
  * @author Artem Bilan
  * @author Deepak Gunasekaran
+ *
  * @since 4.1.9
  * @see FtpRemoteFileTemplate
  */
@@ -52,7 +53,7 @@ public class FtpMessageHandler extends FileTransferringMessageHandler<FTPFile> {
 	/**
 	 * Constructor which sets the RemoteFileTemplate and FileExistsMode.
 	 * @param remoteFileTemplate the remote file template.
-	 * @param fileExistsMode the file exists mode.
+	 * @param mode the file exists mode.
 	 * @deprecated in favor of
 	 * {@link #FtpMessageHandler(FtpRemoteFileTemplate, FileExistsMode)}
 	 */
@@ -63,8 +64,8 @@ public class FtpMessageHandler extends FileTransferringMessageHandler<FTPFile> {
 
 	/**
 	 * Constructor which sets the FtpRemoteFileTemplate and FileExistsMode.
-	 * @param FtpRemoteFileTemplate the remote file template.
-	 * @param fileExistsMode the file exists mode.
+	 * @param ftpRemoteFileTemplate the remote file template.
+	 * @param mode the file exists mode.
 	 * @since 5.4
 	 */
 	public FtpMessageHandler(FtpRemoteFileTemplate ftpRemoteFileTemplate, FileExistsMode mode) {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/outbound/FtpMessageHandler.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/outbound/FtpMessageHandler.java
@@ -48,8 +48,13 @@ public class FtpMessageHandler extends FileTransferringMessageHandler<FTPFile> {
 		super(remoteFileTemplate);
 	}
 
+	@Deprecated
 	public FtpMessageHandler(RemoteFileTemplate<FTPFile> remoteFileTemplate, FileExistsMode mode) {
 		super(remoteFileTemplate, mode);
+	}
+
+	public FtpMessageHandler(FtpRemoteFileTemplate ftpRemoteFileTemplate, FileExistsMode mode) {
+		super(ftpRemoteFileTemplate, mode);
 	}
 
 	@Override

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/outbound/FtpMessageHandler.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/outbound/FtpMessageHandler.java
@@ -30,10 +30,11 @@ import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
 
 /**
- * The FTP specific {@link FileTransferringMessageHandler} extension.
- * Based on the {@link FtpRemoteFileTemplate}.
+ * The FTP specific {@link FileTransferringMessageHandler} extension. Based on the
+ * {@link FtpRemoteFileTemplate}.
  *
  * @author Artem Bilan
+ * @author Deepak Gunasekaran
  * @since 4.1.9
  * @see FtpRemoteFileTemplate
  */
@@ -48,11 +49,24 @@ public class FtpMessageHandler extends FileTransferringMessageHandler<FTPFile> {
 		super(remoteFileTemplate);
 	}
 
+	/**
+	 * Constructor which sets the RemoteFileTemplate and FileExistsMode.
+	 * @param remoteFileTemplate the remote file template.
+	 * @param fileExistsMode the file exists mode.
+	 * @deprecated in favor of
+	 * {@link #FtpMessageHandler(FtpRemoteFileTemplate, FileExistsMode)}
+	 */
 	@Deprecated
 	public FtpMessageHandler(RemoteFileTemplate<FTPFile> remoteFileTemplate, FileExistsMode mode) {
 		super(remoteFileTemplate, mode);
 	}
 
+	/**
+	 * Constructor which sets the FtpRemoteFileTemplate and FileExistsMode.
+	 * @param FtpRemoteFileTemplate the remote file template.
+	 * @param fileExistsMode the file exists mode.
+	 * @since 5.4
+	 */
 	public FtpMessageHandler(FtpRemoteFileTemplate ftpRemoteFileTemplate, FileExistsMode mode) {
 		super(ftpRemoteFileTemplate, mode);
 	}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
@@ -70,7 +70,7 @@ import org.springframework.util.FileCopyUtils;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Joaquin Santana
- *
+ * @author Deepak Gunasekaran
  * @since 5.0
  */
 @SpringJUnitConfig

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
@@ -71,6 +71,7 @@ import org.springframework.util.FileCopyUtils;
  * @author Gary Russell
  * @author Joaquin Santana
  * @author Deepak Gunasekaran
+ *
  * @since 5.0
  */
 @SpringJUnitConfig

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
@@ -36,6 +36,7 @@ import com.jcraft.jsch.ChannelSftp.LsEntry;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Deepak Gunasekaran
+ *
  * @since 5.0
  */
 public final class Sftp {

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
@@ -136,7 +136,8 @@ public final class Sftp {
 	/**
 	 * An {@link SftpMessageHandlerSpec} factory for an outbound channel adapter spec.
 	 * @param sftpRemoteFileTemplate the remote file template.
-     * @return the spec.
+	 * @return the spec.
+	 * @since 5.4
 	 */
 	public static SftpMessageHandlerSpec outboundAdapter(SftpRemoteFileTemplate sftpRemoteFileTemplate) {
 		return new SftpMessageHandlerSpec(sftpRemoteFileTemplate);
@@ -147,6 +148,7 @@ public final class Sftp {
 	 * @param sftpRemoteFileTemplate the remote file template.
 	 * @param fileExistsMode the file exists mode.
 	 * @return the spec.
+	 * @since 5.4
 	 */
 	public static SftpMessageHandlerSpec outboundAdapter(SftpRemoteFileTemplate sftpRemoteFileTemplate,
 			FileExistsMode fileExistsMode) {

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
@@ -35,7 +35,7 @@ import com.jcraft.jsch.ChannelSftp.LsEntry;
  *
  * @author Artem Bilan
  * @author Gary Russell
- *
+ * @author Deepak Gunasekaran
  * @since 5.0
  */
 public final class Sftp {
@@ -124,7 +124,8 @@ public final class Sftp {
 	 * @param remoteFileTemplate the remote file template.
 	 * @param fileExistsMode the file exists mode.
 	 * @return the spec.
-	 * @deprecated in favor of {@link #outboundAdapter(SftpRemoteFileTemplate,FileExistsMode)}
+	 * @deprecated in favor of
+	 * {@link #outboundAdapter(SftpRemoteFileTemplate,FileExistsMode)}
 	 */
 	@Deprecated
 	public static SftpMessageHandlerSpec outboundAdapter(RemoteFileTemplate<ChannelSftp.LsEntry> remoteFileTemplate,

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,9 @@ public final class Sftp {
 	 * An {@link SftpMessageHandlerSpec} factory for an outbound channel adapter spec.
 	 * @param remoteFileTemplate the remote file template.
 	 * @return the spec.
+	 * @deprecated in favor of {@link #outboundAdapter(SftpRemoteFileTemplate)}
 	 */
+	@Deprecated
 	public static SftpMessageHandlerSpec outboundAdapter(RemoteFileTemplate<ChannelSftp.LsEntry> remoteFileTemplate) {
 		return new SftpMessageHandlerSpec(remoteFileTemplate);
 	}
@@ -122,11 +124,34 @@ public final class Sftp {
 	 * @param remoteFileTemplate the remote file template.
 	 * @param fileExistsMode the file exists mode.
 	 * @return the spec.
+	 * @deprecated in favor of {@link #outboundAdapter(SftpRemoteFileTemplate,FileExistsMode)}
 	 */
+	@Deprecated
 	public static SftpMessageHandlerSpec outboundAdapter(RemoteFileTemplate<ChannelSftp.LsEntry> remoteFileTemplate,
 			FileExistsMode fileExistsMode) {
 
 		return new SftpMessageHandlerSpec(remoteFileTemplate, fileExistsMode);
+	}
+
+	/**
+	 * An {@link SftpMessageHandlerSpec} factory for an outbound channel adapter spec.
+	 * @param sftpRemoteFileTemplate the remote file template.
+     * @return the spec.
+	 */
+	public static SftpMessageHandlerSpec outboundAdapter(SftpRemoteFileTemplate sftpRemoteFileTemplate) {
+		return new SftpMessageHandlerSpec(sftpRemoteFileTemplate);
+	}
+
+	/**
+	 * An {@link SftpMessageHandlerSpec} factory for an outbound channel adapter spec.
+	 * @param sftpRemoteFileTemplate the remote file template.
+	 * @param fileExistsMode the file exists mode.
+	 * @return the spec.
+	 */
+	public static SftpMessageHandlerSpec outboundAdapter(SftpRemoteFileTemplate sftpRemoteFileTemplate,
+			FileExistsMode fileExistsMode) {
+
+		return new SftpMessageHandlerSpec(sftpRemoteFileTemplate, fileExistsMode);
 	}
 
 	/**

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/SftpMessageHandlerSpec.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/SftpMessageHandlerSpec.java
@@ -38,16 +38,27 @@ public class SftpMessageHandlerSpec
 		this.target = new SftpMessageHandler(sessionFactory);
 	}
 
+	@Deprecated
 	protected SftpMessageHandlerSpec(RemoteFileTemplate<ChannelSftp.LsEntry> remoteFileTemplate) {
 		this.target = new SftpMessageHandler(remoteFileTemplate.getSessionFactory());
 	}
 
+	@Deprecated
 	protected SftpMessageHandlerSpec(RemoteFileTemplate<ChannelSftp.LsEntry> remoteFileTemplate,
 			FileExistsMode fileExistsMode) {
 
 		this.target =
 				new SftpMessageHandler(new SftpRemoteFileTemplate(remoteFileTemplate.getSessionFactory()),
 						fileExistsMode);
+	}
+
+	protected SftpMessageHandlerSpec(SftpRemoteFileTemplate sftpRemoteFileTemplate) {
+		this.target = new SftpMessageHandler(sftpRemoteFileTemplate);
+	}
+
+	protected SftpMessageHandlerSpec(SftpRemoteFileTemplate sftpRemoteFileTemplate, FileExistsMode fileExistsMode) {
+
+		this.target = new SftpMessageHandler(sftpRemoteFileTemplate, fileExistsMode);
 	}
 
 }

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/SftpMessageHandlerSpec.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/SftpMessageHandlerSpec.java
@@ -29,6 +29,7 @@ import com.jcraft.jsch.ChannelSftp;
  * @author Artem Bilan
  * @author Joaquin Santana
  * @author Deepak Gunasekaran
+ *
  * @since 5.0
  */
 public class SftpMessageHandlerSpec

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/SftpMessageHandlerSpec.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/SftpMessageHandlerSpec.java
@@ -28,7 +28,7 @@ import com.jcraft.jsch.ChannelSftp;
 /**
  * @author Artem Bilan
  * @author Joaquin Santana
- *
+ * @author Deepak Gunasekaran
  * @since 5.0
  */
 public class SftpMessageHandlerSpec

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
@@ -57,6 +57,7 @@ import com.jcraft.jsch.ChannelSftp;
  * @author Gary Russell
  * @author Joaquin Santana
  * @author Deepak Gunasekaran
+ *
  * @since 5.0
  */
 @SpringJUnitConfig

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
@@ -148,6 +148,51 @@ public class SftpTests extends SftpTestSupport {
 		registration.destroy();
 	}
 
+	@Test
+	public void testSftpOutboundFlowSftpTemplate() {
+		SftpRemoteFileTemplate sftpTemplate = new SftpRemoteFileTemplate(sessionFactory());
+		IntegrationFlow flow = f -> f.handle(Sftp.outboundAdapter(sftpTemplate)
+				.useTemporaryFileName(false)
+				.fileNameExpression("headers['" + FileHeaders.FILENAME + "']")
+				.remoteDirectory("sftpTarget"));
+		IntegrationFlowRegistration registration = this.flowContext.registration(flow).register();
+		String fileName = "foo.file";
+		registration.getInputChannel().send(MessageBuilder.withPayload("foo")
+				.setHeader(FileHeaders.FILENAME, fileName)
+				.build());
+
+		ChannelSftp.LsEntry[] files = sftpTemplate.execute(session ->
+				session.list(getTargetRemoteDirectory().getName() + "/" + fileName));
+		assertThat(files.length).isEqualTo(1);
+		assertThat(files[0].getAttrs().getSize()).isEqualTo(3);
+
+		registration.destroy();
+	}
+
+	@Test
+	public void testSftpOutboundFlowSftpTemplateAndMode() {
+		SftpRemoteFileTemplate sftpTemplate = new SftpRemoteFileTemplate(sessionFactory());
+		IntegrationFlow flow = f -> f.handle(Sftp.outboundAdapter(sftpTemplate, FileExistsMode.APPEND)
+				.useTemporaryFileName(false)
+				.fileNameExpression("headers['" + FileHeaders.FILENAME + "']")
+				.remoteDirectory("sftpTarget"));
+		IntegrationFlowRegistration registration = this.flowContext.registration(flow).register();
+		String fileName = "foo.file";
+		registration.getInputChannel().send(MessageBuilder.withPayload("foo")
+				.setHeader(FileHeaders.FILENAME, fileName)
+				.build());
+		registration.getInputChannel().send(MessageBuilder.withPayload("foo")
+				.setHeader(FileHeaders.FILENAME, fileName)
+				.build());
+
+		ChannelSftp.LsEntry[] files = sftpTemplate.execute(session ->
+				session.list(getTargetRemoteDirectory().getName() + "/" + fileName));
+		assertThat(files.length).isEqualTo(1);
+		assertThat(files[0].getAttrs().getSize()).isEqualTo(6);
+
+		registration.destroy();
+	}
+
 
 	@Test
 	@DisabledOnOs(OS.WINDOWS)

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/dsl/SftpTests.java
@@ -56,9 +56,8 @@ import com.jcraft.jsch.ChannelSftp;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Joaquin Santana
- *
+ * @author Deepak Gunasekaran
  * @since 5.0
- *
  */
 @SpringJUnitConfig
 @DirtiesContext


### PR DESCRIPTION
Following are the changes,

1. Deprecated SFTP and FTP classes outboundAdapter method which takes RemoteFileTemplate. Instead created new methods in both classes which takes SftpRemoteFileTemplate and FtpRemoteFileTemplate respectively.
2. Deprecated SftpMessageHandlerSpec's constructor which takes RemoteFileTemplate and added new constructors which takes SftpRemoteFileTemplate
3. Deprecated FtpMessageHandlerSpec's constructor which takes RemoteFileTemplate and added new constructors which takes FtpRemoteFileTemplate. Deprecated FtpMessageHandler's constructor which takes RemoteFileTemplate and added new constructor with ftpRemoteFileTemplate.
4. Added new test cases in FtpTests and SftpTests


Fixes https://github.com/spring-projects/spring-integration/issues/3092