### PR TITLE
GH-3455: default MqttMessConv.toMessageBuilder()

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/MqttMessageConverter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/MqttMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
+import org.springframework.integration.support.MutableMessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.MessageConverter;
 
@@ -28,6 +29,8 @@ import org.springframework.messaging.converter.MessageConverter;
  * a header.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 4.0
  *
  */
@@ -35,7 +38,6 @@ public interface MqttMessageConverter extends MessageConverter {
 
 	/**
 	 * Convert to a Message.
-	 *
 	 * @param topic the topic.
 	 * @param mqttMessage the MQTT message.
 	 * @return the Message.
@@ -44,11 +46,22 @@ public interface MqttMessageConverter extends MessageConverter {
 
 	/**
 	 * Convert to a message builder.
+	 * This method is {@code default} with a delegation to the {@link #toMessage(String, MqttMessage)}
+	 * to avoid a breaking change for migrated projects.
+	 * The delegation will be swapped in the next version.
 	 * @param topic the topic.
 	 * @param mqttMessage the MQTT message.
 	 * @return the builder.
 	 */
-	AbstractIntegrationMessageBuilder<?> toMessageBuilder(String topic, MqttMessage mqttMessage);
+	default AbstractIntegrationMessageBuilder<?> toMessageBuilder(String topic, MqttMessage mqttMessage) {
+		Message<?> message = toMessage(topic, mqttMessage);
+		if (message != null) {
+			return MutableMessageBuilder.fromMessage(message);
+		}
+		else {
+			return null;
+		}
+	}
 
 	static MessageProcessor<Integer> defaultQosProcessor() {
 		return message -> message.getHeaders().get(MqttHeaders.QOS, Integer.class);

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
@@ -90,7 +90,6 @@ import org.springframework.integration.mqtt.outbound.MqttPahoMessageHandler;
 import org.springframework.integration.mqtt.support.DefaultPahoMessageConverter;
 import org.springframework.integration.mqtt.support.MqttHeaderAccessor;
 import org.springframework.integration.mqtt.support.MqttMessageConverter;
-import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
@@ -312,24 +311,20 @@ public class MqttAdapterTests {
 
 		adapter.setConverter(new MqttMessageConverter() {
 
-			@Override public Message<?> toMessage(String topic, MqttMessage mqttMessage) {
+			@Override
+			public Message<?> toMessage(String topic, MqttMessage mqttMessage) {
 				return null;
 			}
 
-			@Override public AbstractIntegrationMessageBuilder<?> toMessageBuilder(String topic,
-					MqttMessage mqttMessage) {
-
+			@Override
+			public Object fromMessage(Message<?> message, Class<?> targetClass) {
 				return null;
 			}
 
-			@Override public Object fromMessage(Message<?> message, Class<?> targetClass) {
+			@Override
+			public Message<?> toMessage(Object payload, MessageHeaders headers) {
 				return null;
 			}
-
-			@Override public Message<?> toMessage(Object payload, MessageHeaders headers) {
-				return null;
-			}
-
 
 		});
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3455

After introduction `MqttMessageConverter.toMessageBuilder()`
(https://github.com/spring-projects/spring-integration/issues/3181)
the existing `MqttMessageConverter` must also implement this new method
where in most cases `toMessage()` must call `toMessageBuilder()` instead though.

* Make `MqttMessageConverter.toMessageBuilder()` as a `default` with a delegation
to the `toMessage()` allowing target implementors to keep their code during
migration without any breaking changes

**Cherry-pick to 5.3.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
