### PR TITLE
Fix XMPP documentation: s/Enhancement Proposal/Extension Protocol/

### DIFF
--- a/src/reference/asciidoc/xmpp.adoc
+++ b/src/reference/asciidoc/xmpp.adoc
@@ -373,7 +373,7 @@ However, you may need to do more than the basics.
 For example, you might need to include formatting (bold, italic, and so on) in a message, which is not defined in the core XMPP specification.
 Well, you can make up a way to do that, but, unless everyone else does it the same way you do, no other software can interpret it (they ignore namespaces they cannot understand).
 
-To solve that problem, the XMPP Standards Foundation (XSF) publishes a series of extra documents, known as https://xmpp.org/extensions/xep-0001.html[XMPP Enhancement Proposals] (XEPs).
+To solve that problem, the XMPP Standards Foundation (XSF) publishes a series of extra documents, known as https://xmpp.org/extensions/xep-0001.html[XMPP Extension Protocols] (XEPs).
 In general, each XEP describes a particular activity (from message formatting to file transfers, multi-user chats, and many more).
 They also provide a standard format for everyone to use for that activity.
 


### PR DESCRIPTION
XMPP XEPs are extension protocols of XMPP "core" (i.e., RFC 6120 and
RFC 6121).

See also https://xmpp.org/extensions/xep-0001.html:
"The focal point of the process is a series of protocol specifications
called XMPP Extension Protocols or XEPs."

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
