### PR TITLE
[WIP][INT-4566 ]-Implement Inbound channel adapter for spring data r2dbc 

### DIFF
--- a/spring-integration-r2dbc/src/main/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSource.java
+++ b/spring-integration-r2dbc/src/main/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSource.java
@@ -157,29 +157,29 @@ public class R2dbcMessageSource extends AbstractMessageSource<Publisher<?>> {
 		return queryMono.flatMapMany(this::select);
 	}
 
-	private Mono<?> selectOne(Object queryMono) {
-		String query = evaluateQueryObject(queryMono);
+	private Mono<?> selectOne(Object queryObject) {
+		String queryString = evaluateQueryObject(queryObject);
 		return this.databaseClient
-				.execute(query)
+				.execute(queryString)
 				.as(this.payloadType)
 				.fetch()
 				.one();
 	}
 
-	private Flux<?> select(Object queryMono) {
-		String query = evaluateQueryObject(queryMono);
+	private Flux<?> select(Object queryObject) {
+		String queryString = evaluateQueryObject(queryObject);
 		return this.databaseClient
-				.execute(query)
+				.execute(queryString)
 				.as(this.payloadType)
 				.fetch()
 				.all();
 	}
 
-	private String evaluateQueryObject(Object query) {
-		if (query instanceof String) {
-			return (String) query;
+	private String evaluateQueryObject(Object queryObject) {
+		if (queryObject instanceof String) {
+			return (String) queryObject;
 		}
 		throw new IllegalStateException("'queryExpression' must evaluate to String " +
-				"or org.springframework.data.relational.core.query.Query, but not: " + query);
+				"or org.springframework.data.relational.core.query.Query, but not: " + queryObject);
 	}
 }

--- a/spring-integration-r2dbc/src/main/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSource.java
+++ b/spring-integration-r2dbc/src/main/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSource.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.r2dbc.inbound;
+
+import org.reactivestreams.Publisher;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.data.r2dbc.core.R2dbcEntityOperations;
+import org.springframework.data.relational.core.query.Query;
+import org.springframework.expression.Expression;
+import org.springframework.expression.TypeLocator;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.expression.spel.support.StandardTypeLocator;
+import org.springframework.integration.endpoint.AbstractMessageSource;
+import org.springframework.integration.expression.ExpressionUtils;
+import org.springframework.integration.expression.ValueExpression;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * An instance of {@link org.springframework.integration.core.MessageSource} which returns
+ * a {@link org.springframework.messaging.Message} with a payload which is the result of
+ * execution of a {@link Query}. When {@code expectSingleResult} is false (default), the R2dbc
+ * {@link Query} is executed using {@link R2dbcEntityOperations#select(Query, Class)} method which
+ * returns a {@link reactor.core.publisher.Flux}.
+ * The returned {@link reactor.core.publisher.Flux} will be used as the payload of the
+ * {@link org.springframework.messaging.Message} returned by the {@link #receive()}
+ * method.
+ * <p>
+ * When {@code expectSingleResult} is true, the {@link R2dbcEntityOperations#selectOne(Query, Class)} is
+ * used instead, and the message payload will be a {@link reactor.core.publisher.Mono}
+ * for the single object returned from the query.
+ *
+ * @author Rohan Mukesh
+ *
+ * @since 5.4
+ *
+ */
+public class R2dbcMessageSource extends AbstractMessageSource<Publisher<?>>
+		implements ApplicationContextAware {
+
+	private Expression queryExpression;
+
+	private StandardEvaluationContext evaluationContext;
+
+	@Nullable
+	private R2dbcEntityOperations r2dbcEntityOperations;
+
+	private Class<?> entityClass;
+
+	private boolean expectSingleResult = false;
+
+	private ApplicationContext applicationContext;
+
+	private volatile boolean initialized = false;
+
+	/**
+	 * Create an instance with the provided {@link R2dbcEntityOperations} and SpEL expression
+	 * which should resolve to a Relational 'query' string.
+	 * It assumes that the {@link R2dbcEntityOperations} is fully initialized and ready to be used.
+	 * The 'queryExpression' will be evaluated on every call to the {@link #receive()} method.
+	 *
+	 * @param r2dbcEntityOperations The reactive r2dbc template.
+	 */
+	public R2dbcMessageSource(R2dbcEntityOperations r2dbcEntityOperations) {
+		Assert.notNull(r2dbcEntityOperations, "'r2dbcEntityOperations' must not be null");
+		this.r2dbcEntityOperations = r2dbcEntityOperations;
+
+	}
+
+	/**
+	 * Allow you to set query String
+	 *{@link org.springframework.data.r2dbc.core.DatabaseClient#execute(String)}
+	 *
+	 * @param query The reactive r2dbc template.
+	 */
+	public void setQuery(String query) {
+		setQueryExpression(new ValueExpression<>(query));
+	}
+
+	public void setQueryExpression(Expression queryExpression) {
+		Assert.notNull(queryExpression, "'queryExpression' must not be null");
+		this.queryExpression = queryExpression;
+	}
+
+	/**
+	 * Allow you to set the type of the entityClass that will be passed to the
+	 * {@link R2dbcEntityOperations#select(Query, Class)} or {@link R2dbcEntityOperations#selectOne(Query, Class)}
+	 * method.
+	 *
+	 * @param entityClass The entity class.
+	 */
+	public void setEntityClass(Class<?> entityClass) {
+		Assert.notNull(entityClass, "'entityClass' must not be null");
+		this.entityClass = entityClass;
+	}
+
+	/**
+	 * Allow you to manage which find* method to invoke on {@link R2dbcEntityOperations}.
+	 * Default is 'false', which means the {@link #receive()} method will use
+	 * the {@link R2dbcEntityOperations#select(Query, Class)} method. If set to 'true',
+	 * {@link #receive()} will use {@link R2dbcEntityOperations#selectOne(Query, Class)},
+	 * and the payload of the returned {@link org.springframework.messaging.Message}
+	 * will be the returned target Object of type
+	 * identified by {@link #entityClass} instead of a List.
+	 *
+	 * @param expectSingleResult true if a single result is expected.
+	 */
+	public void setExpectSingleResult(boolean expectSingleResult) {
+		this.expectSingleResult = expectSingleResult;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "r2dbc:reactive-inbound-channel-adapter";
+	}
+
+	@Override
+	protected void onInit() {
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+		TypeLocator typeLocator = this.evaluationContext.getTypeLocator();
+		if (typeLocator instanceof StandardTypeLocator) {
+			/*
+			 * Register the R2dbc Query DSL package so they don't need a FQCN for QueryBuilder, for example.
+			 */
+			((StandardTypeLocator) typeLocator).registerImport("org.springframework.data.relational.core.query");
+		}
+		this.initialized = true;
+	}
+
+	/**
+	 * Execute a {@link Query} returning its results as the Message payload.
+	 * The payload can be either {@link reactor.core.publisher.Flux} or
+	 * {@link reactor.core.publisher.Mono} of objects of type identified by {@link #entityClass},
+	 * or a single element of type identified by {@link #entityClass}
+	 * based on the value of {@link #expectSingleResult} attribute which defaults to 'false' resulting
+	 * {@link org.springframework.messaging.Message} with payload of type
+	 * {@link reactor.core.publisher.Flux}. The collection name used in the
+	 */
+	@Override
+	public Object doReceive() {
+		Assert.isTrue(this.initialized, "This class is not yet initialized. Invoke its afterPropertiesSet() method");
+		Assert.notNull(this.queryExpression, "'queryExpression' must not be null");
+		Object value = this.queryExpression.getValue(this.evaluationContext);
+		Object result;
+		if (value instanceof Query) {
+			result = executeQuery(((Query) value));
+		}
+		else if (value instanceof String) {
+			result = executeQuery((String) value);
+		}
+		else {
+			throw new IllegalStateException("'queryExpression' must evaluate to String " +
+					"or org.springframework.data.relational.core.query.Query, but not: " + value);
+		}
+		return getMessageBuilderFactory()
+				.withPayload(result);
+	}
+
+	private Object executeQuery(String queryString) {
+		Object result;
+		if (this.expectSingleResult) {
+			result = this.r2dbcEntityOperations.getDatabaseClient()
+					.execute(queryString)
+					.as(this.entityClass)
+					.fetch()
+					.one();
+		}
+		else {
+			result = this.r2dbcEntityOperations.getDatabaseClient()
+					.execute(queryString)
+					.as(this.entityClass)
+					.fetch()
+					.all();
+		}
+		return result;
+	}
+
+	private Object executeQuery(Query query) {
+		Object result;
+		if (this.expectSingleResult) {
+			result = this.r2dbcEntityOperations.selectOne(query, this.entityClass);
+		}
+		else {
+			result = this.r2dbcEntityOperations.select(query, this.entityClass);
+		}
+		return result;
+	}
+
+
+}

--- a/spring-integration-r2dbc/src/main/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSource.java
+++ b/spring-integration-r2dbc/src/main/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSource.java
@@ -73,7 +73,7 @@ public class R2dbcMessageSource extends AbstractMessageSource<Publisher<?>> {
 	 * It assumes that the {@link DatabaseClient} is fully initialized and ready to be used.
 	 * The 'query' will be evaluated on every call to the {@link #receive()} method.
 	 *
-	 * @param databaseClient The reactive r2dbc template.
+	 * @param databaseClient The reactive database client for performing database calls.
 	 * @param query          The query String.
 	 */
 	public R2dbcMessageSource(DatabaseClient databaseClient, String query) {
@@ -81,12 +81,12 @@ public class R2dbcMessageSource extends AbstractMessageSource<Publisher<?>> {
 	}
 
 	/**
-	 * Create an instance with the provided {@link R2dbcEntityOperations} and SpEL expression
+	 * Create an instance with the provided {@link DatabaseClient} and SpEL expression
 	 * which should resolve to a Relational 'query' string.
-	 * It assumes that the {@link R2dbcEntityOperations} is fully initialized and ready to be used.
+	 * It assumes that the {@link DatabaseClient} is fully initialized and ready to be used.
 	 * The 'queryExpression' will be evaluated on every call to the {@link #receive()} method.
 	 *
-	 * @param databaseClient  The reactive r2dbc template.
+	 * @param databaseClient  The reactive for performing database calls.
 	 * @param queryExpression The query expression.
 	 */
 	public R2dbcMessageSource(DatabaseClient databaseClient, Expression queryExpression) {

--- a/spring-integration-r2dbc/src/main/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSource.java
+++ b/spring-integration-r2dbc/src/main/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSource.java
@@ -68,7 +68,6 @@ public class R2dbcMessageSource extends AbstractMessageSource<Publisher<?>> {
 	 * which should resolve to a Relational 'query' string.
 	 * It assumes that the {@link R2dbcEntityOperations} is fully initialized and ready to be used.
 	 * The 'query' will be evaluated on every call to the {@link #receive()} method.
-	 *
 	 * @param r2dbcEntityOperations The reactive r2dbc template.
 	 * @param query                 The query String.
 	 */
@@ -81,7 +80,6 @@ public class R2dbcMessageSource extends AbstractMessageSource<Publisher<?>> {
 	 * which should resolve to a Relational 'query' string.
 	 * It assumes that the {@link R2dbcEntityOperations} is fully initialized and ready to be used.
 	 * The 'queryExpression' will be evaluated on every call to the {@link #receive()} method.
-	 *
 	 * @param r2dbcEntityOperations The reactive r2dbc template.
 	 * @param queryExpression       The query expression.
 	 */
@@ -96,7 +94,6 @@ public class R2dbcMessageSource extends AbstractMessageSource<Publisher<?>> {
 	 * Provide a way to set the type of the entityClass that will be passed to the
 	 * {@link org.springframework.data.r2dbc.core.DatabaseClient#execute(String)}
 	 * method.
-	 *
 	 * @param payloadType The t class.
 	 */
 	public void setPayloadType(Class<?> payloadType) {
@@ -112,7 +109,6 @@ public class R2dbcMessageSource extends AbstractMessageSource<Publisher<?>> {
 	 * and will fetch one and the payload of the returned {@link org.springframework.messaging.Message}
 	 * will be the returned target Object of type
 	 * identified by {@link #payloadType} instead of a List.
-	 *
 	 * @param expectSingleResult true if a single result is expected.
 	 */
 	public void setExpectSingleResult(boolean expectSingleResult) {

--- a/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/config/R2dbcDatabaseConfiguration.java
+++ b/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/config/R2dbcDatabaseConfiguration.java
@@ -17,21 +17,11 @@
 package org.springframework.integration.r2dbc.config;
 
 
-import static org.mockito.Mockito.mock;
-
-import org.mockito.Answers;
-
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
 import org.springframework.data.r2dbc.core.DatabaseClient;
-import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
 import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
-import org.springframework.integration.r2dbc.entity.Person;
-import org.springframework.integration.r2dbc.inbound.R2dbcMessageSource;
-import org.springframework.integration.r2dbc.outbound.R2dbcMessageHandler;
 
 import io.r2dbc.h2.H2ConnectionConfiguration;
 import io.r2dbc.h2.H2ConnectionFactory;
@@ -44,7 +34,7 @@ import io.r2dbc.spi.ConnectionFactory;
  */
 @Configuration
 @EnableR2dbcRepositories(basePackages = "org.springframework.integration.r2dbc.repository")
-public class R2dbcIntegrationTestConfiguration extends AbstractR2dbcConfiguration {
+public class R2dbcDatabaseConfiguration extends AbstractR2dbcConfiguration {
 
 	@Bean
 	@Override
@@ -65,23 +55,4 @@ public class R2dbcIntegrationTestConfiguration extends AbstractR2dbcConfiguratio
 	public DatabaseClient databaseClient(ConnectionFactory connectionFactory) {
 		return DatabaseClient.create(connectionFactory);
 	}
-
-	@Bean
-	public R2dbcMessageHandler r2dbcMessageHandler(DatabaseClient databaseClient) {
-		R2dbcMessageHandler r2dbcMessageHandler = new R2dbcMessageHandler(new R2dbcEntityTemplate(databaseClient));
-		r2dbcMessageHandler.setBeanFactory(mock(BeanFactory.class));
-		r2dbcMessageHandler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
-		r2dbcMessageHandler.afterPropertiesSet();
-		return r2dbcMessageHandler;
-	}
-
-	@Bean
-	public R2dbcMessageSource r2dbcMessageSource(DatabaseClient databaseClient) {
-		R2dbcMessageSource r2dbcMessageSource = new R2dbcMessageSource(databaseClient, "");
-		r2dbcMessageSource.setBeanFactory(mock(BeanFactory.class));
-		r2dbcMessageSource.afterPropertiesSet();
-		r2dbcMessageSource.setPayloadType(Person.class);
-		return r2dbcMessageSource;
-	}
-
 }

--- a/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/config/R2dbcIntegrationTestConfiguration.java
+++ b/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/config/R2dbcIntegrationTestConfiguration.java
@@ -16,10 +16,22 @@
 
 package org.springframework.integration.r2dbc.config;
 
+
+import static org.mockito.Mockito.mock;
+
+import org.mockito.Answers;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
+import org.springframework.data.r2dbc.core.DatabaseClient;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
 import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+import org.springframework.integration.r2dbc.entity.Person;
+import org.springframework.integration.r2dbc.inbound.R2dbcMessageSource;
+import org.springframework.integration.r2dbc.outbound.R2dbcMessageHandler;
 
 import io.r2dbc.h2.H2ConnectionConfiguration;
 import io.r2dbc.h2.H2ConnectionFactory;
@@ -48,4 +60,28 @@ public class R2dbcIntegrationTestConfiguration extends AbstractR2dbcConfiguratio
 				.password("")
 				.option("DB_CLOSE_DELAY=-1").build());
 	}
+
+	@Bean
+	public DatabaseClient databaseClient(ConnectionFactory connectionFactory) {
+		return DatabaseClient.create(connectionFactory);
+	}
+
+	@Bean
+	public R2dbcMessageHandler r2dbcMessageHandler(DatabaseClient databaseClient) {
+		R2dbcMessageHandler r2dbcMessageHandler = new R2dbcMessageHandler(new R2dbcEntityTemplate(databaseClient));
+		r2dbcMessageHandler.setBeanFactory(mock(BeanFactory.class));
+		r2dbcMessageHandler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
+		r2dbcMessageHandler.afterPropertiesSet();
+		return r2dbcMessageHandler;
+	}
+
+	@Bean
+	public R2dbcMessageSource r2dbcMessageSource(DatabaseClient databaseClient) {
+		R2dbcMessageSource r2dbcMessageSource = new R2dbcMessageSource(databaseClient, "");
+		r2dbcMessageSource.setBeanFactory(mock(BeanFactory.class));
+		r2dbcMessageSource.afterPropertiesSet();
+		r2dbcMessageSource.setPayloadType(Person.class);
+		return r2dbcMessageSource;
+	}
+
 }

--- a/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/config/R2dbcIntegrationTestConfiguration.java
+++ b/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/config/R2dbcIntegrationTestConfiguration.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.r2dbc.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+
+import io.r2dbc.h2.H2ConnectionConfiguration;
+import io.r2dbc.h2.H2ConnectionFactory;
+import io.r2dbc.spi.ConnectionFactory;
+
+/**
+ *  @author Rohan Mukesh
+ *
+ *  @since 5.4
+ */
+@Configuration
+@EnableR2dbcRepositories(basePackages = "org.springframework.integration.r2dbc.repository")
+public class R2dbcIntegrationTestConfiguration extends AbstractR2dbcConfiguration {
+
+	@Bean
+	@Override
+	public ConnectionFactory connectionFactory() {
+		return createConnectionFactory();
+	}
+
+	public static ConnectionFactory createConnectionFactory() {
+
+		return new H2ConnectionFactory(H2ConnectionConfiguration.builder()
+				.inMemory("r2dbc")
+				.username("sa")
+				.password("")
+				.option("DB_CLOSE_DELAY=-1").build());
+	}
+}

--- a/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/entity/Person.java
+++ b/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/entity/Person.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.r2dbc.entity;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+/**
+ *  @author Rohan Mukesh
+ *
+ *  @since 5.4
+ */
+@Table
+public class Person {
+
+	@Id
+	private Integer id;
+
+	private String name;
+
+	private Integer age;
+
+	public void setId(Integer id) {
+		this.id = id;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setAge(Integer age) {
+		this.age = age;
+	}
+
+	public Person(String name, Integer age) {
+		this.name = name;
+		this.age = age;
+	}
+
+	public Integer getId() {
+		return this.id;
+	}
+
+	public String getName() {
+		return this.name;
+	}
+
+	public Integer getAge() {
+		return this.age;
+	}
+
+}

--- a/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSourceTests.java
+++ b/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSourceTests.java
@@ -144,7 +144,7 @@ public class R2dbcMessageSourceTests {
 		@Autowired
 		DatabaseClient databaseClient;
 
-		@Bean(name = "r2dbcMessageSourceSelectOne")
+		@Bean
 		public R2dbcMessageSource r2dbcMessageSourceSelectOne() {
 			R2dbcMessageSource r2dbcMessageSource = new R2dbcMessageSource(databaseClient, "select * from person Where id" +
 					" = 1");
@@ -152,14 +152,14 @@ public class R2dbcMessageSourceTests {
 			return r2dbcMessageSource;
 		}
 
-		@Bean(name = "r2dbcMessageSourceSelectMany")
+		@Bean
 		public R2dbcMessageSource r2dbcMessageSourceSelectMany() {
 			R2dbcMessageSource r2dbcMessageSource = new R2dbcMessageSource(databaseClient, "select * from person");
 			r2dbcMessageSource.setPayloadType(Person.class);
 			return r2dbcMessageSource;
 		}
 
-		@Bean(name = "r2dbcMessageSourceError")
+		@Bean
 		public R2dbcMessageSource r2dbcMessageSourceError() {
 			R2dbcMessageSource r2dbcMessageSource = new R2dbcMessageSource(databaseClient, new ValueExpression<>(new Object()));
 			r2dbcMessageSource.setPayloadType(Person.class);

--- a/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSourceTests.java
+++ b/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/inbound/R2dbcMessageSourceTests.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.r2dbc.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
+import org.springframework.data.r2dbc.BadSqlGrammarException;
+import org.springframework.data.r2dbc.core.DatabaseClient;
+import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
+import org.springframework.data.relational.core.query.Criteria;
+import org.springframework.data.relational.core.query.Query;
+import org.springframework.integration.expression.FunctionExpression;
+import org.springframework.integration.expression.ValueExpression;
+import org.springframework.integration.r2dbc.config.R2dbcIntegrationTestConfiguration;
+import org.springframework.integration.r2dbc.entity.Person;
+import org.springframework.integration.r2dbc.outbound.R2dbcMessageHandler;
+import org.springframework.integration.r2dbc.repository.PersonRepository;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import io.r2dbc.h2.H2ConnectionFactory;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Hooks;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+
+/**
+ *  @author Rohan Mukesh
+ *
+ *  @since 5.4
+ */
+@SpringJUnitConfig (R2dbcIntegrationTestConfiguration.class)
+public class R2dbcMessageSourceTests {
+
+	@Autowired
+	DatabaseClient client;
+
+	@Autowired
+	H2ConnectionFactory factory;
+
+	R2dbcEntityTemplate entityTemplate;
+
+	@Autowired
+	PersonRepository personRepository;
+
+	@BeforeEach
+	public void setup() {
+		entityTemplate = new R2dbcEntityTemplate(client);
+		Hooks.onOperatorDebug();
+
+		List<String> statements = Arrays.asList(
+				"DROP TABLE IF EXISTS person;",
+				"CREATE table person (id INT AUTO_INCREMENT NOT NULL, name VARCHAR2, age INT NOT NULL);");
+
+		statements.forEach(it -> client.execute(it)
+				.fetch()
+				.rowsUpdated()
+				.as(StepVerifier::create)
+				.expectNextCount(1)
+				.verifyComplete());
+
+	}
+
+	@Test
+	public void validateSuccessfulQueryWithSingleElementFluxOfQueryObject() {
+		R2dbcMessageHandler handler = new R2dbcMessageHandler(this.entityTemplate);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
+		handler.afterPropertiesSet();
+		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob", 35)).build();
+		waitFor(handler.handleMessage(message));
+
+		R2dbcMessageSource messageSource = new R2dbcMessageSource(this.entityTemplate);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
+		messageSource.afterPropertiesSet();
+		messageSource.setEntityClass(Person.class);
+		messageSource.setQueryExpression(new FunctionExpression<>((m) -> Query.query(Criteria.where("id").is(1))));
+		StepVerifier.create((Flux<Person>) messageSource.receive().getPayload())
+				.assertNext(person -> assertThat(person.getName()).isEqualTo("Bob"))
+				.verifyComplete();
+	}
+
+	@Test
+	public void validateSuccessfulQueryWithMultipleElementFluxOfQueryObject() {
+		R2dbcMessageHandler handler = new R2dbcMessageHandler(this.entityTemplate);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
+		handler.afterPropertiesSet();
+		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob", 35)).build();
+		waitFor(handler.handleMessage(message));
+
+		message = MessageBuilder.withPayload(this.createPerson("Tom", 40)).build();
+		waitFor(handler.handleMessage(message));
+
+		R2dbcMessageSource messageSource = new R2dbcMessageSource(this.entityTemplate);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
+		messageSource.afterPropertiesSet();
+		messageSource.setEntityClass(Person.class);
+		messageSource.setQueryExpression(new FunctionExpression<>((m) -> Query.empty()));
+		StepVerifier.create((Flux<Person>) messageSource.receive().getPayload())
+				.assertNext(person -> assertThat(person.getName()).isEqualTo("Bob"))
+				.assertNext(person -> assertThat(person.getName()).isEqualTo("Tom"))
+				.verifyComplete();
+	}
+
+	@Test
+	public void validateSuccessfulQueryWithSingleElementFluxOfStringObject() {
+		R2dbcMessageHandler handler = new R2dbcMessageHandler(this.entityTemplate);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
+		handler.afterPropertiesSet();
+		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob", 35)).build();
+		waitFor(handler.handleMessage(message));
+
+		R2dbcMessageSource messageSource = new R2dbcMessageSource(this.entityTemplate);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
+		messageSource.afterPropertiesSet();
+		messageSource.setEntityClass(Person.class);
+		messageSource.setQueryExpression(new FunctionExpression<>((m) -> "select * from Person Where id=1"));
+		StepVerifier.create((Flux<Person>) messageSource.receive().getPayload())
+				.assertNext(person -> assertThat(person.getName()).isEqualTo("Bob"))
+				.verifyComplete();
+
+	}
+
+	@Test
+	public void validateSuccessfulQueryWithMultipleElementFluxOfStringObject() {
+		R2dbcMessageHandler handler = new R2dbcMessageHandler(this.entityTemplate);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
+		handler.afterPropertiesSet();
+		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob", 35)).build();
+		waitFor(handler.handleMessage(message));
+
+		message = MessageBuilder.withPayload(this.createPerson("Tom", 40)).build();
+		waitFor(handler.handleMessage(message));
+
+		R2dbcMessageSource messageSource = new R2dbcMessageSource(this.entityTemplate);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
+		messageSource.afterPropertiesSet();
+		messageSource.setEntityClass(Person.class);
+		messageSource.setQueryExpression(new FunctionExpression<>((m) -> "select * from Person"));
+		StepVerifier.create((Flux<Person>) messageSource.receive().getPayload())
+				.assertNext(person -> assertThat(person.getName()).isEqualTo("Bob"))
+				.assertNext(person -> assertThat(person.getName()).isEqualTo("Tom"))
+				.verifyComplete();
+
+	}
+
+	@Test
+	public void validateSuccessfulQueryWithOneExpectedElement() {
+		R2dbcMessageHandler handler = new R2dbcMessageHandler(this.entityTemplate);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
+		handler.afterPropertiesSet();
+		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob", 35)).build();
+		waitFor(handler.handleMessage(message));
+
+		message = MessageBuilder.withPayload(this.createPerson("Tom", 40)).build();
+		waitFor(handler.handleMessage(message));
+
+		R2dbcMessageSource messageSource = new R2dbcMessageSource(this.entityTemplate);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
+		messageSource.afterPropertiesSet();
+		messageSource.setEntityClass(Person.class);
+		messageSource.setExpectSingleResult(true);
+		messageSource.setQueryExpression(new FunctionExpression<>((m) -> "select * from Person where id=1"));
+		StepVerifier.create((Mono<Person>) messageSource.receive().getPayload())
+				.assertNext(person -> assertThat(person.getName()).isEqualTo("Bob"))
+				.verifyComplete();
+
+	}
+
+	@Test
+	public void validateExceptionQueryWithOneExpectedElement() {
+		R2dbcMessageHandler handler = new R2dbcMessageHandler(this.entityTemplate);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
+		handler.afterPropertiesSet();
+		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob", 35)).build();
+		waitFor(handler.handleMessage(message));
+
+		message = MessageBuilder.withPayload(this.createPerson("Tom", 40)).build();
+		waitFor(handler.handleMessage(message));
+
+		R2dbcMessageSource messageSource = new R2dbcMessageSource(this.entityTemplate);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
+		messageSource.afterPropertiesSet();
+		messageSource.setEntityClass(Person.class);
+		messageSource.setExpectSingleResult(true);
+		messageSource.setQueryExpression(new FunctionExpression<>((m) -> "select * from Person"));
+		StepVerifier.create((Mono<Person>) messageSource.receive().getPayload())
+				.expectErrorMatches(throwable -> throwable instanceof IncorrectResultSizeDataAccessException)
+				.verify();
+	}
+
+	@Test
+	public void testBadQueryExpression() {
+		R2dbcMessageHandler handler = new R2dbcMessageHandler(this.entityTemplate);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
+		handler.afterPropertiesSet();
+		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob", 35)).build();
+		waitFor(handler.handleMessage(message));
+
+		message = MessageBuilder.withPayload(this.createPerson("Tom", 40)).build();
+		waitFor(handler.handleMessage(message));
+
+		R2dbcMessageSource messageSource = new R2dbcMessageSource(this.entityTemplate);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
+		messageSource.afterPropertiesSet();
+		messageSource.setEntityClass(Person.class);
+		messageSource.setExpectSingleResult(true);
+		messageSource.setQueryExpression(new ValueExpression("Incorrect"));
+		StepVerifier.create((Mono<Person>) messageSource.receive().getPayload())
+				.expectErrorMatches(throwable -> throwable instanceof BadSqlGrammarException)
+				.verify();
+	}
+
+	@Test
+	public void testAnyOtherObjectQueryExpression() {
+		R2dbcMessageHandler handler = new R2dbcMessageHandler(this.entityTemplate);
+		handler.setBeanFactory(mock(BeanFactory.class));
+		handler.setApplicationContext(mock(ApplicationContext.class, Answers.RETURNS_MOCKS));
+		handler.afterPropertiesSet();
+		Message<Person> message = MessageBuilder.withPayload(this.createPerson("Bob", 35)).build();
+		waitFor(handler.handleMessage(message));
+
+		message = MessageBuilder.withPayload(this.createPerson("Tom", 40)).build();
+		waitFor(handler.handleMessage(message));
+
+		R2dbcMessageSource messageSource = new R2dbcMessageSource(this.entityTemplate);
+		messageSource.setBeanFactory(mock(BeanFactory.class));
+		messageSource.afterPropertiesSet();
+		messageSource.setEntityClass(Person.class);
+		messageSource.setExpectSingleResult(true);
+		messageSource.setQueryExpression(new ValueExpression(new Object()));
+
+		Assertions.assertThrows(IllegalStateException.class, () -> messageSource.receive().getPayload());
+	}
+
+	private Person createPerson(String bob, Integer age) {
+		return new Person(bob, age);
+	}
+
+	private static <T> T waitFor(Mono<T> mono) {
+		return mono.block(Duration.ofSeconds(10));
+	}
+
+}

--- a/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/outbound/R2dbcMessageHandlerTests.java
+++ b/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/outbound/R2dbcMessageHandlerTests.java
@@ -41,6 +41,7 @@ import org.springframework.integration.r2dbc.entity.Person;
 import org.springframework.integration.r2dbc.repository.PersonRepository;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import reactor.core.publisher.Flux;
@@ -54,6 +55,7 @@ import reactor.test.StepVerifier;
  * @since 5.4
  */
 @SpringJUnitConfig
+@DirtiesContext
 public class R2dbcMessageHandlerTests {
 
 	@Autowired
@@ -288,7 +290,7 @@ public class R2dbcMessageHandlerTests {
 		@Autowired
 		DatabaseClient databaseClient;
 
-		@Bean(name = "r2dbcMessageHandler")
+		@Bean
 		public R2dbcMessageHandler r2dbcMessageHandler() {
 			R2dbcMessageHandler r2dbcMessageHandler = new R2dbcMessageHandler(new R2dbcEntityTemplate(databaseClient));
 			return r2dbcMessageHandler;

--- a/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/outbound/R2dbcMessageHandlerTests.java
+++ b/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/outbound/R2dbcMessageHandlerTests.java
@@ -34,36 +34,29 @@ import org.mockito.Answers;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
-import org.springframework.data.r2dbc.config.AbstractR2dbcConfiguration;
 import org.springframework.data.r2dbc.core.DatabaseClient;
 import org.springframework.data.r2dbc.core.R2dbcEntityTemplate;
-import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
 import org.springframework.data.relational.core.query.Criteria;
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.integration.expression.FunctionExpression;
+import org.springframework.integration.r2dbc.config.R2dbcIntegrationTestConfiguration;
+import org.springframework.integration.r2dbc.entity.Person;
+import org.springframework.integration.r2dbc.repository.PersonRepository;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
-import io.r2dbc.h2.H2ConnectionConfiguration;
 import io.r2dbc.h2.H2ConnectionFactory;
-import io.r2dbc.spi.ConnectionFactory;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Hooks;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 /**
- *  @author Rohan Mukesh
- *
- *  @since 5.4
+ * @author Rohan Mukesh
+ * @since 5.4
  */
-@SpringJUnitConfig
-public class R2DbcMessageHandlerTests {
+@SpringJUnitConfig(R2dbcIntegrationTestConfiguration.class)
+public class R2dbcMessageHandlerTests {
 
 	@Autowired
 	DatabaseClient client;
@@ -76,26 +69,6 @@ public class R2DbcMessageHandlerTests {
 	@Autowired
 	PersonRepository personRepository;
 
-	@Configuration
-	@EnableR2dbcRepositories(considerNestedRepositories = true,
-			includeFilters = @ComponentScan.Filter(classes = PersonRepository.class, type = FilterType.ASSIGNABLE_TYPE))
-	static class IntegrationTestConfiguration extends AbstractR2dbcConfiguration {
-
-		@Bean
-		@Override
-		public ConnectionFactory connectionFactory() {
-			return createConnectionFactory();
-		}
-
-	}
-
-	public static ConnectionFactory createConnectionFactory() {
-		return new H2ConnectionFactory(H2ConnectionConfiguration.builder()
-				.inMemory("r2dbc")
-				.username("sa")
-				.password("")
-				.option("DB_CLOSE_DELAY=-1").build());
-	}
 
 	@BeforeEach
 	public void setup() {
@@ -179,7 +152,7 @@ public class R2DbcMessageHandlerTests {
 
 		personRepository.findAll()
 				.as(StepVerifier::create)
-				.consumeNextWith(p -> Assert.assertEquals(Optional.of(40), Optional.ofNullable(p.age)))
+				.consumeNextWith(p -> Assert.assertEquals(Optional.of(40), Optional.ofNullable(p.getAge())))
 				.verifyComplete();
 	}
 
@@ -343,10 +316,6 @@ public class R2DbcMessageHandlerTests {
 
 	private static <T> T waitFor(Mono<T> mono) {
 		return mono.block(Duration.ofSeconds(10));
-	}
-
-	interface PersonRepository extends ReactiveCrudRepository<Person, Integer> {
-
 	}
 
 }

--- a/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/repository/PersonRepository.java
+++ b/spring-integration-r2dbc/src/test/java/org/springframework/integration/r2dbc/repository/PersonRepository.java
@@ -14,53 +14,16 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.r2dbc.outbound;
+package org.springframework.integration.r2dbc.repository;
 
-import org.springframework.data.annotation.Id;
-import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import org.springframework.integration.r2dbc.entity.Person;
 
 /**
  *  @author Rohan Mukesh
  *
  *  @since 5.4
  */
-@Table
-class Person {
-
-	@Id
-	Integer id;
-
-	String name;
-
-	Integer age;
-
-	public void setId(Integer id) {
-		this.id = id;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public void setAge(Integer age) {
-		this.age = age;
-	}
-
-	Person(String name, Integer age) {
-		this.name = name;
-		this.age = age;
-	}
-
-	public Integer getId() {
-		return this.id;
-	}
-
-	public String getName() {
-		return this.name;
-	}
-
-	public Integer getAge() {
-		return this.age;
-	}
+public interface PersonRepository extends ReactiveCrudRepository<Person, Integer> {
 
 }


### PR DESCRIPTION
I have added Inbound channel adapter for spring data r2db.
The inbound adapter (R2dbcMessageSource) allows users to send query in two forms:
 a) String -> This uses databaseclient.execute(..) to execute sql query and return result.
 b) Query Object -> This uses r2dbcEntityOperations.select(..) to execute Query and return result.

I have added Test Class: R2dbcMessageSourceTests with 8 test cases. The test cases tests all the scenarions which includes:
String query Test with Single result or All Results, Query Object Test with Single Result or All Results and check for bad sql grammer, IllegalStateException. 

