### PR TITLE
JDBC lock acquire optimization

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
@@ -73,16 +73,18 @@ public class DefaultLockRepository implements LockRepository, InitializingBean {
 
 	private String deleteQuery = "DELETE FROM %sLOCK WHERE REGION=? AND LOCK_KEY=? AND CLIENT_ID=?";
 
-	private String deleteExpiredQuery = "DELETE FROM %sLOCK WHERE REGION=? AND LOCK_KEY=? AND CREATED_DATE<?";
+	private String deleteExpiredQuery = "DELETE FROM %sLOCK WHERE REGION=? AND CREATED_DATE<?";
 
 	private String deleteAllQuery = "DELETE FROM %sLOCK WHERE REGION=? AND CLIENT_ID=?";
 
-	private String updateQuery = "UPDATE %sLOCK SET CREATED_DATE=? WHERE REGION=? AND LOCK_KEY=? AND CLIENT_ID=?";
+	private String updateQuery = "UPDATE %sLOCK SET CLIENT_ID=?, CREATED_DATE=? WHERE REGION=? AND LOCK_KEY=? AND (CLIENT_ID=? OR CREATED_DATE<?)";
 
 	private String insertQuery = "INSERT INTO %sLOCK (REGION, LOCK_KEY, CLIENT_ID, CREATED_DATE) VALUES (?, ?, ?, ?)";
 
 	private String countQuery =
 			"SELECT COUNT(REGION) FROM %sLOCK WHERE REGION=? AND LOCK_KEY=? AND CLIENT_ID=? AND CREATED_DATE>=?";
+
+	private String renewQuery = "UPDATE %sLOCK SET CREATED_DATE=? WHERE REGION=? AND LOCK_KEY=? AND CLIENT_ID=?";
 
 	/**
 	 * Constructor that initializes the client id that will be associated for
@@ -142,6 +144,7 @@ public class DefaultLockRepository implements LockRepository, InitializingBean {
 		this.updateQuery = String.format(this.updateQuery, this.prefix);
 		this.insertQuery = String.format(this.insertQuery, this.prefix);
 		this.countQuery = String.format(this.countQuery, this.prefix);
+		this.renewQuery = String.format(this.renewQuery, this.prefix);
 	}
 
 	@Override
@@ -157,8 +160,8 @@ public class DefaultLockRepository implements LockRepository, InitializingBean {
 	@Transactional(isolation = Isolation.SERIALIZABLE, timeout = 1)
 	@Override
 	public boolean acquire(String lock) {
-		deleteExpired(lock);
-		if (this.template.update(this.updateQuery, new Date(), this.region, lock, this.id) > 0) {
+		if (this.template.update(this.updateQuery, this.id, new Date(), this.region, lock, this.id,
+				new Date(System.currentTimeMillis() - this.ttl)) > 0) {
 			return true;
 		}
 		try {
@@ -171,19 +174,18 @@ public class DefaultLockRepository implements LockRepository, InitializingBean {
 
 	@Override
 	public boolean isAcquired(String lock) {
-		deleteExpired(lock);
 		return this.template.queryForObject(this.countQuery, Integer.class, // NOSONAR query never returns null
 				this.region, lock, this.id, new Date(System.currentTimeMillis() - this.ttl)) == 1;
 	}
 
-	private void deleteExpired(String lock) {
-		this.template.update(this.deleteExpiredQuery, this.region, lock,
-				new Date(System.currentTimeMillis() - this.ttl));
+	@Override
+	public void deleteExpired() {
+		this.template.update(this.deleteExpiredQuery, this.region, new Date(System.currentTimeMillis() - this.ttl));
 	}
 
 	@Override
 	public boolean renew(String lock) {
-		return this.template.update(this.updateQuery, new Date(), this.region, lock, this.id) > 0;
+		return this.template.update(this.renewQuery, new Date(), this.region, lock, this.id) > 0;
 	}
 
 }

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/LockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/LockRepository.java
@@ -34,6 +34,8 @@ public interface LockRepository extends Closeable {
 
 	void delete(String lock);
 
+	void deleteExpired();
+
 	boolean acquire(String lock);
 
 	boolean renew(String lock);


### PR DESCRIPTION
I think a `DELETE` query at each call of `acquire()` is unoptimized.
So I merged the `deleteExpiredQuery` into `updateQuery` like this:
```
UPDATE %sLOCK SET CREATED_DATE=? WHERE REGION=? AND LOCK_KEY=? AND (CLIENT_ID=? OR CREATED_DATE<?)
```

I kept `deleteExpired()` to clean table for a retro-compatibility.

Does that make sense?