### PR TITLE
GH-3320: Refine lifecycle control in StdIntFlow

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,12 +63,11 @@ import org.springframework.messaging.MessageChannel;
  * @see IntegrationFlows
  * @see org.springframework.integration.dsl.context.IntegrationFlowBeanPostProcessor
  * @see org.springframework.integration.dsl.context.IntegrationFlowContext
+ * @see SmartLifecycle
  */
 public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle {
 
 	private final Map<Object, String> integrationComponents;
-
-	private final List<SmartLifecycle> lifecycles = new LinkedList<>();
 
 	private MessageChannel inputChannel;
 
@@ -113,11 +112,9 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 		if (!this.running) {
 			List<Object> components = new LinkedList<>(this.integrationComponents.keySet());
 			ListIterator<Object> iterator = components.listIterator(this.integrationComponents.size());
-			this.lifecycles.clear();
 			while (iterator.hasPrevious()) {
 				Object component = iterator.previous();
 				if (component instanceof SmartLifecycle) {
-					this.lifecycles.add((SmartLifecycle) component);
 					((SmartLifecycle) component).start();
 				}
 			}
@@ -127,30 +124,29 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 
 	@Override
 	public void stop(Runnable callback) {
-		if (this.lifecycles.size() > 0) {
-			AggregatingCallback aggregatingCallback = new AggregatingCallback(this.lifecycles.size(), callback);
-			ListIterator<SmartLifecycle> iterator = this.lifecycles.listIterator(this.lifecycles.size());
-			while (iterator.hasPrevious()) {
-				SmartLifecycle lifecycle = iterator.previous();
+		AggregatingCallback aggregatingCallback = new AggregatingCallback(this.integrationComponents.size(), callback);
+		for (Object component : integrationComponents.keySet()) {
+			if (component instanceof SmartLifecycle) {
+				SmartLifecycle lifecycle = (SmartLifecycle) component;
 				if (lifecycle.isRunning()) {
 					lifecycle.stop(aggregatingCallback);
-				}
-				else {
-					aggregatingCallback.run();
+					continue;
 				}
 			}
-		}
-		else {
-			callback.run();
+			aggregatingCallback.run();
 		}
 		this.running = false;
 	}
 
 	@Override
 	public void stop() {
-		ListIterator<SmartLifecycle> iterator = this.lifecycles.listIterator(this.lifecycles.size());
-		while (iterator.hasPrevious()) {
-			iterator.previous().stop();
+		for (Object component : integrationComponents.keySet()) {
+			if (component instanceof SmartLifecycle) {
+				SmartLifecycle lifecycle = (SmartLifecycle) component;
+				if (lifecycle.isRunning()) {
+					lifecycle.stop();
+				}
+			}
 		}
 		this.running = false;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
@@ -125,7 +125,7 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 	@Override
 	public void stop(Runnable callback) {
 		AggregatingCallback aggregatingCallback = new AggregatingCallback(this.integrationComponents.size(), callback);
-		for (Object component : integrationComponents.keySet()) {
+		for (Object component : this.integrationComponents.keySet()) {
 			if (component instanceof SmartLifecycle) {
 				SmartLifecycle lifecycle = (SmartLifecycle) component;
 				if (lifecycle.isRunning()) {
@@ -140,7 +140,7 @@ public class StandardIntegrationFlow implements IntegrationFlow, SmartLifecycle 
 
 	@Override
 	public void stop() {
-		for (Object component : integrationComponents.keySet()) {
+		for (Object component : this.integrationComponents.keySet()) {
 			if (component instanceof SmartLifecycle) {
 				SmartLifecycle lifecycle = (SmartLifecycle) component;
 				if (lifecycle.isRunning()) {

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -75,6 +75,7 @@ The following list includes the common DSL method names and the associated EIP e
 Conceptually, integration processes are constructed by composing these endpoints into one or more message flows.
 Note that EIP does not formally define the term 'message flow', but it is useful to think of it as a unit of work that uses well known messaging patterns.
 The DSL provides an `IntegrationFlow` component to define a composition of channels and endpoints between them, but now `IntegrationFlow` plays only the configuration role to populate real beans in the application context and is not used at runtime.
+However the bean for `IntegrationFlow` can be autowired as a `Lifecycle` to control `start()` and `stop()` for the whole flow which is delegated to all the Spring Integration components associated with this `IntegrationFlow`.
 The following example uses the `IntegrationFlows` factory to define an `IntegrationFlow` bean by using EIP-methods from `IntegrationFlowBuilder`:
 
 ====


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3320

Turns out that lifecycle control for the whole bunch of components
in one `IntegrationFlow` is useful in fields.

* Change the logic in the `StandardIntegrationFlow` to let to call
`start()` and `stop()` independently how the flow was registered in
the application context.
This way it can be autowired as a `Lifecycle` to let end-user to
avoid the search for proper component in the flow to stop or start
manually - all the components registered with the flow are going
to be stopped or started respectively

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
