### PR TITLE
GH-3509: Fix Memory Leak with Intercepted TCP Conn

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -615,12 +615,13 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 				if (this.senders.size() == 0) {
 					connection.registerSender(wrapper);
 				}
+				connection.setWrapped(true);
 				connection = wrapper;
 			}
 			return connection;
 		}
 		finally {
-			this.addConnection(connection);
+			addConnection(connection);
 		}
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorFactoryChain.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorFactoryChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.lang.Nullable;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  * @since 2.0
  *
  */
@@ -35,6 +36,10 @@ public class TcpConnectionInterceptorFactoryChain {
 	}
 
 	public void setInterceptors(TcpConnectionInterceptorFactory[] interceptorFactories) {
+		this.interceptorFactories = Arrays.copyOf(interceptorFactories, interceptorFactories.length);
+	}
+
+	public void setInterceptor(TcpConnectionInterceptorFactory... interceptorFactories) {
 		this.interceptorFactories = Arrays.copyOf(interceptorFactories, interceptorFactories.length);
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetClientConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,11 @@ public class TcpNetClientConnectionFactory extends
 			TcpConnectionSupport connection =
 					this.tcpNetConnectionSupport.createNewConnection(socket, false, isLookupHost(),
 					getApplicationEventPublisher(), getComponentName());
-			connection = wrapConnection(connection);
+			TcpConnectionSupport wrapped = wrapConnection(connection);
+			if (wrapped.equals(connection)) {
+				connection.setSenders(getSenders());
+				connection = wrapped;
+			}
 			initializeConnection(connection, socket);
 			this.getTaskExecutor().execute(connection);
 			this.harvestClosedConnections();

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,7 +143,11 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 						setSocketAttributes(socket);
 						TcpConnectionSupport connection = this.tcpNetConnectionSupport.createNewConnection(socket, true,
 								isLookupHost(), getApplicationEventPublisher(), getComponentName());
-						connection = wrapConnection(connection);
+						TcpConnectionSupport wrapped = wrapConnection(connection);
+						if (!wrapped.equals(connection)) {
+							connection.setSenders(getSenders());
+							connection = wrapped;
+						}
 						initializeConnection(connection, socket);
 						getTaskExecutor().execute(connection);
 						harvestClosedConnections();

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,9 @@ public class TcpNioClientConnectionFactory extends
 				((TcpNioSSLConnection) connection).setHandshakeTimeout(sslHandshakeTimeout);
 			}
 			TcpConnectionSupport wrappedConnection = wrapConnection(connection);
+			if (!wrappedConnection.equals(connection)) {
+				connection.setSenders(getSenders());
+			}
 			initializeConnection(wrappedConnection, socketChannel.socket());
 			if (getSoTimeout() > 0) {
 				connection.setLastRead(System.currentTimeMillis());

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -277,6 +277,9 @@ public class TcpNioServerConnectionFactory extends AbstractServerConnectionFacto
 					isLookupHost(), getApplicationEventPublisher(), getComponentName());
 			connection.setUsingDirectBuffers(this.usingDirectBuffers);
 			TcpConnectionSupport wrappedConnection = wrapConnection(connection);
+			if (!wrappedConnection.equals(connection)) {
+				connection.setSenders(getSenders());
+			}
 			initializeConnection(wrappedConnection, socketChannel.socket());
 			return connection;
 		}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/AbstractTcpChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/AbstractTcpChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,40 +16,34 @@
 
 package org.springframework.integration.ip.tcp;
 
-import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.integration.ip.tcp.connection.AbstractConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.HelloWorldInterceptorFactory;
 
 /**
  * @author Gary Russell
+ * @author Mário Dias
+ * @author Artem Bilan
+ *
  * @since 3.0
  *
  */
 public class AbstractTcpChannelAdapterTests {
 
-	private static final ApplicationEventPublisher NOOP_PUBLISHER = new ApplicationEventPublisher() {
-
-		@Override
-		public void publishEvent(ApplicationEvent event) {
-		}
-
-		@Override
-		public void publishEvent(Object event) {
-
-		}
-
-	};
+	private static final ApplicationEventPublisher NOOP_PUBLISHER = event -> { };
 
 	protected HelloWorldInterceptorFactory newInterceptorFactory() {
+		return newInterceptorFactory(NOOP_PUBLISHER);
+	}
+
+	protected HelloWorldInterceptorFactory newInterceptorFactory(ApplicationEventPublisher applicationEventPublisher) {
 		HelloWorldInterceptorFactory factory = new HelloWorldInterceptorFactory();
-		factory.setApplicationEventPublisher(NOOP_PUBLISHER);
+		factory.setApplicationEventPublisher(applicationEventPublisher);
 		return factory;
 	}
 
 	protected void noopPublisher(AbstractConnectionFactory connectionFactory) {
 		connectionFactory.setApplicationEventPublisher(NOOP_PUBLISHER);
 	}
-
 
 }


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3509

When a connection was intercepted, the `TcpSender.add...` was called with the
interceptor, but the `removeDead...` was called with the actual connection,
causing a memory leak.

Always call the `TcpSender` with the outer-most interceptor.

**Cherry-pick to master after reverting previous fix**