### PR TITLE
GH-3523: TcpConnectionEvent Fixes

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,7 +158,6 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 					return connection;
 				}
 			}
-
 			return doObtain(singleUse);
 		}
 		catch (RuntimeException e) {
@@ -190,7 +189,6 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 		if (!singleUse) {
 			setTheConnection(connection);
 		}
-		connection.publishConnectionOpenEvent();
 		return connection;
 	}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -616,6 +616,7 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 					connection.registerSender(wrapper);
 				}
 				connection.setWrapped(true);
+				connection.setWrapper(wrapper);
 				connection = wrapper;
 			}
 			return connection;

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
@@ -98,6 +98,8 @@ public abstract class TcpConnectionSupport implements TcpConnection {
 
 	private boolean wrapped;
 
+	private TcpConnectionSupport wrapper;
+
 	/*
 	 * This boolean is to avoid looking for a temporary listener when not needed
 	 * to avoid a CPU cache flush. This does not have to be volatile because it
@@ -415,9 +417,19 @@ public abstract class TcpConnectionSupport implements TcpConnection {
 	/**
 	 * Set to true if intercepted.
 	 * @param wrapped true if wrapped.
+	 * @since 5.4.5
 	 */
 	public void setWrapped(boolean wrapped) {
 		this.wrapped = wrapped;
+	}
+
+	/**
+	 * Set the wrapper.
+	 * @param wrapper the wrapper.
+	 * @since 5.4.6
+	 */
+	public void setWrapper(TcpConnectionSupport wrapper) {
+		this.wrapper = wrapper;
 	}
 
 	public String getConnectionFactoryName() {
@@ -443,15 +455,30 @@ public abstract class TcpConnectionSupport implements TcpConnection {
 	}
 
 	protected void publishConnectionOpenEvent() {
-		doPublish(new TcpConnectionOpenEvent(this, getConnectionFactoryName()));
+		if (this.wrapper != null) {
+			this.wrapper.publishConnectionOpenEvent();
+		}
+		else {
+			doPublish(new TcpConnectionOpenEvent(this, getConnectionFactoryName()));
+		}
 	}
 
 	protected void publishConnectionCloseEvent() {
-		doPublish(new TcpConnectionCloseEvent(this, getConnectionFactoryName()));
+		if (this.wrapper != null) {
+			this.wrapper.publishConnectionCloseEvent();
+		}
+		else {
+			doPublish(new TcpConnectionCloseEvent(this, getConnectionFactoryName()));
+		}
 	}
 
 	protected void publishConnectionExceptionEvent(Throwable t) {
-		doPublish(new TcpConnectionExceptionEvent(this, getConnectionFactoryName(), t));
+		if (this.wrapper != null) {
+			this.wrapper.publishConnectionExceptionEvent(t);
+		}
+		else {
+			doPublish(new TcpConnectionExceptionEvent(this, getConnectionFactoryName(), t));
+		}
 	}
 
 	/**

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2020 the original author or authors.
+ * Copyright 2001-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -189,9 +189,10 @@ public class TcpNetConnection extends TcpConnectionSupport implements Scheduling
 	 */
 	@Override
 	public void run() {
-		if (logger.isDebugEnabled()) {
-			logger.debug(getConnectionId() + " Reading...");
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug(getConnectionId() + " Reading...");
 		}
+		publishConnectionOpenEvent();
 		while (true) {
 			if (!receiveAndProcessMessage()) {
 				break;

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
@@ -184,7 +184,6 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 				initializeConnection(connection, socket);
 				getTaskExecutor().execute(connection);
 				harvestClosedConnections();
-				connection.publishConnectionOpenEvent();
 			}
 			catch (RuntimeException ex) {
 				this.logger.error(ex, () ->

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -106,6 +106,7 @@ public class TcpNioClientConnectionFactory extends
 				connection.setLastRead(System.currentTimeMillis());
 			}
 			this.channelMap.put(socketChannel, connection);
+			wrappedConnection.publishConnectionOpenEvent();
 			this.newChannels.add(socketChannel);
 			this.selector.wakeup();
 			return wrappedConnection;
@@ -125,9 +126,9 @@ public class TcpNioClientConnectionFactory extends
 		boolean connected = socketChannel.finishConnect();
 		long timeLeft = getConnectTimeout().toMillis();
 		while (!connected && timeLeft > 0) {
-			Thread.sleep(50); // NOSONAR Magic #
+			Thread.sleep(5); // NOSONAR Magic #
 			connected = socketChannel.finishConnect();
-			timeLeft -= 50; // NOSONAR Magic #
+			timeLeft -= 5; // NOSONAR Magic #
 		}
 		if (!connected) {
 			throw new IOException("Not connected after connectTimeout");

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioServerConnectionFactory.java
@@ -258,7 +258,6 @@ public class TcpNioServerConnectionFactory extends AbstractServerConnectionFacto
 				}
 				this.channelMap.put(channel, connection);
 				channel.register(selectorForNewSocket, SelectionKey.OP_READ, connection);
-				connection.publishConnectionOpenEvent();
 			}
 		}
 		catch (IOException ex) {
@@ -281,6 +280,7 @@ public class TcpNioServerConnectionFactory extends AbstractServerConnectionFacto
 				connection.setSenders(getSenders());
 			}
 			initializeConnection(wrappedConnection, socketChannel.socket());
+			wrappedConnection.publishConnectionOpenEvent();
 			return connection;
 		}
 		catch (Exception ex) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ConnectionToConnectionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,7 @@ public class ConnectionToConnectionTests {
 	@SuppressWarnings("unchecked")
 	private void testConnectGuts(AbstractClientConnectionFactory client, AbstractServerConnectionFactory server,
 			String gatewayName, boolean expectExceptionOnClose) throws Exception {
+
 		TestingUtilities.waitListening(server, null);
 		client.setPort(server.getPort());
 		client.start();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/InterceptedSharedConnectionTests-context.xml
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/InterceptedSharedConnectionTests-context.xml
@@ -45,6 +45,28 @@
 		interceptor-factory-chain="helloWorldInterceptors"
 	/>
 
+	<int-ip:tcp-connection-factory id="netServer"
+		type="server"
+		port="0"
+		serializer="serializer"
+		deserializer="deserializer"
+		using-nio="false"
+		single-use="true"
+		interceptor-factory-chain="helloWorldInterceptors"
+	/>
+
+	<int-ip:tcp-connection-factory id="netClient"
+		type="client"
+		host="localhost"
+		port="0"
+		single-use="true"
+		so-timeout="100000"
+		using-nio="false"
+		serializer="serializer"
+		deserializer="deserializer"
+		interceptor-factory-chain="helloWorldInterceptors"
+	/>
+
 	<int:channel id="input" />
 
 	<int:channel id="replies">
@@ -70,6 +92,16 @@
 		connection-factory="server"/>
 
 	<int:channel id="loop" />
+
+	<int-ip:tcp-inbound-channel-adapter id="inboundNetServer"
+		channel="loop2"
+		connection-factory="netServer"/>
+
+	<int-ip:tcp-outbound-channel-adapter id="outboundNetServer"
+		channel="loop2"
+		connection-factory="netServer"/>
+
+	<int:channel id="loop2" />
 
 	<bean class="org.springframework.integration.ip.tcp.InterceptedSharedConnectionTests$Listener" />
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3523

- `TcpNetConnection` - publish open event on reader thread to avoid race with first read.
- Intercepted connections - Ensure that the event source is always the outermost interceptor.
- Also reduce delays during NIO client connect.

**cherry-pick to 5.4.x**
