### PR TITLE
GH-3437: Add `MessageRecoverer` to AMQP Inbounds

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpBaseInboundChannelAdapterSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpBaseInboundChannelAdapterSpec.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.amqp.dsl;
 
+import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
@@ -99,6 +100,18 @@ public class AmqpBaseInboundChannelAdapterSpec<S extends AmqpBaseInboundChannelA
 	 */
 	public S recoveryCallback(RecoveryCallback<?> recoveryCallback) {
 		this.target.setRecoveryCallback(recoveryCallback);
+		return _this();
+	}
+
+	/**
+	 * Set a {@link MessageRecoverer} when using retry within the adapter.
+	 * @param messageRecoverer the callback.
+	 * @return the spec.
+	 * @since 5.5
+	 * @see AmqpInboundChannelAdapter#setMessageRecoverer(MessageRecoverer)
+	 */
+	public S messageRecoverer(MessageRecoverer messageRecoverer) {
+		this.target.setMessageRecoverer(messageRecoverer);
 		return _this();
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpBaseInboundGatewaySpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpBaseInboundGatewaySpec.java
@@ -17,7 +17,9 @@
 package org.springframework.integration.amqp.dsl;
 
 import org.springframework.amqp.rabbit.batch.BatchingStrategy;
+import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
 import org.springframework.integration.amqp.inbound.AmqpInboundGateway;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
@@ -173,6 +175,18 @@ public class AmqpBaseInboundGatewaySpec<S extends AmqpBaseInboundGatewaySpec<S>>
 	 */
 	public S replyHeadersMappedLast(boolean replyHeadersMappedLast) {
 		this.target.setReplyHeadersMappedLast(replyHeadersMappedLast);
+		return _this();
+	}
+
+	/**
+	 * Set a {@link MessageRecoverer} when using retry within the adapter.
+	 * @param messageRecoverer the callback.
+	 * @return the spec.
+	 * @since 5.5
+	 * @see AmqpInboundChannelAdapter#setMessageRecoverer(MessageRecoverer)
+	 */
+	public S messageRecoverer(MessageRecoverer messageRecoverer) {
+		this.target.setMessageRecoverer(messageRecoverer);
 		return _this();
 	}
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -29,6 +29,8 @@ import org.springframework.amqp.rabbit.batch.SimpleBatchingStrategy;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareBatchMessageListener;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
+import org.springframework.amqp.rabbit.retry.MessageBatchRecoverer;
+import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.MessageConversionException;
 import org.springframework.amqp.support.converter.MessageConverter;
@@ -110,6 +112,8 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 
 	private RecoveryCallback<?> recoveryCallback;
 
+	private MessageRecoverer messageRecoverer;
+
 	private BatchingStrategy batchingStrategy = new SimpleBatchingStrategy(0, 0, 0L);
 
 	private boolean bindSourceMessage;
@@ -154,12 +158,23 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 
 	/**
 	 * Set a {@link RecoveryCallback} when using retry within the adapter.
+	 * Mutually exclusive with {@link #setMessageRecoverer(MessageRecoverer)}.
 	 * @param recoveryCallback the callback.
 	 * @since 4.3.10
 	 * @see #setRetryTemplate(RetryTemplate)
 	 */
 	public void setRecoveryCallback(RecoveryCallback<?> recoveryCallback) {
 		this.recoveryCallback = recoveryCallback;
+	}
+
+	/**
+	 * Configure a {@link MessageRecoverer} for retry operations.
+	 * A more AMQP-specific convenience instead of {@link #setRecoveryCallback(RecoveryCallback)}.
+	 * @param messageRecoverer the {@link MessageRecoverer} to use.
+	 * @since 5.5
+	 */
+	public void setMessageRecoverer(MessageRecoverer messageRecoverer) {
+		this.messageRecoverer = messageRecoverer;
 	}
 
 	/**
@@ -206,6 +221,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 			Assert.state(getErrorChannel() == null, "Cannot have an 'errorChannel' property when a 'RetryTemplate' is "
 					+ "provided; use an 'ErrorMessageSendingRecoverer' in the 'recoveryCallback' property to "
 					+ "send an error message when retries are exhausted");
+			setupRecoveryCallbackIfAny();
 		}
 		Listener messageListener;
 		if (this.messageListenerContainer.isConsumerBatchEnabled()) {
@@ -217,6 +233,38 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 		this.messageListenerContainer.setMessageListener(messageListener);
 		this.messageListenerContainer.afterPropertiesSet();
 		super.onInit();
+	}
+
+	private void setupRecoveryCallbackIfAny() {
+		Assert.state(this.recoveryCallback == null || this.messageRecoverer == null,
+				"Only one of 'recoveryCallback' or 'messageRecoverer' may be provided, but not both");
+		if (this.messageRecoverer != null) {
+			if (this.messageListenerContainer.isConsumerBatchEnabled()) {
+				Assert.isInstanceOf(MessageBatchRecoverer.class, this.messageRecoverer,
+						"The 'messageRecoverer' must be an instance of MessageBatchRecoverer " +
+								"when consumer configured for batch mode");
+				this.recoveryCallback =
+						context -> {
+							@SuppressWarnings("unchecked")
+							List<Message> messagesToRecover =
+									(List<Message>) RetrySynchronizationManager.getContext()
+											.getAttribute(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE);
+							((MessageBatchRecoverer) this.messageRecoverer).recover(messagesToRecover,
+									context.getLastThrowable());
+							return null;
+						};
+			}
+			else {
+				this.recoveryCallback =
+						context -> {
+							Message messageToRecover =
+									(Message) RetrySynchronizationManager.getContext()
+											.getAttribute(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE);
+							this.messageRecoverer.recover(messageToRecover, context.getLastThrowable());
+							return null;
+						};
+			}
+		}
 	}
 
 	@Override

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ import org.springframework.amqp.rabbit.batch.SimpleBatchingStrategy;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
-import org.springframework.amqp.rabbit.retry.MessageBatchRecoverer;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.MessageConverter;

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -30,6 +30,8 @@ import org.springframework.amqp.rabbit.batch.SimpleBatchingStrategy;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
+import org.springframework.amqp.rabbit.retry.MessageBatchRecoverer;
+import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
@@ -83,7 +85,9 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 
 	private RetryTemplate retryTemplate;
 
-	private RecoveryCallback<? extends Object> recoveryCallback;
+	private RecoveryCallback<?> recoveryCallback;
+
+	private MessageRecoverer messageRecoverer;
 
 	private BatchingStrategy batchingStrategy = new SimpleBatchingStrategy(0, 0, 0L);
 
@@ -181,12 +185,23 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 
 	/**
 	 * Set a {@link RecoveryCallback} when using retry within the gateway.
+	 * Mutually exclusive with {@link #setMessageRecoverer(MessageRecoverer)}.
 	 * @param recoveryCallback the callback.
 	 * @since 4.3.10
 	 * @see #setRetryTemplate(RetryTemplate)
 	 */
 	public void setRecoveryCallback(RecoveryCallback<? extends Object> recoveryCallback) {
 		this.recoveryCallback = recoveryCallback;
+	}
+
+	/**
+	 * Configure a {@link MessageRecoverer} for retry operations.
+	 * A more AMQP-specific convenience instead of {@link #setRecoveryCallback(RecoveryCallback)}.
+	 * @param messageRecoverer the {@link MessageRecoverer} to use.
+	 * @since 5.5
+	 */
+	public void setMessageRecoverer(MessageRecoverer messageRecoverer) {
+		this.messageRecoverer = messageRecoverer;
 	}
 
 	/**
@@ -239,6 +254,7 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 			Assert.state(getErrorChannel() == null, "Cannot have an 'errorChannel' property when a 'RetryTemplate' is "
 					+ "provided; use an 'ErrorMessageSendingRecoverer' in the 'recoveryCallback' property to "
 					+ "send an error message when retries are exhausted");
+			setupRecoveryCallbackIfAny();
 		}
 		Listener messageListener = new Listener();
 		this.messageListenerContainer.setMessageListener(messageListener);
@@ -251,6 +267,21 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 			logger.warn("Usually, when using a RetryTemplate you should use an ErrorMessageSendingRecoverer and not "
 					+ "provide an errorChannel. Using an errorChannel could defeat retry and will receive an error "
 					+ "message for each delivery attempt.");
+		}
+	}
+
+	private void setupRecoveryCallbackIfAny() {
+		Assert.state(this.recoveryCallback == null || this.messageRecoverer == null,
+				"Only one of 'recoveryCallback' or 'messageRecoverer' may be provided, but not both");
+		if (this.messageRecoverer != null) {
+				this.recoveryCallback =
+						context -> {
+							Message messageToRecover =
+									(Message) RetrySynchronizationManager.getContext()
+											.getAttribute(AmqpMessageHeaderErrorMessageStrategy.AMQP_RAW_MESSAGE);
+							this.messageRecoverer.recover(messageToRecover, context.getLastThrowable());
+							return null;
+						};
 		}
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -17,6 +17,8 @@
 package org.springframework.integration.amqp.inbound;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -30,10 +32,13 @@ import static org.mockito.Mockito.when;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.amqp.core.AcknowledgeMode;
@@ -47,6 +52,7 @@ import org.springframework.amqp.rabbit.listener.AbstractMessageListenerContainer
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareBatchMessageListener;
 import org.springframework.amqp.rabbit.listener.api.ChannelAwareMessageListener;
+import org.springframework.amqp.rabbit.retry.MessageBatchRecoverer;
 import org.springframework.amqp.rabbit.support.ListenerExecutionFailedException;
 import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
@@ -363,6 +369,39 @@ public class InboundEndpointTests {
 	}
 
 	@Test
+	public void testRetryWithMessageRecovererOnMessageAdapter() throws Exception {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		adapter.setOutputChannel(new DirectChannel());
+		adapter.setRetryTemplate(new RetryTemplate());
+		AtomicReference<org.springframework.amqp.core.Message> recoveredMessage = new AtomicReference<>();
+		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
+		CountDownLatch recoveredLatch = new CountDownLatch(1);
+		adapter.setMessageRecoverer((message, cause) -> {
+			recoveredMessage.set(message);
+			recoveredError.set(cause);
+			recoveredLatch.countDown();
+		});
+		adapter.afterPropertiesSet();
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		org.springframework.amqp.core.Message amqpMessage =
+				org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
+						.andProperties(new MessageProperties())
+						.build();
+		listener.onMessage(amqpMessage, null);
+
+		assertThat(recoveredLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		assertThat(recoveredError.get())
+				.isInstanceOf(MessagingException.class)
+				.extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
+				.contains("Dispatcher has no");
+
+		assertThat(recoveredMessage.get()).isSameAs(amqpMessage);
+	}
+
+	@Test
 	public void testRetryWithinOnMessageGateway() throws Exception {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
@@ -388,6 +427,39 @@ public class InboundEndpointTests {
 						org.springframework.amqp.core.Message.class);
 		assertThat(amqpMessage).isNotNull();
 		assertThat(errors.receive(0)).isNull();
+	}
+
+	@Test
+	public void testRetryWithMessageRecovererOnMessageGateway() throws Exception {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
+		adapter.setRequestChannel(new DirectChannel());
+		adapter.setRetryTemplate(new RetryTemplate());
+		AtomicReference<org.springframework.amqp.core.Message> recoveredMessage = new AtomicReference<>();
+		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
+		CountDownLatch recoveredLatch = new CountDownLatch(1);
+		adapter.setMessageRecoverer((message, cause) -> {
+			recoveredMessage.set(message);
+			recoveredError.set(cause);
+			recoveredLatch.countDown();
+		});
+		adapter.afterPropertiesSet();
+		ChannelAwareMessageListener listener = (ChannelAwareMessageListener) container.getMessageListener();
+		org.springframework.amqp.core.Message amqpMessage =
+				org.springframework.amqp.core.MessageBuilder.withBody("foo".getBytes())
+						.andProperties(new MessageProperties())
+						.build();
+		listener.onMessage(amqpMessage, null);
+
+		assertThat(recoveredLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		assertThat(recoveredError.get())
+				.isInstanceOf(MessagingException.class)
+				.extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
+				.contains("Dispatcher has no");
+
+		assertThat(recoveredMessage.get()).isSameAs(amqpMessage);
 	}
 
 	@SuppressWarnings({ "unchecked" })
@@ -443,7 +515,7 @@ public class InboundEndpointTests {
 
 	@SuppressWarnings({ "unchecked" })
 	@Test
-	public void testConsumerBatchExtract() throws Exception {
+	public void testConsumerBatchExtract() {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
 		container.setConsumerBatchEnabled(true);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
@@ -462,12 +534,12 @@ public class InboundEndpointTests {
 		assertThat(received).isNotNull();
 		assertThat(((List<String>) received.getPayload())).contains("test1", "test2");
 		assertThat(received.getHeaders().get(AmqpInboundChannelAdapter.CONSOLIDATED_HEADERS, List.class))
-			.hasSize(2);
+				.hasSize(2);
 	}
 
 	@SuppressWarnings({ "unchecked" })
 	@Test
-	public void testConsumerBatch() throws Exception {
+	public void testConsumerBatch() {
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
 		container.setConsumerBatchEnabled(true);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
@@ -484,12 +556,37 @@ public class InboundEndpointTests {
 		Message<?> received = out.receive(0);
 		assertThat(received).isNotNull();
 		assertThat(((List<Message<String>>) received.getPayload()))
-			.extracting(message -> message.getPayload())
-			.contains("test1", "test2");
+				.extracting(message -> message.getPayload())
+				.contains("test1", "test2");
 	}
 
 	@Test
-	public void testAdapterConversionErrorConsumerBatchExtract() throws Exception {
+	public void testConsumerBatchAndWrongMessageRecoverer() {
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(mock(ConnectionFactory.class));
+		container.setConsumerBatchEnabled(true);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setMessageRecoverer((message, cause) -> { });
+		assertThatIllegalArgumentException()
+				.isThrownBy(adapter::afterPropertiesSet)
+				.withMessageStartingWith("The 'messageRecoverer' must be an instance of MessageBatchRecoverer " +
+						"when consumer configured for batch mode");
+	}
+
+	@Test
+	public void testExclusiveRecover() {
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(mock(AbstractMessageListenerContainer.class));
+		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setMessageRecoverer((message, cause) -> { });
+		adapter.setRecoveryCallback(context -> null);
+		assertThatIllegalStateException()
+				.isThrownBy(adapter::afterPropertiesSet)
+				.withMessageStartingWith("Only one of 'recoveryCallback' or 'messageRecoverer' may be provided, " +
+						"but not both");
+	}
+
+	@Test
+	public void testAdapterConversionErrorConsumerBatchExtract() {
 		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
@@ -546,7 +643,7 @@ public class InboundEndpointTests {
 	}
 
 	@Test
-	public void testAdapterConversionErrorConsumerBatch() throws Exception {
+	public void testAdapterConversionErrorConsumerBatch() {
 		Connection connection = mock(Connection.class);
 		doAnswer(invocation -> mock(Channel.class)).when(connection).createChannel(anyBoolean());
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
@@ -602,7 +699,7 @@ public class InboundEndpointTests {
 	}
 
 	@Test
-	public void testRetryWithinOnMessageAdapterConsumerBatch() throws Exception {
+	public void testRetryWithinOnMessageAdapterConsumerBatch() {
 		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
 		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		container.setConsumerBatchEnabled(true);
@@ -641,10 +738,49 @@ public class InboundEndpointTests {
 		List<Message<?>> msgs = (List<Message<?>>) payload.getFailedMessage().getPayload();
 		assertThat(msgs).hasSize(2);
 		assertThat(msgs).extracting(msg -> StaticMessageHeaderAccessor.getDeliveryAttempt(msg).get())
-			.contains(3, 3);
+				.contains(3, 3);
 		assertThat(msgs).extracting(msg -> msg.getHeaders().get(AmqpHeaders.DELIVERY_TAG, Long.class))
-			.contains(42L, 43L);
+				.contains(42L, 43L);
 		assertThat(errors.receive(0)).isNull();
+	}
+
+	@Test
+	public void testRetryWithMessageRecovererOnMessageAdapterConsumerBatch() throws InterruptedException {
+		ConnectionFactory connectionFactory = mock(ConnectionFactory.class);
+		SimpleMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
+		container.setConsumerBatchEnabled(true);
+		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
+		adapter.setOutputChannel(new DirectChannel());
+		adapter.setRetryTemplate(new RetryTemplate());
+		AtomicReference<List<org.springframework.amqp.core.Message>> recoveredMessages = new AtomicReference<>();
+		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
+		CountDownLatch recoveredLatch = new CountDownLatch(1);
+		adapter.setMessageRecoverer((MessageBatchRecoverer) (messages, cause) -> {
+			recoveredMessages.set(messages);
+			recoveredError.set(cause);
+			recoveredLatch.countDown();
+		});
+		adapter.afterPropertiesSet();
+		ChannelAwareBatchMessageListener listener = (ChannelAwareBatchMessageListener) container.getMessageListener();
+		MessageProperties messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(42L);
+		List<org.springframework.amqp.core.Message> messages = new ArrayList<>();
+		messages.add(new org.springframework.amqp.core.Message("test1".getBytes(), messageProperties));
+		messageProperties = new MessageProperties();
+		messageProperties.setContentType("text/plain");
+		messageProperties.setDeliveryTag(43L);
+		messages.add(new org.springframework.amqp.core.Message("test2".getBytes(), messageProperties));
+		listener.onMessageBatch(messages, null);
+
+		assertThat(recoveredLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		assertThat(recoveredError.get())
+				.isInstanceOf(MessagingException.class)
+				.extracting(Throwable::getMessage, InstanceOfAssertFactories.STRING)
+				.contains("Dispatcher has no");
+
+		assertThat(recoveredMessages.get()).isSameAs(messages);
 	}
 
 	public static class Foo {
@@ -673,7 +809,7 @@ public class InboundEndpointTests {
 
 			Foo foo = (Foo) o;
 
-			return !(bar != null ? !bar.equals(foo.bar) : foo.bar != null);
+			return Objects.equals(bar, foo.bar);
 
 		}
 

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -199,7 +199,7 @@ The JMS inbound channel adapter is using a `JmsDestinationPollingSource` under t
 The AMQP inbound channel adapter uses an `AbstractMessageListenerContainer` and is message driven.
 In that regard, it is more similar to the JMS message-driven channel adapter.
 
-Starting with version 5.5, the `AmqpInboundChannelAdapter` can configured with a `org.springframework.amqp.rabbit.retry.MessageRecoverer` strategy which is used in the `RecoveryCallback` when retry operation is called internally.
+Starting with version 5.5, the `AmqpInboundChannelAdapter` can be configured with an `org.springframework.amqp.rabbit.retry.MessageRecoverer` strategy which is used in the `RecoveryCallback` when the retry operation is called internally.
 See `setMessageRecoverer()` JavaDocs for more information.
 
 ==== Configuring with Java Configuration
@@ -400,7 +400,7 @@ if you anticipate cases when no `replyTo` property exists in the request message
 
 See the note in <<amqp-inbound-channel-adapter>> about configuring the `listener-container` attribute.
 
-Starting with version 5.5, the `AmqpInboundChannelAdapter` can configured with an `org.springframework.amqp.rabbit.retry.MessageRecoverer` strategy which is used in the `RecoveryCallback` when retry operation is called internally.
+Starting with version 5.5, the `AmqpInboundChannelAdapter` can be configured with an `org.springframework.amqp.rabbit.retry.MessageRecoverer` strategy which is used in the `RecoveryCallback` when the retry operation is called internally.
 See `setMessageRecoverer()` JavaDocs for more information.
 
 ==== Configuring with Java Configuration

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -199,6 +199,9 @@ The JMS inbound channel adapter is using a `JmsDestinationPollingSource` under t
 The AMQP inbound channel adapter uses an `AbstractMessageListenerContainer` and is message driven.
 In that regard, it is more similar to the JMS message-driven channel adapter.
 
+Starting with version 5.5, the `AmqpInboundChannelAdapter` can configured with a `org.springframework.amqp.rabbit.retry.MessageRecoverer` strategy which is used in the `RecoveryCallback` when retry operation is called internally.
+See `setMessageRecoverer()` JavaDocs for more information.
+
 ==== Configuring with Java Configuration
 
 The following Spring Boot application shows an example of configuring the inbound adapter with Java configuration:
@@ -293,6 +296,8 @@ When receiving batched messages, by default, the listener containers extract eac
 Starting with version 5.2, if the container's `deBatchingEnabled` property is set to `false`, the de-batching is performed by the adapter instead, and a single `Message<List<?>>` is produced with the payload being a list of the fragment payloads (after conversion if appropriate).
 
 The default `BatchingStrategy` is the `SimpleBatchingStrategy`, but this can be overridden on the adapter.
+
+NOTE: The `org.springframework.amqp.rabbit.retry.MessageBatchRecoverer` must be used with batches when recovery is required for retry operations.
 
 === Polled Inbound Channel Adapter
 
@@ -394,6 +399,9 @@ You must either specify this option or configure a default `exchange` and `routi
 if you anticipate cases when no `replyTo` property exists in the request message.
 
 See the note in <<amqp-inbound-channel-adapter>> about configuring the `listener-container` attribute.
+
+Starting with version 5.5, the `AmqpInboundChannelAdapter` can configured with an `org.springframework.amqp.rabbit.retry.MessageRecoverer` strategy which is used in the `RecoveryCallback` when retry operation is called internally.
+See `setMessageRecoverer()` JavaDocs for more information.
 
 ==== Configuring with Java Configuration
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -21,6 +21,5 @@ If you are interested in more details, see the Issue Tracker tickets that were r
 [[x5.5-amqp]]
 ==== AMQP Changes
 
-The `AmqpInboundChannelAdapter` and `AmqpInboundGateway` (and respective Java DSL builders) now support an `org.springframework.amqp.rabbit.retry.MessageRecoverer` as an AMQP-specific alternative to a general purpose `RecoveryCallback`.
+The `AmqpInboundChannelAdapter` and `AmqpInboundGateway` (and the respective Java DSL builders) now support an `org.springframework.amqp.rabbit.retry.MessageRecoverer` as an AMQP-specific alternative to the general purpose `RecoveryCallback`.
 See <<./amqp.adoc#amqp,AMQP Support>> for more information.
-

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -17,3 +17,10 @@ If you are interested in more details, see the Issue Tracker tickets that were r
 
 [[x5.5-general]]
 === General Changes
+
+[[x5.5-amqp]]
+==== AMQP Changes
+
+The `AmqpInboundChannelAdapter` and `AmqpInboundGateway` (and respective Java DSL builders) now support an `org.springframework.amqp.rabbit.retry.MessageRecoverer` as an AMQP-specific alternative to a general purpose `RecoveryCallback`.
+See <<./amqp.adoc#amqp,AMQP Support>> for more information.
+


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3437

For better end-user experience with AMQP Inbound Endpoints, expose
a `MessageRecoverer` option
* Test the feature and document this new option

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
