### PR TITLE
Kafka Outbound Endpoints - Add futuresChannel

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaProducerMessageHandlerSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaProducerMessageHandlerSpec.java
@@ -354,6 +354,28 @@ public class KafkaProducerMessageHandlerSpec<K, V, S extends KafkaProducerMessag
 	}
 
 	/**
+	 * Set the channel to which send futures are sent.
+	 * @param futuresChannel the channel.
+	 * @return the spec.
+	 * @since 5.4
+	 */
+	public S futuresChannel(MessageChannel futuresChannel) {
+		this.target.setFuturesChannel(futuresChannel);
+		return _this();
+	}
+
+	/**
+	 * Set the channel to which send futures are sent.
+	 * @param futuresChannel the channel name.
+	 * @return the spec.
+	 * @since 5.4
+	 */
+	public S futuresChannel(String futuresChannel) {
+		this.target.setFuturesChannelName(futuresChannel);
+		return _this();
+	}
+
+	/**
 	 * A {@link KafkaTemplate}-based {@link KafkaProducerMessageHandlerSpec} extension.
 	 *
 	 * @param <K> the key type.

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/KafkaIntegrationHeaders.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/support/KafkaIntegrationHeaders.java
@@ -36,4 +36,9 @@ public final class KafkaIntegrationHeaders {
 	 */
 	public static final String FLUSH = KafkaHeaders.PREFIX + "flush";
 
+	/**
+	 * Set to a token to correlate a send Future.
+	 */
+	public static final String FUTURE_TOKEN = KafkaHeaders.PREFIX + "futureToken";
+
 }

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -22,10 +22,13 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
@@ -109,12 +112,16 @@ class KafkaOutboundAdapterParserTests {
 		@SuppressWarnings("unchecked")
 		ProducerFactory<Integer, String> pf = mock(ProducerFactory.class);
 		given(pf.createProducer()).willReturn(mockProducer);
+		Map<String, Object> props = new HashMap<>();
+		props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 10);
+		given(pf.getConfigurationProperties()).willReturn(props);
 		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
 		KafkaProducerMessageHandler<Integer, String> handler = new KafkaProducerMessageHandler<>(template);
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 
 		handler.setSync(true);
+		handler.setSendTimeout(10);
 		handler.setTopicExpression(new LiteralExpression("foo"));
 
 		Executors.newSingleThreadExecutor()

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -847,3 +847,81 @@ public IntegrationFlow flow() {
 ====
 
 When an integration flow starts with an interface, the proxy that is created has the name of the flow bean, appended with ".gateway" so this bean name can be used a a `@Qualifier` if needed.
+
+[[read-process-write]]
+=== Performance Considerations for read/process/write Scenarios
+
+Many applications consume from a topic, perform some processing and write to another topic.
+In most, cases, if the write fails, the application would want to throw an exception so the incoming request can be retried and/or sent to a dead letter topic.
+This functionality is supported by the underlying message listener container, together with a suitably configured error handler.
+However, in order to support this, we need to block the listener thread until the success (or failure) of the write operation so that any exceptions can be thrown to the container.
+When consuming single records, this is achieved by setting the `sync` property on the outbound adapter.
+However, when consuming batches, using `sync` causes a significant performance degradation because the application would wait for the result of each send before sending the next message.
+Starting with version 5.4, you can now perform multiple sends and then wait for the results of those sends afterwards.
+This is achieved by adding a `futuresChannel` to the message handler.
+To enable the feature add `KafkaIntegrationHeaders.FUTURE_TOKEN` to the outbound messages; this can then be used to correlate a `Future` to a particular sent message.
+Here is an example of how you might use this feature:
+
+====
+[source, java]
+----
+@SpringBootApplication
+public class FuturesChannelApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(FuturesChannelApplication.class, args);
+    }
+
+    @Bean
+    IntegrationFlow inbound(ConsumerFactory<String, String> consumerFactory, Handler handler) {
+        return IntegrationFlows.from(Kafka.messageDrivenChannelAdapter(consumerFactory, ListenerMode.batch, "inTopic"))
+                .handle(handler)
+                .get();
+    }
+
+    @Bean
+    IntegrationFlow outbound(KafkaTemplate<String, String> kafkaTemplate) {
+        return IntegrationFlows.from(Gate.class)
+                .enrichHeaders(h -> h
+                        .header(KafkaHeaders.TOPIC, "outTopic")
+                        .headerExpression(KafkaIntegrationHeaders.FUTURE_TOKEN, "headers[id]"))
+                .handle(Kafka.outboundChannelAdapter(kafkaTemplate)
+                        .futuresChannel("futures"))
+                .get();
+    }
+
+    @Bean
+    PollableChannel futures() {
+        return new QueueChannel();
+    }
+
+}
+
+@Component
+@DependsOn("outbound")
+class Handler {
+
+    @Autowired
+    Gate gate;
+
+    @Autowired
+    PollableChannel futures;
+
+    public void handle(List<String> input) throws Exception {
+        System.out.println(input);
+        input.forEach(str -> this.gate.send(str.toUpperCase()));
+        for (int i = 0; i < input.size(); i++) {
+            Message<?> future = this.futures.receive(10000);
+            ((Future<?>) future.getPayload()).get(10, TimeUnit.SECONDS);
+        }
+    }
+
+}
+
+interface Gate {
+
+    void send(String out);
+
+}
+----
+====

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -23,6 +23,9 @@ See <<./kafka.adoc#kafka,Spring for Apache Kafka Support>> for more information.
 The `KafkaProducerMessageHandler` `sendTimeoutExpression` default has changed.
 See <<./kafka.adoc#kafka-outbound,Kafka Outbound Channel Adapter>> for more information.
 
+You can now access the `Future<?>` for underlying `send()` operations.
+See <<./kafka.adoc#read-process-write>> for more information.
+
 [[x5.4-r2dbc]]
 ==== R2DBC Channel Adapters
 


### PR DESCRIPTION
Currently, the only way to block is to set `sync=true` which waits for the future.
The problem with this is it only supports one-at-a-time publication.

Add an option to send the send futures to a channel, allowing the application to
send multiple records and then wait on the futures later.

Also fix long-running test.

**Needs docs before merging**