### PR TITLE
GH-3541: Properly guard when no json-path in CP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -249,8 +249,6 @@ configure(javaProjects) { subproject ->
 		testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
 		testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 		testImplementation 'io.projectreactor:reactor-test'
-		testImplementation "com.jayway.jsonpath:json-path:$jsonpathVersion"
-		testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 
 		testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 		testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -488,6 +486,7 @@ project('spring-integration-file') {
 		testImplementation project(':spring-integration-jdbc')
 		testImplementation "com.h2database:h2:$h2Version"
 		testImplementation "io.lettuce:lettuce-core:$lettuceVersion"
+		testImplementation "com.jayway.jsonpath:json-path:$jsonpathVersion"
 	}
 }
 
@@ -546,6 +545,9 @@ project('spring-integration-http') {
 		testImplementation ("org.springframework.security:spring-security-test:$springSecurityVersion") {
 			exclude group: 'org.springframework'
 		}
+		testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+
+		testRuntimeOnly "com.jayway.jsonpath:json-path:$jsonpathVersion"
 	}
 }
 
@@ -556,7 +558,9 @@ project('spring-integration-ip') {
 		testImplementation project(':spring-integration-stream')
 		testImplementation project(':spring-integration-event')
 		testImplementation "org.hamcrest:hamcrest-core:$hamcrestVersion"
+
 		testRuntimeOnly "com.esotericsoftware:kryo-shaded:$kryoShadedVersion"
+		testRuntimeOnly 'com.fasterxml.jackson.core:jackson-databind'
 	}
 }
 
@@ -573,6 +577,8 @@ project('spring-integration-jdbc') {
 		testImplementation "org.postgresql:postgresql:$postgresVersion"
 		testImplementation "mysql:mysql-connector-java:$mysqlVersion"
 		testImplementation "org.apache.commons:commons-dbcp2:$commonsDbcp2Version"
+
+		testRuntimeOnly 'com.fasterxml.jackson.core:jackson-databind'
 	}
 }
 
@@ -625,7 +631,6 @@ project('spring-integration-kafka') {
 		testImplementation "org.springframework.kafka:spring-kafka-test:$springKafkaVersion"
 		testImplementation "org.hamcrest:hamcrest-core:$hamcrestVersion"
 
-		testRuntimeOnly 'com.fasterxml.jackson.core:jackson-core'
 		testRuntimeOnly 'com.fasterxml.jackson.core:jackson-databind'
 	}
 }
@@ -674,6 +679,7 @@ project('spring-integration-mqtt') {
 		api "org.eclipse.paho:org.eclipse.paho.client.mqttv3:$pahoMqttClientVersion"
 
 		testImplementation project(':spring-integration-jmx')
+		testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 	}
 }
 
@@ -687,6 +693,7 @@ project('spring-integration-redis') {
 
 		testImplementation "io.lettuce:lettuce-core:$lettuceVersion"
 		testImplementation "org.hamcrest:hamcrest-core:$hamcrestVersion"
+		testImplementation 'com.fasterxml.jackson.core:jackson-databind'
 	}
 }
 
@@ -806,6 +813,9 @@ project('spring-integration-webflux') {
 		testImplementation ("org.springframework.security:spring-security-test:$springSecurityVersion") {
 			exclude group: 'org.springframework'
 		}
+		testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+
+		testRuntimeOnly "com.jayway.jsonpath:json-path:$jsonpathVersion"
 	}
 }
 
@@ -818,6 +828,8 @@ project('spring-integration-websocket') {
 
 		testImplementation project(':spring-integration-event')
 		testImplementation "org.apache.tomcat.embed:tomcat-embed-websocket:$tomcatVersion"
+
+		testRuntimeOnly 'com.fasterxml.jackson.core:jackson-databind'
 	}
 }
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
@@ -58,6 +58,7 @@ import org.springframework.integration.handler.support.MapArgumentResolver;
 import org.springframework.integration.handler.support.PayloadExpressionArgumentResolver;
 import org.springframework.integration.handler.support.PayloadsArgumentResolver;
 import org.springframework.integration.json.JsonNodeWrapperToJsonNodeConverter;
+import org.springframework.integration.json.JsonPathUtils;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.NullAwarePayloadArgumentResolver;
 import org.springframework.integration.support.SmartLifecycleRoleController;
@@ -121,8 +122,7 @@ class DefaultConfiguringBeanFactoryPostProcessor
 
 		Class<?> jsonPathClass = null;
 		try {
-			jsonPathClass = ClassUtils.forName(IntegrationConfigUtils.BASE_PACKAGE + ".json.JsonPathUtils",
-					ClassUtils.getDefaultClassLoader());
+			jsonPathClass = ClassUtils.forName("com.jayway.jsonpath.JsonPath", ClassUtils.getDefaultClassLoader());
 		}
 		catch (@SuppressWarnings("unused") ClassNotFoundException e) {
 			LOGGER.debug("The '#jsonPath' SpEL function cannot be registered: " +
@@ -406,7 +406,8 @@ class DefaultConfiguringBeanFactoryPostProcessor
 				&& !this.beanFactory.containsBean(jsonPathBeanName)
 				&& !REGISTRIES_PROCESSED.contains(registryId)) {
 
-			IntegrationConfigUtils.registerSpelFunctionBean(this.registry, jsonPathBeanName, JSON_PATH_CLASS, "evaluate");
+			IntegrationConfigUtils.registerSpelFunctionBean(this.registry, jsonPathBeanName,
+					JsonPathUtils.class, "evaluate");
 		}
 	}
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/configuration/EnableMBeanExportTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/configuration/EnableMBeanExportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,7 @@ import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,16 +43,14 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jmx.support.MBeanServerFactoryBean;
 import org.springframework.mock.env.MockEnvironment;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Artem Bilan
  * @author Gary Russell
  * @since 4.0
  */
-@ContextConfiguration(initializers = EnableMBeanExportTests.EnvironmentApplicationContextInitializer.class)
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig(initializers = EnableMBeanExportTests.EnvironmentApplicationContextInitializer.class)
 @DirtiesContext
 public class EnableMBeanExportTests {
 
@@ -72,6 +69,8 @@ public class EnableMBeanExportTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testEnableMBeanExport() throws MalformedObjectNameException, ClassNotFoundException {
+		assertThat(beanFactory.containsBean("jsonPath")).isFalse(); // GH-3541
+		assertThat(beanFactory.containsBean("xPath")).isFalse(); // GH-3541
 
 		assertThat(this.exporter.getServer()).isSameAs(this.mBeanServer);
 		String[] componentNamePatterns = TestUtils.getPropertyValue(this.exporter, "componentNamePatterns", String[].class);
@@ -103,11 +102,11 @@ public class EnableMBeanExportTests {
 
 	@Configuration
 	@EnableIntegration
-	@EnableIntegrationMBeanExport(server = "#{mbeanServer}",
+	@EnableIntegrationMBeanExport(
+			server = "#{mbeanServer}",
 			defaultDomain = "${managed.domain}",
-			managedComponents = {"input", "${managed.component}"})
-	@EnableIntegrationManagement(
-		defaultLoggingEnabled = "false")
+			managedComponents = { "input", "${managed.component}" })
+	@EnableIntegrationManagement(defaultLoggingEnabled = "false")
 	public static class ContextConfiguration {
 
 		@Bean


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3541

* Fix `DefaultConfiguringBeanFactoryPostProcessor` to check for `jsonPath` bean
a `com.jayway.jsonpath.JsonPath` on CP instead of `JsonPathUtils`
which is always there since it is a part of `spring-integration-core`
* Remove `json-path` and `jackson-databind` from tests classpath
to be sure that we have coverage for the mentioned above option classpath entries
* Add `json-path` and `jackson-databind` into test classpath whenever it is necessary

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
