### PR TITLE
Add Error Handling to ReactiveRedisStreamMessageProducer

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/ReactiveRedisStreamMessageProducer.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/ReactiveRedisStreamMessageProducer.java
@@ -34,6 +34,8 @@ import org.springframework.integration.redis.support.RedisHeaders;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -227,8 +229,13 @@ public class ReactiveRedisStreamMessageProducer extends MessageProducerSupport {
 												.subscribe());
 					}
 					return builder.build();
+				}).onErrorContinue((ex, event) -> {
+					MessagingException messagingException =
+							new MessagingException("Cannot deserialize Redis Stream Record", ex);
+					if (!sendErrorMessageIfNecessary(new GenericMessage<>(event), messagingException)) {
+						logger.getLog().error(messagingException);
+					}
 				});
-
 		subscribeToPublisher(messageFlux);
 	}
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/ReactiveRedisStreamMessageProducerTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/ReactiveRedisStreamMessageProducerTests.java
@@ -22,6 +22,8 @@ import static org.awaitility.Awaitility.await;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -30,16 +32,25 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.PendingMessagesSummary;
 import org.springframework.data.redis.connection.stream.ReadOffset;
 import org.springframework.data.redis.connection.stream.StreamInfo;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.data.redis.stream.StreamReceiver;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.acks.SimpleAcknowledgment;
+import org.springframework.integration.annotation.IntegrationComponentScan;
 import org.springframework.integration.channel.FluxMessageChannel;
+import org.springframework.integration.channel.PublishSubscribeChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.handler.ReactiveMessageHandlerAdapter;
 import org.springframework.integration.redis.outbound.ReactiveRedisStreamMessageHandler;
 import org.springframework.integration.redis.rules.RedisAvailable;
@@ -48,8 +59,11 @@ import org.springframework.integration.redis.rules.RedisAvailableTests;
 import org.springframework.integration.redis.support.RedisHeaders;
 import org.springframework.integration.redis.util.Address;
 import org.springframework.integration.redis.util.Person;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import reactor.core.publisher.Flux;
@@ -63,6 +77,7 @@ import reactor.test.StepVerifier;
  *
  * @since 5.4
  */
+@ContextConfiguration
 @RunWith(SpringRunner.class)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests {
@@ -75,7 +90,10 @@ public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests
 	FluxMessageChannel fluxMessageChannel;
 
 	@Autowired
-	ReactiveRedisStreamMessageProducer redisStreamMessageProducer;
+	ReactiveRedisStreamMessageProducer reactiveRedisStreamProducer;
+
+	@Autowired
+	ReactiveRedisStreamMessageProducer reactiveErrorRedisStreamProducer;
 
 	@Autowired
 	ReactiveRedisTemplate<String, ?> template;
@@ -100,27 +118,27 @@ public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests
 
 	@After
 	public void tearDown() {
-		this.redisStreamMessageProducer.stop();
+		this.reactiveRedisStreamProducer.stop();
 		RedisAvailableRule.connectionFactory.resetConnection();
 	}
 
 	@Test
 	@RedisAvailable
 	public void testConsumerGroupCreation() {
-		this.redisStreamMessageProducer.setCreateConsumerGroup(true);
-		this.redisStreamMessageProducer.setConsumerName(CONSUMER);
-		this.redisStreamMessageProducer.afterPropertiesSet();
+		this.reactiveRedisStreamProducer.setCreateConsumerGroup(true);
+		this.reactiveRedisStreamProducer.setConsumerName(CONSUMER);
+		this.reactiveRedisStreamProducer.afterPropertiesSet();
 
 		Flux.from(this.fluxMessageChannel).subscribe();
 
-		this.redisStreamMessageProducer.start();
+		this.reactiveRedisStreamProducer.start();
 
 		this.template.opsForStream()
 				.groups(STREAM_KEY)
 				.next()
 				.as(StepVerifier::create)
 				.assertNext((infoGroup) ->
-						assertThat(infoGroup.groupName()).isEqualTo(this.redisStreamMessageProducer.getBeanName()))
+						assertThat(infoGroup.groupName()).isEqualTo(this.reactiveRedisStreamProducer.getBeanName()))
 				.thenCancel()
 				.verify(Duration.ofSeconds(10));
 	}
@@ -132,10 +150,10 @@ public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests
 		Person person = new Person(address, "Attoumane");
 		this.messageHandler.handleMessage(new GenericMessage<>(person));
 
-		this.redisStreamMessageProducer.setCreateConsumerGroup(false);
-		this.redisStreamMessageProducer.setConsumerName(null);
-		this.redisStreamMessageProducer.setReadOffset(ReadOffset.from("0-0"));
-		this.redisStreamMessageProducer.afterPropertiesSet();
+		this.reactiveRedisStreamProducer.setCreateConsumerGroup(false);
+		this.reactiveRedisStreamProducer.setConsumerName(null);
+		this.reactiveRedisStreamProducer.setReadOffset(ReadOffset.from("0-0"));
+		this.reactiveRedisStreamProducer.afterPropertiesSet();
 
 		StepVerifier stepVerifier =
 				Flux.from(this.fluxMessageChannel)
@@ -148,7 +166,7 @@ public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests
 						.thenCancel()
 						.verifyLater();
 
-		this.redisStreamMessageProducer.start();
+		this.reactiveRedisStreamProducer.start();
 
 		stepVerifier.verify(Duration.ofSeconds(10));
 	}
@@ -160,17 +178,17 @@ public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests
 		Person person = new Person(address, "John Snow");
 
 		this.template.opsForStream()
-				.createGroup(STREAM_KEY, this.redisStreamMessageProducer.getBeanName())
+				.createGroup(STREAM_KEY, this.reactiveRedisStreamProducer.getBeanName())
 				.as(StepVerifier::create)
 				.assertNext(message -> assertThat(message).isEqualTo("OK"))
 				.thenCancel()
 				.verify(Duration.ofSeconds(10));
 
-		this.redisStreamMessageProducer.setCreateConsumerGroup(false);
-		this.redisStreamMessageProducer.setConsumerName(CONSUMER);
-		this.redisStreamMessageProducer.setReadOffset(ReadOffset.latest());
-		this.redisStreamMessageProducer.afterPropertiesSet();
-		this.redisStreamMessageProducer.start();
+		this.reactiveRedisStreamProducer.setCreateConsumerGroup(false);
+		this.reactiveRedisStreamProducer.setConsumerName(CONSUMER);
+		this.reactiveRedisStreamProducer.setReadOffset(ReadOffset.latest());
+		this.reactiveRedisStreamProducer.afterPropertiesSet();
+		this.reactiveRedisStreamProducer.start();
 
 		StepVerifier stepVerifier =
 				Flux.from(this.fluxMessageChannel)
@@ -196,13 +214,13 @@ public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests
 		String consumerGroup = "testGroup";
 		String consumerName = "testConsumer";
 
-		this.redisStreamMessageProducer.setCreateConsumerGroup(true);
-		this.redisStreamMessageProducer.setAutoAck(false);
-		this.redisStreamMessageProducer.setConsumerGroup(consumerGroup);
-		this.redisStreamMessageProducer.setConsumerName(consumerName);
-		this.redisStreamMessageProducer.setReadOffset(ReadOffset.latest());
-		this.redisStreamMessageProducer.afterPropertiesSet();
-		this.redisStreamMessageProducer.start();
+		this.reactiveRedisStreamProducer.setCreateConsumerGroup(true);
+		this.reactiveRedisStreamProducer.setAutoAck(false);
+		this.reactiveRedisStreamProducer.setConsumerGroup(consumerGroup);
+		this.reactiveRedisStreamProducer.setConsumerName(consumerName);
+		this.reactiveRedisStreamProducer.setReadOffset(ReadOffset.latest());
+		this.reactiveRedisStreamProducer.afterPropertiesSet();
+		this.reactiveRedisStreamProducer.start();
 
 		AtomicReference<SimpleAcknowledgment> acknowledgmentReference = new AtomicReference<>();
 
@@ -239,8 +257,48 @@ public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests
 				.verifyComplete();
 	}
 
+	@Test
+	@RedisAvailable
+	public void testReadingNextMessagesWhenSerializationException() {
+		Address address = new Address("Winterfell, Westeros");
+		Person person = new Person(address, "John Snow");
+
+		String consumerGroup = "testGroup";
+		String consumerName = "testConsumer";
+
+		this.reactiveErrorRedisStreamProducer.setCreateConsumerGroup(true);
+		this.reactiveErrorRedisStreamProducer.setAutoAck(false);
+		this.reactiveErrorRedisStreamProducer.setConsumerGroup(consumerGroup);
+		this.reactiveErrorRedisStreamProducer.setConsumerName(consumerName);
+		this.reactiveErrorRedisStreamProducer.setReadOffset(ReadOffset.latest());
+		this.reactiveErrorRedisStreamProducer.afterPropertiesSet();
+		this.reactiveErrorRedisStreamProducer.start();
+
+		StepVerifier stepVerifier =
+				Flux.from(this.fluxMessageChannel)
+					.as(StepVerifier::create)
+					.expectNextCount(0)
+					.thenCancel()
+					.verifyLater();
+
+		this.messageHandler.handleMessage(new GenericMessage<>(person));
+
+		stepVerifier.verify(Duration.ofSeconds(10));
+
+		Mono<PendingMessagesSummary> pendingZeroMessage =
+				template.opsForStream().pending(STREAM_KEY, consumerGroup);
+
+		StepVerifier.create(pendingZeroMessage)
+					.assertNext(pendingMessagesSummary ->
+							assertThat(pendingMessagesSummary.getTotalPendingMessages()).isEqualTo(1L))
+					.verifyComplete();
+	}
+
 	@Configuration
+	@EnableIntegration
+	@IntegrationComponentScan
 	static class ContextConfig {
+		private final Log logger = LogFactory.getLog(this.getClass());
 
 		@Bean
 		ReactiveRedisStreamMessageHandler redisStreamMessageHandler() {
@@ -264,6 +322,37 @@ public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests
 		}
 
 		@Bean
+		PublishSubscribeChannel errorChannel() {
+			return MessageChannels.publishSubscribe()
+									.get();
+		}
+
+		@Bean
+		ReactiveRedisStreamMessageProducer reactiveErrorRedisStreamProducer() {
+			Jackson2JsonRedisSerializer jacksonSerializer = new Jackson2JsonRedisSerializer(Person.class);
+			final StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
+
+			RedisSerializationContext<String, Object> serializationContext = RedisSerializationContext
+					.<String, Object>newSerializationContext()
+					.key(stringRedisSerializer)
+					.value(jacksonSerializer)
+					.hashKey(stringRedisSerializer)
+					.hashValue(jacksonSerializer)
+					.build();
+			ReactiveRedisStreamMessageProducer messageProducer =
+					new ReactiveRedisStreamMessageProducer(RedisAvailableRule.connectionFactory, STREAM_KEY);
+			messageProducer.setStreamReceiverOptions(
+					StreamReceiver.StreamReceiverOptions.builder()
+														.pollTimeout(Duration.ofMillis(100))
+														.serializer(serializationContext)
+														.build());
+			messageProducer.setAutoStartup(false);
+			messageProducer.setOutputChannel(fluxMessageChannel());
+			messageProducer.setErrorChannel(errorChannel());
+			return messageProducer;
+		}
+
+		@Bean
 		ReactiveRedisStreamMessageProducer reactiveRedisStreamProducer() {
 			ReactiveRedisStreamMessageProducer messageProducer =
 					new ReactiveRedisStreamMessageProducer(RedisAvailableRule.connectionFactory, STREAM_KEY);
@@ -275,6 +364,20 @@ public class ReactiveRedisStreamMessageProducerTests extends RedisAvailableTests
 			messageProducer.setAutoStartup(false);
 			messageProducer.setOutputChannel(fluxMessageChannel());
 			return messageProducer;
+		}
+
+		@Bean
+		public IntegrationFlow errorHandlingFlow(ReactiveRedisTemplate<String, ?> reactiveStreamOperations) {
+			return IntegrationFlows.from("errorChannel")
+									.handle(message -> {
+										reactiveStreamOperations.opsForStream()
+																.acknowledge("testGroup",
+																((MapRecord) ((ErrorMessage) message)
+																.getOriginalMessage().getPayload()))
+																.block();
+										logger.info("Error Message:" + ((MessagingException) message.getPayload()).fillInStackTrace().getMessage());
+									})
+									.get();
 		}
 
 	}


### PR DESCRIPTION
* Use 'onErrorContinue' to continue receiving messages from Stream
