### PR TITLE
GH-3446: Stream support in the MessageGroupStore

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.messaging.Message;
@@ -160,7 +161,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	@Override
 	@ManagedAttribute
 	public long getMessageCount() {
-		Collection<?> messageIds = doListKeys(this.messagePrefix + "*");
+		Collection<?> messageIds = doListKeys(this.messagePrefix + '*');
 		return (messageIds != null) ? messageIds.size() : 0;
 	}
 
@@ -347,10 +348,18 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	@Override
+	public Stream<Message<?>> streamMessagesForGroup(Object groupId) {
+		return getGroupMetadata(groupId)
+				.getMessageIds()
+				.stream()
+				.map(this::getMessage);
+	}
+
+	@Override
 	@SuppressWarnings("unchecked")
 	public Iterator<MessageGroup> iterator() {
 		final Iterator<?> idIterator = normalizeKeys(
-				(Collection<String>) doListKeys(this.groupPrefix + "*"))
+				(Collection<String>) doListKeys(this.groupPrefix + '*'))
 				.iterator();
 		return new MessageGroupIterator(idIterator);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,15 @@
 package org.springframework.integration.store;
 
 import java.util.Collection;
+import java.util.stream.Stream;
 
 import org.springframework.messaging.Message;
 
 /**
  * A group of messages that are correlated with each other and should be processed in the same context.
  * <p>
- * The message group allows implementations to be mutable, but this behavior is optional. Implementations should take
- * care to document their thread safety and mutability.
+ * The message group allows implementations to be mutable, but this behavior is optional.
+ * Implementations should take care to document their thread safety and mutability.
  *
  * @author Dave Syer
  * @author Oleg Zhurakousky
@@ -35,7 +36,6 @@ public interface MessageGroup {
 
 	/**
 	 * Query if the message can be added.
-	 *
 	 * @param message The message.
 	 * @return true if the message can be added.
 	 */
@@ -57,11 +57,19 @@ public interface MessageGroup {
 	boolean remove(Message<?> messageToRemove);
 
 	/**
-	 * Returns all available Messages from the group at the time of invocation
-	 *
+	 * Return all available Messages from the group at the time of invocation
 	 * @return The messages.
 	 */
 	Collection<Message<?>> getMessages();
+
+	/**
+	 * Return a stream for messages stored in this group.
+	 * @return the {@link Stream} for messages in this group.
+	 * @since 5.5
+	 */
+	default Stream<Message<?>> streamMessages() {
+		return getMessages().stream();
+	}
 
 	/**
 	 * @return the key that links these messages together

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupQueue.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupQueue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -42,6 +43,7 @@ import org.springframework.util.Assert;
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 2.0
  *
@@ -118,7 +120,7 @@ public class MessageGroupQueue extends AbstractQueue<Message<?>> implements Bloc
 
 	@Override
 	public Iterator<Message<?>> iterator() {
-		return getMessages().iterator();
+		return stream().iterator();
 	}
 
 	/**
@@ -164,29 +166,24 @@ public class MessageGroupQueue extends AbstractQueue<Message<?>> implements Bloc
 
 	@Override
 	public Message<?> peek() {
-		Message<?> message = null;
-		final Lock lock = this.storeLock;
 		try {
-			lock.lockInterruptibly();
-			try {
-				Collection<Message<?>> messages = getMessages();
-				if (!messages.isEmpty()) {
-					message = messages.iterator().next();
-				}
+			this.storeLock.lockInterruptibly();
+			try (Stream<Message<?>> messageStream = stream()) {
+				return messageStream.findFirst().orElse(null);
 			}
 			finally {
-				lock.unlock();
+				this.storeLock.unlock();
 			}
 		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 		}
-		return message;
+		return null;
 	}
 
 	@Override
 	public Message<?> poll(long timeout, TimeUnit unit) throws InterruptedException {
-		Message<?> message = null;
+		Message<?> message;
 		long timeoutInNanos = unit.toNanos(timeout);
 		final Lock lock = this.storeLock;
 		lock.lockInterruptibly();
@@ -325,7 +322,7 @@ public class MessageGroupQueue extends AbstractQueue<Message<?>> implements Bloc
 
 	@Override
 	public Message<?> take() throws InterruptedException {
-		Message<?> message = null;
+		Message<?> message;
 		final Lock lock = this.storeLock;
 		lock.lockInterruptibly();
 
@@ -344,6 +341,11 @@ public class MessageGroupQueue extends AbstractQueue<Message<?>> implements Bloc
 
 	protected Collection<Message<?>> getMessages() {
 		return this.messageGroupStore.getMessageGroup(this.groupId).getMessages();
+	}
+
+	@Override
+	public Stream<Message<?>> stream() {
+		return this.messageGroupStore.getMessageGroup(this.groupId).streamMessages();
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.store;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
@@ -141,6 +142,16 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * @since 4.3
 	 */
 	Collection<Message<?>> getMessagesForGroup(Object groupId);
+
+	/**
+	 * Return a stream for messages stored in the provided group.
+	 * @param groupId the group id to retrieve messages.
+	 * @return the {@link Stream} for messages in this group.
+	 * @since 5.5
+	 */
+	default Stream<Message<?>> streamMessagesForGroup(Object groupId) {
+		return getMessagesForGroup(groupId).stream();
+	}
 
 	/**
 	 * Invoked when a MessageGroupStore expires a group.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/PersistentMessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/PersistentMessageGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import java.util.AbstractCollection;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Spliterator;
+import java.util.stream.Stream;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -29,6 +31,7 @@ import org.springframework.messaging.Message;
 
 /**
  * @author Artem Bilan
+ *
  * @since 4.3
  */
 class PersistentMessageGroup implements MessageGroup {
@@ -57,6 +60,16 @@ class PersistentMessageGroup implements MessageGroup {
 	@Override
 	public Collection<Message<?>> getMessages() {
 		return Collections.unmodifiableCollection(this.messages);
+	}
+
+	/**
+	 * The resulting {@link Stream} must be closed after use,
+	 * it can be declared as a resource in a {@code try-with-resources} statement.
+	 * @return the stream of messages in this group.
+	 */
+	@Override
+	public Stream<Message<?>> streamMessages() {
+		return this.messageGroupStore.streamMessagesForGroup(this.original.getGroupId());
 	}
 
 	@Override
@@ -222,6 +235,16 @@ class PersistentMessageGroup implements MessageGroup {
 		@Override
 		public int size() {
 			return PersistentMessageGroup.this.size();
+		}
+
+		@Override
+		public Spliterator<Message<?>> spliterator() {
+			return streamMessages().spliterator();
+		}
+
+		@Override
+		public Stream<Message<?>> stream() {
+			return streamMessages();
 		}
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,7 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,8 +34,7 @@ import org.springframework.integration.handler.DelayHandler;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.interceptor.MatchAlwaysTransactionAttributeSource;
 import org.springframework.transaction.interceptor.NameMatchTransactionAttributeSource;
@@ -51,8 +49,7 @@ import org.springframework.transaction.interceptor.TransactionInterceptor;
  *
  * @since 1.0.3
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@SpringJUnitConfig
 public class DelayerParserTests {
 
 	@Autowired
@@ -70,7 +67,7 @@ public class DelayerParserTests {
 				.isEqualTo("headers.foo");
 		assertThat(TestUtils.getPropertyValue(delayHandler, "messagingTemplate.sendTimeout", Long.class))
 				.isEqualTo(987L);
-		assertThat(TestUtils.getPropertyValue(delayHandler, "taskScheduler")).isNull();
+		assertThat(TestUtils.getPropertyValue(delayHandler, "taskScheduler")).isNotNull();
 	}
 
 	@Test
@@ -110,7 +107,8 @@ public class DelayerParserTests {
 		assertThat(adviceChain.size()).isEqualTo(1);
 		Object advice = adviceChain.get(0);
 		assertThat(advice instanceof TransactionInterceptor).isTrue();
-		TransactionAttributeSource transactionAttributeSource = ((TransactionInterceptor) advice).getTransactionAttributeSource();
+		TransactionAttributeSource transactionAttributeSource =
+				((TransactionInterceptor) advice).getTransactionAttributeSource();
 		assertThat(transactionAttributeSource instanceof MatchAlwaysTransactionAttributeSource).isTrue();
 		Method method = MessageHandler.class.getMethod("handleMessage", Message.class);
 		TransactionDefinition definition = transactionAttributeSource.getTransactionAttribute(method, null);
@@ -130,7 +128,8 @@ public class DelayerParserTests {
 
 		Object txAdvice = adviceChain.get(1);
 		assertThat(txAdvice.getClass()).isEqualTo(TransactionInterceptor.class);
-		TransactionAttributeSource transactionAttributeSource = ((TransactionInterceptor) txAdvice).getTransactionAttributeSource();
+		TransactionAttributeSource transactionAttributeSource =
+				((TransactionInterceptor) txAdvice).getTransactionAttributeSource();
 		assertThat(transactionAttributeSource.getClass()).isEqualTo(NameMatchTransactionAttributeSource.class);
 		HashMap<?, ?> nameMap = TestUtils.getPropertyValue(transactionAttributeSource, "nameMap", HashMap.class);
 		assertThat(nameMap.toString()).isEqualTo("{*=PROPAGATION_REQUIRES_NEW,ISOLATION_DEFAULT,readOnly}");

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -424,6 +425,17 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 		return messageWrappers.stream()
 				.map(MessageWrapper::getMessage)
 				.collect(Collectors.toList());
+	}
+
+	@Override
+	public Stream<Message<?>> streamMessagesForGroup(Object groupId) {
+		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
+		Query query = whereGroupIdOrder(groupId);
+		Stream<MessageWrapper> messageWrappers =
+				this.template.stream(query, MessageWrapper.class, this.collectionName)
+						.stream();
+
+		return messageWrappers.map(MessageWrapper::getMessage);
 	}
 
 	@Override

--- a/src/reference/asciidoc/message-store.adoc
+++ b/src/reference/asciidoc/message-store.adoc
@@ -100,12 +100,9 @@ For this reason, you should either not perform such manipulation or set the `cop
 [[message-group-factory]]
 ==== Using `MessageGroupFactory`
 
-Starting with version 4.3, some `MessageGroupStore` implementations can be injected with a custom
-`MessageGroupFactory` strategy to create and customize the `MessageGroup` instances used by the `MessageGroupStore`.
-This defaults to a `SimpleMessageGroupFactory`, which produces `SimpleMessageGroup` instances based on the `GroupType.HASH_SET`
-(`LinkedHashSet`) internal collection.
-Other possible options are `SYNCHRONISED_SET` and `BLOCKING_QUEUE`, where the last one can be used to reinstate the
-previous `SimpleMessageGroup` behavior.
+Starting with version 4.3, some `MessageGroupStore` implementations can be injected with a custom `MessageGroupFactory` strategy to create and customize the `MessageGroup` instances used by the `MessageGroupStore`.
+This defaults to a `SimpleMessageGroupFactory`, which produces `SimpleMessageGroup` instances based on the `GroupType.HASH_SET` (`LinkedHashSet`) internal collection.
+Other possible options are `SYNCHRONISED_SET` and `BLOCKING_QUEUE`, where the last one can be used to reinstate the previous `SimpleMessageGroup` behavior.
 Also the `PERSISTENT` option is available.
 See the next section for more information.
 Starting with version 5.0.1, the `LIST` option is also available for when the order and uniqueness of messages in the group does not matter.
@@ -113,16 +110,12 @@ Starting with version 5.0.1, the `LIST` option is also available for when the or
 [[lazy-load-message-group]]
 ==== Persistent `MessageGroupStore` and Lazy-load
 
-Starting with version 4.3, all persistent `MessageGroupStore` instances retrieve `MessageGroup` instances and their `messages`
-from the store in the lazy-load manner.
-In most cases, it is useful for the correlation `MessageHandler` instances (see <<./aggregator.adoc#aggregator,Aggregator>> and <<./resequencer.adoc#resequencer,Resequencer>>),
-when it would add overhead to load entire the `MessageGroup` from the store on each correlation operation.
+Starting with version 4.3, all persistent `MessageGroupStore` instances retrieve `MessageGroup` instances and their `messages` from the store in the lazy-load manner.
+In most cases, it is useful for the correlation `MessageHandler` instances (see <<./aggregator.adoc#aggregator,Aggregator>> and <<./resequencer.adoc#resequencer,Resequencer>>), when it would add overhead to load entire the `MessageGroup` from the store on each correlation operation.
 
 You can use the `AbstractMessageGroupStore.setLazyLoadMessageGroups(false)` option to switch off the lazy-load behavior from the configuration.
 
-Our performance tests for lazy-load on MongoDB `MessageStore` (<<./mongodb.adoc#mongodb-message-store,MongoDB Message Store>>) and
-`<aggregator>` (<<./aggregator.adoc#aggregator,Aggregator>>)
-use a custom `release-strategy` similar to the following:
+Our performance tests for lazy-load on MongoDB `MessageStore` (<<./mongodb.adoc#mongodb-message-store,MongoDB Message Store>>) and `<aggregator>` (<<./aggregator.adoc#aggregator,Aggregator>>) use a custom `release-strategy` similar to the following:
 
 ====
 [source,xml]
@@ -149,3 +142,9 @@ ms     %     Task name
 ...
 ----
 ====
+
+However starting with version 5.5, all the persistent `MessageGroupStore` implementations provide a `streamMessagesForGroup(Object groupId)` contract based on the target database streaming API.
+This improves resources utilization when groups are very big in the store.
+Internally in the framework this new API is used in the <<./delayer.adoc#delayer,Delayer>> (for example) when it reschedules persisted messages on startup.
+A returned `Stream<Message<?>>` must be closed in the end of processing, e.g. via auto-close by the `try-with-resources`.
+Whenever a `PersistentMessageGroup` is used, its `streamMessages()` delegates to the `MessageGroupStore.streamMessagesForGroup()`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -18,6 +18,9 @@ If you are interested in more details, see the Issue Tracker tickets that were r
 [[x5.5-general]]
 === General Changes
 
+
+All the persistent `MessageGroupStore` implementation provide a `streamMessagesForGroup(Object groupId)` contract based on the target database streaming API.
+See <<./message-store.adoc#message-store,Message Store>> for more information.
 [[x5.5-amqp]]
 ==== AMQP Changes
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3446

* For better resources utilization provide a `Stream<Message<?>>` API
on the `MessageGroupStore`, `MessageGroup` and `MessageGroupQueue`
* Use this API in the `DelayHandler` when it reschedules persisted messages

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
