### PR TITLE
Get correct next execution date from the trigger

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
@@ -85,10 +85,11 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 		return adapter;
 	}
 
-	private MessageSource<?> createMessageSource(Object beanArg, String beanName, Method methodArg) {
+	private MessageSource<?> createMessageSource(Object beanArg, String beanNameArg, Method methodArg) {
 		MessageSource<?> messageSource = null;
 		Object bean = beanArg;
 		Method method = methodArg;
+		String beanName = beanNameArg;
 		if (AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
 			Object target = resolveTargetBeanFromMethodWithBeanAnnotation(method);
 			Class<?> targetClass = target.getClass();
@@ -106,10 +107,12 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 			else if (target instanceof Supplier<?>) {
 				method = ClassUtils.SUPPLIER_GET_METHOD;
 				bean = target;
+				beanName += '.' + methodArg.getName();
 			}
 			else if (ClassUtils.KOTLIN_FUNCTION_0_INVOKE_METHOD != null) {
 				method = ClassUtils.KOTLIN_FUNCTION_0_INVOKE_METHOD;
 				bean = target;
+				beanName += '.' + methodArg.getName();
 			}
 		}
 		if (messageSource == null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -366,7 +366,7 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 																.update(triggerContext.lastScheduledExecutionTime(),
 																		triggerContext.lastActualExecutionTime(),
 																		new Date())
-												)), 1)
+												)), 0)
 				.repeat(this::isRunning)
 				.doOnSubscribe(subs -> this.subscription = subs);
 	}


### PR DESCRIPTION
With the `time-source` in Spring Cloud Stream we noticed
that first two items have the same (or close) value
when the `time-supplier` is used with the reactive output channel.
Turns out the `contactMap()` with `prefetch == 1` asks two
upstream elements immediately not waiting for a completion
for the fist one.
This way we were not able to update `triggerContext` for the proper
`lastCompletionTime`

* Change `AbstractPollingEndpoint` to `prefetch = 0` for the
"fair" upstream request
* Verify the behavior with the new
`ReactiveInboundChannelAdapterTests.testTimeSupplierConsistency()`
* Mark `ReactiveInboundChannelAdapterTests` as `@LongRunningTest`
since it is now pretty long waiting for all the 3 dates to verify
* Fix `InboundChannelAdapterAnnotationPostProcessor` to properly
register `MethodInvokingMessageSource` when we have more than one
`Supplier` with the `@InboundChannelAdapter` in the same configuration
class

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
