### PR TITLE
INT-3585: JsonPropertyAccessor: skip failed parse

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
@@ -70,7 +70,14 @@ public class JsonPropertyAccessor implements PropertyAccessor {
 
 	@Override
 	public boolean canRead(EvaluationContext context, Object target, String name) throws AccessException {
-		JsonNode node = asJson(target);
+		JsonNode node;
+		try {
+			node = asJson(target);
+		}
+		catch (AccessException e) {
+			// Cannot parse - treat as not a JSON
+			return false;
+		}
 		Integer index = maybeIndex(name);
 		if (node instanceof ArrayNode) {
 			return index != null;

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests-context.xml
@@ -11,15 +11,22 @@
 
 	<object-to-json-transformer id="defaultTransformer" input-channel="defaultObjectMapperInput"/>
 
-	<object-to-json-transformer id="emptyContentTypeTransformer" input-channel="customObjectMapperInput" content-type=""/>
+	<object-to-json-transformer id="emptyContentTypeTransformer" input-channel="customObjectMapperInput"
+								content-type=""/>
 
-	<object-to-json-transformer id="overriddenContentTypeTransformer" input-channel="customObjectMapperInput" content-type="text/xml"/>
+	<object-to-json-transformer id="overriddenContentTypeTransformer" input-channel="customObjectMapperInput"
+								content-type="text/xml"/>
 
 	<object-to-json-transformer id="customJsonObjectMapperTransformer" input-channel="customJsonObjectMapperInput"
 								object-mapper="customJsonObjectMapper"/>
 
 	<object-to-json-transformer id="jsonNodeTransformer" input-channel="jsonNodeInput" result-type="NODE"/>
 
-	<beans:bean id="customJsonObjectMapper" class="org.springframework.integration.json.ObjectToJsonTransformerParserTests$CustomJsonObjectMapper"/>
+	<beans:bean id="customJsonObjectMapper"
+				class="org.springframework.integration.json.ObjectToJsonTransformerParserTests$CustomJsonObjectMapper"/>
+
+	<spel-property-accessors>
+		<beans:bean id="json" class="org.springframework.integration.json.JsonPropertyAccessor"/>
+	</spel-property-accessors>
 
 </beans:beans>


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-3585

Even if this fix doesn't provide an order support,
it does cover an original premise of an issue
With this fix the order of accessors doesn't matter.

* Catch an `AccessException` in the `JsonPropertyAccessor.canRead()` and return `false`
to let the rest accessors to deal with the property requested

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
