### PR TITLE
Fix mngmt dependency for MetricsCaptor

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
@@ -65,12 +65,11 @@ public class IntegrationManagementConfiguration implements ImportAware, Environm
 	@Bean(name = IntegrationManagementConfigurer.MANAGEMENT_CONFIGURER_NAME)
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 	public IntegrationManagementConfigurer managementConfigurer(ObjectProvider<MetricsCaptor> metricsCaptorProvider) {
-
 		IntegrationManagementConfigurer configurer = new IntegrationManagementConfigurer();
 		configurer.setDefaultLoggingEnabled(
 				Boolean.parseBoolean(this.environment.resolvePlaceholders(
 						(String) this.attributes.get("defaultLoggingEnabled"))));
-		configurer.setMetricsCaptor(metricsCaptorProvider.getIfUnique());
+		configurer.setMetricsCaptorProvider(metricsCaptorProvider);
 		return configurer;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfigurer.java
@@ -23,6 +23,7 @@ import java.util.Set;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
@@ -73,6 +74,8 @@ public class IntegrationManagementConfigurer
 
 	private MetricsCaptor metricsCaptor;
 
+	private ObjectProvider<MetricsCaptor> metricsCaptorProvider;
+
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = applicationContext;
@@ -110,12 +113,24 @@ public class IntegrationManagementConfigurer
 		this.metricsCaptor = metricsCaptor;
 	}
 
+	void setMetricsCaptorProvider(ObjectProvider<MetricsCaptor> metricsCaptorProvider) {
+		this.metricsCaptorProvider = metricsCaptorProvider;
+	}
+
+	@Nullable
+	MetricsCaptor obtainMetricsCaptor() {
+		if (this.metricsCaptor == null && this.metricsCaptorProvider != null) {
+			this.metricsCaptor = this.metricsCaptorProvider.getIfUnique();
+		}
+		return this.metricsCaptor;
+	}
+
 	@Override
 	public void afterSingletonsInstantiated() {
 		Assert.state(this.applicationContext != null, "'applicationContext' must not be null");
 		Assert.state(MANAGEMENT_CONFIGURER_NAME.equals(this.beanName), getClass().getSimpleName()
 				+ " bean name must be " + MANAGEMENT_CONFIGURER_NAME);
-		if (this.metricsCaptor != null) {
+		if (obtainMetricsCaptor() != null) {
 			injectCaptor();
 			registerComponentGauges();
 		}
@@ -144,7 +159,7 @@ public class IntegrationManagementConfigurer
 
 	@Override
 	public Object postProcessAfterInitialization(Object bean, String name) throws BeansException {
-		if (this.singletonsInstantiated && this.metricsCaptor != null && bean instanceof IntegrationManagement) {
+		if (this.singletonsInstantiated && obtainMetricsCaptor() != null && bean instanceof IntegrationManagement) {
 			((IntegrationManagement) bean).registerMetricsCaptor(this.metricsCaptor);
 		}
 		return bean;


### PR DESCRIPTION
The `IntegrationManagementConfigurer` is a `BeanPostProcessor`
so it must not have direct dependency injection for other beans.
In our case it is a `MetricsCaptor` injected from the
`IntegrationManagementConfiguration`

* Fix `IntegrationManagementConfiguration` and `IntegrationManagementConfigurer`
to rely on the `ObjectProvider<MetricsCaptor>` instead

Tested against latest Spring Boot

**Cherry-pick to `5.3.x` & `5.2.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
