### PR TITLE
GH-3455: default MqttMessageConverter.toMessage

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/DefaultPahoMessageConverter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/DefaultPahoMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.mqtt.support;
 
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 
@@ -57,9 +58,9 @@ public class DefaultPahoMessageConverter implements MqttMessageConverter, BeanFa
 
 	private BytesMessageMapper bytesMessageMapper;
 
-	private volatile boolean payloadAsBytes = false;
+	private boolean payloadAsBytes = false;
 
-	private volatile BeanFactory beanFactory;
+	private BeanFactory beanFactory;
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
@@ -82,7 +83,7 @@ public class DefaultPahoMessageConverter implements MqttMessageConverter, BeanFa
 	 * @param defaultRetained the default retained.
 	 */
 	public DefaultPahoMessageConverter(int defaultQos, boolean defaultRetained) {
-		this(defaultQos, defaultRetained, "UTF-8");
+		this(defaultQos, defaultRetained, StandardCharsets.UTF_8.name());
 	}
 
 	/**
@@ -124,7 +125,7 @@ public class DefaultPahoMessageConverter implements MqttMessageConverter, BeanFa
 	public DefaultPahoMessageConverter(int defaultQos, MessageProcessor<Integer> qosProcessor, boolean defaultRetained,
 			MessageProcessor<Boolean> retainedProcessor) {
 
-		this(defaultQos, qosProcessor, defaultRetained, retainedProcessor, "UTF-8");
+		this(defaultQos, qosProcessor, defaultRetained, retainedProcessor, StandardCharsets.UTF_8.name());
 	}
 
 	/**
@@ -202,11 +203,6 @@ public class DefaultPahoMessageConverter implements MqttMessageConverter, BeanFa
 				() -> "This converter can only convert an 'MqttMessage'; received: "
 						+ mqttMessage.getClass().getName());
 		return toMessage(null, (MqttMessage) mqttMessage);
-	}
-
-	@Override
-	public Message<?> toMessage(String topic, MqttMessage mqttMessage) {
-		return toMessageBuilder(topic, mqttMessage).build();
 	}
 
 	@Override

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/MqttMessageConverter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/MqttMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,8 @@ import org.springframework.messaging.converter.MessageConverter;
  * a header.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.0
  *
  */
@@ -35,12 +37,20 @@ public interface MqttMessageConverter extends MessageConverter {
 
 	/**
 	 * Convert to a Message.
-	 *
+	 * The default implementation calls {@link #toMessageBuilder(String, MqttMessage)}.
 	 * @param topic the topic.
 	 * @param mqttMessage the MQTT message.
 	 * @return the Message.
 	 */
-	Message<?> toMessage(String topic, MqttMessage mqttMessage);
+	default Message<?> toMessage(String topic, MqttMessage mqttMessage) {
+		AbstractIntegrationMessageBuilder<?> builder = toMessageBuilder(topic, mqttMessage);
+		if (builder != null) {
+			return builder.build();
+		}
+		else {
+			return null;
+		}
+	}
 
 	/**
 	 * Convert to a message builder.

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
@@ -312,24 +312,20 @@ public class MqttAdapterTests {
 
 		adapter.setConverter(new MqttMessageConverter() {
 
-			@Override public Message<?> toMessage(String topic, MqttMessage mqttMessage) {
+			@Override
+			public AbstractIntegrationMessageBuilder<?> toMessageBuilder(String topic, MqttMessage mqttMessage) {
 				return null;
 			}
 
-			@Override public AbstractIntegrationMessageBuilder<?> toMessageBuilder(String topic,
-					MqttMessage mqttMessage) {
-
+			@Override
+			public Object fromMessage(Message<?> message, Class<?> targetClass) {
 				return null;
 			}
 
-			@Override public Object fromMessage(Message<?> message, Class<?> targetClass) {
+			@Override
+			public Message<?> toMessage(Object payload, MessageHeaders headers) {
 				return null;
 			}
-
-			@Override public Message<?> toMessage(Object payload, MessageHeaders headers) {
-				return null;
-			}
-
 
 		});
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3455

After introduction `MqttMessageConverter.toMessageBuilder()`
(https://github.com/spring-projects/spring-integration/issues/3181)
the existing `MqttMessageConverter` must also implement this new method
where in most cases `toMessage()` call `toMessageBuilder()`

* Make `MqttMessageConverter.toMessage()` as a `default` with a delegation
to the `toMessageBuilder()` allowing target implementors to avoid extra
method

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
