### PR TITLE
GH-3526: Fix Infinite Loop in FailoverCConnFactory

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
@@ -283,6 +283,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 								+ ", trying another");
 					}
 					if (restartedList && (lastFactoryToTry == null || lastFactoryToTry.equals(nextFactory))) {
+						logger.debug("Failover failed to find a connection");
 						/*
 						 *  We've tried every factory including the
 						 *  one the current connection was on.

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -264,7 +264,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 			if (!this.factoryIterator.hasNext()) {
 				this.factoryIterator = this.connectionFactories.iterator();
 			}
-			boolean retried = false;
+			boolean restartedList = false;
 			while (!success) {
 				try {
 					nextFactory = this.factoryIterator.next();
@@ -282,17 +282,17 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 								+ e.toString()
 								+ ", trying another");
 					}
+					if (restartedList && (lastFactoryToTry == null || lastFactoryToTry.equals(nextFactory))) {
+						/*
+						 *  We've tried every factory including the
+						 *  one the current connection was on.
+						 */
+						this.open = false;
+						throw e;
+					}
 					if (!this.factoryIterator.hasNext()) {
-						if (retried && (lastFactoryToTry == null || lastFactoryToTry.equals(nextFactory))) {
-							/*
-							 *  We've tried every factory including the
-							 *  one the current connection was on.
-							 */
-							this.open = false;
-							throw e;
-						}
 						this.factoryIterator = this.connectionFactories.iterator();
-						retried = true;
+						restartedList = true;
 					}
 				}
 			}

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
@@ -345,10 +345,14 @@ public abstract class TcpConnectionSupport implements TcpConnection {
 			return this.testListener;
 		}
 		if (this.manualListenerRegistration && !this.testFailed) {
-			if (this.logger.isDebugEnabled()) {
+			boolean debugEnabled = this.logger.isDebugEnabled();
+			if (debugEnabled) {
 				this.logger.debug(getConnectionId() + " Waiting for listener registration");
 			}
 			waitForListenerRegistration();
+			if (debugEnabled) {
+				this.logger.debug(getConnectionId() + " Listener registered");
+			}
 		}
 		return this.listener;
 	}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -62,6 +62,7 @@ import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.ip.tcp.TcpInboundGateway;
 import org.springframework.integration.ip.tcp.TcpOutboundGateway;
 import org.springframework.integration.ip.util.TestingUtilities;
+import org.springframework.integration.test.condition.LogLevels;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.util.SimplePool;
 import org.springframework.messaging.Message;
@@ -205,6 +206,10 @@ public class FailoverClientConnectionFactoryTests {
 		Mockito.verify(conn2).send(message);
 	}
 
+	@LogLevels(level = "DEBUG", classes =
+			{ FailoverClientConnectionFactory.class, TcpNetClientConnectionFactory.class, TcpNetConnection.class },
+			categories =
+			"org.springframework.integration.ip.tcp.connection.FailoverClientConnectionFactory$FailoverTcpConnection")
 	@Test
 	void failoverAllDeadAfterSuccess() throws Exception {
 		ServerSocket ss1 = ServerSocketFactory.getDefault().createServerSocket(0);
@@ -224,6 +229,8 @@ public class FailoverClientConnectionFactoryTests {
 		});
 		TcpNetClientConnectionFactory cf1 = new TcpNetClientConnectionFactory("localhost", ss1.getLocalPort());
 		TcpNetClientConnectionFactory cf2 = new TcpNetClientConnectionFactory("localhost", port2);
+		cf1.setApplicationEventPublisher(event -> { });
+		cf2.setApplicationEventPublisher(event -> { });
 		FailoverClientConnectionFactory fccf = new FailoverClientConnectionFactory(List.of(cf1, cf2));
 		CountDownLatch latch = new CountDownLatch(1);
 		fccf.registerListener(msf -> {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -229,10 +229,12 @@ public class FailoverClientConnectionFactoryTests {
 		});
 		TcpNetClientConnectionFactory cf1 = new TcpNetClientConnectionFactory("localhost", ss1.getLocalPort());
 		TcpNetClientConnectionFactory cf2 = new TcpNetClientConnectionFactory("localhost", port2);
-		cf1.setApplicationEventPublisher(event -> { });
+		CountDownLatch latch = new CountDownLatch(2);
+		cf1.setApplicationEventPublisher(event -> {
+			latch.countDown();
+		});
 		cf2.setApplicationEventPublisher(event -> { });
 		FailoverClientConnectionFactory fccf = new FailoverClientConnectionFactory(List.of(cf1, cf2));
-		CountDownLatch latch = new CountDownLatch(1);
 		fccf.registerListener(msf -> {
 			latch.countDown();
 			return false;


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3526

`FailoverClientConnectionFactory`

The logic to detect we had iterated over all factories and including
the one from which the previous connection was established was incorrect,
causing an infite loop until one of the factory connections was successful.

Change the logic to detect we have reset the iterator and the current failure
is from the same factory as the one from which the previous connection was
established.

**cherry-pick to 5.4.x, 5.3.x, 5.2.x**
