### PR TITLE
Add gauges for queue channel size

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
@@ -95,7 +95,7 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 						(channel) -> getQueueSize())
 						.tag("name", getComponentName() == null ? "unknown" : getComponentName())
 						.tag("type", "channel")
-						.description("The size of queue channel.")
+						.description("The size of queue channel")
 						.build();
 
 		this.remainingCapacityGauge =
@@ -103,7 +103,7 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 						(channel) -> getRemainingCapacity())
 						.tag("name", getComponentName() == null ? "unknown" : getComponentName())
 						.tag("type", "channel")
-						.description("The remaining.capacity of queue channel.")
+						.description("The remaining.capacity of queue channel")
 						.build();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
@@ -95,7 +95,7 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 						(channel) -> getQueueSize())
 						.tag("name", getComponentName() == null ? "unknown" : getComponentName())
 						.tag("type", "channel")
-						.description("The size of queue channel")
+						.description("The size of the queue channel")
 						.build();
 
 		this.remainingCapacityGauge =
@@ -103,7 +103,7 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 						(channel) -> getRemainingCapacity())
 						.tag("name", getComponentName() == null ? "unknown" : getComponentName())
 						.tag("type", "channel")
-						.description("The remaining.capacity of queue channel")
+						.description("The remaining capacity of the queue channel")
 						.build();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
@@ -25,6 +25,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.integration.core.MessageSelector;
+import org.springframework.integration.support.management.metrics.GaugeFacade;
+import org.springframework.integration.support.management.metrics.MetricsCaptor;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -48,6 +50,12 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 	private final Queue<Message<?>> queue;
 
 	protected final Semaphore queueSemaphore = new Semaphore(0); // NOSONAR final
+
+	@Nullable
+	private GaugeFacade sizeGauge;
+
+	@Nullable
+	private GaugeFacade remainingCapacityGauge;
 
 	/**
 	 * Create a channel with the specified queue.
@@ -77,6 +85,26 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 	 */
 	public QueueChannel() {
 		this(new LinkedBlockingQueue<>());
+	}
+
+	@Override
+	public void registerMetricsCaptor(MetricsCaptor metricsCaptor) {
+		super.registerMetricsCaptor(metricsCaptor);
+		this.sizeGauge =
+				metricsCaptor.gaugeBuilder("spring.integration.channel.queue.size", this,
+						(channel) -> getQueueSize())
+						.tag("name", getComponentName() == null ? "unknown" : getComponentName())
+						.tag("type", "channel")
+						.description("The size of queue channel.")
+						.build();
+
+		this.remainingCapacityGauge =
+				metricsCaptor.gaugeBuilder("spring.integration.channel.queue.remaining.capacity", this,
+						(channel) -> getRemainingCapacity())
+						.tag("name", getComponentName() == null ? "unknown" : getComponentName())
+						.tag("type", "channel")
+						.description("The remaining.capacity of queue channel.")
+						.build();
 	}
 
 	@Override
@@ -204,6 +232,17 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 		else {
 			//Assume that underlying Queue implementation takes care of its size on "offer".
 			return Integer.MAX_VALUE;
+		}
+	}
+
+	@Override
+	public void destroy() {
+		super.destroy();
+		if (this.sizeGauge != null) {
+			this.sizeGauge.remove();
+		}
+		if (this.remainingCapacityGauge != null) {
+			this.remainingCapacityGauge.remove();
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
@@ -285,8 +285,8 @@ public class IntegrationManagementConfigurer
 	}
 
 	private void injectCaptor() {
-		Map<String, IntegrationManagement> managed = this.applicationContext
-				.getBeansOfType(IntegrationManagement.class);
+		Map<String, IntegrationManagement> managed =
+				this.applicationContext.getBeansOfType(IntegrationManagement.class);
 		for (Entry<String, IntegrationManagement> entry : managed.entrySet()) {
 			IntegrationManagement bean = entry.getValue();
 			if (!getOverrides(bean).loggingConfigured) {
@@ -299,7 +299,7 @@ public class IntegrationManagementConfigurer
 	@Override
 	public Object postProcessAfterInitialization(Object bean, String name) throws BeansException {
 		if (this.singletonsInstantiated) {
-			if (bean instanceof IntegrationManagement) {
+			if (this.metricsCaptor != null && bean instanceof IntegrationManagement) {
 				((IntegrationManagement) bean).registerMetricsCaptor(this.metricsCaptor);
 			}
 			return doConfigureMetrics(bean, name);

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,9 +92,8 @@ public class MicrometerMetricsTests {
 	@Autowired
 	private NullChannel nullChannel;
 
-	@SuppressWarnings("unchecked")
 	@Test
-	public void testSend() {
+	public void testMicrometerMetrics() {
 		GenericMessage<String> message = new GenericMessage<>("foo");
 		this.channel.send(message);
 		assertThatExceptionOfType(MessagingException.class)
@@ -161,6 +160,16 @@ public class MicrometerMetricsTests {
 				.tag("name", "queue")
 				.tag("result", "success")
 				.counter().count()).isEqualTo(1);
+
+		this.queue.send(message);
+
+		assertThat(registry.get("spring.integration.channel.queue.size")
+				.tag("name", "queue")
+				.gauge().value()).isEqualTo(2d);
+
+		assertThat(registry.get("spring.integration.channel.queue.remaining.capacity")
+				.tag("name", "queue")
+				.gauge().value()).isEqualTo(8d);
 
 		assertThat(registry.get("spring.integration.send")
 				.tag("name", "nullChannel")
@@ -260,7 +269,7 @@ public class MicrometerMetricsTests {
 
 		@Bean
 		public QueueChannel queue() {
-			return new QueueChannel();
+			return new QueueChannel(10);
 		}
 
 		@Bean

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
@@ -92,6 +92,7 @@ public class MicrometerMetricsTests {
 	@Autowired
 	private NullChannel nullChannel;
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testMicrometerMetrics() {
 		GenericMessage<String> message = new GenericMessage<>("foo");

--- a/src/reference/asciidoc/metrics.adoc
+++ b/src/reference/asciidoc/metrics.adoc
@@ -165,6 +165,20 @@ It is possible to customize the names and tags of `Meters` created by integratio
 The https://github.com/spring-projects/spring-integration/blob/master/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerCustomMetricsTests.java[MicrometerCustomMetricsTests] test case shows a simple example of how to do that.
 You can also further customize the meters by overloading the `build()` methods on builder subclasses.
 
+Starting with version 5.1.13, the `QueueChannel` exposes Micrometer gauges for queue size and remaining capacity:
+
+* `name`: `spring.integration.channel.queue.size`
+* `tag`: `type:channel`
+* `tag`: `name:<componentName>`
+* `description`: `The size of queue channel`
+
+and
+
+* `name`: `spring.integration.channel.queue.remaining.capacity`
+* `tag`: `type:channel`
+* `tag`: `name:<componentName>`
+* `description`: `The remaining.capacity of queue channel`
+
 [[mgmt-channel-features]]
 ==== `MessageChannel` Metric Features
 


### PR DESCRIPTION
The `QueueChannel` provides a current size and remaining capacity metrics

* Add Micrometer gauges into `QueueChannel` to expose the current values
of the size and remaining capacity

**Cherry-pick to 5.3.x, 5.2.x & 5.1.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
