### PR TITLE
Special handle for void in the RSocketOutGateway

### DIFF
--- a/src/reference/asciidoc/rsocket.adoc
+++ b/src/reference/asciidoc/rsocket.adoc
@@ -188,6 +188,9 @@ public Flux<?> flattenRSocketResponse(Flux<?> payload) {
 
 Or subscribed explicitly in the target application logic.
 
+The expected response type can also be configured (or evaluated via expression) to `void` treating this gateway as an outbound channel adapter.
+However the `outputChannel` still has to be configured (even if it just a `NullChannel`) to initiate a subscription to the returned `Mono`.
+
 See <<rsocket-java-config>> for samples how to configure an `RSocketOutboundGateway` endpoint a deal with payloads downstream.
 
 [[rsocket-namespace]]


### PR DESCRIPTION
To avoid extra `Publisher` subscription work in the target
application "flatten" a returned empty `Flux` for the `void`
expected type into a `Mono.empty()` for automatic subscription
on the output channel

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
