### PR TITLE
SO-62761903: Inject BF into Gateway's correlator

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -794,23 +794,21 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 				}
 				else if (replyChan instanceof PollableChannel) {
 					PollingConsumer endpoint = new PollingConsumer((PollableChannel) replyChan, handler);
-					if (beanFactory != null) {
-						endpoint.setBeanFactory(beanFactory);
-					}
 					endpoint.setReceiveTimeout(this.replyTimeout);
-					endpoint.afterPropertiesSet();
 					correlator = endpoint;
 				}
 				else if (replyChan instanceof ReactiveStreamsSubscribableChannel) {
-					ReactiveStreamsConsumer endpoint =
-							new ReactiveStreamsConsumer(replyChan, (Subscriber<Message<?>>) handler);
-					endpoint.afterPropertiesSet();
-					correlator = endpoint;
+					correlator = new ReactiveStreamsConsumer(replyChan, (Subscriber<Message<?>>) handler);
 				}
 				else {
 					throw new MessagingException("Unsupported 'replyChannel' type [" + replyChan.getClass() + "]."
 							+ "SubscribableChannel or PollableChannel type are supported.");
 				}
+
+				if (beanFactory != null) {
+					correlator.setBeanFactory(beanFactory);
+				}
+				correlator.afterPropertiesSet();
 				this.replyMessageCorrelator = correlator;
 			}
 			if (isRunning()) {


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/62761903/spring-integration-reactive-streams-support-exception-in-creating-a-reactive

The `MessagingGatewaySupport` creates an internal endpoint
for consuming messages from the provided `replyChannel`.
The endpoint type depends on the channel type.
The `ReactiveStreamsConsumer` was missing a `BeanFactory` injection
causing an error when `ReactiveStreamsConsumer` tries to extract a default `ErrorHandler`
from `BeanFactory`

* Refactor `MessagingGatewaySupport` to inject a `BeanFactory` to all
the possible correlator endpoints.
Also always call `afterPropertiesSet()` for all of them

**Cherry-pick to 5.3.x & 5.2.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
