### PR TITLE
Gateway: Propagate Error to the errorChannel

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -528,7 +528,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 				sample.stop(sendTimer());
 			}
 		}
-		catch (Throwable ex) {
+		catch (Throwable ex) { // NOSONAR (catch throwable)
 			if (logger.isDebugEnabled()) {
 				logger.debug("failure occurred in gateway sendAndReceive: " + ex.getMessage());
 			}
@@ -543,14 +543,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 					reply instanceof ErrorMessage
 							? ((ErrorMessage) reply).getPayload()
 							: (Throwable) reply;
-			try {
-				return handleSendAndReceiveError(object, requestMessage, error, shouldConvert);
-			}
-			catch (MessagingException me) {
-				if (me.getCause() instanceof Error) { // NOSONAR
-					throw (Error) me.getCause();
-				}
-			}
+			return handleSendAndReceiveError(object, requestMessage, error, shouldConvert);
 		}
 		return reply;
 	}
@@ -572,6 +565,9 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 						? errorFlowReply.getPayload()
 						: errorFlowReply;
 			}
+		}
+		else if (error instanceof Error) {
+			throw (Error) error;
 		}
 		else {
 			Throwable errorToReThrow = error;

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -528,7 +528,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 				sample.stop(sendTimer());
 			}
 		}
-		catch (Exception ex) {
+		catch (Throwable ex) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("failure occurred in gateway sendAndReceive: " + ex.getMessage());
 			}
@@ -543,7 +543,14 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 					reply instanceof ErrorMessage
 							? ((ErrorMessage) reply).getPayload()
 							: (Throwable) reply;
-			return handleSendAndReceiveError(object, requestMessage, error, shouldConvert);
+			try {
+				return handleSendAndReceiveError(object, requestMessage, error, shouldConvert);
+			}
+			catch (MessagingException me) {
+				if (me.getCause() instanceof Error) { // NOSONAR
+					throw (Error) me.getCause();
+				}
+			}
 		}
 		return reply;
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
@@ -36,7 +36,6 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageBuilder;

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
@@ -17,7 +17,7 @@
 package org.springframework.integration.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 
 import java.time.Duration;
@@ -27,7 +27,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.annotation.Gateway;
@@ -36,6 +36,7 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageBuilder;
@@ -88,13 +89,10 @@ public class AsyncGatewayTests {
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = (TestEchoService) proxyFactory.getObject();
 		Future<Message<?>> f = service.returnMessage("foo");
-		try {
-			f.get(10000, TimeUnit.MILLISECONDS);
-			fail("Expected Exception");
-		}
-		catch (ExecutionException e) {
-			assertThat(e.getCause()).isEqualTo(error);
-		}
+
+		assertThatExceptionOfType(ExecutionException.class)
+				.isThrownBy(() -> f.get(10000, TimeUnit.MILLISECONDS))
+				.withCause(error);
 	}
 
 	@Test
@@ -134,7 +132,7 @@ public class AsyncGatewayTests {
 	}
 
 	@Test
-	public void customFutureReturned() throws Exception {
+	public void customFutureReturned() {
 		QueueChannel requestChannel = new QueueChannel();
 		addThreadEnricher(requestChannel);
 		startResponder(requestChannel);


### PR DESCRIPTION
See SO for more info:
https://stackoverflow.com/questions/64456946/handle-exceptions-errors-other-than-messagingexception-ie-other-error-excepti

In the versions before `5.2.x` the `Error` was wrapped to the `MessagingException`
in the `AbstractRequestHandlerAdvice` and this one was handled properly
on the gateway level with its `errorChannel` configured

* Fix `MessagingGatewaySupport` to catch all the `Throwable` and try to send them as `ErrorMessage`
to the `errorChannel`.
Otherwise unwrap returned `MessagingException` and re-throw an `Error` as is to keep
the current behavior for non-handled exceptions

**Cherry-pick to 5.3.x & 5.2.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
