### PR TITLE
Fix subscribers race condition in FluxChannel

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -66,6 +66,8 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 
 	private boolean shouldTrack = false;
 
+	private volatile boolean active;
+
 	protected MessageProducerSupport() {
 		this.setPhase(Integer.MAX_VALUE / 2);
 	}
@@ -159,6 +161,14 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 		return this.messagingTemplate;
 	}
 
+	protected void setActive(boolean active) {
+		this.active = active;
+	}
+
+	public boolean isActive() {
+		return this.active;
+	}
+
 	@Override
 	public IntegrationPatternType getIntegrationPatternType() {
 		return IntegrationPatternType.inbound_channel_adapter;
@@ -187,6 +197,7 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 	 */
 	@Override
 	protected void doStart() {
+		setActive(true);
 	}
 
 	/**
@@ -196,6 +207,7 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 	 */
 	@Override
 	protected void doStop() {
+		setActive(false);
 	}
 
 	protected void sendMessage(Message<?> messageArg) {
@@ -222,7 +234,7 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 						.map(this::trackMessageIfAny)
 						.doOnComplete(this::stop)
 						.doOnCancel(this::stop)
-						.takeWhile((message) -> isRunning());
+						.takeWhile((message) -> isActive());
 
 		if (channelForSubscription instanceof ReactiveStreamsSubscribableChannel) {
 			((ReactiveStreamsSubscribableChannel) channelForSubscription).subscribeTo(messageFlux);

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveMessageSourceProducer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveMessageSourceProducer.java
@@ -63,6 +63,7 @@ public class ReactiveMessageSourceProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
+		super.doStart();
 		subscribeToPublisher(this.messageFlux);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ReactiveMessageProducerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ReactiveMessageProducerTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.integration.endpoint;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
@@ -52,17 +50,18 @@ public class ReactiveMessageProducerTests {
 
 	@Test
 	public void test() {
-		assertThat(this.producer.isRunning()).isTrue();
+		StepVerifier stepVerifier =
+				StepVerifier.create(
+						Flux.from(this.fluxMessageChannel)
+								.map(Message::getPayload)
+								.cast(String.class))
+						.expectNext("test1", "test2")
+						.thenCancel()
+						.verifyLater();
 
-		StepVerifier.create(
-				Flux.from(this.fluxMessageChannel)
-						.map(Message::getPayload)
-						.cast(String.class))
-				.expectNext("test1", "test2")
-				.thenCancel()
-				.verify(Duration.ofSeconds(10));
+		this.producer.start();
 
-		assertThat(this.producer.isRunning()).isFalse();
+		stepVerifier.verify(Duration.ofSeconds(10));
 	}
 
 	@Configuration
@@ -81,10 +80,12 @@ public class ReactiveMessageProducerTests {
 
 						@Override
 						protected void doStart() {
+							super.doStart();
 							subscribeToPublisher(Flux.just("test1", "test2").map(GenericMessage::new));
 						}
 
 					};
+			producer.setAutoStartup(false);
 			producer.setOutputChannel(fluxMessageChannel());
 			return producer;
 		}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/AbstractInternetProtocolReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/AbstractInternetProtocolReceivingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.integration.ip;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
@@ -32,6 +31,8 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public abstract class AbstractInternetProtocolReceivingChannelAdapter
@@ -55,8 +56,6 @@ public abstract class AbstractInternetProtocolReceivingChannelAdapter
 	private boolean taskExecutorSet;
 
 	private int poolSize = 5;
-
-	private volatile boolean active;
 
 	private volatile boolean listening;
 
@@ -108,48 +107,6 @@ public abstract class AbstractInternetProtocolReceivingChannelAdapter
 		return this.receiveBufferSize;
 	}
 
-	/**
-	 * Protected by lifecycleLock
-	 */
-	@Override
-	protected void doStart() {
-		if (!this.active) {
-			this.active = true;
-			String beanName = this.getComponentName();
-			checkTaskExecutor((beanName == null ? "" : beanName + "-") + this.getComponentType());
-			this.taskExecutor.execute(this);
-		}
-	}
-
-	/**
-	 * Creates a default task executor if none was supplied.
-	 *
-	 * @param threadName The thread name.
-	 */
-	protected void checkTaskExecutor(final String threadName) {
-		if (this.active && this.taskExecutor == null) {
-			Executor executor = Executors.newFixedThreadPool(this.poolSize, new ThreadFactory() {
-				@Override
-				public Thread newThread(Runnable runner) {
-					Thread thread = new Thread(runner);
-					thread.setName(threadName);
-					thread.setDaemon(true);
-					return thread;
-				}
-			});
-			this.taskExecutor = executor;
-		}
-	}
-
-	@Override
-	protected void doStop() {
-		this.active = false;
-		if (!this.taskExecutorSet && this.taskExecutor != null) {
-			((ExecutorService) this.taskExecutor).shutdown();
-			this.taskExecutor = null;
-		}
-	}
-
 	public boolean isListening() {
 		return this.listening;
 	}
@@ -197,10 +154,41 @@ public abstract class AbstractInternetProtocolReceivingChannelAdapter
 	}
 
 	/**
-	 * @return the active
+	 * Protected by lifecycleLock
 	 */
-	public boolean isActive() {
-		return this.active;
+	@Override
+	protected void doStart() {
+		super.doStart();
+		String beanName = getComponentName();
+		checkTaskExecutor((beanName == null ? "" : beanName + "-") + getComponentType());
+		this.taskExecutor.execute(this);
+	}
+
+	/**
+	 * Creates a default task executor if none was supplied.
+	 *
+	 * @param threadName The thread name.
+	 */
+	protected void checkTaskExecutor(final String threadName) {
+		if (isActive() && this.taskExecutor == null) {
+			this.taskExecutor =
+					Executors.newFixedThreadPool(this.poolSize,
+							(runner) -> {
+						Thread thread = new Thread(runner);
+						thread.setName(threadName);
+						thread.setDaemon(true);
+						return thread;
+					});
+		}
+	}
+
+	@Override
+	protected void doStop() {
+		super.doStop();
+		if (!this.taskExecutorSet && this.taskExecutor != null) {
+			((ExecutorService) this.taskExecutor).shutdown();
+			this.taskExecutor = null;
+		}
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.integration.ip.tcp.connection.ConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpListener;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 
 /**
@@ -40,11 +41,13 @@ import org.springframework.util.Assert;
  * a client factory, the sender owns the connection.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  *
  */
 public class TcpReceivingChannelAdapter
-	extends MessageProducerSupport implements TcpListener, ClientModeCapable, OrderlyShutdownCapable {
+		extends MessageProducerSupport implements TcpListener, ClientModeCapable, OrderlyShutdownCapable {
 
 	private AbstractConnectionFactory clientConnectionFactory;
 
@@ -60,8 +63,6 @@ public class TcpReceivingChannelAdapter
 
 	private volatile ClientModeConnectionManager clientModeConnectionManager;
 
-	private volatile boolean active;
-
 	private volatile boolean shuttingDown;
 
 	private final AtomicInteger activeCount = new AtomicInteger();
@@ -71,9 +72,7 @@ public class TcpReceivingChannelAdapter
 		boolean isErrorMessage = message instanceof ErrorMessage;
 		try {
 			if (this.shuttingDown) {
-				if (logger.isInfoEnabled()) {
-					logger.info("Inbound message ignored; shutting down; " + message.toString());
-				}
+				logger.info(() -> "Inbound message ignored; shutting down; " + message.toString());
 			}
 			else {
 				if (isErrorMessage) {
@@ -124,40 +123,34 @@ public class TcpReceivingChannelAdapter
 	@Override // protected by super#lifecycleLock
 	protected void doStart() {
 		super.doStart();
-		if (!this.active) {
-			this.active = true;
-			this.shuttingDown = false;
-			if (this.serverConnectionFactory != null) {
-				this.serverConnectionFactory.start();
-			}
-			if (this.clientConnectionFactory != null) {
-				this.clientConnectionFactory.start();
-			}
-			if (this.isClientMode) {
-				ClientModeConnectionManager manager = new ClientModeConnectionManager(
-						this.clientConnectionFactory);
-				this.clientModeConnectionManager = manager;
-				Assert.state(this.getTaskScheduler() != null, "Client mode requires a task scheduler");
-				this.scheduledFuture = this.getTaskScheduler().scheduleAtFixedRate(manager, this.retryInterval);
-			}
+		this.shuttingDown = false;
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.start();
+		}
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.start();
+		}
+		if (this.isClientMode) {
+			ClientModeConnectionManager manager = new ClientModeConnectionManager(this.clientConnectionFactory);
+			this.clientModeConnectionManager = manager;
+			TaskScheduler taskScheduler = getTaskScheduler();
+			Assert.state(taskScheduler != null, "Client mode requires a task scheduler");
+			this.scheduledFuture = taskScheduler.scheduleAtFixedRate(manager, this.retryInterval);
 		}
 	}
 
 	@Override // protected by super#lifecycleLock
 	protected void doStop() {
 		super.doStop();
-		if (this.active) {
-			this.active = false;
-			if (this.scheduledFuture != null) {
-				this.scheduledFuture.cancel(true);
-			}
-			this.clientModeConnectionManager = null;
-			if (this.clientConnectionFactory != null) {
-				this.clientConnectionFactory.stop();
-			}
-			if (this.serverConnectionFactory != null) {
-				this.serverConnectionFactory.stop();
-			}
+		if (this.scheduledFuture != null) {
+			this.scheduledFuture.cancel(true);
+		}
+		this.clientModeConnectionManager = null;
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.stop();
+		}
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.stop();
 		}
 	}
 
@@ -165,7 +158,6 @@ public class TcpReceivingChannelAdapter
 	 * Sets the client or server connection factory; for this (an inbound adapter), if
 	 * the factory is a client connection factory, the sockets are owned by a sending
 	 * channel adapter and this adapter is used to receive replies.
-	 *
 	 * @param connectionFactory the connectionFactory to set
 	 */
 	public void setConnectionFactory(AbstractConnectionFactory connectionFactory) {
@@ -217,8 +209,7 @@ public class TcpReceivingChannelAdapter
 	}
 
 	/**
-	 * @param isClientMode
-	 *            the isClientMode to set
+	 * @param isClientMode the isClientMode to set
 	 */
 	public void setClientMode(boolean isClientMode) {
 		this.isClientMode = isClientMode;
@@ -232,8 +223,7 @@ public class TcpReceivingChannelAdapter
 	}
 
 	/**
-	 * @param retryInterval
-	 *            the retryInterval to set
+	 * @param retryInterval the retryInterval to set
 	 */
 	public void setRetryInterval(long retryInterval) {
 		this.retryInterval = retryInterval;
@@ -251,7 +241,7 @@ public class TcpReceivingChannelAdapter
 
 	@Override
 	public void retryConnection() {
-		if (this.active && this.isClientMode && this.clientModeConnectionManager != null) {
+		if (isActive() && this.isClientMode && this.clientModeConnectionManager != null) {
 			this.clientModeConnectionManager.run();
 		}
 	}
@@ -264,7 +254,8 @@ public class TcpReceivingChannelAdapter
 
 	@Override
 	public int afterShutdown() {
-		this.stop();
+		stop();
 		return this.activeCount.get();
 	}
+
 }

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbChangeStreamMessageProducer.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbChangeStreamMessageProducer.java
@@ -110,6 +110,7 @@ public class MongoDbChangeStreamMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
+		super.doStart();
 		Flux<Message<?>> changeStreamFlux =
 				this.mongoOperations.changeStream(this.collection, this.options, this.domainType)
 						.map(event ->

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
@@ -82,8 +82,6 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 
 	private boolean rightPop = true;
 
-	private volatile boolean active;
-
 	private volatile boolean listening;
 
 	private volatile Runnable stopCallback;
@@ -243,7 +241,7 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 		}
 		catch (Exception ex) {
 			this.listening = false;
-			if (this.active) {
+			if (isActive()) {
 				logger.error(ex,
 						"Failed to execute listening task. Will attempt to resubmit in " + this.recoveryInterval
 								+ " milliseconds.");
@@ -259,10 +257,8 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 
 	@Override
 	protected void doStart() {
-		if (!this.active) {
-			this.active = true;
-			this.restart();
-		}
+		super.doStart();
+		this.restart();
 	}
 
 	/**
@@ -303,7 +299,6 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 	@Override
 	protected void doStop() {
 		super.doStop();
-		this.active = false;
 		this.listening = false;
 	}
 
@@ -345,14 +340,14 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 		@Override
 		public void run() {
 			try {
-				while (RedisQueueMessageDrivenEndpoint.this.active) {
+				while (isActive()) {
 					RedisQueueMessageDrivenEndpoint.this.listening = true;
-					RedisQueueMessageDrivenEndpoint.this.popMessageAndSend();
+					popMessageAndSend();
 				}
 			}
 			finally {
-				if (RedisQueueMessageDrivenEndpoint.this.active) {
-					RedisQueueMessageDrivenEndpoint.this.restart();
+				if (isActive()) {
+					restart();
 				}
 				else if (RedisQueueMessageDrivenEndpoint.this.stopCallback != null) {
 					RedisQueueMessageDrivenEndpoint.this.stopCallback.run();

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,8 +108,6 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 
 	private AbstractBrokerMessageHandler brokerHandler;
 
-	private volatile boolean active;
-
 	public WebSocketInboundChannelAdapter(IntegrationWebSocketContainer webSocketContainer) {
 		this(webSocketContainer, new SubProtocolHandlerRegistry(new PassThruSubProtocolHandler()));
 	}
@@ -127,10 +125,10 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 					try {
 						handleMessageAndSend(message);
 					}
-					catch (Exception e) {
+					catch (Exception ex) {
 						throw IntegrationUtils.wrapInHandlingExceptionIfNecessary(message,
 								() -> "Failed to handle and process message in the ["
-										+ WebSocketInboundChannelAdapter.this + ']', e);
+										+ WebSocketInboundChannelAdapter.this + ']', ex);
 					}
 				});
 	}
@@ -267,7 +265,7 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 
 	@Override
 	protected void doStart() {
-		this.active = true;
+		super.doStart();
 		if (this.webSocketContainer instanceof Lifecycle) {
 			((Lifecycle) this.webSocketContainer).start();
 		}
@@ -275,17 +273,18 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 
 	@Override
 	protected void doStop() {
-		this.active = false;
+		super.doStop();
 		if (this.webSocketContainer instanceof Lifecycle) {
 			((Lifecycle) this.webSocketContainer).stop();
 		}
 	}
 
-	private boolean isActive() {
-		if (!this.active) {
+	public boolean isActive() {
+		boolean active = super.isActive();
+		if (!active) {
 			logger.warn("MessageProducer '" + this + "' isn't started to accept WebSocket events.");
 		}
-		return this.active;
+		return active;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
@@ -90,8 +90,6 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	private volatile Mono<ZMQ.Socket> socketMono;
 
-	private volatile boolean active;
-
 	public ZeroMqMessageProducer(ZContext context) {
 		this(context, SocketType.PAIR);
 	}
@@ -212,7 +210,7 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 	@ManagedOperation
 	public void subscribeToTopics(String... topics) {
 		Assert.state(SocketType.SUB.equals(this.socketType), "Only SUB socket can accept a subscription option.");
-		Assert.state(this.active, "This message producer is not active to accept a new subscription.");
+		Assert.state(isActive(), "This message producer is not active to accept a new subscription.");
 
 		Flux.fromArray(topics)
 				.flatMap((topic) ->
@@ -223,7 +221,7 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 	@ManagedOperation
 	public void unsubscribeFromTopics(String... topics) {
 		Assert.state(SocketType.SUB.equals(this.socketType), "Only SUB socket can accept a unsubscription option.");
-		Assert.state(this.active, "This message producer is not active to cancel a subscription.");
+		Assert.state(isActive(), "This message producer is not active to cancel a subscription.");
 
 		Flux.fromArray(topics)
 				.flatMap((topic) ->
@@ -233,6 +231,7 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
+		super.doStart();
 		this.socketMono =
 				Mono.just(this.context.createSocket(this.socketType))
 						.publishOn(this.consumerScheduler)
@@ -255,8 +254,6 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 						.cache()
 						.publishOn(this.consumerScheduler);
 
-		this.active = true;
-
 		Flux<? extends Message<?>> dataFlux =
 				this.socketMono
 						.flatMap((socket) -> {
@@ -273,8 +270,8 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 						.doOnError((error) ->
 								logger.error(error, () -> "Error processing ZeroMQ message in the " + this))
 						.repeatWhenEmpty((repeat) ->
-								this.active ? repeat.delayElements(this.consumeDelay) : repeat)
-						.repeat(() -> this.active)
+								isActive() ? repeat.delayElements(this.consumeDelay) : repeat)
+						.repeat(this::isActive)
 						.doOnComplete(this.consumerScheduler::dispose);
 
 		subscribeToPublisher(dataFlux);
@@ -296,13 +293,13 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStop() {
-		this.active = false;
+		super.doStop();
 		this.socketMono.doOnNext(ZMQ.Socket::close).subscribe();
 	}
 
 	@Override
 	public void destroy() {
-		this.active = false;
+		setActive(false);
 		super.destroy();
 		this.socketMono.doOnNext(ZMQ.Socket::close).block();
 	}


### PR DESCRIPTION
It is possible that
`this.sink.currentSubscriberCount() > 0)` is `true` in the `FluxMessageChannel`
before actually a `subscriber` is added to the source `Publisher`,
so we may end up with a condition when we can already emit, but
there is nothing to accept

* Defer `this.subscribedSignal.emitNext(true)` in the `FluxMessageChannel`
into the `doOnSubscribe()` of the `Flux` from `sink`
* Fix `Flux.destroy()` to emit `false` for the `subscribedSignal` before
calling `emitComplete()`.
Turns out that `delaySubscription()` can react for the completion signal
where the last value was `true` in the `Sinks.many().replay().limit(1)`
* Fix `MessageProducerSupport` to extract an `active` flag and set it before
`isRunning` - the `Flux` subscription relies on the `takeWhile()`
where in case of `autoStartup = false` we will never start consume because
it is set to `true` already after `doStart()`
* Refactor all the `MessageProducerSupport` implementation with similar
`active` state to use already one from the super class

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
