### PR TITLE
GH-3344: Treat kotlin.Unit return as null in MMIH

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -1102,7 +1102,9 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			}
 			try {
 				Object result = this.invocableHandlerMethod.invoke(message);
-				if (result != null && result.getClass().getName().equals("kotlin.Unit")) {
+				if (result != null
+						&& org.springframework.integration.util.ClassUtils.isKotlinUnit(result.getClass())) {
+
 					result = null;
 				}
 				return result;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -576,6 +576,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		localHandlerMethodFactory.afterPropertiesSet();
 	}
 
+	@Nullable
 	private Object invokeHandlerMethod(HandlerMethod handlerMethod, ParametersWrapper parameters) {
 		try {
 			return handlerMethod.invoke(parameters);
@@ -1093,13 +1094,18 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			this.invocableHandlerMethod = newInvocableHandlerMethod;
 		}
 
+		@Nullable
 		public Object invoke(ParametersWrapper parameters) {
 			Message<?> message = parameters.getMessage();
 			if (this.canProcessMessageList) {
 				message = new MutableMessage<>(parameters.getMessages(), parameters.getHeaders());
 			}
 			try {
-				return this.invocableHandlerMethod.invoke(message);
+				Object result = this.invocableHandlerMethod.invoke(message);
+				if (result != null && result.getClass().getName().equals("kotlin.Unit")) {
+					result = null;
+				}
+				return result;
 			}
 			catch (RuntimeException ex) { // NOSONAR no way to handle conditional catch according Sonar rules
 				throw ex;

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
@@ -83,6 +83,11 @@ public abstract class ClassUtils {
 	 */
 	public static final Class<?> KOTLIN_FUNCTION_1_CLASS;
 
+	/**
+	 * The {@code kotlin.Unit} class object.
+	 */
+	public static final Class<?> KOTLIN_UNIT_CLASS;
+
 	static {
 		PRIMITIVE_WRAPPER_TYPE_MAP.put(Boolean.class, boolean.class);
 		PRIMITIVE_WRAPPER_TYPE_MAP.put(Byte.class, byte.class);
@@ -160,6 +165,18 @@ public abstract class ClassUtils {
 		}
 		finally {
 			KOTLIN_FUNCTION_1_CLASS = kotlinClass;
+		}
+
+		kotlinClass = null;
+		try {
+			kotlinClass = org.springframework.util.ClassUtils.forName("kotlin.Unit",
+					org.springframework.util.ClassUtils.getDefaultClassLoader());
+		}
+		catch (ClassNotFoundException e) {
+			//Ignore: assume no Kotlin in classpath
+		}
+		finally {
+			KOTLIN_UNIT_CLASS = kotlinClass;
 		}
 	}
 
@@ -245,6 +262,16 @@ public abstract class ClassUtils {
 	 */
 	public static boolean isKotlinFaction1(Class<?> aClass) {
 		return KOTLIN_FUNCTION_1_CLASS != null && KOTLIN_FUNCTION_1_CLASS.isAssignableFrom(aClass);
+	}
+
+	/**
+	 * Check if class is {@code kotlin.Unit}.
+	 * @param aClass the {@link Class} to check.
+	 * @return true if class is a {@code kotlin.Unit} implementation.
+	 * @since 5.4
+	 */
+	public static boolean isKotlinUnit(Class<?> aClass) {
+		return KOTLIN_UNIT_CLASS != null && KOTLIN_UNIT_CLASS.isAssignableFrom(aClass);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/ClassUtils.java
@@ -268,7 +268,7 @@ public abstract class ClassUtils {
 	 * Check if class is {@code kotlin.Unit}.
 	 * @param aClass the {@link Class} to check.
 	 * @return true if class is a {@code kotlin.Unit} implementation.
-	 * @since 5.4
+	 * @since 5.3.2
 	 */
 	public static boolean isKotlinUnit(Class<?> aClass) {
 		return KOTLIN_UNIT_CLASS != null && KOTLIN_UNIT_CLASS.isAssignableFrom(aClass);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3344

When function lambda doesn't return anything (e.g. a `void` method call is the last one),
Kotlin produces a `kotlin.Unit` instance as a return value which is not null and produced
as a reply message payload.

* Fix `MessagingMethodInvokerHelper` to treat a `kotlin.Unit` as `null` for reply
making Kotlin lambdas working the same way as Java lambdas when we don't return anything
from from there

**Cherry-pick to `5.3.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
