### PR TITLE
Fix `@InChAdapter` for several supplier beans

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,7 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 				MessagingAnnotationUtils.resolveAttribute(annotations, AnnotationUtils.VALUE, String.class);
 		Assert.hasText(channelName, "The channel ('value' attribute of @InboundChannelAdapter) can't be empty.");
 
-		MessageSource<?> messageSource = null;
+		MessageSource<?> messageSource;
 		try {
 			messageSource = createMessageSource(bean, beanName, method);
 		}
@@ -85,10 +85,11 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 		return adapter;
 	}
 
-	private MessageSource<?> createMessageSource(Object beanArg, String beanName, Method methodArg) {
+	private MessageSource<?> createMessageSource(Object beanArg, String beanNameArg, Method methodArg) {
 		MessageSource<?> messageSource = null;
 		Object bean = beanArg;
 		Method method = methodArg;
+		String beanName = beanNameArg;
 		if (AnnotatedElementUtils.isAnnotated(method, Bean.class.getName())) {
 			Object target = resolveTargetBeanFromMethodWithBeanAnnotation(method);
 			Class<?> targetClass = target.getClass();
@@ -106,10 +107,12 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 			else if (target instanceof Supplier<?>) {
 				method = ClassUtils.SUPPLIER_GET_METHOD;
 				bean = target;
+				beanName += '.' + methodArg.getName();
 			}
 			else if (ClassUtils.KOTLIN_FUNCTION_0_INVOKE_METHOD != null) {
 				method = ClassUtils.KOTLIN_FUNCTION_0_INVOKE_METHOD;
 				bean = target;
+				beanName += '.' + methodArg.getName();
 			}
 		}
 		if (messageSource == null) {
@@ -130,7 +133,7 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 	@Override
 	protected String generateHandlerBeanName(String originalBeanName, Method method) {
 		return super.generateHandlerBeanName(originalBeanName, method)
-				.replaceFirst(IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX + "$", ".source");
+				.replaceFirst(IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX + '$', ".source");
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ReactiveInboundChannelAdapterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ReactiveInboundChannelAdapterTests.java
@@ -88,6 +88,12 @@ public class ReactiveInboundChannelAdapterTests {
 		}
 
 		@Bean
+		@InboundChannelAdapter(value = "fluxChannel", autoStartup = "false", poller = @Poller(fixedDelay = "100000"))
+		public Supplier<String> anotherSupplier() {
+			return () -> "void";
+		}
+
+		@Bean
 		public MessageChannel fluxChannel() {
 			return new FluxMessageChannel();
 		}


### PR DESCRIPTION
The `InboundChannelAdapterAnnotationPostProcessor` doesn't use a bean method name
when it parses a `Supplier` bean and only uses a configuration class name + `get`
for method part

* Fix `InboundChannelAdapterAnnotationPostProcessor` to also include a bean method
name into the final bean name for the `MethodInvokingMessageSource` based on
the `Supplier` bean
* Modify `ReactiveInboundChannelAdapterTests` to add one more `Supplier` with the
`@InboundChannelAdapter` to ensure that configuration is still valid after the fix

**Cherry-pick to 5.2.x & 5.1.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
