### PR TITLE
GH-3306: Remove setters from registration object

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,34 +119,16 @@ public interface IntegrationFlowContext {
 		String getId();
 
 		/**
-		 * Set the flow id.
-		 * @param id the id.
-		 */
-		void setId(String id);
-
-		/**
 		 * Return the flow.
 		 * @return the flow.
 		 */
 		IntegrationFlow getIntegrationFlow();
 
 		/**
-		 * Set the integration flow.
-		 * @param integrationFlow the flow.
-		 */
-		void setIntegrationFlow(IntegrationFlow integrationFlow);
-
-		/**
 		 * Return the flow input channel.
 		 * @return the channel.
 		 */
 		MessageChannel getInputChannel();
-
-		/**
-		 * Set the flow context.
-		 * @param integrationFlowContext the context.
-		 */
-		void setIntegrationFlowContext(IntegrationFlowContext integrationFlowContext);
 
 		/**
 		 * Obtain a {@link MessagingTemplate} with its default destination set to the input channel

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
@@ -47,6 +47,7 @@ import org.springframework.messaging.MessageChannel;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Artem Vozhdayenko
  *
  * @since 5.0
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
@@ -45,6 +45,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Alexander Shaklein
+ * @author Artem Vozhdayenko
  *
  * @since 5.1
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowRegistration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowRegistration.java
@@ -32,6 +32,7 @@ import org.springframework.messaging.MessageChannel;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Artem Vozhdayenko
  *
  * @since 5.1
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowRegistration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowRegistration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,11 +39,11 @@ import org.springframework.messaging.MessageChannel;
  */
 class StandardIntegrationFlowRegistration implements IntegrationFlowRegistration {
 
-	private IntegrationFlow integrationFlow;
+	private final IntegrationFlow integrationFlow;
 
-	private IntegrationFlowContext integrationFlowContext;
+	private final IntegrationFlowContext integrationFlowContext;
 
-	private String id;
+	private final String id;
 
 	private MessageChannel inputChannel;
 
@@ -51,28 +51,15 @@ class StandardIntegrationFlowRegistration implements IntegrationFlowRegistration
 
 	private ConfigurableListableBeanFactory beanFactory;
 
-	StandardIntegrationFlowRegistration(IntegrationFlow integrationFlow) {
+	StandardIntegrationFlowRegistration(IntegrationFlow integrationFlow, IntegrationFlowContext integrationFlowContext, String id) {
 		this.integrationFlow = integrationFlow;
+		this.integrationFlowContext = integrationFlowContext;
+		this.id = id;
 	}
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) {
 		this.beanFactory = (ConfigurableListableBeanFactory) beanFactory;
-	}
-
-	@Override
-	public void setIntegrationFlowContext(IntegrationFlowContext integrationFlowContext) {
-		this.integrationFlowContext = integrationFlowContext;
-	}
-
-	@Override
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	@Override
-	public void setIntegrationFlow(IntegrationFlow integrationFlow) {
-		this.integrationFlow = integrationFlow;
 	}
 
 	@Override


### PR DESCRIPTION
To prevent API misuse (one can set ID after doing a registration which
will do nothing actually), it is safer to remove set* methods from
StandardIntegrationFlowRegistration object. Providing some related
refactoring like making fields 'final', adjusting usages to keep correct
behavior of the builder.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->


Closes #3306