### PR TITLE
INT-4377: aggregator groupTimeout as Date

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
@@ -107,7 +107,7 @@ public abstract class CorrelationHandlerSpec<S extends CorrelationHandlerSpec<S,
 	}
 
 	/**
-	 * Specify a SpEL expression to evaluate group timeout for scheduled expiration.
+	 * Specify a SpEL expression to evaluate the group timeout for scheduled expiration.
 	 * Must return {@link java.util.Date}, {@link java.lang.Long} or {@link String} as a long.
 	 * @param groupTimeoutExpression the group timeout expression string.
 	 * @return the handler spec.

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/CorrelationHandlerSpec.java
@@ -107,6 +107,8 @@ public abstract class CorrelationHandlerSpec<S extends CorrelationHandlerSpec<S,
 	}
 
 	/**
+	 * Specify a SpEL expression to evaluate group timeout for scheduled expiration.
+	 * Must return {@link java.util.Date}, {@link java.lang.Long} or {@link String} as a long.
 	 * @param groupTimeoutExpression the group timeout expression string.
 	 * @return the handler spec.
 	 * @see AbstractCorrelatingMessageHandler#setGroupTimeoutExpression
@@ -122,11 +124,12 @@ public abstract class CorrelationHandlerSpec<S extends CorrelationHandlerSpec<S,
 	 * based on the message group.
 	 * Usually used with a JDK8 lambda:
 	 * <p>{@code .groupTimeout(g -> g.size() * 2000L)}.
+	 * Must return {@link java.util.Date}, {@link java.lang.Long} or {@link String} a long.
 	 * @param groupTimeoutFunction a function invoked to resolve the group timeout in milliseconds.
 	 * @return the handler spec.
 	 * @see AbstractCorrelatingMessageHandler#setGroupTimeoutExpression
 	 */
-	public S groupTimeout(Function<MessageGroup, Long> groupTimeoutFunction) {
+	public S groupTimeout(Function<MessageGroup, ?> groupTimeoutFunction) {
 		this.handler.setGroupTimeoutExpression(new FunctionExpression<>(groupTimeoutFunction));
 		return _this();
 	}

--- a/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration.xsd
+++ b/spring-integration-core/src/main/resources/org/springframework/integration/config/spring-integration.xsd
@@ -3913,6 +3913,7 @@
 							the MessageGroup won't be scheduled to be forced complete.
 							The action taken when the group is forced complete depends on the
 							'send-partial-result-on-expiry' attribute.
+                            Can be evaluated directly to 'java.util.Date' instance for a scheduled task.
 							Mutually exclusive with the 'group-timeout' attribute.
 						</xsd:documentation>
 					</xsd:annotation>

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests-context.xml
@@ -47,7 +47,7 @@
 
 	<aggregator input-channel="groupTimeoutExpressionAggregatorInput" output-channel="output" discard-channel="discard"
 				send-partial-result-on-expiry="true"
-				group-timeout-expression="size() ge 2 ? 100 : null"
+				group-timeout-expression="size() ge 2 ? new java.util.Date(timestamp + 200) : null"
 			    release-strategy-expression="messages[0].headers.sequenceNumber == messages[0].headers.sequenceSize"/>
 
 	<aggregator input-channel="zeroGroupTimeoutExpressionAggregatorInput" output-channel="output" discard-channel="discard"

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.function.Function;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -42,7 +41,7 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Iwein Fuld
@@ -51,7 +50,7 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Artem Bilan
  * @author Gary Russell
  */
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
 public class AggregatorIntegrationTests {
 
@@ -273,6 +272,5 @@ public class AggregatorIntegrationTests {
 		}
 
 	}
-
 
 }

--- a/src/reference/asciidoc/aggregator.adoc
+++ b/src/reference/asciidoc/aggregator.adoc
@@ -721,7 +721,7 @@ The reaper initiates forced completion for all `MessageGroup` s in the `MessageG
 The `groupTimeout` does it for each `MessageGroup` individually if a new message does not arrive during the `groupTimeout`.
 Also, the reaper can be used to remove empty groups (empty groups are retained in order to discard late messages if `expire-groups-upon-completion` is false).
 
-Starting with version 5.5, the `groupTimeoutExpression` can be evaluate to a `java.util.Date` instance.
+Starting with version 5.5, the `groupTimeoutExpression` can be evaluated to a `java.util.Date` instance.
 This can be useful in cases like determining a scheduled task moment based on the group creation time (`MessageGroup.getTimestamp()`) instead of a current message arrival as it is calculated when `groupTimeoutExpression` is evaluated to `long`:
 
 ====

--- a/src/reference/asciidoc/aggregator.adoc
+++ b/src/reference/asciidoc/aggregator.adoc
@@ -691,7 +691,7 @@ In the preceding example, the root object of the SpEL evaluation context is the 
 [[agg-and-group-to]]
 ====== Aggregator and Group Timeout
 
-Starting with version 4.0, two new mutually exclusive attributes have been introduced: `group-timeout` and `group-timeout-expression` (see the earlier description).
+Starting with version 4.0, two new mutually exclusive attributes have been introduced: `group-timeout` and `group-timeout-expression`.
 See <<aggregator-xml>>.
 In some cases, you may need to emit the aggregator result (or discard the group) after a timeout if the `ReleaseStrategy` does not release when the current message arrives.
 For this purpose, the `groupTimeout` option lets scheduling the `MessageGroup` be forced to complete, as the following example shows:
@@ -720,6 +720,16 @@ There is a difference between `groupTimeout` behavior and `MessageGroupStoreReap
 The reaper initiates forced completion for all `MessageGroup` s in the `MessageGroupStore` periodically.
 The `groupTimeout` does it for each `MessageGroup` individually if a new message does not arrive during the `groupTimeout`.
 Also, the reaper can be used to remove empty groups (empty groups are retained in order to discard late messages if `expire-groups-upon-completion` is false).
+
+Starting with version 5.5, the `groupTimeoutExpression` can be evaluate to a `java.util.Date` instance.
+This can be useful in cases like determining a scheduled task moment based on the group creation time (`MessageGroup.getTimestamp()`) instead of a current message arrival as it is calculated when `groupTimeoutExpression` is evaluated to `long`:
+
+====
+[source,xml]
+----
+group-timeout-expression="size() ge 2 ? new java.util.Date(timestamp + 200) : null"
+----
+====
 
 [[aggregator-annotations]]
 ===== Configuring an Aggregator with Annotations

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -34,7 +34,7 @@ The `ConsumerEndpointFactoryBean` now accept a `reactiveCustomizer` `Function` t
 This is covered as a `ConsumerEndpointSpec.reactive()` option in Java DSL and as a `@Reactive` nested annotation for the messaging annotations.
 See <<./reactive-streams.adoc#reactive-streams,Reactive Streams Support>> for more information.
 
-The `groupTimeoutExpression` for a correlation message handler (an `Aggregator` and `Resequencer`) can now be evaluated to `java.util.Date` for some fine-grained scheduling use-cases.
+The `groupTimeoutExpression` for a correlation message handler (an `Aggregator` and `Resequencer`) can now be evaluated to a `java.util.Date` for some fine-grained scheduling use-cases.
 See <<./aggregator.adoc#aggregator,Aggregator>> for more information.
 
 [[x5.5-amqp]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -34,6 +34,9 @@ The `ConsumerEndpointFactoryBean` now accept a `reactiveCustomizer` `Function` t
 This is covered as a `ConsumerEndpointSpec.reactive()` option in Java DSL and as a `@Reactive` nested annotation for the messaging annotations.
 See <<./reactive-streams.adoc#reactive-streams,Reactive Streams Support>> for more information.
 
+The `groupTimeoutExpression` for a correlation message handler (an `Aggregator` and `Resequencer`) can now be evaluated to `java.util.Date` for some fine-grained scheduling use-cases.
+See <<./aggregator.adoc#aggregator,Aggregator>> for more information.
+
 [[x5.5-amqp]]
 ==== AMQP Changes
 


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-4377

Change the `groupTimeoutExpression` logic to let it to be evaluated to `Date`
instance for some fine-grained scheduling use-case, e.g. to determine a
scheduling moment from the group creation time (`timestamp`) instead of a
current message arrival

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/master/CONTRIBUTING.adoc).
-->
