### PR TITLE
Expose `error.ignoreFailures` global property

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
@@ -219,6 +219,9 @@ class DefaultConfiguringBeanFactoryPostProcessor
 					BeanDefinitionBuilder.rootBeanDefinition(PublishSubscribeChannel.class)
 							.addConstructorArgValue(IntegrationProperties.getExpressionFor(
 									IntegrationProperties.ERROR_CHANNEL_REQUIRE_SUBSCRIBERS))
+							.addPropertyValue("ignoreFailures",
+									IntegrationProperties.getExpressionFor(
+											IntegrationProperties.ERROR_CHANNEL_IGNORE_FAILURES))
 							.getBeanDefinition());
 
 			BeanDefinition loggingHandler =

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
@@ -67,6 +67,14 @@ public final class IntegrationProperties {
 			INTEGRATION_PROPERTIES_PREFIX + "channels.error.requireSubscribers";
 
 	/**
+	 * Specifies the value for {@link org.springframework.integration.channel.PublishSubscribeChannel#ignoreFailures}
+	 * on a global default {@link IntegrationContextUtils#ERROR_CHANNEL_BEAN_NAME}.
+	 */
+	public static final String ERROR_CHANNEL_IGNORE_FAILURES =
+			INTEGRATION_PROPERTIES_PREFIX + "channels.error.ignoreFailures";
+
+
+	/**
 	 * Specifies the value of {@link org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler#poolSize}
 	 * for the {@code taskScheduler} bean initialized by the Integration infrastructure.
 	 */

--- a/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties
+++ b/spring-integration-core/src/main/resources/META-INF/spring.integration.default.properties
@@ -2,6 +2,7 @@ spring.integration.channels.autoCreate=true
 spring.integration.channels.maxUnicastSubscribers=0x7fffffff
 spring.integration.channels.maxBroadcastSubscribers=0x7fffffff
 spring.integration.channels.error.requireSubscribers=true
+spring.integration.channels.error.ignoreFailures=true
 spring.integration.taskScheduler.poolSize=10
 spring.integration.messagingTemplate.throwExceptionOnLateReply=false
 # Defaults to MessageHeaders.ID and MessageHeaders.TIMESTAMP

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ErrorChannelAutoCreationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ErrorChannelAutoCreationTests.java
@@ -41,6 +41,8 @@ public class ErrorChannelAutoCreationTests {
 		assertThat(this.errorChannel).isInstanceOf(PublishSubscribeChannel.class);
 		assertThat(TestUtils.getPropertyValue(this.errorChannel, "dispatcher.requireSubscribers", Boolean.class))
 				.isTrue();
+		assertThat(TestUtils.getPropertyValue(this.errorChannel, "dispatcher.ignoreFailures", Boolean.class))
+				.isTrue();
 	}
 
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,6 @@ import org.springframework.integration.channel.FixedSubscriberChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.config.GlobalChannelInterceptor;
-import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowDefinition;
@@ -60,7 +59,6 @@ import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.JmsDestinationPollingSource;
 import org.springframework.integration.scheduling.PollerMetadata;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.condition.LogLevels;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.core.JmsTemplate;
@@ -88,8 +86,6 @@ import org.springframework.transaction.PlatformTransactionManager;
  * @since 5.0
  */
 @SpringJUnitConfig
-@LogLevels(level = "debug",
-		categories = {"org.springframework", "org.springframework.integration", "org.apache"})
 @DirtiesContext
 public class JmsTests extends ActiveMQMultiContextTests {
 
@@ -480,7 +476,7 @@ public class JmsTests extends ActiveMQMultiContextTests {
 		public IntegrationFlow jmsMessageDrivenRedeliveryFlow() {
 			return IntegrationFlows
 					.from(Jms.messageDrivenChannelAdapter(jmsConnectionFactory())
-							.errorChannel(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME)
+							.errorChannel("errorChannelForRedelivery")
 							.destination("jmsMessageDrivenRedelivery")
 							.configureListenerContainer(c -> c
 									.transactionManager(mock(PlatformTransactionManager.class))
@@ -500,7 +496,7 @@ public class JmsTests extends ActiveMQMultiContextTests {
 
 		@Bean
 		public IntegrationFlow errorHandlingFlow() {
-			return IntegrationFlows.from(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME)
+			return IntegrationFlows.from("errorChannelForRedelivery")
 					.handle(m -> {
 						MessagingException exception = (MessagingException) m.getPayload();
 						redeliveryLatch().countDown();

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -169,6 +169,7 @@ spring.integration.messagingTemplate.throwExceptionOnLateReply=false <5>
 spring.integration.readOnly.headers= <6>
 spring.integration.endpoints.noAutoStartup= <7>
 spring.integration.channels.error.requireSubscribers=true <8>
+spring.integration.channels.error.ignoreFailures=true <9>
 ----
 
 <1> When true, `input-channel` instances are automatically declared as `DirectChannel` instances when not explicitly found in the application context.
@@ -199,6 +200,9 @@ Since version 4.3.12.
 <8> A boolean flag to indicate that default global `errorChannel` must be configured with the `requireSubscribers` option.
 Since version 5.4.3.
 See <<./error-handling.adoc#error-handling,Error Handling>> for more information.
+
+<9> A boolean flag to indicate that default global `errorChannel` must ignore dispatching errors and pass the message to the next handler.
+Since version 5.5.
 ====
 
 These properties can be overridden by adding a `/META-INF/spring.integration.properties` file to the classpath.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -18,9 +18,13 @@ If you are interested in more details, see the Issue Tracker tickets that were r
 [[x5.5-general]]
 === General Changes
 
-
 All the persistent `MessageGroupStore` implementation provide a `streamMessagesForGroup(Object groupId)` contract based on the target database streaming API.
 See <<./message-store.adoc#message-store,Message Store>> for more information.
+
+A `spring.integration.channels.error.requireSubscribers=true` global property is added to indicate that global default `errorChannel` must be configured with the `requireSubscribers` option (or not).
+A `spring.integration.channels.error.ignoreFailures=true` global property is added to indicate that global default `errorChannel` must ignore (or not) dispatching errors and pass the message to the next handler.
+See <<./configuration.adoc#global-properties,Global Properties>> for more information.
+
 [[x5.5-amqp]]
 ==== AMQP Changes
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -21,8 +21,8 @@ If you are interested in more details, see the Issue Tracker tickets that were r
 All the persistent `MessageGroupStore` implementation provide a `streamMessagesForGroup(Object groupId)` contract based on the target database streaming API.
 See <<./message-store.adoc#message-store,Message Store>> for more information.
 
-A `spring.integration.channels.error.requireSubscribers=true` global property is added to indicate that global default `errorChannel` must be configured with the `requireSubscribers` option (or not).
-A `spring.integration.channels.error.ignoreFailures=true` global property is added to indicate that global default `errorChannel` must ignore (or not) dispatching errors and pass the message to the next handler.
+The `spring.integration.channels.error.requireSubscribers=true` global property is added to indicate that global default `errorChannel` must be configured with the `requireSubscribers` option (or not).
+The `spring.integration.channels.error.ignoreFailures=true` global property is added to indicate that global default `errorChannel` must ignore (or not) dispatching errors and pass the message to the next handler.
 See <<./configuration.adoc#global-properties,Global Properties>> for more information.
 
 [[x5.5-amqp]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -21,8 +21,8 @@ If you are interested in more details, see the Issue Tracker tickets that were r
 All the persistent `MessageGroupStore` implementation provide a `streamMessagesForGroup(Object groupId)` contract based on the target database streaming API.
 See <<./message-store.adoc#message-store,Message Store>> for more information.
 
-The `spring.integration.channels.error.requireSubscribers=true` global property is added to indicate that global default `errorChannel` must be configured with the `requireSubscribers` option (or not).
-The `spring.integration.channels.error.ignoreFailures=true` global property is added to indicate that global default `errorChannel` must ignore (or not) dispatching errors and pass the message to the next handler.
+The `spring.integration.channels.error.requireSubscribers=true` global property is added to indicate that the global default `errorChannel` must be configured with the `requireSubscribers` option (or not).
+The `spring.integration.channels.error.ignoreFailures=true` global property is added to indicate that the global default `errorChannel` must ignore (or not) dispatching errors and pass the message to the next handler.
 See <<./configuration.adoc#global-properties,Global Properties>> for more information.
 
 [[x5.5-amqp]]


### PR DESCRIPTION
The global default `errorChannel` can have more then only one logging subscriber.
There is no guarantee in which order subscribers are called and one of them fails
the rest are not called.

* Expose `spring.integration.channels.error.ignoreFailures` global property for
default `errorChannel` and make it `true` by default for better end-user experience
when it is expected to have error being handled by all the subscribers

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
