### PR TITLE
GH-3394: Fix Redis (and some other) docs

### DIFF
--- a/src/reference/asciidoc/endpoint-summary.adoc
+++ b/src/reference/asciidoc/endpoint-summary.adoc
@@ -138,9 +138,15 @@ The following table summarizes the various endpoints with quick links to the app
 | N
 | N
 
+| *R2DBC*
+| <<./r2dbc.adoc#r2dbc-inbound-channel-adapter,R2DBC Inbound Channel Adapter>>
+| <<./r2dbc.adoc#r2dbc-outbound-channel-adapter,R2DBC Outbound Channel Adapter>>
+| N
+| N
+
 | *Redis*
-| <<./redis.adoc#redis-inbound-channel-adapter,Redis Inbound Channel Adapter>> and <<./redis.adoc#redis-queue-inbound-channel-adapter,Redis Queue Inbound Channel Adapter>> and <<./redis.adoc#redis-store-inbound-channel-adapter,Redis Store Inbound Channel Adapter>>
-| <<./redis.adoc#redis-outbound-channel-adapter,Redis Outbound Channel Adapter>> and <<./redis.adoc#redis-queue-outbound-channel-adapter,Redis Queue Outbound Channel Adapter>> and <<./redis.adoc#redis-store-outbound-channel-adapter,RedisStore Outbound Channel Adapter>>
+| <<./redis.adoc#redis-inbound-channel-adapter,Redis Inbound Channel Adapter>>, <<./redis.adoc#redis-queue-inbound-channel-adapter,Redis Queue Inbound Channel Adapter>>, <<./redis.adoc#redis-store-inbound-channel-adapter,Redis Store Inbound Channel Adapter>>, <<./redis.adoc#redis-stream-inbound,Redis Stream Inbound Channel Adapter>>
+| <<./redis.adoc#redis-outbound-channel-adapter,Redis Outbound Channel Adapter>>, <<./redis.adoc#redis-queue-outbound-channel-adapter,Redis Queue Outbound Channel Adapter>>, <<./redis.adoc#redis-store-outbound-channel-adapter,RedisStore Outbound Channel Adapter>>, <<./redis.adoc#redis-stream-outbound,Redis Stream Outbound Channel Adapter>>
 | <<./redis.adoc#redis-queue-inbound-gateway,Redis Queue Inbound Gateway>>
 | <<./redis.adoc#redis-outbound-gateway,Redis Outbound Command Gateway>> and <<./redis.adoc#redis-queue-outbound-gateway,Redis Queue Outbound Gateway>>
 
@@ -219,6 +225,11 @@ The following table summarizes the various endpoints with quick links to the app
 | *XMPP*
 | <<./xmpp.adoc#xmpp-messages,XMPP Messages>> and <<./xmpp.adoc#xmpp-presence,XMPP Presence>>
 | <<./xmpp.adoc#xmpp-messages,XMPP Messages>> and <<./xmpp.adoc#xmpp-presence,XMPP Presence>>
+| N
+| N
+| *ZeroMQ*
+| <<./zeromq.adoc#zeromq-inbound-channel-adapter,ZeroMQ Inbound Channel Adapter>>
+| <<./zeromq.adoc#zeromq-outbound-channel-adapter,ZeroMQ outbound Channel Adapter>>
 | N
 | N
 |===

--- a/src/reference/asciidoc/index-single.adoc
+++ b/src/reference/asciidoc/index-single.adoc
@@ -49,6 +49,8 @@ include::./jpa.adoc[]
 
 include::./jms.adoc[]
 
+include::./jmx.adoc[]
+
 include::./kafka.adoc[]
 
 include::./mail.adoc[]

--- a/src/reference/asciidoc/index.adoc
+++ b/src/reference/asciidoc/index.adoc
@@ -34,6 +34,7 @@ This documentation is also available as single searchable link:index-single.html
 <<./jdbc.adoc#jdbc,JDBC Support>> ::
 <<./jpa.adoc#jpa,JPA Support>> ::
 <<./jms.adoc#jms,JMS Support>> ::
+<<./jmx.adoc#jmx,JMX Support>> ::
 <<./kafka.adoc#kafka,Apache Kafka Support>> ::
 <<./mail.adoc#mail,Mail Support>> ::
 <<./mongodb.adoc#mongodb,MongoDb Support>> ::

--- a/src/reference/asciidoc/r2dbc.adoc
+++ b/src/reference/asciidoc/r2dbc.adoc
@@ -24,11 +24,11 @@ compile "org.springframework.integration:spring-integration-r2dbc:{project-versi
 ====
 
 [[r2dbc-inbound-channel-adapter]]
-=== Inbound Channel Adapter
+=== R2DBC Inbound Channel Adapter
 
 TBD
 
 [[r2dbc-outbound-channel-adapter]]
-=== Outbound Channel Adapter
+=== R2DBC Outbound Channel Adapter
 
 TBD

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -654,7 +654,7 @@ If you provide neither attribute, the `payload` is used as the command arguments
 ====
 
 You can use the `<int-redis:outbound-gateway>` as a common component to perform any desired Redis operation.
-For example, the following examlpe shows how to get incremented values from Redis atomic number:
+The following example shows how to get incremented values from Redis atomic number:
 
 ====
 [source,xml]
@@ -739,9 +739,10 @@ The following listing shows the available attributes for a Redis queue inbound g
         recovery-interval=""/>  <11>
 ----
 
-<1> The `MessageChannel` from which this endpoint receives `Message` instances.
-<2> The `MessageChannel` where this endpoint sends reply `Message` instances.
-<3> A reference to a Spring `TaskExecutor` (or a standard JDK 1.5+ `Executor`) bean.
+<1> The `MessageChannel` where this endpoint sends `Message` instances created from the Redis data.
+<2> The `MessageChannel` from where this endpoint waits for reply `Message` instances.
+Optional - the `replyChannel` header is still in use.
+<3> A reference to a Spring `TaskExecutor` (or a standard JDK `Executor`) bean.
 It is used for the underlying listening task.
 It defaults to a `SimpleAsyncTaskExecutor`.
 <4> The timeout (in milliseconds) to wait until the reply message is sent.
@@ -789,12 +790,13 @@ You should set the expiry at a large enough value to prevent this condition, but
 
 Starting with version 5.0, the `RedisLockRegistry` implements `ExpirableLockRegistry`, which removes locks last acquired more than `age` ago and that are not currently locked.
 
-[[redis-stream-outbound]]
-=== Redis Stream Outbound Channel Adapter
-
-TBD
 
 [[redis-stream-inbound]]
 === Redis Stream Inbound Channel Adapter
+
+TBD
+
+[[redis-stream-outbound]]
+=== Redis Stream Outbound Channel Adapter
 
 TBD

--- a/src/reference/asciidoc/zeromq.adoc
+++ b/src/reference/asciidoc/zeromq.adoc
@@ -104,21 +104,21 @@ ZeroMqChannel zeroMqPubSubChannel(ZContext context) {
 ====
 
 [[zeromq-inbound-channel-adapter]]
-=== ZeroMq Inbound Channel Adapter
+=== ZeroMQ Inbound Channel Adapter
 
 The `ZeroMqMessageProducer` is a `MessageProducerSupport` implementation with reactive semantics.
-It constantly reads the data from a ZeroMq socket in a non-blocking manner and publishes the messages to an infinite `Flux` which is subscribed to by a `FluxMessageChannel` or explicitly in the `start()` method, if the output channel is not reactive.
+It constantly reads the data from a ZeroMQ socket in a non-blocking manner and publishes the messages to an infinite `Flux` which is subscribed to by a `FluxMessageChannel` or explicitly in the `start()` method, if the output channel is not reactive.
 When no data are received on the socket, a `consumeDelay` (defaults to 1 second) is applied before the next read attempt.
 
 
 Only `SocketType.PAIR`, `SocketType.PULL` and `SocketType.SUB` are supported by the `ZeroMqMessageProducer`.
 This component can connect to the remote socket or bind onto TCP protocol with the provided or random port.
-The actual port can be obtained via `getBoundPort()` after this component is started and ZeroMq socket is bound.
+The actual port can be obtained via `getBoundPort()` after this component is started and ZeroMQ socket is bound.
 The socket options (e.g. security or write timeout) can be configured via `setSocketConfigurer(Consumer<ZMQ.Socket> socketConfigurer)` callback.
 
 If the `receiveRaw` option is set to `true`, a `ZMsg`, consumed from the socket, is sent as is in the payload of the produced `Message`: it's up to the downstream flow to parse and convert  the `ZMsg`.
 Otherwise an `InboundMessageMapper` is used to convert the consumed data into a `Message`.
-If the received `ZMsg` is multi-frame, the first frame is treated as the `ZeroMqHeaders.TOPIC` header this ZeroMq message was published to.
+If the received `ZMsg` is multi-frame, the first frame is treated as the `ZeroMqHeaders.TOPIC` header this ZeroMQ message was published to.
 
 With `SocketType.SUB`, the `ZeroMqMessageProducer` uses the provided `topics` option for subscriptions; defaults to subscribe to all.
 Subscriptions can be adjusted at runtime using `subscribeToTopics()` and `unsubscribeFromTopics()` `@ManagedOperation` s.
@@ -142,15 +142,15 @@ ZeroMqMessageProducer zeroMqMessageProducer(ZContext context, MessageChannel out
 ====
 
 [[zeromq-outbound-channel-adapter]]
-=== ZeroMq Outbound Channel Adapter
+=== ZeroMQ Outbound Channel Adapter
 
-The `ZeroMqMessageHandler` is a `ReactiveMessageHandler` implementation to produce publish messages into a ZeroMq socket.
+The `ZeroMqMessageHandler` is a `ReactiveMessageHandler` implementation to produce publish messages into a ZeroMQ socket.
 Only `SocketType.PAIR`, `SocketType.PUSH` and `SocketType.PUB` are supported.
-The `ZeroMqMessageHandler` only supports connecting the ZeroMq socket; binding is not supported.
-When the `SocketType.PUB` is used, the `topicExpression` is evaluated against a request message to inject a topic frame into a ZeroMq message if it is not null.
+The `ZeroMqMessageHandler` only supports connecting the ZeroMQ socket; binding is not supported.
+When the `SocketType.PUB` is used, the `topicExpression` is evaluated against a request message to inject a topic frame into a ZeroMQ message if it is not null.
 The subscriber side (`SocketType.SUB`) must receive the topic frame first before parsing the actual data.
 When the payload of the request message is a `ZMsg`, no conversion or topic extraction is performed: the `ZMsg` is sent into a socket as is and it is not destroyed for possible further reuse.
-Otherwise an `OutboundMessageMapper<byte[]>` is used to convert a request message (or just its payload) into a ZeroMq frame to publish.
+Otherwise an `OutboundMessageMapper<byte[]>` is used to convert a request message (or just its payload) into a ZeroMQ frame to publish.
 By default a `ConvertingBytesMessageMapper` is used supplied with a `ConfigurableCompositeMessageConverter`.
 The socket options (e.g. security or write timeout) can be configured via `setSocketConfigurer(Consumer<ZMQ.Socket> socketConfigurer)` callback.
 
@@ -172,7 +172,7 @@ ZeroMqMessageHandler zeroMqMessageHandler(ZContext context) {
 ====
 
 [[zeromq-dsl]]
-=== ZeroMq Java DSL Support
+=== ZeroMQ Java DSL Support
 
 The `spring-integration-zeromq` provide a convenient Java DSL fluent API via `ZeroMq` factory and `IntegrationComponentSpec` implementations for the components mentioned above.
 
@@ -188,7 +188,7 @@ This is a sample of Java DSL for `ZeroMqChannel`:
 ----
 ====
 
-The Inbound Channel Adapter for ZeroMq Java DSL is:
+The Inbound Channel Adapter for ZeroMQ Java DSL is:
 
 ====
 [source,java]
@@ -203,7 +203,7 @@ IntegrationFlows.from(
 ----
 ====
 
-The Outbound Channel Adapter for ZeroMq Java DSL is:
+The Outbound Channel Adapter for ZeroMQ Java DSL is:
 
 ====
 [source,java]


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3394

* Fix (wrong) copied/pasted text in the Redis Queue Inbound Gateway attribute
descriptions
* Fix some docs typos
* Add `jmx.adoc` into an `index.adoc` and `index-single.adoc`
* Add R2DBC, Redis Stream and ZeroMQ channel adapters into an `endpoint-summary.adoc`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
