### PR TITLE
GH-3473: Fix dead lock around lifecycleLock

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -117,8 +117,8 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 				this.roleController.addLifecycleToRole(this.role, this);
 			}
 			catch (@SuppressWarnings("unused") NoSuchBeanDefinitionException e) {
-					this.logger.trace("No LifecycleRoleController in the context");
-				}
+				this.logger.trace("No LifecycleRoleController in the context");
+			}
 		}
 	}
 
@@ -144,13 +144,7 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 
 	@Override
 	public final boolean isRunning() {
-		this.lifecycleLock.lock();
-		try {
-			return this.running;
-		}
-		finally {
-			this.lifecycleLock.unlock();
-		}
+		return this.running;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3473

When `AbstractEndpoint.start()` and `AbstractEndpoint.isRunning()`
are called from different thread on `synchronized` methods,
we may end up with a dead lock: one thread waits for monitor on
`synchronized` and another waits for the `lifecycleLock`

* Change `AbstractEndpoint.isRunning()` to a plain `return this.running;`
- there is no reason in a lock around returning this `volatile` property state

**Cherry-pick to 5.4.x & 5.3.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
