### PR TITLE
GH-3438: Add Build from Source into CONTRIBUTING

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: trusty
 language: java
-jdk: oraclejdk8
+jdk: oraclejdk11
 sudo: false
 services:
   - mongodb

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -51,6 +51,69 @@ _you should now see 'upstream' in addition to 'origin' where 'upstream' is the S
 7. `git branch -a`
 _you should see branches on origin as well as upstream, including 'master'_
 
+== Build from Source
+
+The build system for the project is https://gradle.org/[Gradle].
+It is recommended to rely on the `wrapper` provided in the project code based and use a `gradlew` script from command line for the target operation system.
+The current Gradle version in use you can obtain from the `/gradle/gradle-wrapper.properties` file in the source tree.
+It is also recommended to use a Gradle import feature of your IDE for the best contribution experience.
+
+The minimum JDK version at the moment is `11` (mostly for tests - production code is still `1.8`).
+You always can find the currently required Java version in the `build.gradle`.
+For example, for the current project version:
+
+----
+compileJava {
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
+}
+
+compileTestJava {
+    sourceCompatibility = 11
+}
+
+compileKotlin {
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+compileTestKotlin {
+    kotlinOptions {
+        jvmTarget = '11'
+    }
+}
+----
+
+To build and install jars into your local Maven cache:
+
+----
+./gradlew publishToMavenLocal
+----
+
+To build api Javadoc (results will be in `build/api`):
+
+----
+./gradlew api
+----
+
+To build reference documentation (results will be in `build/reference`):
+
+----
+./gradlew reference
+----
+
+To build complete distribution including `-dist`, `-docs`, and `-schema` zip files (results will be in `build/distributions`)
+
+----
+./gradlew dist
+----
+
+You can build and test only specific module if your contribution is only over there
+
+----
+./gradlew :spring-integration-webflux:test
+----
+
 == A Day in the Life of a Contributor
 
 * _Always_ work on topic branches (Typically use the GitHub issue ID as the branch name).
@@ -134,7 +197,9 @@ Use `@since` tags for newly-added public API types and methods e.g.
  * ...
  *
  * @author First Last
+ *
  * @since 3.0
+ *
  * @see ...
  */
 ----
@@ -162,6 +227,8 @@ It is also acceptable to submit test cases on a per GH issue basis.
 
 Use `git rebase --interactive`, `git add --patch` and other tools to "squash" multiple commits into atomic changes.
 In addition to the man pages for git, there are many resources online to help you understand how these tools work.
+However we do recommend to do this only for the first commit in the PR.
+All the subsequent commits added after review should preserve the history for better context of the previous and current changes.
 
 == Use your real name in git commits
 

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -96,19 +96,19 @@ To build api Javadoc (results will be in `build/api`):
 ./gradlew api
 ----
 
-To build reference documentation (results will be in `build/reference`):
+To build the reference documentation (results will be in `build/docs/asciidoc` and `build/docs/asciidocPdf`):
 
 ----
 ./gradlew reference
 ----
 
-To build complete distribution including `-dist`, `-docs`, and `-schema` zip files (results will be in `build/distributions`)
+To build complete distribution including `-dist`, `-docs`, and `-schema` zip files (results will be in `build/distributions`):
 
 ----
 ./gradlew dist
 ----
 
-You can build and test only specific module if your contribution is only over there
+You can build and test only a specific module if your contribution is only over there:
 
 ----
 ./gradlew :spring-integration-webflux:test

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ To build api Javadoc (results will be in `build/api`):
 
     ./gradlew api
 
-To build reference documentation (results will be in `build/reference`):
+To build the reference documentation (results will be in `build/docs/asciidoc` and `build/docs/asciidocPdf`):
 
     ./gradlew reference
 
-To build complete distribution including `-dist`, `-docs`, and `-schema` zip files (results will be in `build/distributions`)
+To build complete distribution including `-dist`, `-docs`, and `-schema` zip files (results will be in `build/distributions`):
 
     ./gradlew dist
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,7 @@ To check out the project and build from the source, do the following:
     cd spring-integration
     ./gradlew build
 
-**NOTE:** While Spring Integration runs with Java SE 6 or higher, a Java 8 compiler is required to build the project.
-
-If you encounter out of memory errors during the build, increase an available heap and permgen for Gradle:
-
-    GRADLE_OPTS='-XX:MaxPermSize=1024m -Xmx1024m'
+**NOTE:** While Spring Integration runs with Java SE 8 or higher, a Java 11 compiler is required to build the project.
 
 To build and install jars into your local Maven cache:
 
@@ -58,6 +54,8 @@ free of errors.
 To generate IDEA metadata (.iml and .ipr files), do the following:
 
     ./gradlew idea
+
+See also [Contributor Guidelines](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
 
 # Resources
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3438

It is not clear at the moment what Java version and what build system is used
in the project from the `CONTRIBUTING.adoc`

* Add `Build from Source` section into the `CONTRIBUTING.adoc`
* Point to the `CONTRIBUTING.adoc` from the top level `README.md`
* Fix the current Java version in the `README.md`
* Mention that `Squash commits` must be avoided for subsequent commits into the PR

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
