### PR TITLE
INT-4444: Introduce `@Reactive` & `reactive()`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregator.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.messaging.handler.annotation.ValueConstants;
+
 /**
  * Indicates that a method is capable of aggregating messages.
  * <p>
@@ -109,11 +111,10 @@ public @interface Aggregator {
 	Poller[] poller() default { };
 
 	/**
-	 * @return the {@link Reactive} options for a consumer endpoint.
-	 * This attribute is an {@code array} just to allow an empty default (not reactive).
-	 * Only one {@link Reactive} element is allowed.
+	 * @return the {@link Reactive} marker for a consumer endpoint.
 	 * Mutually exclusive with {@link #poller()}.
+	 * @since 5.5
 	 */
-	Reactive[] reactive() default { };
+	Reactive reactive() default @Reactive(ValueConstants.DEFAULT_NONE);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,8 +104,16 @@ public @interface Aggregator {
 	 * @return the {@link Poller} options for a polled endpoint
 	 * ({@link org.springframework.integration.scheduling.PollerMetadata}).
 	 * This attribute is an {@code array} just to allow an empty default (no poller).
-	 * Only one {@link Poller} element is allowed.
+	 * Mutually exclusive with {@link #reactive()}.
 	 */
 	Poller[] poller() default { };
+
+	/**
+	 * @return the {@link Reactive} options for a consumer endpoint.
+	 * This attribute is an {@code array} just to allow an empty default (not reactive).
+	 * Only one {@link Reactive} element is allowed.
+	 * Mutually exclusive with {@link #poller()}.
+	 */
+	Reactive[] reactive() default { };
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeFrom.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeFrom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,8 +69,16 @@ public @interface BridgeFrom {
 	 * @return the {@link Poller} options for a polled endpoint
 	 * ({@link org.springframework.integration.scheduling.PollerMetadata}).
 	 * This attribute is an {@code array} just to allow an empty default (no poller).
-	 * Only one {@link Poller} element is allowed.
+	 * Mutually exclusive with {@link #reactive()}.
 	 */
 	Poller[] poller() default { };
+
+	/**
+	 * @return the {@link Reactive} options for a consumer endpoint.
+	 * This attribute is an {@code array} just to allow an empty default (not reactive).
+	 * Only one {@link Reactive} element is allowed.
+	 * Mutually exclusive with {@link #poller()}.
+	 */
+	Reactive[] reactive() default { };
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeFrom.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeFrom.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.messaging.handler.annotation.ValueConstants;
+
 /**
  * Messaging Annotation to mark a {@link org.springframework.context.annotation.Bean}
  * method for a {@link org.springframework.messaging.MessageChannel} to produce a
@@ -74,11 +76,10 @@ public @interface BridgeFrom {
 	Poller[] poller() default { };
 
 	/**
-	 * @return the {@link Reactive} options for a consumer endpoint.
-	 * This attribute is an {@code array} just to allow an empty default (not reactive).
-	 * Only one {@link Reactive} element is allowed.
+	 * @return the {@link Reactive} marker for a consumer endpoint.
 	 * Mutually exclusive with {@link #poller()}.
+	 * @since 5.5
 	 */
-	Reactive[] reactive() default { };
+	Reactive reactive() default @Reactive(ValueConstants.DEFAULT_NONE);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeTo.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeTo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,8 +50,8 @@ import java.lang.annotation.Target;
 public @interface BridgeTo {
 
 	/**
-	 * @return the outbound channel name to send the message to
-	 * {@link org.springframework.integration.handler.BridgeHandler}.
+	 * @return the outbound channel name to send the message to for the
+	 * {@link org.springframework.integration.handler.BridgeHandler} reply.
 	 * Optional: when omitted the message is sent to the {@code reply-channel}
 	 * in its headers (if present - an exception is thrown otherwise).
 	 */
@@ -73,11 +73,19 @@ public @interface BridgeTo {
 	String phase() default "";
 
 	/**
-	 * @return the {@link org.springframework.integration.annotation.Poller} options for a polled endpoint
+	 * @return the {@link Poller} options for a polled endpoint
 	 * ({@link org.springframework.integration.scheduling.PollerMetadata}).
 	 * This attribute is an {@code array} just to allow an empty default (no poller).
-	 * Only one {@link org.springframework.integration.annotation.Poller} element is allowed.
+	 * Mutually exclusive with {@link #reactive()}.
 	 */
 	Poller[] poller() default { };
+
+	/**
+	 * @return the {@link Reactive} options for a consumer endpoint.
+	 * This attribute is an {@code array} just to allow an empty default (not reactive).
+	 * Only one {@link Reactive} element is allowed.
+	 * Mutually exclusive with {@link #poller()}.
+	 */
+	Reactive[] reactive() default { };
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeTo.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeTo.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.messaging.handler.annotation.ValueConstants;
+
 /**
  * Messaging Annotation to mark a {@link org.springframework.context.annotation.Bean}
  * method for a {@link org.springframework.messaging.MessageChannel} to produce a
@@ -81,11 +83,10 @@ public @interface BridgeTo {
 	Poller[] poller() default { };
 
 	/**
-	 * @return the {@link Reactive} options for a consumer endpoint.
-	 * This attribute is an {@code array} just to allow an empty default (not reactive).
-	 * Only one {@link Reactive} element is allowed.
+	 * @return the {@link Reactive} marker for a consumer endpoint.
 	 * Mutually exclusive with {@link #poller()}.
+	 * @since 5.5
 	 */
-	Reactive[] reactive() default { };
+	Reactive reactive() default @Reactive(ValueConstants.DEFAULT_NONE);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import java.lang.annotation.Target;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
@@ -126,8 +127,17 @@ public @interface Filter {
 	 * @return the {@link Poller} options for a polled endpoint
 	 * ({@link org.springframework.integration.scheduling.PollerMetadata}).
 	 * This attribute is an {@code array} just to allow an empty default (no poller).
-	 * Only one {@link Poller} element is allowed.
+	 * Mutually exclusive with {@link #reactive()}.
 	 */
 	Poller[] poller() default { };
+
+	/**
+	 * @return the {@link Reactive} options for a consumer endpoint.
+	 * This attribute is an {@code array} just to allow an empty default (not reactive).
+	 * Only one {@link Reactive} element is allowed.
+	 * Mutually exclusive with {@link #poller()}.
+	 */
+	Reactive[] reactive() default { };
+
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.messaging.handler.annotation.ValueConstants;
+
 /**
  * Indicates that a method is capable of playing the role of a Message Filter.
  * <p>
@@ -132,12 +134,10 @@ public @interface Filter {
 	Poller[] poller() default { };
 
 	/**
-	 * @return the {@link Reactive} options for a consumer endpoint.
-	 * This attribute is an {@code array} just to allow an empty default (not reactive).
-	 * Only one {@link Reactive} element is allowed.
+	 * @return the {@link Reactive} marker for a consumer endpoint.
 	 * Mutually exclusive with {@link #poller()}.
+	 * @since 5.5
 	 */
-	Reactive[] reactive() default { };
-
+	Reactive reactive() default @Reactive(ValueConstants.DEFAULT_NONE);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Reactive.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Reactive.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Provides a reactive configuration options for the consumer endpoint making
+ * any input channel as a reactive stream source of data.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.5
+ */
+@Target({})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Reactive {
+
+	/**
+	 * @return the function bean name to be used in the
+	 * {@link reactor.core.publisher.Flux#transform} on the input channel
+	 * {@link reactor.core.publisher.Flux}.
+	 */
+	String value() default "";
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Reactive.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Reactive.java
@@ -21,7 +21,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Provides a reactive configuration options for the consumer endpoint making
+ * Provides reactive configuration options for the consumer endpoint making
  * any input channel as a reactive stream source of data.
  *
  * @author Artem Bilan

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Router.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Router.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -150,8 +150,16 @@ public @interface Router {
 	 * @return the {@link Poller} options for a polled endpoint
 	 * ({@link org.springframework.integration.scheduling.PollerMetadata}).
 	 * This attribute is an {@code array} just to allow an empty default (no poller).
-	 * Only one {@link Poller} element is allowed.
+	 * Mutually exclusive with {@link #reactive()}.
 	 */
 	Poller[] poller() default { };
+
+	/**
+	 * @return the {@link Reactive} options for a consumer endpoint.
+	 * This attribute is an {@code array} just to allow an empty default (not reactive).
+	 * Only one {@link Reactive} element is allowed.
+	 * Mutually exclusive with {@link #poller()}.
+	 */
+	Reactive[] reactive() default { };
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Router.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Router.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.messaging.handler.annotation.ValueConstants;
+
 /**
  * Indicates that a method is capable of resolving to a channel or channel name
  * based on a message, message header(s), or both.
@@ -155,11 +157,10 @@ public @interface Router {
 	Poller[] poller() default { };
 
 	/**
-	 * @return the {@link Reactive} options for a consumer endpoint.
-	 * This attribute is an {@code array} just to allow an empty default (not reactive).
-	 * Only one {@link Reactive} element is allowed.
+	 * @return the {@link Reactive} marker for a consumer endpoint.
 	 * Mutually exclusive with {@link #poller()}.
+	 * @since 5.5
 	 */
-	Reactive[] reactive() default { };
+	Reactive reactive() default @Reactive(ValueConstants.DEFAULT_NONE);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivator.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.messaging.handler.annotation.ValueConstants;
+
 /**
  * Indicates that a method is capable of handling a message or message payload.
  * <p>
@@ -126,11 +128,10 @@ public @interface ServiceActivator {
 	Poller[] poller() default { };
 
 	/**
-	 * @return the {@link Reactive} options for a consumer endpoint.
-	 * This attribute is an {@code array} just to allow an empty default (not reactive).
-	 * Only one {@link Reactive} element is allowed.
+	 * @return the {@link Reactive} marker for a consumer endpoint.
 	 * Mutually exclusive with {@link #poller()}.
+	 * @since 5.5
 	 */
-	Reactive[] reactive() default { };
+	Reactive reactive() default @Reactive(ValueConstants.DEFAULT_NONE);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -121,7 +121,16 @@ public @interface ServiceActivator {
 	 * ({@link org.springframework.integration.scheduling.PollerMetadata}).
 	 * This attribute is an {@code array} just to allow an empty default (no poller).
 	 * Only one {@link Poller} element is allowed.
+	 * Mutually exclusive with {@link #reactive()}.
 	 */
 	Poller[] poller() default { };
+
+	/**
+	 * @return the {@link Reactive} options for a consumer endpoint.
+	 * This attribute is an {@code array} just to allow an empty default (not reactive).
+	 * Only one {@link Reactive} element is allowed.
+	 * Mutually exclusive with {@link #poller()}.
+	 */
+	Reactive[] reactive() default { };
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,8 +115,16 @@ public @interface Splitter {
 	 * @return the {@link Poller} options for a polled endpoint
 	 * ({@link org.springframework.integration.scheduling.PollerMetadata}).
 	 * This attribute is an {@code array} just to allow an empty default (no poller).
-	 * Only one {@link Poller} element is allowed.
+	 * Mutually exclusive with {@link #reactive()}.
 	 */
 	Poller[] poller() default { };
+
+	/**
+	 * @return the {@link Reactive} options for a consumer endpoint.
+	 * This attribute is an {@code array} just to allow an empty default (not reactive).
+	 * Only one {@link Reactive} element is allowed.
+	 * Mutually exclusive with {@link #poller()}.
+	 */
+	Reactive[] reactive() default { };
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitter.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.messaging.handler.annotation.ValueConstants;
+
 /**
  * Indicates that a method is capable of splitting a single message or message
  * payload to produce multiple messages or payloads.
@@ -120,11 +122,10 @@ public @interface Splitter {
 	Poller[] poller() default { };
 
 	/**
-	 * @return the {@link Reactive} options for a consumer endpoint.
-	 * This attribute is an {@code array} just to allow an empty default (not reactive).
-	 * Only one {@link Reactive} element is allowed.
+	 * @return the {@link Reactive} marker for a consumer endpoint.
 	 * Mutually exclusive with {@link #poller()}.
+	 * @since 5.5
 	 */
-	Reactive[] reactive() default { };
+	Reactive reactive() default @Reactive(ValueConstants.DEFAULT_NONE);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Transformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Transformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,8 +91,16 @@ public @interface Transformer {
 	 * @return the {@link Poller} options for a polled endpoint
 	 * ({@link org.springframework.integration.scheduling.PollerMetadata}).
 	 * This attribute is an {@code array} just to allow an empty default (no poller).
-	 * Only one {@link Poller} element is allowed.
+	 * Mutually exclusive with {@link #reactive()}.
 	 */
 	Poller[] poller() default { };
+
+	/**
+	 * @return the {@link Reactive} options for a consumer endpoint.
+	 * This attribute is an {@code array} just to allow an empty default (not reactive).
+	 * Only one {@link Reactive} element is allowed.
+	 * Mutually exclusive with {@link #poller()}.
+	 */
+	Reactive[] reactive() default { };
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Transformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Transformer.java
@@ -22,6 +22,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.messaging.handler.annotation.ValueConstants;
+
 /**
  * Indicates that a method is capable of transforming a message, message header,
  * or message payload.
@@ -96,11 +98,10 @@ public @interface Transformer {
 	Poller[] poller() default { };
 
 	/**
-	 * @return the {@link Reactive} options for a consumer endpoint.
-	 * This attribute is an {@code array} just to allow an empty default (not reactive).
-	 * Only one {@link Reactive} element is allowed.
+	 * @return the {@link Reactive} marker for a consumer endpoint.
 	 * Mutually exclusive with {@link #poller()}.
+	 * @since 5.5
 	 */
-	Reactive[] reactive() default { };
+	Reactive reactive() default @Reactive(ValueConstants.DEFAULT_NONE);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.integration.annotation.IdempotentReceiver;
 import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.annotation.Reactive;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.MessagePublishingErrorHandler;
 import org.springframework.integration.config.IntegrationConfigUtils;
@@ -75,6 +76,7 @@ import org.springframework.integration.support.channel.ChannelResolverUtils;
 import org.springframework.integration.util.ClassUtils;
 import org.springframework.integration.util.MessagingAnnotationUtils;
 import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.PollableChannel;
@@ -88,6 +90,8 @@ import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
+
+import reactor.core.publisher.Flux;
 
 /**
  * Base class for Method-level annotation post-processors.
@@ -291,7 +295,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		boolean createEndpoint = StringUtils.hasText(inputChannel);
 		if (!createEndpoint && beanAnnotationAware()) {
 			boolean isBean = AnnotatedElementUtils.isAnnotated(method, Bean.class.getName());
-			Assert.isTrue(!isBean, "A channel name in '" + getInputChannelAttribute() + "' is required when " +
+			Assert.isTrue(!isBean, () -> "A channel name in '" + getInputChannelAttribute() + "' is required when " +
 					this.annotationType + " is used on '@Bean' methods.");
 		}
 		return createEndpoint;
@@ -362,7 +366,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 					throw e;
 				}
 			}
-			Assert.notNull(inputChannel, "failed to resolve inputChannel '" + inputChannelName + "'");
+			Assert.notNull(inputChannel, () -> "failed to resolve inputChannel '" + inputChannelName + "'");
 
 			endpoint = doCreateEndpoint(handler, inputChannel, annotations);
 		}
@@ -371,35 +375,77 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	protected AbstractEndpoint doCreateEndpoint(MessageHandler handler, MessageChannel inputChannel,
 			List<Annotation> annotations) {
+
 		AbstractEndpoint endpoint;
-		if (inputChannel instanceof PollableChannel) {
-			PollingConsumer pollingConsumer = new PollingConsumer((PollableChannel) inputChannel, handler);
-			configurePollingEndpoint(pollingConsumer, annotations);
-			endpoint = pollingConsumer;
+
+
+		Poller[] pollers = MessagingAnnotationUtils.resolveAttribute(annotations, "poller", Poller[].class);
+		Reactive[] reactive = MessagingAnnotationUtils.resolveAttribute(annotations, "reactive", Reactive[].class);
+
+		Assert.state(ObjectUtils.isEmpty(reactive) || ObjectUtils.isEmpty(pollers),
+				"The 'poller' and 'reactive' are mutually exclusive.");
+
+		if (inputChannel instanceof Publisher ||
+				handler instanceof ReactiveMessageHandlerAdapter ||
+				!ObjectUtils.isEmpty(reactive)) {
+
+			endpoint = reactiveStreamsConsumer(inputChannel, handler, reactive);
+		}
+		else if (inputChannel instanceof SubscribableChannel) {
+			Assert.state(ObjectUtils.isEmpty(pollers), () ->
+					"A '@Poller' should not be specified for Annotation-based " +
+							"endpoint, since '" + inputChannel + "' is a SubscribableChannel (not pollable).");
+			endpoint = new EventDrivenConsumer((SubscribableChannel) inputChannel, handler);
+		}
+		else if (inputChannel instanceof PollableChannel) {
+			endpoint = pollingConsumer(inputChannel, handler, pollers);
 		}
 		else {
-			Poller[] pollers = MessagingAnnotationUtils.resolveAttribute(annotations, "poller", Poller[].class);
-			Assert.state(ObjectUtils.isEmpty(pollers), "A '@Poller' should not be specified for Annotation-based " +
-					"endpoint, since '" + inputChannel + "' is a SubscribableChannel (not pollable).");
-			if (inputChannel instanceof Publisher) {
-				if (handler instanceof ReactiveMessageHandlerAdapter) {
-					endpoint = new ReactiveStreamsConsumer(inputChannel,
-							((ReactiveMessageHandlerAdapter) handler).getDelegate());
-				}
-				else {
-					endpoint = new ReactiveStreamsConsumer(inputChannel, handler);
-				}
-			}
-			else {
-				endpoint = new EventDrivenConsumer((SubscribableChannel) inputChannel, handler);
-			}
+			throw new IllegalArgumentException("Unsupported 'inputChannel' type: '"
+					+ inputChannel.getClass().getName() + "'. " +
+					"Must be one of 'SubscribableChannel', 'PollableChannel' or 'ReactiveStreamsSubscribableChannel'");
 		}
+
 		return endpoint;
 	}
 
-	protected void configurePollingEndpoint(AbstractPollingEndpoint pollingEndpoint, List<Annotation> annotations) {
+	private ReactiveStreamsConsumer reactiveStreamsConsumer(MessageChannel channel, MessageHandler handler,
+			Reactive[] reactives) {
+
+		ReactiveStreamsConsumer reactiveStreamsConsumer;
+		if (handler instanceof ReactiveMessageHandlerAdapter) {
+			reactiveStreamsConsumer = new ReactiveStreamsConsumer(channel,
+					((ReactiveMessageHandlerAdapter) handler).getDelegate());
+		}
+		else {
+			reactiveStreamsConsumer = new ReactiveStreamsConsumer(channel, handler);
+		}
+
+		if (!ObjectUtils.isEmpty(reactives)) {
+			Assert.state(reactives.length == 1,
+					"The 'reactive' for an Annotation-based endpoint can have only one '@Reactive'.");
+			Reactive reactive = reactives[0];
+			String functionBeanName = reactive.value();
+			if (StringUtils.hasText(functionBeanName)) {
+				@SuppressWarnings("unchecked")
+				Function<? super Flux<Message<?>>, ? extends Publisher<Message<?>>> reactiveCustomizer =
+						this.beanFactory.getBean(functionBeanName, Function.class);
+				reactiveStreamsConsumer.setReactiveCustomizer(reactiveCustomizer);
+			}
+		}
+
+
+		return reactiveStreamsConsumer;
+	}
+
+	private PollingConsumer pollingConsumer(MessageChannel inputChannel, MessageHandler handler, Poller[] pollers) {
+		PollingConsumer pollingConsumer = new PollingConsumer((PollableChannel) inputChannel, handler);
+		configurePollingEndpoint(pollingConsumer, pollers);
+		return pollingConsumer;
+	}
+
+	protected void configurePollingEndpoint(AbstractPollingEndpoint pollingEndpoint, Poller[] pollers) {
 		PollerMetadata pollerMetadata;
-		Poller[] pollers = MessagingAnnotationUtils.resolveAttribute(annotations, "poller", Poller[].class);
 		if (!ObjectUtils.isEmpty(pollers)) {
 			Assert.state(pollers.length == 1,
 					"The 'poller' for an Annotation-based endpoint can have only one '@Poller'.");
@@ -516,7 +562,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 			name = baseName;
 			int count = 1;
 			while (this.beanFactory.containsBean(name)) {
-				name = baseName + "#" + (++count);
+				name = baseName + '#' + (++count);
 			}
 		}
 		return name + IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/InboundChannelAdapterAnnotationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.integration.annotation.InboundChannelAdapter;
+import org.springframework.integration.annotation.Poller;
 import org.springframework.integration.config.IntegrationConfigUtils;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.MethodInvokingMessageSource;
@@ -64,7 +65,7 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 				MessagingAnnotationUtils.resolveAttribute(annotations, AnnotationUtils.VALUE, String.class);
 		Assert.hasText(channelName, "The channel ('value' attribute of @InboundChannelAdapter) can't be empty.");
 
-		MessageSource<?> messageSource = null;
+		MessageSource<?> messageSource;
 		try {
 			messageSource = createMessageSource(bean, beanName, method);
 		}
@@ -80,7 +81,8 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 		SourcePollingChannelAdapter adapter = new SourcePollingChannelAdapter();
 		adapter.setOutputChannelName(channelName);
 		adapter.setSource(messageSource);
-		configurePollingEndpoint(adapter, annotations);
+		Poller[] pollers = MessagingAnnotationUtils.resolveAttribute(annotations, "poller", Poller[].class);
+		configurePollingEndpoint(adapter, pollers);
 
 		return adapter;
 	}
@@ -133,7 +135,7 @@ public class InboundChannelAdapterAnnotationPostProcessor extends
 	@Override
 	protected String generateHandlerBeanName(String originalBeanName, Method method) {
 		return super.generateHandlerBeanName(originalBeanName, method)
-				.replaceFirst(IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX + "$", ".source");
+				.replaceFirst(IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX + '$', ".source");
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ConsumerEndpointSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.aopalliance.aop.Advice;
 import org.aopalliance.intercept.MethodInterceptor;
@@ -41,6 +42,7 @@ import org.springframework.transaction.TransactionManager;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.springframework.util.Assert;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
@@ -79,6 +81,26 @@ public abstract class ConsumerEndpointSpec<S extends ConsumerEndpointSpec<S, H>,
 	@Override
 	public S poller(PollerMetadata pollerMetadata) {
 		this.endpointFactoryBean.setPollerMetadata(pollerMetadata);
+		return _this();
+	}
+
+	/**
+	 * Make the consumer endpoint as reactive independently of an input channel.
+	 * @return the spec
+	 * @since 5.5
+	 */
+	public S reactive() {
+		return reactive(Function.identity());
+	}
+	/**
+	 * Make the consumer endpoint as reactive independently of an input channel and
+	 * apply the provided function into the {@link Flux#transform(Function)} operator.
+	 * @param reactiveCustomizer the function to transform {@link Flux} for the input channel.
+	 * @return the spec
+	 * @since 5.5
+	 */
+	public S reactive(Function<? super Flux<Message<?>>, ? extends Publisher<Message<?>>> reactiveCustomizer) {
+		this.endpointFactoryBean.setReactiveCustomizer(reactiveCustomizer);
 		return _this();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingAnnotationUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/MessagingAnnotationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,11 +61,9 @@ public final class MessagingAnnotationUtils {
 	@SuppressWarnings("unchecked")
 	public static <T> T resolveAttribute(List<Annotation> annotations, String name, Class<T> requiredType) {
 		for (Annotation annotation : annotations) {
-			if (annotation != null) {
-				Object value = AnnotationUtils.getValue(annotation, name);
-				if (value != null && value.getClass() == requiredType && hasValue(value)) {
-					return (T) value;
-				}
+			Object value = AnnotationUtils.getValue(annotation, name);
+			if (requiredType.isInstance(value) && hasValue(value)) {
+				return (T) value;
 			}
 		}
 		return null;

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -48,6 +50,7 @@ import org.springframework.integration.annotation.BridgeTo;
 import org.springframework.integration.annotation.Filter;
 import org.springframework.integration.annotation.InboundChannelAdapter;
 import org.springframework.integration.annotation.Poller;
+import org.springframework.integration.annotation.Reactive;
 import org.springframework.integration.annotation.Router;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.Splitter;
@@ -81,6 +84,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.test.StepVerifier;
@@ -145,10 +149,12 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 	@Autowired
 	private MessageChannel messageConsumerServiceChannel;
 
+	@Autowired
+	private CountDownLatch reactiveCustomizerLatch;
+
 	@Test
-	public void testMessagingAnnotationsFlow() {
+	public void testMessagingAnnotationsFlow() throws InterruptedException {
 		Stream.of(this.sourcePollingChannelAdapters).forEach(AbstractEndpoint::start);
-		//this.sourcePollingChannelAdapter.start();
 		for (int i = 0; i < 10; i++) {
 			Message<?> receive = this.discardChannel.receive(10000);
 			assertThat(receive).isNotNull();
@@ -164,6 +170,9 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 							"'messagingAnnotationsWithBeanAnnotationTests.ContextConfiguration.filter.filter.handler'");
 
 		}
+
+		assertThat(reactiveCustomizerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
 		for (Message<?> message : this.collector) {
 			assertThat(((Integer) message.getPayload()) % 2).isNotEqualTo(0);
 			MessageHistory messageHistory = MessageHistory.read(message);
@@ -336,7 +345,17 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		}
 
 		@Bean
-		@Splitter(inputChannel = "splitterChannel")
+		public CountDownLatch reactiveCustomizerLatch() {
+			return new CountDownLatch(10);
+		}
+
+		@Bean
+		public Function<Flux<?>, Flux<?>> reactiveCustomizer(CountDownLatch reactiveCustomizerLatch) {
+			return flux -> flux.doOnNext(data -> reactiveCustomizerLatch.countDown());
+		}
+
+		@Bean
+		@Splitter(inputChannel = "splitterChannel", reactive = @Reactive("reactiveCustomizer"))
 		public MessageHandler splitter() {
 			DefaultMessageSplitter defaultMessageSplitter = new DefaultMessageSplitter();
 			defaultMessageSplitter.setOutputChannelName("serviceChannel");

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,30 +29,41 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
 
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 
+import org.springframework.aop.ThrowsAdvice;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.Lifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.annotation.Reactive;
+import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlows;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.dsl.context.IntegrationFlowContext;
+import org.springframework.integration.endpoint.AbstractEndpoint;
+import org.springframework.integration.endpoint.ReactiveStreamsConsumer;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.annotation.Schedules;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
+import io.vavr.collection.Stream;
 import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
 
 
 /**
@@ -72,6 +83,9 @@ public class ReactiveStreamsTests {
 	@Autowired
 	@Qualifier("pollableReactiveFlow")
 	private Publisher<Message<Integer>> pollablePublisher;
+
+	@Autowired
+	private AbstractEndpoint reactiveTransformer;
 
 	@Autowired
 	@Qualifier("reactiveStreamsMessageSource")
@@ -115,6 +129,7 @@ public class ReactiveStreamsTests {
 
 	@Test
 	void testPollableReactiveFlow() throws Exception {
+		assertThat(this.reactiveTransformer).isInstanceOf(ReactiveStreamsConsumer.class);
 		this.inputChannel.send(new GenericMessage<>("1,2,3,4,5"));
 
 		CountDownLatch latch = new CountDownLatch(6);
@@ -216,9 +231,7 @@ public class ReactiveStreamsTests {
 		CountDownLatch latch = new CountDownLatch(1);
 		Flux.from(this.singleChannelFlow)
 				.map(m -> m.getPayload().toUpperCase())
-				.subscribe(p -> {
-					latch.countDown();
-				});
+				.subscribe(p -> latch.countDown());
 		this.singleChannel.send(new GenericMessage<>("foo"));
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
@@ -228,11 +241,25 @@ public class ReactiveStreamsTests {
 		CountDownLatch latch = new CountDownLatch(1);
 		Flux.from(this.fixedSubscriberChannelFlow)
 				.map(m -> m.getPayload().toUpperCase())
-				.subscribe(p -> {
-					latch.countDown();
-				});
+				.subscribe(p -> latch.countDown());
 		this.fixedSubscriberChannel.send(new GenericMessage<>("bar"));
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Autowired
+	MessageChannel directChannel;
+
+	@Test
+	void testReactiveCustomizer() throws InterruptedException {
+		Flux.fromStream(IntStream.range(1, 100).boxed())
+
+				.subscribe(value -> System.out.println(Thread.currentThread().getName() + ": " + value));
+
+		/*for (int i = 0; i < 100; i++) {
+			this.directChannel.send(new GenericMessage<>(i));
+		}
+*/
+		Thread.sleep(1000);
 	}
 
 	@Configuration
@@ -254,14 +281,12 @@ public class ReactiveStreamsTests {
 		}
 
 		@Bean
-		public Publisher<Message<Integer>> pollableReactiveFlow() {
+		public IntegrationFlow reactiveEndpointFlow() {
 			return IntegrationFlows
 					.from("inputChannel")
-					.split(s -> s.delimiters(","))
-					.<String, Integer>transform(Integer::parseInt)
-					.channel(MessageChannels.queue())
-					.log()
-					.toReactivePublisher();
+					.<String, Integer>transform(Integer::parseInt,
+							e -> e.reactive(flux -> flux.publishOn(Schedulers.parallel())))
+					.get();
 		}
 
 		@Bean
@@ -278,6 +303,16 @@ public class ReactiveStreamsTests {
 					.from("fixedSubscriberChannel", true)
 					.log()
 					.toReactivePublisher();
+		}
+
+		@Bean
+		public Function<Flux<?>, Flux<?>> publishOnCustomizer() {
+			return flux -> flux.publishOn(Schedulers.parallel());
+		}
+
+		@ServiceActivator(inputChannel = "directChannel", reactive = @Reactive("publishOnCustomizer"))
+		public void handleReactive(String payload) {
+			System.out.println(Thread.currentThread().getName() + ": " + payload);
 		}
 
 	}

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -501,7 +501,7 @@ public void handleReactive(String payload) {
 ====
 
 The `reactive()` attribute on the messaging annotations is mutually exclusive with the `poller()` attribute.
-See <<configuration-using-poller-annotation>> and <<../reactive-streams.adoc#reactive-streams, Reactive Streams Support>> for more information.
+See <<configuration-using-poller-annotation>> and <<./reactive-streams.adoc#reactive-streams, Reactive Streams Support>> for more information.
 
 ==== Using the `@InboundChannelAdapter` Annotation
 

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -471,6 +471,38 @@ Starting with version 4.3.3, the `@Poller` annotation has the `errorChannel` att
 This attribute plays the same role as `error-channel` in the `<poller>` XML component.
 See <<./endpoint.adoc#endpoint-namespace,Endpoint Namespace Support>> for more information.
 
+The `poller()` attribute on the messaging annotations is mutually exclusive with the `reactive()` attribute.
+See next section for more information.
+
+[[configuration-using-reactive-annotation]]
+==== Using `@Reactive` Annotation
+
+The `ReactiveStreamsConsumer` has been around since version 5.0, but it was applied only when an input channel for the endpoint is a `FluxMessageChannel` (or any `org.reactivestreams.Publisher` implementation).
+Starting with version 5.3, its instance is also created by the framework when the target message handler is a `ReactiveMessageHandler` independently of the input channel type.
+The `@Reactive` sub-annotation (similar to mentioned above `@Poller`) has been introduced for all the messaging annotations starting with version 5.5.
+It accepts an optional `Function<? super Flux<Message<?>>, ? extends Publisher<Message<?>>>` bean reference and, independently of the input channel type and message handler, turns the target endpoint into the `ReactiveStreamsConsumer` instance.
+The function is used from the `Flux.transform()` operator to apply some customization (`publishOn()`, `doOnNext()`, `log()`, `retry()` etc.) on a reactive stream source from the input channel.
+
+The following example demonstrates how to change the publishing thread from the input channel independently of the final subscriber and producer to that `DirectChannel`:
+
+====
+[source,java]
+----
+@Bean
+public Function<Flux<?>, Flux<?>> publishOnCustomizer() {
+    return flux -> flux.publishOn(Schedulers.parallel());
+}
+
+@ServiceActivator(inputChannel = "directChannel", reactive = @Reactive("publishOnCustomizer"))
+public void handleReactive(String payload) {
+    ...
+}
+----
+====
+
+The `reactive()` attribute on the messaging annotations is mutually exclusive with the `poller()` attribute.
+See <<configuration-using-poller-annotation>> and <<../reactive-streams.adoc#reactive-streams, Reactive Streams Support>> for more information.
+
 ==== Using the `@InboundChannelAdapter` Annotation
 
 Version 4.0 introduced the `@InboundChannelAdapter` method-level annotation.

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -262,6 +262,31 @@ See https://docs.spring.io/spring-integration/api/org/springframework/integratio
 IMPORTANT: If you use the DSL to construct a `PollerSpec` as a `@Bean`, do not call the `get()` method in the bean definition.
 The `PollerSpec` is a `FactoryBean` that generates the `PollerMetadata` object from the specification and initializes all of its properties.
 
+[[java-dsl-reactive]]
+=== The `reactive()` Endpoint
+
+Starting with version 5.5, the `ConsumerEndpointSpec` provide a `reactive()` configuration property with an optional customizer `Function<? super Flux<Message<?>>, ? extends Publisher<Message<?>>>`.
+This option makes the target endpoint as a `ReactiveStreamsConsumer` instance independently of the input channel type, which is turned to the `Flux` via `IntegrationReactiveUtils.messageChannelToFlux()`.
+The provided function is used from the `Flux.transform()` operator to customize (`publishOn()`, `log()`, `doOnNext()` etc.) a reactive stream source from the input channel.
+
+The following example demonstrates how to change the publishing thread from the input channel independently of the final subscriber and producer to that `DirectChannel`:
+
+====
+[source,java]
+----
+@Bean
+public IntegrationFlow reactiveEndpointFlow() {
+    return IntegrationFlows
+            .from("inputChannel")
+            .<String, Integer>transform(Integer::parseInt,
+                    e -> e.reactive(flux -> flux.publishOn(Schedulers.parallel())))
+            .get();
+}
+----
+====
+
+See <<../reactive-streams.adoc#reactive-streams, Reactive Streams Support>> for more information.
+
 [[java-dsl-endpoints]]
 === DSL and Endpoint Configuration
 

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -265,8 +265,8 @@ The `PollerSpec` is a `FactoryBean` that generates the `PollerMetadata` object f
 [[java-dsl-reactive]]
 === The `reactive()` Endpoint
 
-Starting with version 5.5, the `ConsumerEndpointSpec` provide a `reactive()` configuration property with an optional customizer `Function<? super Flux<Message<?>>, ? extends Publisher<Message<?>>>`.
-This option makes the target endpoint as a `ReactiveStreamsConsumer` instance independently of the input channel type, which is turned to the `Flux` via `IntegrationReactiveUtils.messageChannelToFlux()`.
+Starting with version 5.5, the `ConsumerEndpointSpec` provides a `reactive()` configuration property with an optional customizer `Function<? super Flux<Message<?>>, ? extends Publisher<Message<?>>>`.
+This option configures the target endpoint as a `ReactiveStreamsConsumer` instance, independently of the input channel type, which is converted to a `Flux` via `IntegrationReactiveUtils.messageChannelToFlux()`.
 The provided function is used from the `Flux.transform()` operator to customize (`publishOn()`, `log()`, `doOnNext()` etc.) a reactive stream source from the input channel.
 
 The following example demonstrates how to change the publishing thread from the input channel independently of the final subscriber and producer to that `DirectChannel`:

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -285,7 +285,7 @@ public IntegrationFlow reactiveEndpointFlow() {
 ----
 ====
 
-See <<../reactive-streams.adoc#reactive-streams, Reactive Streams Support>> for more information.
+See <<./reactive-streams.adoc#reactive-streams, Reactive Streams Support>> for more information.
 
 [[java-dsl-endpoints]]
 === DSL and Endpoint Configuration

--- a/src/reference/asciidoc/reactive-streams.adoc
+++ b/src/reference/asciidoc/reactive-streams.adoc
@@ -62,9 +62,13 @@ A consumer for the `FluxMessageChannel` must be a `org.reactivestreams.Subscribe
 Fortunately, all of the `MessageHandler` implementations in Spring Integration also implement a `CoreSubscriber` from project Reactor.
 And thanks to a `ReactiveStreamsConsumer` implementation in between, the whole integration flow configuration is left transparent for target developers.
 In this case, the flow behavior is changed from an imperative push model to a reactive pull model.
-A `ReactiveStreamsConsumer` can also be used to turn any `MessageChannel` into a reactive source using `MessageChannelReactiveUtils`, making an integration flow partially reactive.
+A `ReactiveStreamsConsumer` can also be used to turn any `MessageChannel` into a reactive source using `IntegrationReactiveUtils`, making an integration flow partially reactive.
 
 See <<./channel.adoc#flux-message-channel,`FluxMessageChannel`>> for more information.
+
+Starting with version 5.5, the `ConsumerEndpointSpec` introduces a `reactive()` option to make the endpoint in the flow as a `ReactiveStreamsConsumer` independently of the input channel.
+The optional `Function<? super Flux<Message<?>>, ? extends Publisher<Message<?>>>` can be provided to customise a source `Flux` from the input channel via `Flux.transform()` operation, e.g. with the `publishOn()`, `doOnNext()`, `retry()` etc.
+This functionality is represented as a `@Reactive` sub-annotation for all the messaging annotation (`@ServiceActivator`, `@Splitter` etc.) via their `reactive()` attribute.
 
 === Source Polling Channel Adapter
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -30,6 +30,10 @@ An `AbstractPollingEndpoint` (source polling channel adapter and polling consume
 It can be changed to different value later on, e.g. via a Control Bus.
 See <<./endpoint.adoc#endpoint-pollingconsumer,Polling Consumer>> for more information.
 
+The `ConsumerEndpointFactoryBean` now accept a `reactiveCustomizer` `Function` to any input channel as reactive stream source and use a `ReactiveStreamsConsumer` underneath.
+This is covered as a `ConsumerEndpointSpec.reactive()` option in Java DSL and as a `@Reactive` nested annotation for the messaging annotations.
+See <<./reactive-streams.adoc#reactive-streams,Reactive Streams Support>> for more information.
+
 [[x5.5-amqp]]
 ==== AMQP Changes
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4444

Right now the high-level API creates a `ReactiveStreamsConsumer`
only when the input channel is a `Publisher<?>` impl or target handler
is a `ReactiveMessageHandler`

* Add `@Reactive[] reactive()` attribute to messaging annotations
* Add `ConsumerEndpointSpec.reactive()`
Both options point to the same `ConsumerEndpointFactoryBean.setReactiveCustomizer()`
making the target endpoint always as a `ReactiveStreamsConsumer` independently of
the input channel and target handler
* Use the `Function` to customize a source `Flux` from the channel
* Test and document a new feature

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
