### PR TITLE
Rely on `MProducerSupport.active` for `Flux`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -368,7 +368,7 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 																		triggerContext.lastActualExecutionTime(),
 																		new Date())
 												)), 0)
-				.repeat(this::isRunning)
+				.repeat(this::isActive)
 				.doOnSubscribe(subs -> this.subscription = subs);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -161,10 +161,6 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 		return this.messagingTemplate;
 	}
 
-	protected void setActive(boolean active) {
-		this.active = active;
-	}
-
 	public boolean isActive() {
 		return this.active;
 	}
@@ -197,7 +193,7 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 	 */
 	@Override
 	protected void doStart() {
-		setActive(true);
+		this.active = true;
 	}
 
 	/**
@@ -207,7 +203,7 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 	 */
 	@Override
 	protected void doStop() {
-		setActive(false);
+		this.active = false;
 	}
 
 	protected void sendMessage(Message<?> messageArg) {
@@ -306,6 +302,12 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 		else {
 			return message;
 		}
+	}
+
+	@Override
+	public void destroy() {
+		this.active = false;
+		super.destroy();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -66,8 +66,6 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 
 	private boolean shouldTrack = false;
 
-	private volatile boolean active;
-
 	protected MessageProducerSupport() {
 		this.setPhase(Integer.MAX_VALUE / 2);
 	}
@@ -161,10 +159,6 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 		return this.messagingTemplate;
 	}
 
-	public boolean isActive() {
-		return this.active;
-	}
-
 	@Override
 	public IntegrationPatternType getIntegrationPatternType() {
 		return IntegrationPatternType.inbound_channel_adapter;
@@ -193,7 +187,6 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 	 */
 	@Override
 	protected void doStart() {
-		this.active = true;
 	}
 
 	/**
@@ -203,7 +196,6 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 	 */
 	@Override
 	protected void doStop() {
-		this.active = false;
 	}
 
 	protected void sendMessage(Message<?> messageArg) {
@@ -302,12 +294,6 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 		else {
 			return message;
 		}
-	}
-
-	@Override
-	public void destroy() {
-		this.active = false;
-		super.destroy();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -66,6 +66,8 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 
 	private boolean shouldTrack = false;
 
+	private volatile boolean active;
+
 	protected MessageProducerSupport() {
 		this.setPhase(Integer.MAX_VALUE / 2);
 	}
@@ -159,6 +161,14 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 		return this.messagingTemplate;
 	}
 
+	protected void setActive(boolean active) {
+		this.active = active;
+	}
+
+	public boolean isActive() {
+		return this.active;
+	}
+
 	@Override
 	public IntegrationPatternType getIntegrationPatternType() {
 		return IntegrationPatternType.inbound_channel_adapter;
@@ -187,6 +197,7 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 	 */
 	@Override
 	protected void doStart() {
+		setActive(true);
 	}
 
 	/**
@@ -196,6 +207,7 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 	 */
 	@Override
 	protected void doStop() {
+		setActive(false);
 	}
 
 	protected void sendMessage(Message<?> messageArg) {
@@ -222,7 +234,7 @@ public abstract class MessageProducerSupport extends AbstractEndpoint implements
 						.map(this::trackMessageIfAny)
 						.doOnComplete(this::stop)
 						.doOnCancel(this::stop)
-						.takeWhile((message) -> isRunning());
+						.takeWhile((message) -> isActive());
 
 		if (channelForSubscription instanceof ReactiveStreamsSubscribableChannel) {
 			((ReactiveStreamsSubscribableChannel) channelForSubscription).subscribeTo(messageFlux);

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveMessageSourceProducer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveMessageSourceProducer.java
@@ -63,6 +63,7 @@ public class ReactiveMessageSourceProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
+		super.doStart();
 		subscribeToPublisher(this.messageFlux);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveMessageSourceProducer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveMessageSourceProducer.java
@@ -63,7 +63,6 @@ public class ReactiveMessageSourceProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
-		super.doStart();
 		subscribeToPublisher(this.messageFlux);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -1042,6 +1042,7 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 
 	@Override
 	public void destroy() {
+		super.destroy();
 		this.gatewayMap.values().forEach(MethodInvocationGateway::destroy);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -861,9 +861,9 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 
 	@Override
 	public void destroy() {
+		super.destroy();
 		this.timers.forEach(MeterFacade::remove);
 		this.timers.clear();
-		super.destroy();
 	}
 
 	private static class DefaultRequestMapper implements InboundMessageMapper<Object> {

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ReactiveMessageProducerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ReactiveMessageProducerTests.java
@@ -16,8 +16,6 @@
 
 package org.springframework.integration.endpoint;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
@@ -52,17 +50,18 @@ public class ReactiveMessageProducerTests {
 
 	@Test
 	public void test() {
-		assertThat(this.producer.isRunning()).isTrue();
+		StepVerifier stepVerifier =
+				StepVerifier.create(
+						Flux.from(this.fluxMessageChannel)
+								.map(Message::getPayload)
+								.cast(String.class))
+						.expectNext("test1", "test2")
+						.thenCancel()
+						.verifyLater();
 
-		StepVerifier.create(
-				Flux.from(this.fluxMessageChannel)
-						.map(Message::getPayload)
-						.cast(String.class))
-				.expectNext("test1", "test2")
-				.thenCancel()
-				.verify(Duration.ofSeconds(10));
+		this.producer.start();
 
-		assertThat(this.producer.isRunning()).isFalse();
+		stepVerifier.verify(Duration.ofSeconds(10));
 	}
 
 	@Configuration
@@ -81,10 +80,12 @@ public class ReactiveMessageProducerTests {
 
 						@Override
 						protected void doStart() {
+							super.doStart();
 							subscribeToPublisher(Flux.just("test1", "test2").map(GenericMessage::new));
 						}
 
 					};
+			producer.setAutoStartup(false);
 			producer.setOutputChannel(fluxMessageChannel());
 			return producer;
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/ApacheCommonsFileTailingMessageProducer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/ApacheCommonsFileTailingMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,19 +23,21 @@ import org.apache.commons.io.input.TailerListener;
  * File tailer that delegates to the Apache Commons Tailer.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 3.0
  *
  */
 public class ApacheCommonsFileTailingMessageProducer extends FileTailingMessageProducerSupport
 		implements TailerListener {
 
+	private long pollingDelay = 1000;
+
+	private boolean end = true;
+
+	private boolean reopen = false;
+
 	private volatile Tailer tailer;
-
-	private volatile long pollingDelay = 1000;
-
-	private volatile boolean end = true;
-
-	private volatile boolean reopen = false;
 
 	/**
 	 * The delay between checks of the file for new content in milliseconds.
@@ -71,8 +73,8 @@ public class ApacheCommonsFileTailingMessageProducer extends FileTailingMessageP
 	@Override
 	protected void doStart() {
 		super.doStart();
-		Tailer theTailer = new Tailer(this.getFile(), this, this.pollingDelay, this.end, this.reopen);
-		this.getTaskExecutor().execute(theTailer);
+		Tailer theTailer = new Tailer(getFile(), this, this.pollingDelay, this.end, this.reopen);
+		getTaskExecutor().execute(theTailer);
 		this.tailer = theTailer;
 	}
 
@@ -88,9 +90,9 @@ public class ApacheCommonsFileTailingMessageProducer extends FileTailingMessageP
 
 	@Override
 	public void fileNotFound() {
-		this.publish("File not found: " + this.getFile().getAbsolutePath());
+		publish("File not found: " + getFile().getAbsolutePath());
 		try {
-			Thread.sleep(this.getMissingFileDelay());
+			Thread.sleep(getMissingFileDelay());
 		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
@@ -99,7 +101,7 @@ public class ApacheCommonsFileTailingMessageProducer extends FileTailingMessageP
 
 	@Override
 	public void fileRotated() {
-		this.publish("File rotated: " + this.getFile().getAbsolutePath());
+		publish("File rotated: " + getFile().getAbsolutePath());
 	}
 
 	@Override
@@ -109,7 +111,7 @@ public class ApacheCommonsFileTailingMessageProducer extends FileTailingMessageP
 
 	@Override
 	public void handle(Exception ex) {
-		this.publish(ex.getMessage());
+		publish(ex.getMessage());
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/FileTailingMessageProducerSupport.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/FileTailingMessageProducerSupport.java
@@ -150,7 +150,6 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 
 	@Override
 	protected void doStart() {
-		super.doStart();
 		if (this.idleEventInterval > 0) {
 			this.idleEventScheduledFuture = getTaskScheduler().scheduleWithFixedDelay(() -> {
 				long now = System.currentTimeMillis();
@@ -167,7 +166,6 @@ public abstract class FileTailingMessageProducerSupport extends MessageProducerS
 
 	@Override
 	protected void doStop() {
-		super.doStop();
 		if (this.idleEventScheduledFuture != null) {
 			this.idleEventScheduledFuture.cancel(true);
 		}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/AbstractInternetProtocolReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/AbstractInternetProtocolReceivingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.integration.ip;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
@@ -32,6 +31,8 @@ import org.springframework.util.Assert;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public abstract class AbstractInternetProtocolReceivingChannelAdapter
@@ -55,8 +56,6 @@ public abstract class AbstractInternetProtocolReceivingChannelAdapter
 	private boolean taskExecutorSet;
 
 	private int poolSize = 5;
-
-	private volatile boolean active;
 
 	private volatile boolean listening;
 
@@ -108,48 +107,6 @@ public abstract class AbstractInternetProtocolReceivingChannelAdapter
 		return this.receiveBufferSize;
 	}
 
-	/**
-	 * Protected by lifecycleLock
-	 */
-	@Override
-	protected void doStart() {
-		if (!this.active) {
-			this.active = true;
-			String beanName = this.getComponentName();
-			checkTaskExecutor((beanName == null ? "" : beanName + "-") + this.getComponentType());
-			this.taskExecutor.execute(this);
-		}
-	}
-
-	/**
-	 * Creates a default task executor if none was supplied.
-	 *
-	 * @param threadName The thread name.
-	 */
-	protected void checkTaskExecutor(final String threadName) {
-		if (this.active && this.taskExecutor == null) {
-			Executor executor = Executors.newFixedThreadPool(this.poolSize, new ThreadFactory() {
-				@Override
-				public Thread newThread(Runnable runner) {
-					Thread thread = new Thread(runner);
-					thread.setName(threadName);
-					thread.setDaemon(true);
-					return thread;
-				}
-			});
-			this.taskExecutor = executor;
-		}
-	}
-
-	@Override
-	protected void doStop() {
-		this.active = false;
-		if (!this.taskExecutorSet && this.taskExecutor != null) {
-			((ExecutorService) this.taskExecutor).shutdown();
-			this.taskExecutor = null;
-		}
-	}
-
 	public boolean isListening() {
 		return this.listening;
 	}
@@ -197,10 +154,41 @@ public abstract class AbstractInternetProtocolReceivingChannelAdapter
 	}
 
 	/**
-	 * @return the active
+	 * Protected by lifecycleLock
 	 */
-	public boolean isActive() {
-		return this.active;
+	@Override
+	protected void doStart() {
+		super.doStart();
+		String beanName = getComponentName();
+		checkTaskExecutor((beanName == null ? "" : beanName + "-") + getComponentType());
+		this.taskExecutor.execute(this);
+	}
+
+	/**
+	 * Creates a default task executor if none was supplied.
+	 *
+	 * @param threadName The thread name.
+	 */
+	protected void checkTaskExecutor(final String threadName) {
+		if (isActive() && this.taskExecutor == null) {
+			this.taskExecutor =
+					Executors.newFixedThreadPool(this.poolSize,
+							(runner) -> {
+						Thread thread = new Thread(runner);
+						thread.setName(threadName);
+						thread.setDaemon(true);
+						return thread;
+					});
+		}
+	}
+
+	@Override
+	protected void doStop() {
+		super.doStop();
+		if (!this.taskExecutorSet && this.taskExecutor != null) {
+			((ExecutorService) this.taskExecutor).shutdown();
+			this.taskExecutor = null;
+		}
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/AbstractInternetProtocolReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/AbstractInternetProtocolReceivingChannelAdapter.java
@@ -158,7 +158,6 @@ public abstract class AbstractInternetProtocolReceivingChannelAdapter
 	 */
 	@Override
 	protected void doStart() {
-		super.doStart();
 		String beanName = getComponentName();
 		checkTaskExecutor((beanName == null ? "" : beanName + "-") + getComponentType());
 		this.taskExecutor.execute(this);
@@ -184,7 +183,6 @@ public abstract class AbstractInternetProtocolReceivingChannelAdapter
 
 	@Override
 	protected void doStop() {
-		super.doStop();
 		if (!this.taskExecutorSet && this.taskExecutor != null) {
 			((ExecutorService) this.taskExecutor).shutdown();
 			this.taskExecutor = null;

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpInboundGateway.java
@@ -75,8 +75,6 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 
 	private long retryInterval = DEFAULT_RETRY_INTERVAL;
 
-	private volatile boolean active;
-
 	private volatile ClientModeConnectionManager clientModeConnectionManager;
 
 	private volatile ScheduledFuture<?> scheduledFuture;
@@ -206,8 +204,7 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 	protected void onInit() {
 		super.onInit();
 		if (this.isClientMode) {
-			Assert.notNull(this.clientConnectionFactory,
-					"For client-mode, connection factory must be type='client'");
+			Assert.notNull(this.clientConnectionFactory, "For client-mode, connection factory must be type='client'");
 			Assert.isTrue(!this.clientConnectionFactory.isSingleUse(),
 					"For client-mode, connection factory must have single-use='false'");
 		}
@@ -216,40 +213,34 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 	@Override // protected by super#lifecycleLock
 	protected void doStart() {
 		super.doStart();
-		if (!this.active) {
-			this.active = true;
-			this.shuttingDown = false;
-			if (this.serverConnectionFactory != null) {
-				this.serverConnectionFactory.start();
-			}
-			if (this.clientConnectionFactory != null) {
-				this.clientConnectionFactory.start();
-			}
-			if (this.isClientMode) {
-				ClientModeConnectionManager manager =
-						new ClientModeConnectionManager(this.clientConnectionFactory);
-				this.clientModeConnectionManager = manager;
-				Assert.state(getTaskScheduler() != null, "Client mode requires a task scheduler");
-				this.scheduledFuture = getTaskScheduler().scheduleAtFixedRate(manager, this.retryInterval);
-			}
+		this.shuttingDown = false;
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.start();
+		}
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.start();
+		}
+		if (this.isClientMode) {
+			ClientModeConnectionManager manager =
+					new ClientModeConnectionManager(this.clientConnectionFactory);
+			this.clientModeConnectionManager = manager;
+			Assert.state(getTaskScheduler() != null, "Client mode requires a task scheduler");
+			this.scheduledFuture = getTaskScheduler().scheduleAtFixedRate(manager, this.retryInterval);
 		}
 	}
 
 	@Override // protected by super#lifecycleLock
 	protected void doStop() {
 		super.doStop();
-		if (this.active) {
-			this.active = false;
-			if (this.scheduledFuture != null) {
-				this.scheduledFuture.cancel(true);
-			}
-			this.clientModeConnectionManager = null;
-			if (this.clientConnectionFactory != null) {
-				this.clientConnectionFactory.stop();
-			}
-			if (this.serverConnectionFactory != null) {
-				this.serverConnectionFactory.stop();
-			}
+		if (this.scheduledFuture != null) {
+			this.scheduledFuture.cancel(true);
+		}
+		this.clientModeConnectionManager = null;
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.stop();
+		}
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.stop();
 		}
 	}
 
@@ -297,7 +288,7 @@ public class TcpInboundGateway extends MessagingGatewaySupport implements
 
 	@Override
 	public void retryConnection() {
-		if (this.active && this.isClientMode && this.clientModeConnectionManager != null) {
+		if (isActive() && this.isClientMode && this.clientModeConnectionManager != null) {
 			this.clientModeConnectionManager.run();
 		}
 	}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.integration.ip.tcp.connection.ConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.TcpListener;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 
 /**
@@ -40,11 +41,13 @@ import org.springframework.util.Assert;
  * a client factory, the sender owns the connection.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  *
  */
 public class TcpReceivingChannelAdapter
-	extends MessageProducerSupport implements TcpListener, ClientModeCapable, OrderlyShutdownCapable {
+		extends MessageProducerSupport implements TcpListener, ClientModeCapable, OrderlyShutdownCapable {
 
 	private AbstractConnectionFactory clientConnectionFactory;
 
@@ -60,8 +63,6 @@ public class TcpReceivingChannelAdapter
 
 	private volatile ClientModeConnectionManager clientModeConnectionManager;
 
-	private volatile boolean active;
-
 	private volatile boolean shuttingDown;
 
 	private final AtomicInteger activeCount = new AtomicInteger();
@@ -71,9 +72,7 @@ public class TcpReceivingChannelAdapter
 		boolean isErrorMessage = message instanceof ErrorMessage;
 		try {
 			if (this.shuttingDown) {
-				if (logger.isInfoEnabled()) {
-					logger.info("Inbound message ignored; shutting down; " + message.toString());
-				}
+				logger.info(() -> "Inbound message ignored; shutting down; " + message.toString());
 			}
 			else {
 				if (isErrorMessage) {
@@ -124,40 +123,34 @@ public class TcpReceivingChannelAdapter
 	@Override // protected by super#lifecycleLock
 	protected void doStart() {
 		super.doStart();
-		if (!this.active) {
-			this.active = true;
-			this.shuttingDown = false;
-			if (this.serverConnectionFactory != null) {
-				this.serverConnectionFactory.start();
-			}
-			if (this.clientConnectionFactory != null) {
-				this.clientConnectionFactory.start();
-			}
-			if (this.isClientMode) {
-				ClientModeConnectionManager manager = new ClientModeConnectionManager(
-						this.clientConnectionFactory);
-				this.clientModeConnectionManager = manager;
-				Assert.state(this.getTaskScheduler() != null, "Client mode requires a task scheduler");
-				this.scheduledFuture = this.getTaskScheduler().scheduleAtFixedRate(manager, this.retryInterval);
-			}
+		this.shuttingDown = false;
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.start();
+		}
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.start();
+		}
+		if (this.isClientMode) {
+			ClientModeConnectionManager manager = new ClientModeConnectionManager(this.clientConnectionFactory);
+			this.clientModeConnectionManager = manager;
+			TaskScheduler taskScheduler = getTaskScheduler();
+			Assert.state(taskScheduler != null, "Client mode requires a task scheduler");
+			this.scheduledFuture = taskScheduler.scheduleAtFixedRate(manager, this.retryInterval);
 		}
 	}
 
 	@Override // protected by super#lifecycleLock
 	protected void doStop() {
 		super.doStop();
-		if (this.active) {
-			this.active = false;
-			if (this.scheduledFuture != null) {
-				this.scheduledFuture.cancel(true);
-			}
-			this.clientModeConnectionManager = null;
-			if (this.clientConnectionFactory != null) {
-				this.clientConnectionFactory.stop();
-			}
-			if (this.serverConnectionFactory != null) {
-				this.serverConnectionFactory.stop();
-			}
+		if (this.scheduledFuture != null) {
+			this.scheduledFuture.cancel(true);
+		}
+		this.clientModeConnectionManager = null;
+		if (this.clientConnectionFactory != null) {
+			this.clientConnectionFactory.stop();
+		}
+		if (this.serverConnectionFactory != null) {
+			this.serverConnectionFactory.stop();
 		}
 	}
 
@@ -165,7 +158,6 @@ public class TcpReceivingChannelAdapter
 	 * Sets the client or server connection factory; for this (an inbound adapter), if
 	 * the factory is a client connection factory, the sockets are owned by a sending
 	 * channel adapter and this adapter is used to receive replies.
-	 *
 	 * @param connectionFactory the connectionFactory to set
 	 */
 	public void setConnectionFactory(AbstractConnectionFactory connectionFactory) {
@@ -217,8 +209,7 @@ public class TcpReceivingChannelAdapter
 	}
 
 	/**
-	 * @param isClientMode
-	 *            the isClientMode to set
+	 * @param isClientMode the isClientMode to set
 	 */
 	public void setClientMode(boolean isClientMode) {
 		this.isClientMode = isClientMode;
@@ -232,8 +223,7 @@ public class TcpReceivingChannelAdapter
 	}
 
 	/**
-	 * @param retryInterval
-	 *            the retryInterval to set
+	 * @param retryInterval the retryInterval to set
 	 */
 	public void setRetryInterval(long retryInterval) {
 		this.retryInterval = retryInterval;
@@ -251,7 +241,7 @@ public class TcpReceivingChannelAdapter
 
 	@Override
 	public void retryConnection() {
-		if (this.active && this.isClientMode && this.clientModeConnectionManager != null) {
+		if (isActive() && this.isClientMode && this.clientModeConnectionManager != null) {
 			this.clientModeConnectionManager.run();
 		}
 	}
@@ -264,7 +254,8 @@ public class TcpReceivingChannelAdapter
 
 	@Override
 	public int afterShutdown() {
-		this.stop();
+		stop();
 		return this.activeCount.get();
 	}
+
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
@@ -122,7 +122,6 @@ public class TcpReceivingChannelAdapter
 
 	@Override // protected by super#lifecycleLock
 	protected void doStart() {
-		super.doStart();
 		this.shuttingDown = false;
 		if (this.serverConnectionFactory != null) {
 			this.serverConnectionFactory.start();
@@ -141,7 +140,6 @@ public class TcpReceivingChannelAdapter
 
 	@Override // protected by super#lifecycleLock
 	protected void doStop() {
-		super.doStop();
 		if (this.scheduledFuture != null) {
 			this.scheduledFuture.cancel(true);
 		}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -159,12 +159,7 @@ public class JmsInboundGateway extends MessagingGatewaySupport implements Orderl
 	@Override
 	public void destroy() {
 		this.endpoint.destroy();
-		try {
-			super.destroy();
-		}
-		catch (Exception e) {
-			throw new IllegalStateException(e);
-		}
+		super.destroy();
 	}
 
 	@Override

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -214,9 +214,8 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 
 	@Override
 	public void destroy() {
-		stop();
-		this.listenerContainer.destroy();
 		super.destroy();
+		this.listenerContainer.destroy();
 	}
 
 	@Override

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
@@ -56,6 +56,7 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 	 */
 	public JmsMessageDrivenEndpoint(AbstractMessageListenerContainer listenerContainer,
 			ChannelPublishingJmsMessageListener listener) {
+
 		this(listenerContainer, listener, true);
 	}
 
@@ -65,11 +66,12 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 	 * 'transacted'.
 	 * @param listenerContainer the container.
 	 * @param listener the listener.
-	 * @param externalContainer true if the container is externally configured and should not have its ackmode
+	 * @param externalContainer true if the container is externally configured and should not have its ack mode
 	 * coerced when no sessionAcknowledgeMode was supplied.
 	 */
 	private JmsMessageDrivenEndpoint(AbstractMessageListenerContainer listenerContainer,
 			ChannelPublishingJmsMessageListener listener, boolean externalContainer) {
+
 		Assert.notNull(listenerContainer, "listener container must not be null");
 		Assert.notNull(listener, "listener must not be null");
 		if (listenerContainer.getMessageListener() != null) {
@@ -171,12 +173,12 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 		if (!this.listenerContainer.isActive()) {
 			this.listenerContainer.afterPropertiesSet();
 		}
-		String sessionAckeMode = this.sessionAcknowledgeMode;
-		if (sessionAckeMode == null && !this.externalContainer
+		String sessionAckMode = this.sessionAcknowledgeMode;
+		if (sessionAckMode == null && !this.externalContainer
 				&& DefaultMessageListenerContainer.class.isAssignableFrom(this.listenerContainer.getClass())) {
-			sessionAckeMode = JmsAdapterUtils.SESSION_TRANSACTED_STRING;
+			sessionAckMode = JmsAdapterUtils.SESSION_TRANSACTED_STRING;
 		}
-		Integer acknowledgeMode = JmsAdapterUtils.parseAcknowledgeMode(sessionAckeMode);
+		Integer acknowledgeMode = JmsAdapterUtils.parseAcknowledgeMode(sessionAckMode);
 		if (acknowledgeMode != null) {
 			if (JmsAdapterUtils.SESSION_TRANSACTED == acknowledgeMode) {
 				this.listenerContainer.setSessionTransacted(true);
@@ -185,7 +187,7 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 				this.listenerContainer.setSessionAcknowledgeMode(acknowledgeMode);
 			}
 		}
-		this.listener.setComponentName(this.getComponentName());
+		this.listener.setComponentName(getComponentName());
 	}
 
 	@Override
@@ -212,21 +214,14 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 
 	@Override
 	public void destroy() {
-		if (this.isRunning()) {
-			this.stop();
-		}
+		stop();
 		this.listenerContainer.destroy();
-		try {
-			super.destroy();
-		}
-		catch (Exception e) {
-			throw new IllegalStateException(e);
-		}
+		super.destroy();
 	}
 
 	@Override
 	public int beforeShutdown() {
-		this.stop();
+		stop();
 		return 0;
 	}
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -187,11 +187,13 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport implem
 
 	@Override
 	protected void doStart() {
+		super.doStart();
 		this.messageListenerContainer.start();
 	}
 
 	@Override
 	protected void doStop() {
+		super.doStop();
 		this.messageListenerContainer.stop();
 	}
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbChangeStreamMessageProducer.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbChangeStreamMessageProducer.java
@@ -110,6 +110,7 @@ public class MongoDbChangeStreamMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
+		super.doStart();
 		Flux<Message<?>> changeStreamFlux =
 				this.mongoOperations.changeStream(this.collection, this.options, this.domainType)
 						.map(event ->

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbChangeStreamMessageProducer.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/inbound/MongoDbChangeStreamMessageProducer.java
@@ -110,7 +110,6 @@ public class MongoDbChangeStreamMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
-		super.doStart();
 		Flux<Message<?>> changeStreamFlux =
 				this.mongoOperations.changeStream(this.collection, this.options, this.domainType)
 						.map(event ->

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -200,7 +200,6 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 	@Override
 	protected void doStart() {
 		Assert.state(getTaskScheduler() != null, "A 'taskScheduler' is required");
-		super.doStart();
 		try {
 			connectAndSubscribe();
 		}
@@ -213,7 +212,6 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 	@Override
 	protected synchronized void doStop() {
 		cancelReconnect();
-		super.doStop();
 		if (this.client != null) {
 			try {
 				if (this.consumerStopAction.equals(ConsumerStopAction.UNSUBSCRIBE_ALWAYS)

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/ReactiveRedisStreamMessageProducer.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/ReactiveRedisStreamMessageProducer.java
@@ -179,8 +179,6 @@ public class ReactiveRedisStreamMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
-		super.doStart();
-
 		StreamOffset<String> offset = StreamOffset.create(this.streamKey, this.readOffset);
 
 		Flux<? extends Record<String, ?>> events;

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2019 the original author or authors.
+ * Copyright 2007-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,14 +140,12 @@ public class RedisInboundChannelAdapter extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
-		super.doStart();
 		this.container.start();
 	}
 
 
 	@Override
 	protected void doStop() {
-		super.doStop();
 		this.container.stop();
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
@@ -257,8 +257,7 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 
 	@Override
 	protected void doStart() {
-		super.doStart();
-		this.restart();
+		restart();
 	}
 
 	/**

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpoint.java
@@ -82,8 +82,6 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 
 	private boolean rightPop = true;
 
-	private volatile boolean active;
-
 	private volatile boolean listening;
 
 	private volatile Runnable stopCallback;
@@ -243,7 +241,7 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 		}
 		catch (Exception ex) {
 			this.listening = false;
-			if (this.active) {
+			if (isActive()) {
 				logger.error(ex,
 						"Failed to execute listening task. Will attempt to resubmit in " + this.recoveryInterval
 								+ " milliseconds.");
@@ -259,10 +257,8 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 
 	@Override
 	protected void doStart() {
-		if (!this.active) {
-			this.active = true;
-			this.restart();
-		}
+		super.doStart();
+		this.restart();
 	}
 
 	/**
@@ -303,7 +299,6 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 	@Override
 	protected void doStop() {
 		super.doStop();
-		this.active = false;
 		this.listening = false;
 	}
 
@@ -345,14 +340,14 @@ public class RedisQueueMessageDrivenEndpoint extends MessageProducerSupport
 		@Override
 		public void run() {
 			try {
-				while (RedisQueueMessageDrivenEndpoint.this.active) {
+				while (isActive()) {
 					RedisQueueMessageDrivenEndpoint.this.listening = true;
-					RedisQueueMessageDrivenEndpoint.this.popMessageAndSend();
+					popMessageAndSend();
 				}
 			}
 			finally {
-				if (RedisQueueMessageDrivenEndpoint.this.active) {
-					RedisQueueMessageDrivenEndpoint.this.restart();
+				if (isActive()) {
+					restart();
 				}
 				else if (RedisQueueMessageDrivenEndpoint.this.stopCallback != null) {
 					RedisQueueMessageDrivenEndpoint.this.stopCallback.run();

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/TcpSyslogReceivingChannelAdapter.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/TcpSyslogReceivingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.messaging.Message;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 3.0
  *
  */
@@ -84,19 +85,17 @@ public class TcpSyslogReceivingChannelAdapter extends SyslogReceivingChannelAdap
 
 	@Override
 	protected void doStart() {
-		super.doStart();
 		this.connectionFactory.start();
 	}
 
 	@Override
 	protected void doStop() {
-		super.doStop();
 		this.connectionFactory.stop();
 	}
 
 	@Override
 	public boolean onMessage(Message<?> message) {
-		this.convertAndSend(message);
+		convertAndSend(message);
 		return false;
 	}
 

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/UdpSyslogReceivingChannelAdapter.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/UdpSyslogReceivingChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.integration.ip.udp.UnicastReceivingChannelAdapter;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 3.0
  *
  */
@@ -33,8 +34,8 @@ public class UdpSyslogReceivingChannelAdapter extends SyslogReceivingChannelAdap
 
 	private volatile boolean udpAdapterSet;
 
-	public void setUdpAdapter(UnicastReceivingChannelAdapter udpAdpter) {
-		this.udpAdapter = udpAdpter;
+	public void setUdpAdapter(UnicastReceivingChannelAdapter udpAdapter) {
+		this.udpAdapter = udpAdapter;
 		this.udpAdapterSet = true;
 	}
 
@@ -65,7 +66,7 @@ public class UdpSyslogReceivingChannelAdapter extends SyslogReceivingChannelAdap
 					"of the provided 'UnicastReceivingChannelAdapter' to support Syslog conversion " +
 					"for the incoming UDP packets");
 		}
-		this.udpAdapter.setOutputChannel(new FixedSubscriberChannel(message -> convertAndSend(message)));
+		this.udpAdapter.setOutputChannel(new FixedSubscriberChannel(this::convertAndSend));
 		if (!this.udpAdapterSet) {
 			this.udpAdapter.afterPropertiesSet();
 		}
@@ -73,13 +74,11 @@ public class UdpSyslogReceivingChannelAdapter extends SyslogReceivingChannelAdap
 
 	@Override
 	protected void doStart() {
-		super.doStart();
 		this.udpAdapter.start();
 	}
 
 	@Override
 	protected void doStop() {
-		super.doStop();
 		this.udpAdapter.stop();
 	}
 

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,8 +108,6 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 
 	private AbstractBrokerMessageHandler brokerHandler;
 
-	private volatile boolean active;
-
 	public WebSocketInboundChannelAdapter(IntegrationWebSocketContainer webSocketContainer) {
 		this(webSocketContainer, new SubProtocolHandlerRegistry(new PassThruSubProtocolHandler()));
 	}
@@ -127,10 +125,10 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 					try {
 						handleMessageAndSend(message);
 					}
-					catch (Exception e) {
+					catch (Exception ex) {
 						throw IntegrationUtils.wrapInHandlingExceptionIfNecessary(message,
 								() -> "Failed to handle and process message in the ["
-										+ WebSocketInboundChannelAdapter.this + ']', e);
+										+ WebSocketInboundChannelAdapter.this + ']', ex);
 					}
 				});
 	}
@@ -267,7 +265,7 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 
 	@Override
 	protected void doStart() {
-		this.active = true;
+		super.doStart();
 		if (this.webSocketContainer instanceof Lifecycle) {
 			((Lifecycle) this.webSocketContainer).start();
 		}
@@ -275,17 +273,18 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 
 	@Override
 	protected void doStop() {
-		this.active = false;
+		super.doStop();
 		if (this.webSocketContainer instanceof Lifecycle) {
 			((Lifecycle) this.webSocketContainer).stop();
 		}
 	}
 
-	private boolean isActive() {
-		if (!this.active) {
+	public boolean isActive() {
+		boolean active = super.isActive();
+		if (!active) {
 			logger.warn("MessageProducer '" + this + "' isn't started to accept WebSocket events.");
 		}
-		return this.active;
+		return active;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
@@ -265,7 +265,6 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 
 	@Override
 	protected void doStart() {
-		super.doStart();
 		if (this.webSocketContainer instanceof Lifecycle) {
 			((Lifecycle) this.webSocketContainer).start();
 		}
@@ -273,7 +272,6 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 
 	@Override
 	protected void doStop() {
-		super.doStop();
 		if (this.webSocketContainer instanceof Lifecycle) {
 			((Lifecycle) this.webSocketContainer).stop();
 		}

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
@@ -231,7 +231,6 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
-		super.doStart();
 		this.socketMono =
 				Mono.just(this.context.createSocket(this.socketType))
 						.publishOn(this.consumerScheduler)
@@ -293,7 +292,6 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStop() {
-		super.doStop();
 		this.socketMono.doOnNext(ZMQ.Socket::close).subscribe();
 	}
 

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
@@ -299,7 +299,6 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	@Override
 	public void destroy() {
-		setActive(false);
 		super.destroy();
 		this.socketMono.doOnNext(ZMQ.Socket::close).block();
 	}

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
@@ -90,8 +90,6 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	private volatile Mono<ZMQ.Socket> socketMono;
 
-	private volatile boolean active;
-
 	public ZeroMqMessageProducer(ZContext context) {
 		this(context, SocketType.PAIR);
 	}
@@ -212,7 +210,7 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 	@ManagedOperation
 	public void subscribeToTopics(String... topics) {
 		Assert.state(SocketType.SUB.equals(this.socketType), "Only SUB socket can accept a subscription option.");
-		Assert.state(this.active, "This message producer is not active to accept a new subscription.");
+		Assert.state(isActive(), "This message producer is not active to accept a new subscription.");
 
 		Flux.fromArray(topics)
 				.flatMap((topic) ->
@@ -223,7 +221,7 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 	@ManagedOperation
 	public void unsubscribeFromTopics(String... topics) {
 		Assert.state(SocketType.SUB.equals(this.socketType), "Only SUB socket can accept a unsubscription option.");
-		Assert.state(this.active, "This message producer is not active to cancel a subscription.");
+		Assert.state(isActive(), "This message producer is not active to cancel a subscription.");
 
 		Flux.fromArray(topics)
 				.flatMap((topic) ->
@@ -233,6 +231,7 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStart() {
+		super.doStart();
 		this.socketMono =
 				Mono.just(this.context.createSocket(this.socketType))
 						.publishOn(this.consumerScheduler)
@@ -255,8 +254,6 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 						.cache()
 						.publishOn(this.consumerScheduler);
 
-		this.active = true;
-
 		Flux<? extends Message<?>> dataFlux =
 				this.socketMono
 						.flatMap((socket) -> {
@@ -273,8 +270,8 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 						.doOnError((error) ->
 								logger.error(error, () -> "Error processing ZeroMQ message in the " + this))
 						.repeatWhenEmpty((repeat) ->
-								this.active ? repeat.delayElements(this.consumeDelay) : repeat)
-						.repeat(() -> this.active)
+								isActive() ? repeat.delayElements(this.consumeDelay) : repeat)
+						.repeat(this::isActive)
 						.doOnComplete(this.consumerScheduler::dispose);
 
 		subscribeToPublisher(dataFlux);
@@ -296,13 +293,13 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	@Override
 	protected void doStop() {
-		this.active = false;
+		super.doStop();
 		this.socketMono.doOnNext(ZMQ.Socket::close).subscribe();
 	}
 
 	@Override
 	public void destroy() {
-		this.active = false;
+		setActive(false);
 		super.destroy();
 		this.socketMono.doOnNext(ZMQ.Socket::close).block();
 	}


### PR DESCRIPTION
* Fix `MessageProducerSupport` to extract an `active` flag and set it before
`isRunning` - the `Flux` subscription relies on the `takeWhile()`
where in case of `autoStartup = false` we will never start consume because
it is set to `true` already after `doStart()`
* Refactor all the `MessageProducerSupport` implementation with similar
`active` state to use already one from the super class

**Cherry-pick to 5.3.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
