### PR TITLE
GH-3488: Fix Persisent Filters with Recursion

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractDirectoryAwareFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractDirectoryAwareFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ package org.springframework.integration.file.filters;
  * This permits, for example, pattern matching on just files when using recursion
  * to examine a directory tree.
  *
+ * @param <F> the file type.
+ *
  * @author Gary Russell
  * @since 5.0
  *
@@ -29,6 +31,8 @@ public abstract class AbstractDirectoryAwareFileListFilter<F> extends AbstractFi
 
 	private boolean alwaysAcceptDirectories;
 
+	private boolean forRecursion;
+
 	/**
 	 * Set to true so that filters that support this feature can unconditionally pass
 	 * directories; default false.
@@ -36,6 +40,22 @@ public abstract class AbstractDirectoryAwareFileListFilter<F> extends AbstractFi
 	 */
 	public void setAlwaysAcceptDirectories(boolean alwaysAcceptDirectories) {
 		this.alwaysAcceptDirectories = alwaysAcceptDirectories;
+	}
+
+	@Override
+	public boolean isForRecursion() {
+		return this.forRecursion;
+	}
+
+	/**
+	 * Set to true to inform a recursive gateway operation to use the full file path as
+	 * the metadata key. Also sets {@link #alwaysAcceptDirectories}.
+	 * @param forRecursion true to use the full path.
+	 * @since 5.3.6
+	 */
+	public void setForRecursion(boolean forRecursion) {
+		this.forRecursion = forRecursion;
+		this.alwaysAcceptDirectories = forRecursion;
 	}
 
 	protected boolean alwaysAccept(F file) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,13 +31,15 @@ import org.springframework.util.Assert;
  * Files are deemed as already 'seen' if they exist in the store and have the
  * same modified time as the current file.
  *
+ * @param <F> the file type.
+ *
  * @author Gary Russell
  * @author Artem Bilan
  *
  * @since 3.0
  *
  */
-public abstract class AbstractPersistentAcceptOnceFileListFilter<F> extends AbstractFileListFilter<F>
+public abstract class AbstractPersistentAcceptOnceFileListFilter<F> extends AbstractDirectoryAwareFileListFilter<F>
 		implements ReversibleFileListFilter<F>, ResettableFileListFilter<F>, Closeable {
 
 	protected final ConcurrentMetadataStore store; // NOSONAR
@@ -73,6 +75,9 @@ public abstract class AbstractPersistentAcceptOnceFileListFilter<F> extends Abst
 
 	@Override
 	public boolean accept(F file) {
+		if (alwaysAccept(file)) {
+			return true;
+		}
 		String key = buildKey(file);
 		String newValue = value(file);
 		String oldValue = this.store.putIfAbsent(key, newValue);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,15 @@ public interface FileListFilter<F> {
 	 * @see #accept(Object)
 	 */
 	default boolean supportsSingleFileFiltering() {
+		return false;
+	}
+
+	/**
+	 * Return true if this filter is being used for recursion.
+	 * @return whether or not to filter based on the full path.
+	 * @since 5.3.6
+	 */
+	default boolean isForRecursion() {
 		return false;
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileSystemPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/FileSystemPersistentAcceptOnceFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,5 +52,9 @@ public class FileSystemPersistentAcceptOnceFileListFilter extends AbstractPersis
 		return file.exists();
 	}
 
+	@Override
+	protected boolean isDirectory(File file) {
+		return file.isDirectory();
+	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -98,6 +98,8 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	 */
 	private FileListFilter<F> filter;
 
+	private boolean filterAfterEnhancement;
+
 	/**
 	 * A {@link FileListFilter} that runs against the <em>local</em> file system view when
 	 * using MPUT.
@@ -403,6 +405,15 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	 */
 	public void setFilter(FileListFilter<F> filter) {
 		this.filter = filter;
+		this.filterAfterEnhancement = filter != null
+				&& filter.isForRecursion()
+				&& filter.supportsSingleFileFiltering()
+				&& this.options.contains(Option.RECURSIVE);
+		if (filter != null && !filter.isForRecursion()) {
+			this.logger.warn("When using recursion, you will normally want to set the filter's "
+					+ "'forRecursion' property; otherwise files added deep into the "
+					+ "directory tree may not be detected");
+		}
 	}
 
 	/**
@@ -944,12 +955,19 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		List<F> lsFiles = new ArrayList<>();
 		String remoteDirectory = buildRemotePath(directory, subDirectory);
 
-		F[] files = session.list(remoteDirectory);
-		boolean recursion = this.options.contains(Option.RECURSIVE);
+		F[] list = session.list(remoteDirectory);
+		List<F> files;
+		if (!this.filterAfterEnhancement) {
+			files = filterFiles(list);
+		}
+		else {
+			files = Arrays.asList(list);
+		}
 		if (!ObjectUtils.isEmpty(files)) {
-			for (F file : filterFiles(files)) {
+			for (F file : files) {
 				if (file != null) {
-					processFile(session, directory, subDirectory, lsFiles, recursion, file);
+					processFile(session, directory, subDirectory, lsFiles, this.options.contains(Option.RECURSIVE),
+							file);
 				}
 			}
 		}
@@ -971,24 +989,38 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		return (this.filter != null) ? this.filter.filterFiles(files) : Arrays.asList(files);
 	}
 
+	protected final F filterFile(F file) {
+		if (this.filter.accept(file)) {
+			return file;
+		}
+		else {
+			return null;
+		}
+	}
+
 	private void processFile(Session<F> session, String directory, String subDirectory, List<F> lsFiles,
 			boolean recursion, F file) throws IOException {
 
-		String fileName = getFilename(file);
+		F fileToAdd = file;
+		if (recursion && StringUtils.hasText(subDirectory)) {
+			fileToAdd = enhanceNameWithSubDirectory(file, subDirectory);
+		}
+		if (this.filterAfterEnhancement) {
+			if (!this.filter.accept(fileToAdd)) {
+				return;
+			}
+		}
+		String fileName = getFilename(fileToAdd);
 		final boolean isDirectory = isDirectory(file);
 		boolean isDots = hasDots(fileName);
 		if ((this.options.contains(Option.SUBDIRS) || !isDirectory)
 				&& (!isDots || this.options.contains(Option.ALL))) {
 
-			F fileToAdd = file;
-			if (recursion && StringUtils.hasText(subDirectory)) {
-				fileToAdd = enhanceNameWithSubDirectory(file, subDirectory);
-			}
 			lsFiles.add(fileToAdd);
 		}
 
 		if (recursion && isDirectory && !isDots) {
-			lsFiles.addAll(listFilesInRemoteDir(session, directory, subDirectory + fileName +
+			lsFiles.addAll(listFilesInRemoteDir(session, directory, fileName +
 					this.remoteFileTemplate.getRemoteFileSeparator()));
 		}
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/CompositeFileListFilterTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/CompositeFileListFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -138,6 +138,12 @@ public class CompositeFileListFilterTests {
 				return true;
 			}
 
+
+			@Override
+			public boolean isForRecursion() {
+				return true;
+			}
+
 			@Override
 			public boolean accept(String file) {
 				return true;
@@ -147,6 +153,7 @@ public class CompositeFileListFilterTests {
 		assertThat(compo.accept("foo")).isTrue();
 		compo.addFilter(s -> null);
 		assertThat(compo.supportsSingleFileFiltering()).isFalse();
+		assertThat(compo.isForRecursion()).isTrue();
 		compo.close();
 	}
 
@@ -155,6 +162,7 @@ public class CompositeFileListFilterTests {
 		CompositeFileListFilter<String> compo =
 				new CompositeFileListFilter<>(Collections.singletonList(s -> null));
 		assertThat(compo.supportsSingleFileFiltering()).isFalse();
+		assertThat(compo.isForRecursion()).isFalse();
 		compo.close();
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/PersistentAcceptOnceFileListFilterTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/PersistentAcceptOnceFileListFilterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,12 @@ public class PersistentAcceptOnceFileListFilterTests extends AcceptOnceFileListF
 					protected String fileName(String file) {
 						return file;
 					}
+
+					@Override
+					protected boolean isDirectory(String file) {
+						return false;
+					}
+
 				};
 		doTestRollback(filter);
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/RemoteFileTestSupport.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/RemoteFileTestSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,8 @@ public abstract class RemoteFileTestSupport {
 	protected static File remoteTemporaryFolder;
 
 	protected static File localTemporaryFolder;
+
+	protected static File scratchTemporaryFolder;
 
 	protected volatile File sourceRemoteDirectory;
 
@@ -167,6 +169,14 @@ public abstract class RemoteFileTestSupport {
 		fos = new FileOutputStream(file);
 		fos.write("subLocal1".getBytes());
 		fos.close();
+	}
+
+	public static File getScratchTempFolder() {
+		if (scratchTemporaryFolder == null) {
+			scratchTemporaryFolder = new File(temporaryFolder.toFile().getAbsolutePath() + File.separator + "scratch");
+			scratchTemporaryFolder.mkdirs();
+		}
+		return scratchTemporaryFolder;
 	}
 
 	protected static File getRemoteTempFolder() {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -388,6 +388,11 @@ public class StreamingInboundTests {
 		@Override
 		protected String fileName(String file) {
 			return file;
+		}
+
+		@Override
+		protected boolean isDirectory(String file) {
+			return false;
 		}
 
 	}

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/filters/FtpPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/filters/FtpPersistentAcceptOnceFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,11 @@ public class FtpPersistentAcceptOnceFileListFilter extends AbstractPersistentAcc
 	@Override
 	protected String fileName(FTPFile file) {
 		return file.getName();
+	}
+
+	@Override
+	protected boolean isDirectory(FTPFile file) {
+		return file.isDirectory();
 	}
 
 }

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/filters/SftpPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/filters/SftpPersistentAcceptOnceFileListFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,11 @@ public class SftpPersistentAcceptOnceFileListFilter extends AbstractPersistentAc
 	@Override
 	protected String fileName(LsEntry file) {
 		return file.getFilename();
+	}
+
+	@Override
+	protected boolean isDirectory(LsEntry file) {
+		return file.getAttrs().isDir();
 	}
 
 }

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -87,7 +87,7 @@
 							  expression="payload"
 							  command-options="-R"
 							  mode="REPLACE_IF_MODIFIED"
-							  filter="dotStarDotTxtFilter"
+							  filter="persistentFilter"
 							  local-directory-expression="@extraConfig.targetLocalDirectoryName + #remoteDirectory"
 							  local-filename-generator-expression="#remoteFileName.replaceFirst('sftpSource', 'localTarget')"
 							  reply-channel="output"/>
@@ -97,6 +97,19 @@
 		<constructor-arg value="^.*\.txt$" />
 		<property name="alwaysAcceptDirectories" value="true" />
 	</bean>
+
+	<bean id="persistentFilter" class="org.springframework.integration.sftp.filters.SftpPersistentAcceptOnceFileListFilter">
+		<constructor-arg ref="store"/>
+		<constructor-arg value="test"/>
+		<property name="forRecursion" value="true"/>
+		<property name="flushOnUpdate" value="true"/>
+	</bean>
+
+	<bean id="store" class="org.springframework.integration.metadata.PropertiesPersistingMetadataStore">
+		<property name="baseDirectory"
+			value="#{T(org.springframework.integration.file.remote.RemoteFileTestSupport).getScratchTempFolder().absolutePath}"/>
+	</bean>
+
 
 	<int:channel id="inboundMGetRecursiveFiltered"/>
 

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -78,6 +78,13 @@ When used with a shared data store (such as `Redis` with the `RedisMetadataStore
 Since version 4.1.5, this filter has a new property (`flushOnUpdate`), which causes it to flush the metadata store on every update (if the store implements `Flushable`).
 ====
 
+The persistent file list filters now have a boolean property `forRecursion`.
+Setting this property to `true`, also sets `alwaysAcceptDirectories`, which means that the recursive operation on the outbound gateways (`ls` and `mget`) will now always traverse the full directory tree each time.
+This is to solve a problem where changes deep in the directory tree were not detected.
+In addition, `forRecursion=true` causes the full path to files to be used as the metadata store keys; this solves a problem where the filter did not work properly if a file with the same name appears multiple times in different directories.
+IMPORTANT: This means that existing keys in a persistent metadata store will not be found for files beneath the top level directory.
+For this reason, the property is `false` by default; this may change in a future release.
+
 The following example configures a `FileReadingMessageSource` with a filter:
 
 ====
@@ -1189,3 +1196,10 @@ If a filter returns `true` in `supportsSingleFileFiltering`, it **must** impleme
 If a remote filter does not support single file filtering (such as the `AbstractMarkerFilePresentFileListFilter`), the adapters revert to the previous behavior.
 
 If multiple filters are in used (using a `CompositeFileListFilter` or `ChainFileListFilter`), then **all** of the delegate filters must support single file filtering in order for the composite filter to support it.
+
+The persistent file list filters now have a boolean property `forRecursion`.
+Setting this property to `true`, also sets `alwaysAcceptDirectories`, which means that the recursive operation on the outbound gateways (`ls` and `mget`) will now always traverse the full directory tree each time.
+This is to solve a problem where changes deep in the directory tree were not detected.
+In addition, `forRecursion=true` causes the full path to files to be used as the metadata store keys; this solves a problem where the filter did not work properly if a file with the same name appears multiple times in different directories.
+IMPORTANT: This means that existing keys in a persistent metadata store will not be found for files beneath the top level directory.
+For this reason, the property is `false` by default; this may change in a future release.

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -1165,6 +1165,13 @@ The `-dirs` option is not allowed (the recursive `mget` uses the recursive `ls` 
 Typically, you would use the `#remoteDirectory` variable in the `local-directory-expression` so that the remote directory structure is retained locally.
 =====
 
+The persistent file list filters now have a boolean property `forRecursion`.
+Setting this property to `true`, also sets `alwaysAcceptDirectories`, which means that the recursive operation on the outbound gateways (`ls` and `mget`) will now always traverse the full directory tree each time.
+This is to solve a problem where changes deep in the directory tree were not detected.
+In addition, `forRecursion=true` causes the full path to files to be used as the metadata store keys; this solves a problem where the filter did not work properly if a file with the same name appears multiple times in different directories.
+IMPORTANT: This means that existing keys in a persistent metadata store will not be found for files beneath the top level directory.
+For this reason, the property is `false` by default; this may change in a future release.
+
 Starting with version 5.0, the `FtpSimplePatternFileListFilter` and `FtpRegexPatternFileListFilter` can be configured to always pass directories by setting the `alwaysAcceptDirectories` property to `true`.
 Doing so allows recursion for a simple pattern, as the following examples show:
 

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -1125,6 +1125,13 @@ The `-dirs` option is not allowed (the recursive `mget` uses the recursive `ls` 
 Typically, you would use the `#remoteDirectory` variable in the `local-directory-expression` so that the remote directory structure is retained locally.
 =====
 
+The persistent file list filters now have a boolean property `forRecursion`.
+Setting this property to `true`, also sets `alwaysAcceptDirectories`, which means that the recursive operation on the outbound gateways (`ls` and `mget`) will now always traverse the full directory tree each time.
+This is to solve a problem where changes deep in the directory tree were not detected.
+In addition, `forRecursion=true` causes the full path to files to be used as the metadata store keys; this solves a problem where the filter did not work properly if a file with the same name appears multiple times in different directories.
+IMPORTANT: This means that existing keys in a persistent metadata store will not be found for files beneath the top level directory.
+For this reason, the property is `false` by default; this may change in a future release.
+
 Starting with version 5.0, you can configure the `SftpSimplePatternFileListFilter` and `SftpRegexPatternFileListFilter` to always pass directories by setting the `alwaysAcceptDirectorties` to `true`.
 Doing so allows recursion for a simple pattern, as the following examples show:
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -47,3 +47,13 @@ See <<./redis.adoc#redis,Redis Support>> for more information.
 The `HttpRequestExecutingMessageHandler` doesn't fallback to the `application/x-java-serialized-object` content type any more and lets the `RestTemplate` make the final decision for the request body conversion based on the `HttpMessageConverter` provided.
 
 See <<./http.adoc#http,HTTP Support>> for more information.
+
+[[x5.5-file]]
+==== File/FTP/SFTP Changes
+
+The persistent file list filters now have a boolean property `forRecursion`.
+Setting this property to `true`, also sets `alwaysAcceptDirectories`, which means that the recursive operation on the outbound gateways (`ls` and `mget`) will now always traverse the full directory tree each time.
+This is to solve a problem where changes deep in the directory tree were not detected.
+In addition, `forRecursion=true` causes the full path to files to be used as the metadata store keys; this solves a problem where the filter did not work properly if a file with the same name appears multiple times in different directories.
+IMPORTANT: This means that existing keys in a persistent metadata store will not be found for files beneath the top level directory.
+For this reason, the property is `false` by default; this may change in a future release.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3488

Resolves two problems:

- When changes are made deep in the directory tree, they were not detected because
  the directory is in the metadata store and only passes the filter if a file
  immediately under it is changed, changing the directory's timestamp.

This is solved by subclassing `AbstractDirectoryAwareFileListFilter`, allowing its
`alwaysAcceptDirectories` property to be set.

- Only the filename was used as a metadata key; causing problems if a file with the
  same name appears multiple times in the tree.

This is solved with a new property on `AbstractDirectoryAwareFileListFilter` used by
the gateways to determine whether to filter the raw file names returned by the session
(previous behavior) or the full path relative to the root directory.

**cherry-pick to 5.4.x, 5.3.x**
