### PR TITLE
Improve IMAP IDLE tests

### DIFF
--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -185,13 +185,10 @@ public class ImapMailReceiverTests {
 		receiver.setMaxFetchSize(1);
 		receiver.setShouldDeleteMessages(false);
 		receiver.setShouldMarkMessagesAsRead(true);
-		receiver.setCancelIdleInterval(1);
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		setUpScheduler(receiver, taskScheduler);
 		receiver.setUserFlag("testSIUserFlag");
 		receiver.afterPropertiesSet();
-		LogAccessor logger = spy(TestUtils.getPropertyValue(receiver, "logger", LogAccessor.class));
-		new DirectFieldAccessor(receiver).setPropertyValue("logger", logger);
 		ImapIdleChannelAdapter adapter = new ImapIdleChannelAdapter(receiver);
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
@@ -237,7 +234,6 @@ public class ImapMailReceiverTests {
 		}
 		assertThat(channel.receive(20000)).isNotNull(); // new message after idle
 		assertThat(channel.receive(100)).isNull(); // no new message after second and third idle
-		verify(logger).debug("Canceling IDLE");
 
 		adapter.stop();
 		taskScheduler.shutdown();

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/mail/TestMailServer.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/mail/TestMailServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -254,7 +254,7 @@ public final class TestMailServer {
 			/**
 			 * Time to wait while IDLE before returning a result.
 			 */
-			private static final int IDLE_WAIT_TIME = 1000;
+			private static final int IDLE_WAIT_TIME = 500;
 
 			ImapHandler(Socket socket) {
 				super(socket);


### PR DESCRIPTION
This forces the race condition that was fixed in #3535 consistently.
Before the IdleCanceler was used to cancle the `idle()` call in addition
to the normal flow. That should not be necessary.
