### PR TITLE
Update local maven install in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you encounter out of memory errors during the build, increase an available he
 
 To build and install jars into your local Maven cache:
 
-    ./gradlew install
+    ./gradlew publishToMavenLocal
 
 To build api Javadoc (results will be in `build/api`):
 


### PR DESCRIPTION
The task `install`does not exist, `./gradlew publishToMavenLocal`needs to be used instead. Finding during review tasks in #3355. 