### PR TITLE
GH-3497: `ReplyProducerCleaner`: check only MPs

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3100,12 +3100,15 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 		@Override
 		public boolean requiresDestruction(Object bean) {
-			return BaseIntegrationFlowDefinition.REFERENCED_REPLY_PRODUCERS.contains(bean);
+			return bean instanceof MessageProducer &&
+					BaseIntegrationFlowDefinition.REFERENCED_REPLY_PRODUCERS.contains(bean);
 		}
 
 		@Override
 		public void postProcessBeforeDestruction(Object bean, String beanName) throws BeansException {
-			BaseIntegrationFlowDefinition.REFERENCED_REPLY_PRODUCERS.remove(bean);
+			if (bean instanceof MessageProducer) {
+				BaseIntegrationFlowDefinition.REFERENCED_REPLY_PRODUCERS.remove(bean);
+			}
 		}
 
 	}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3497

The `BaseIntegrationFlowDefinition.REFERENCED_REPLY_PRODUCERS` is filled up
only with the `MessageProducer` instances.
Therefore no reason to calculate a hash code for every single bean passed
to the `ReplyProducerCleaner.requiresDestruction()`

* Check for the `MessageProducer` instance before passing the bean to the
`BaseIntegrationFlowDefinition.REFERENCED_REPLY_PRODUCERS.contains()`
* Check for the `MessageProducer` in the `ReplyProducerCleaner.postProcessBeforeDestruction()`,
too.
It can be called independently of the `requiresDestruction()` and will calculate a hash code
from the bean again for nothing

**Cherry-pick to 5.4.x & 5.3.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
