### PR TITLE
GH-3366: Document HTTP request mapping limitation

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.servlet.http.HttpServletRequest;
@@ -78,6 +79,14 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * register HTTP endpoints at runtime for dynamically declared beans, e.g. via
  * {@link org.springframework.integration.dsl.context.IntegrationFlowContext}, and unregister
  * them during the {@link BaseHttpInboundEndpoint} destruction.
+ *<p>
+ * This class extends a standard Spring MVC {@link RequestMappingHandlerMapping} and inherits
+ * most of its logic, especially {@link #handleNoMatch(Set, String, HttpServletRequest)},
+ * which thrown a specific {@code 4xx} error to the HTTP response when mapping doesn't match
+ * for some reason preventing tries for the rest mapping handlers in the application context.
+ * This way it is not recommended to configure the same path for both Spring Integration and
+ * Spring MVC request mappings since it is not going to be tried against different configuration
+ * in other mapping handlers.
  *
  * @author Artem Bilan
  * @author Gary Russell

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/IntegrationRequestMappingHandlerMapping.java
@@ -80,13 +80,13 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  * {@link org.springframework.integration.dsl.context.IntegrationFlowContext}, and unregister
  * them during the {@link BaseHttpInboundEndpoint} destruction.
  *<p>
- * This class extends a standard Spring MVC {@link RequestMappingHandlerMapping} and inherits
+ * This class extends the Spring MVC {@link RequestMappingHandlerMapping} class, inheriting
  * most of its logic, especially {@link #handleNoMatch(Set, String, HttpServletRequest)},
- * which thrown a specific {@code 4xx} error to the HTTP response when mapping doesn't match
- * for some reason preventing tries for the rest mapping handlers in the application context.
- * This way it is not recommended to configure the same path for both Spring Integration and
- * Spring MVC request mappings since it is not going to be tried against different configuration
- * in other mapping handlers.
+ * which throws a specific {@code 4xx} error for the HTTP response, when mapping doesn't match
+ * for some reason, preventing calls to any remaining mapping handlers in the application context.
+ * For this reason, configuring the same path for both Spring Integration and
+ * Spring MVC request mappings (e.g. `POST` in one and `GET` in the other) is not supported;
+ * the MVC mapping will not be found.
  *
  * @author Artem Bilan
  * @author Gary Russell

--- a/src/reference/asciidoc/http.adoc
+++ b/src/reference/asciidoc/http.adoc
@@ -349,8 +349,8 @@ The following example shows how to do so:
 
 For more information regarding handler mappings, see https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html[the Spring Framework Web Servlet documentation] or https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html[the Spring Framework Web Reactive documentation].
 
-IMPORTANT: The `IntegrationRequestMappingHandlerMapping` extends a standard Spring MVC `RequestMappingHandlerMapping` and inherits most of its logic, especially `handleNoMatch(Set, String, HttpServletRequest)`, which thrown a specific `4xx` error to the HTTP response when mapping doesn't match for some reason preventing tries for the rest mapping handlers in the application context.
-This way it is not recommended to configure the same path for both Spring Integration and Spring MVC request mappings since it is not going to be tried against different configuration in other mapping handlers.
+IMPORTANT: The `IntegrationRequestMappingHandlerMapping` extends the Spring MVC `RequestMappingHandlerMapping` class, inheriting most of its logic, especially `handleNoMatch(Set, String, HttpServletRequest)`, which throws a specific `4xx` error for the HTTP response, when mapping doesn't match for some reason, preventing calls to any remaining mapping handlers in the application context.
+For this reason, configuring the same path for both Spring Integration and Spring MVC request mappings (e.g. `POST` in one and `GET` in the other) is not supported; the MVC mapping will not be found..
 
 [[http-cors]]
 ==== Cross-origin Resource Sharing (CORS) Support

--- a/src/reference/asciidoc/http.adoc
+++ b/src/reference/asciidoc/http.adoc
@@ -349,6 +349,9 @@ The following example shows how to do so:
 
 For more information regarding handler mappings, see https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html[the Spring Framework Web Servlet documentation] or https://docs.spring.io/spring/docs/current/spring-framework-reference/web-reactive.html[the Spring Framework Web Reactive documentation].
 
+IMPORTANT: The `IntegrationRequestMappingHandlerMapping` extends a standard Spring MVC `RequestMappingHandlerMapping` and inherits most of its logic, especially `handleNoMatch(Set, String, HttpServletRequest)`, which thrown a specific `4xx` error to the HTTP response when mapping doesn't match for some reason preventing tries for the rest mapping handlers in the application context.
+This way it is not recommended to configure the same path for both Spring Integration and Spring MVC request mappings since it is not going to be tried against different configuration in other mapping handlers.
+
 [[http-cors]]
 ==== Cross-origin Resource Sharing (CORS) Support
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3366

The same path cannot be mapped both Spring Integration and MVC ways

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
