### PR TITLE
GH-3520 Make TcpConnectionInterceptorSupport.getConnectionId() final

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ public abstract class TcpConnectionInterceptorSupport extends TcpConnectionSuppo
 	}
 
 	@Override
-	public String getConnectionId() {
+	public final String getConnectionId() {
 		return this.theConnection.getConnectionId();
 	}
 


### PR DESCRIPTION
Fixes [GH-3520](https://github.com/spring-projects/spring-integration/issues/3520)

Overriding the connection id will cause routing problems because the connection id in inbound messages is from the core connection, not the interceptor.

Signed-off-by: Deepesh <deepeshvrm1@gmail.com>
