### PR TITLE
GH-3373: Support IPV6 in AbstractInboundFileSynch

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -493,10 +493,13 @@ public abstract class AbstractInboundFileSynchronizer<F>
 				if (this.preserveTimestamp && !localFile.setLastModified(modified)) {
 					throw new IllegalStateException("Could not sent last modified on file: " + localFile);
 				}
-				String[] hostPort = session.getHostPort().split(":");
+				String hostPort = session.getHostPort();
+				int colonIndex = hostPort.lastIndexOf(":");
+				String host = hostPort.substring(0, colonIndex);
+				String port = hostPort.substring(colonIndex + 1);
 				try {
 					String remoteFileMetadata =
-							new URI(protocol(), null, hostPort[0], Integer.parseInt(hostPort[1]),
+							new URI(protocol(), null, host, Integer.parseInt(port),
 									'/' + remoteDirectoryPath, null, remoteFileName)
 									.toString();
 					this.remoteFileMetadataStore.put(buildMetadataKey(localFile), remoteFileMetadata);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3373

The `AbstractInboundFileSynchronizer` doesn't consider that
`hostPort` from `Session` could be in an IPv6 syntax

* Parse the `hostPort` from `Session` in a manner that only the last
`:` is treated as a port delimiter

**Cherry-pick to 5.3.x & 5.2.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
