### PR TITLE
Fix compatibility with Java 8 for ByteBuffer

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/EmbeddedJsonHeadersMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.support.json;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
@@ -248,18 +249,18 @@ public class EmbeddedJsonHeadersMessageMapper implements BytesMessageMapper {
 		if (buffer.remaining() > 4) { // NOSONAR
 			int headersLen = buffer.getInt();
 			if (headersLen >= 0 && headersLen < buffer.remaining() - 4) { // NOSONAR
-				buffer.position(headersLen + 4); // NOSONAR
+				((Buffer) buffer).position(headersLen + 4); // NOSONAR
 				int payloadLen = buffer.getInt();
 				if (payloadLen != buffer.remaining()) {
 					return null;
 				}
 				else {
-					buffer.position(4); // NOSONAR
+					((Buffer) buffer).position(4); // NOSONAR
 					@SuppressWarnings("unchecked")
 					Map<String, Object> headers = this.objectMapper.readValue(bytes, buffer.position(), headersLen,
 							Map.class);
 
-					buffer.position(buffer.position() + headersLen);
+					((Buffer) buffer).position(buffer.position() + headersLen);
 					buffer.getInt();
 					Object payload;
 					byte[] payloadBytes = new byte[payloadLen];

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioSSLConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioSSLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.ip.tcp.connection;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.Semaphore;
@@ -135,7 +136,7 @@ public class TcpNioSSLConnection extends TcpNioConnection {
 			networkBuffer.compact();
 		}
 		else {
-			networkBuffer.clear();
+			((Buffer) networkBuffer).clear();
 		}
 		if (logger.isDebugEnabled()) {
 			logger.debug("sendToPipe.x " + resultToString(result) + ", remaining: " + networkBuffer.remaining());
@@ -160,7 +161,7 @@ public class TcpNioSSLConnection extends TcpNioConnection {
 			case NEED_UNWRAP:
 			case FINISHED:
 			case NOT_HANDSHAKING:
-				this.decoded.clear();
+				((Buffer) this.decoded).clear();
 				result = this.sslEngine.unwrap(networkBuffer, this.decoded);
 				if (logger.isDebugEnabled()) {
 					logger.debug("After unwrap: " + resultToString(result));
@@ -171,13 +172,13 @@ public class TcpNioSSLConnection extends TcpNioConnection {
 							this.allocateEncryptionBuffer(this.sslEngine.getSession().getApplicationBufferSize());
 				}
 				if (result.bytesProduced() > 0) {
-					this.decoded.flip();
+					((Buffer) this.decoded).flip();
 					super.sendToPipe(this.decoded);
 				}
 				break;
 			case NEED_WRAP:
 				if (!resumeWriterIfNeeded()) {
-					this.encoded.clear();
+					((Buffer) this.encoded).clear();
 					result = this.sslEngine.wrap(networkBuffer, this.encoded);
 					if (logger.isDebugEnabled()) {
 						logger.debug("After wrap: " + resultToString(result));
@@ -186,7 +187,7 @@ public class TcpNioSSLConnection extends TcpNioConnection {
 						this.encoded = this.allocateEncryptionBuffer(this.sslEngine.getSession().getPacketBufferSize());
 					}
 					else {
-						this.encoded.flip();
+						((Buffer) this.encoded).flip();
 						getSSLChannelOutputStream().writeEncoded(this.encoded);
 					}
 				}
@@ -393,9 +394,9 @@ public class TcpNioSSLConnection extends TcpNioConnection {
 		}
 
 		private void writeEncodedIfAny() throws IOException {
-			TcpNioSSLConnection.this.encoded.flip();
+			((Buffer) TcpNioSSLConnection.this.encoded).flip();
 			writeEncoded(TcpNioSSLConnection.this.encoded);
-			TcpNioSSLConnection.this.encoded.clear();
+			((Buffer) TcpNioSSLConnection.this.encoded).clear();
 		}
 
 		/**
@@ -430,7 +431,7 @@ public class TcpNioSSLConnection extends TcpNioConnection {
 		 * Encrypts plain text data. The result may indicate handshaking is needed.
 		 */
 		private SSLEngineResult encode(ByteBuffer plainText) throws IOException {
-			TcpNioSSLConnection.this.encoded.clear();
+			((Buffer) TcpNioSSLConnection.this.encoded).clear();
 			SSLEngineResult result =
 					TcpNioSSLConnection.this.sslEngine.wrap(plainText, TcpNioSSLConnection.this.encoded);
 			if (logger.isDebugEnabled()) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.ip.udp;
 import java.io.UncheckedIOException;
 import java.io.UnsupportedEncodingException;
 import java.net.DatagramPacket;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.UUID;
@@ -303,7 +304,7 @@ public class DatagramPacketMessageMapper implements InboundMessageMapper<Datagra
 		}
 		finally {
 			//reposition the buffer
-			buffer.position(pos);
+			((Buffer) buffer).position(pos);
 		}
 	}
 


### PR DESCRIPTION
When we build with Java 9+ and target for Java 8,
we get an incompatible bytecode around these method for `ByteBuffer`:

```
position(int)
limit(int)
mark()
reset()
clear()
flip()
rewind()
```

The recommendation is to cast to `Buffer` when we call these methods

* Fix all the production code using `ByteBuffer` for recommended cast to `Buffer`

Related to https://build.spring.io/browse/INTEXT-AWS-306

See more info in this Jetty issue: https://github.com/eclipse/jetty.project/issues/3244

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
