### PR TITLE
Upgrade to spring-amqp 2.3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ ext {
 	servletApiVersion = '4.0.1'
 	smackVersion = '4.3.5'
 	soapVersion = '1.4.0'
-	springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '2.3.1'
+	springAmqpVersion = project.hasProperty('springAmqpVersion') ? project.springAmqpVersion : '2.3.4'
 	springDataVersion = project.hasProperty('springDataVersion') ? project.springDataVersion : '2021.0.0-SNAPSHOT'
 	springKafkaVersion = '2.7.0-SNAPSHOT'
 	springRetryVersion = '1.3.0'

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AbstractAmqpOutboundEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -730,11 +730,20 @@ public abstract class AbstractAmqpOutboundEndpoint extends AbstractReplyProducin
 		}
 
 		@Override
+		@Deprecated
 		public void setReturnedMessage(org.springframework.amqp.core.Message returnedMessage) {
 			if (this.userData instanceof CorrelationData) {
 				((CorrelationData) this.userData).setReturnedMessage(returnedMessage);
 			}
 			super.setReturnedMessage(returnedMessage);
+		}
+
+		@Override
+		public void setReturned(ReturnedMessage returned) {
+			if (this.userData instanceof CorrelationData) {
+				((CorrelationData) this.userData).setReturned(returned);
+			}
+			super.setReturned(returned);
 		}
 
 	}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -201,7 +201,7 @@ public class AmqpOutboundEndpoint extends AbstractAmqpOutboundEndpoint
 			if (!confirm.isAck()) {
 				throw new AmqpException("Negative publisher confirm received: " + confirm);
 			}
-			if (correlationData.getReturnedMessage() != null) {
+			if (correlationData.getReturned() != null) {
 				throw new AmqpException("Message was returned by the broker");
 			}
 		}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AsyncAmqpOutboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AsyncAmqpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ public class AsyncAmqpOutboundGateway extends AbstractAmqpOutboundEndpoint {
 							AsyncAmqpOutboundGateway.this.messageConverter);
 					sendOutput(returnedMessage, returnChannel, true);
 				}
-				this.correlationData.setReturnedMessage(amre.getReturnedMessage());
+				this.correlationData.setReturned(amre.getReturned());
 				/*
 				 *  Complete the user's future (if present) since the async template will only complete
 				 *  once, successfully, or with a failure.

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -235,7 +235,7 @@ public class AmqpOutboundEndpointTests {
 		Confirm confirm = corrData.getFuture().get(10, TimeUnit.SECONDS);
 		assertThat(confirm).isNotNull();
 		assertThat(confirm.isAck()).isTrue();
-		assertThat(corrData.getReturnedMessage()).isNotNull();
+		assertThat(corrData.getReturned()).isNotNull();
 	}
 
 	@Test

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests2.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,7 +85,7 @@ public class AmqpOutboundEndpointTests2 {
 				.setHeader(AmqpHeaders.PUBLISH_CONFIRM_CORRELATION, corr)
 				.build());
 		assertThat(corr.getFuture().get(10, TimeUnit.SECONDS).isAck()).isTrue();
-		assertThat(corr.getReturnedMessage()).isNotNull();
+		assertThat(corr.getReturned()).isNotNull();
 	}
 
 	@Test

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AsyncAmqpGatewayTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AsyncAmqpGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -253,7 +253,7 @@ class AsyncAmqpGatewayTests {
 				.setHeader(AmqpHeaders.PUBLISH_CONFIRM_CORRELATION, corr)
 				.build());
 		assertThat(corr.getFuture().get(10, TimeUnit.SECONDS).isAck()).isTrue();
-		assertThat(corr.getReturnedMessage()).isNotNull();
+		assertThat(corr.getReturned()).isNotNull();
 
 		asyncTemplate.stop();
 		ccf.destroy();


### PR DESCRIPTION
- remove uses of deprecated method
- correctly call delegate in correlation data wrapper
