### PR TITLE
Resolve deprecations for `MulticastSocket`

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/MulticastReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/MulticastReceivingChannelAdapter.java
@@ -19,6 +19,7 @@ package org.springframework.integration.ip.udp;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
 import java.net.NetworkInterface;
 
@@ -69,12 +70,12 @@ public class MulticastReceivingChannelAdapter extends UnicastReceivingChannelAda
 			try {
 				int port = getPort();
 				MulticastSocket socket = port == 0 ? new MulticastSocket() : new MulticastSocket(port);
-				String localAddress = this.getLocalAddress();
+				String localAddress = getLocalAddress();
 				if (localAddress != null) {
-					socket.setNetworkInterface(NetworkInterface.getByName(localAddress));
+					socket.setNetworkInterface(NetworkInterface.getByInetAddress(InetAddress.getByName(localAddress)));
 				}
 				setSocketAttributes(socket);
-				socket.joinGroup(InetAddress.getByName(this.group));
+				socket.joinGroup(new InetSocketAddress(this.group, 0), null);
 				setSocket(socket);
 			}
 			catch (IOException e) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/MulticastSendingMessageHandler.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/MulticastSendingMessageHandler.java
@@ -167,7 +167,7 @@ public class MulticastSendingMessageHandler extends UnicastSendingMessageHandler
 			}
 			setSocketAttributes(socket);
 			if (this.localAddress != null) {
-				socket.setNetworkInterface(NetworkInterface.getByName(this.localAddress));
+				socket.setNetworkInterface(NetworkInterface.getByInetAddress(InetAddress.getByName(this.localAddress)));
 			}
 			this.multicastSocket = socket;
 		}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketMulticastSendingHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketMulticastSendingHandlerTests.java
@@ -30,7 +30,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -73,7 +72,7 @@ public class DatagramPacketMulticastSendingHandlerTests {
 				MulticastSocket socket1 = new MulticastSocket(testPort);
 				socket1.setNetworkInterface(multicastRule.getNic());
 				InetAddress group = InetAddress.getByName(multicastAddress);
-				socket1.joinGroup(group);
+				socket1.joinGroup(new InetSocketAddress(group, 0), null);
 				listening.countDown();
 				socket1.receive(receivedPacket);
 				socket1.close();
@@ -98,7 +97,7 @@ public class DatagramPacketMulticastSendingHandlerTests {
 		handler.setBeanFactory(mock(BeanFactory.class));
 		NetworkInterface nic = this.multicastRule.getNic();
 		if (nic != null) {
-			handler.setLocalAddress(nic.getName());
+			handler.setLocalAddress(nic.getInetAddresses().nextElement().getHostName());
 		}
 		handler.afterPropertiesSet();
 		handler.handleMessage(MessageBuilder.withPayload(payload).build());
@@ -108,7 +107,6 @@ public class DatagramPacketMulticastSendingHandlerTests {
 	}
 
 	@Test
-	@Ignore("Doesn't work on Java 14")
 	public void verifySendMulticastWithAcks() throws Exception {
 
 		MulticastSocket socket;
@@ -134,7 +132,7 @@ public class DatagramPacketMulticastSendingHandlerTests {
 				socket1.setNetworkInterface(multicastRule.getNic());
 				socket1.setSoTimeout(8000);
 				InetAddress group = InetAddress.getByName(multicastAddress);
-				socket1.joinGroup(group);
+				socket1.joinGroup(new InetSocketAddress(group, 0), null);
 				listening.countDown();
 				assertThat(ackListening.await(10, TimeUnit.SECONDS)).isTrue();
 				socket1.receive(receivedPacket);
@@ -170,7 +168,7 @@ public class DatagramPacketMulticastSendingHandlerTests {
 		assertThat(listening.await(10000, TimeUnit.MILLISECONDS)).isTrue();
 		MulticastSendingMessageHandler handler =
 				new MulticastSendingMessageHandler(multicastAddress, testPort, true, true, "localhost", 0, 10000);
-		handler.setLocalAddress(this.multicastRule.getNic().getName());
+		handler.setLocalAddress(this.multicastRule.getNic().getInetAddresses().nextElement().getHostName());
 		handler.setMinAcksForSuccess(2);
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/MulticastRule.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/MulticastRule.java
@@ -29,6 +29,7 @@ import org.junit.runners.model.Statement;
 import org.springframework.integration.ip.util.SocketTestUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.SocketUtils;
 
 /**
  * @author Artem Bilan
@@ -62,7 +63,7 @@ public class MulticastRule extends TestWatcher {
 			throw new IllegalStateException(e);
 		}
 		if (this.nic != null) {
-			System.setProperty("multicast.local.address", this.nic.getName());
+			System.setProperty("multicast.local.address", this.nic.getInetAddresses().nextElement().getHostName());
 		}
 	}
 
@@ -75,7 +76,7 @@ public class MulticastRule extends TestWatcher {
 		}
 		try {
 			MulticastSocket socket = new MulticastSocket();
-			socket.joinGroup(new InetSocketAddress(this.group, 161), nic);
+			socket.joinGroup(new InetSocketAddress(this.group, SocketUtils.findAvailableUdpPort()), nic);
 			socket.close();
 		}
 		catch (Exception e) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
@@ -254,7 +254,7 @@ public class UdpChannelAdapterTests {
 		adapter.setOutputChannel(channel);
 		NetworkInterface nic = this.multicastRule.getNic();
 		if (nic != null) {
-			adapter.setLocalAddress(nic.getName());
+			adapter.setLocalAddress(nic.getInetAddresses().nextElement().getHostName());
 		}
 		adapter.start();
 		SocketTestUtils.waitListening(adapter);
@@ -283,7 +283,7 @@ public class UdpChannelAdapterTests {
 		adapter.setOutputChannel(channel);
 		NetworkInterface nic = this.multicastRule.getNic();
 		if (nic != null) {
-			adapter.setLocalAddress(nic.getName());
+			adapter.setLocalAddress(nic.getInetAddresses().nextElement().getHostName());
 		}
 		adapter.start();
 		SocketTestUtils.waitListening(adapter);
@@ -291,7 +291,7 @@ public class UdpChannelAdapterTests {
 		MulticastSendingMessageHandler handler =
 				new MulticastSendingMessageHandler(this.multicastRule.getGroup(), adapter.getPort());
 		if (nic != null) {
-			handler.setLocalAddress(nic.getName());
+			handler.setLocalAddress(nic.getInetAddresses().nextElement().getHostName());
 		}
 		Message<byte[]> message = MessageBuilder.withPayload("ABCD".getBytes()).build();
 		handler.handleMessage(message);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpMulticastEndToEndTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpMulticastEndToEndTests.java
@@ -53,6 +53,7 @@ import org.springframework.messaging.support.GenericMessage;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class UdpMulticastEndToEndTests implements Runnable {
@@ -100,7 +101,7 @@ public class UdpMulticastEndToEndTests implements Runnable {
 		StandardEnvironment env = new StandardEnvironment();
 		Properties props = new Properties();
 		props.setProperty("port", Integer.toString(launcher.getReceiverPort()));
-		PropertiesPropertySource pps = new PropertiesPropertySource("ftpprops", props);
+		PropertiesPropertySource pps = new PropertiesPropertySource("udpprops", props);
 		env.getPropertySources().addLast(pps);
 		applicationContext.setEnvironment(env);
 		applicationContext.refresh();
@@ -116,7 +117,7 @@ public class UdpMulticastEndToEndTests implements Runnable {
 		String testingIpText;
 		try {
 			testingIpText = ">>>>>>> Testing IP (multicast) " + new Date();
-			inputChannel.send(new GenericMessage<String>(testingIpText));
+			inputChannel.send(new GenericMessage<>(testingIpText));
 			sentFirst.countDown();
 			try {
 				Thread.sleep(hangAroundFor); // give some time for console interaction

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/util/SocketTestUtils.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/util/SocketTestUtils.java
@@ -355,11 +355,20 @@ public class SocketTestUtils {
 		Enumeration<NetworkInterface> interfaces = NetworkInterface.getNetworkInterfaces();
 		while (interfaces.hasMoreElements()) {
 			NetworkInterface networkInterface = interfaces.nextElement();
-			if (!networkInterface.isLoopback()
-					&& (!multicast || networkInterface.supportsMulticast())
-					&& !networkInterface.getName().contains("vboxnet")
-					&& networkInterface.getInetAddresses().hasMoreElements()) {
-				return networkInterface;
+			if ((!multicast || networkInterface.supportsMulticast())
+					&& !networkInterface.getName().contains("vboxnet")) {
+
+				Enumeration<InetAddress> addressesFromNetworkInterface = networkInterface.getInetAddresses();
+				while (addressesFromNetworkInterface.hasMoreElements()) {
+					InetAddress inetAddress = addressesFromNetworkInterface.nextElement();
+					if (inetAddress.isSiteLocalAddress()
+							&& !inetAddress.isAnyLocalAddress()
+							&& !inetAddress.isLinkLocalAddress()
+							&& !inetAddress.isLoopbackAddress()) {
+
+						return networkInterface;
+					}
+				}
 			}
 		}
 		return null;


### PR DESCRIPTION
* Use new `joinGroup(SocketAddress, NetworkInterface)` API
* Resolve `NetworkInterface` in UDP components as
`getByInetAddress(InetAddress.getByName(localAddress))`
* join group as `socket.joinGroup(new InetSocketAddress(this.group, 0), null);`
* Fix `SocketTestUtils.chooseANic()` to select a real `NetworkInterface`
bound to a real IP address
* Fix `MulticastRule` to populate a `multicast.local.address` against a
host name for the network interface not an interface logical name

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
