### PR TITLE
Fix MeterRegistry eager load

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptorRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptorRegistrar.java
@@ -51,19 +51,16 @@ public class MicrometerMetricsCaptorRegistrar implements ImportBeanDefinitionReg
 
 	@Override
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
+		ListableBeanFactory beanFactory = (ListableBeanFactory) registry;
 		if (METER_REGISTRY_CLASS != null
-				&& !registry.containsBeanDefinition(MicrometerMetricsCaptor.MICROMETER_CAPTOR_NAME)) {
-			String[] beanNamesForType =
-					((ListableBeanFactory) registry).getBeanNamesForType(METER_REGISTRY_CLASS, false, false);
-			for (String beanName : beanNamesForType) {
-				registry.registerBeanDefinition(MicrometerMetricsCaptor.MICROMETER_CAPTOR_NAME,
-						BeanDefinitionBuilder.genericBeanDefinition(MicrometerMetricsCaptor.class)
-								.addConstructorArgReference(beanName)
-								.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
-								.getBeanDefinition());
-				return;
-			}
+				&& !registry.containsBeanDefinition(MicrometerMetricsCaptor.MICROMETER_CAPTOR_NAME)
+				&& beanFactory.getBeanNamesForType(METER_REGISTRY_CLASS, false, false).length > 0) {
 
+			registry.registerBeanDefinition(MicrometerMetricsCaptor.MICROMETER_CAPTOR_NAME,
+					BeanDefinitionBuilder.genericBeanDefinition(MicrometerMetricsCaptor.class)
+							.addConstructorArgValue(beanFactory.getBeanProvider(METER_REGISTRY_CLASS))
+							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
+							.getBeanDefinition());
 		}
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/IntegrationManagementConfigurerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/IntegrationManagementConfigurerTests.java
@@ -23,9 +23,10 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -41,6 +42,7 @@ import org.springframework.messaging.MessageChannel;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 4.2
  *
@@ -67,7 +69,7 @@ public class IntegrationManagementConfigurerTests {
 		assertThat(handler.isLoggingEnabled()).isTrue();
 		assertThat(source.isLoggingEnabled()).isTrue();
 		ApplicationContext ctx = mock(ApplicationContext.class);
-		Map<String, IntegrationManagement> beans = new HashMap<String, IntegrationManagement>();
+		Map<String, IntegrationManagement> beans = new HashMap<>();
 		beans.put("foo", channel);
 		beans.put("bar", handler);
 		beans.put("baz", source);
@@ -84,12 +86,12 @@ public class IntegrationManagementConfigurerTests {
 
 	@Test
 	public void testEmptyAnnotation() {
-		AnnotationConfigApplicationContext ctx =
-				new AnnotationConfigApplicationContext(ConfigEmptyAnnotation.class);
-		AbstractMessageChannel channel = ctx.getBean("channel", AbstractMessageChannel.class);
-		channel = ctx.getBean("loggingOffChannel", AbstractMessageChannel.class);
-		assertThat(channel.isLoggingEnabled()).isFalse();
-		ctx.close();
+		try (ConfigurableApplicationContext ctx = new AnnotationConfigApplicationContext(ConfigEmptyAnnotation.class)) {
+			AbstractMessageChannel channel = ctx.getBean("channel", AbstractMessageChannel.class);
+			assertThat(channel.isLoggingEnabled()).isTrue();
+			channel = ctx.getBean("loggingOffChannel", AbstractMessageChannel.class);
+			assertThat(channel.isLoggingEnabled()).isFalse();
+		}
 	}
 
 	@Configuration
@@ -108,6 +110,7 @@ public class IntegrationManagementConfigurerTests {
 			directChannel.setLoggingEnabled(false);
 			return directChannel;
 		}
+
 	}
 
 }


### PR DESCRIPTION
If there is a `MeterRegistry` bean (any) in the application context,
we add a `MicrometerMetricsCaptor` bean which populates meters further
from the components.
In some case we may load a `MicrometerMetricsCaptor` bean too early
so, not all the stuff around `MeterRegistry` maybe ready.
See Spring Boot and its `MetricsAutoConfiguration`

* Fix the `MicrometerMetricsCaptorRegistrar` the way to rely on the
`ObjectProvider<MeterRegistry>` instead
* Add package protected ctor to the `MicrometerMetricsCaptor` to
provide a target `MeterRegistry` on demand

All of that will ensure that we use an already post-processed `MeterRegistry`
including Spring Boot auto-configuration

**Cherry-pick to 5.3.x & 5.2.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
