### PR TITLE
GH-3470: Resolve JDK8 Runtime Problem

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.net.SocketTimeoutException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
@@ -432,7 +433,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 			if (logger.isTraceEnabled()) {
 				logger.trace("After read: " + this.rawBuffer.position() + '/' + this.rawBuffer.limit());
 			}
-			this.rawBuffer.flip();
+			((Buffer) this.rawBuffer).flip();
 			if (logger.isTraceEnabled()) {
 				logger.trace("After flip: " + this.rawBuffer.position() + '/' + this.rawBuffer.limit());
 			}
@@ -572,6 +573,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	 * @since 5.2
 	 * @see SocketChannel#shutdownInput()
 	 */
+	@Override
 	public void shutdownInput() throws IOException {
 		this.socketChannel.shutdownInput();
 	}
@@ -582,6 +584,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	 * @since 5.2
 	 * @see SocketChannel#shutdownOutput()
 	 */
+	@Override
 	public void shutdownOutput() throws IOException {
 		this.socketChannel.shutdownOutput();
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3470

In order to catch issues like this at compile time, we need to set
the `bootClasspath` to ensure API compatibility but this would need some
consistent way to point the JDK 8 libs on all platforms (CI, GitHub Workflows,
dev machines, etc).
