### PR TITLE
Make `@IntegrationConverter` Native compatible

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/CustomConversionServiceFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/CustomConversionServiceFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.context;
+package org.springframework.integration.config;
 
 import org.springframework.context.support.ConversionServiceFactoryBean;
 import org.springframework.core.convert.ConversionService;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
@@ -389,7 +389,7 @@ public class DefaultConfiguringBeanFactoryPostProcessor
 	private void jsonPath(int registryId) throws LinkageError {
 		String jsonPathBeanName = "jsonPath";
 		if (JSON_PATH_PRESENT) {
-			if(!this.beanFactory.containsBean(jsonPathBeanName) && !REGISTRIES_PROCESSED.contains(registryId)) {
+			if (!this.beanFactory.containsBean(jsonPathBeanName) && !REGISTRIES_PROCESSED.contains(registryId)) {
 				IntegrationConfigUtils.registerSpelFunctionBean(this.registry, jsonPathBeanName,
 						JsonPathUtils.class, "evaluate");
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConfigUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConfigUtils.java
@@ -20,6 +20,7 @@ import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.context.IntegrationContextUtils;
 
 /**
  * Shared utility methods for Integration configuration.
@@ -30,7 +31,11 @@ import org.springframework.integration.channel.DirectChannel;
  */
 public final class IntegrationConfigUtils {
 
-	public static final String BASE_PACKAGE = "org.springframework.integration";
+	/**
+	 * @deprecated in favor of {@link IntegrationContextUtils#BASE_PACKAGE}.
+	 */
+	@Deprecated
+	public static final String BASE_PACKAGE = IntegrationContextUtils.BASE_PACKAGE;
 
 	public static final String HANDLER_ALIAS_SUFFIX = ".handler";
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConverterInitializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConverterInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,20 +16,10 @@
 
 package org.springframework.integration.config;
 
-import java.util.Set;
-
-import org.springframework.beans.BeanMetadataElement;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
-import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.beans.factory.config.RuntimeBeanReference;
-import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
-import org.springframework.beans.factory.support.ManagedSet;
 import org.springframework.beans.factory.support.RootBeanDefinition;
-import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.core.type.MethodMetadata;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.utils.IntegrationUtils;
 
@@ -40,56 +30,20 @@ import org.springframework.integration.support.utils.IntegrationUtils;
  */
 public class IntegrationConverterInitializer implements IntegrationConfigurationInitializer {
 
-	private static final String CONTEXT_PACKAGE = "org.springframework.integration.context.";
-
 	@Override
 	public void initialize(ConfigurableListableBeanFactory beanFactory) throws BeansException {
 		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) beanFactory;
 
-		for (String beanName : registry.getBeanDefinitionNames()) {
-			BeanDefinition beanDefinition = registry.getBeanDefinition(beanName);
-			if (beanDefinition instanceof AnnotatedBeanDefinition) {
-				AnnotationMetadata metadata = ((AnnotatedBeanDefinition) beanDefinition).getMetadata();
-				boolean hasIntegrationConverter = metadata.hasAnnotation(IntegrationConverter.class.getName());
-
-				if (!hasIntegrationConverter && beanDefinition.getSource() instanceof MethodMetadata) {
-					MethodMetadata beanMethod = (MethodMetadata) beanDefinition.getSource();
-					hasIntegrationConverter = beanMethod.isAnnotated(IntegrationConverter.class.getName()); // NOSONAR never null
-				}
-
-				if (hasIntegrationConverter) {
-					this.registerConverter(registry, new RuntimeBeanReference(beanName));
-				}
-			}
-		}
-	}
-
-	@SuppressWarnings("unchecked")
-	public void registerConverter(BeanDefinitionRegistry registry, BeanMetadataElement converterBeanDefinition) {
-		Set<BeanMetadataElement> converters = new ManagedSet<BeanMetadataElement>();
 		if (!registry.containsBeanDefinition(IntegrationContextUtils.CONVERTER_REGISTRAR_BEAN_NAME)) {
-			BeanDefinitionBuilder converterRegistrarBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-					CONTEXT_PACKAGE + "ConverterRegistrar").addConstructorArgValue(converters);
 			registry.registerBeanDefinition(IntegrationContextUtils.CONVERTER_REGISTRAR_BEAN_NAME,
-					converterRegistrarBuilder.getBeanDefinition());
-
-			if (!registry.containsBeanDefinition(IntegrationUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME)) {
-				registry.registerBeanDefinition(IntegrationUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME,
-						new RootBeanDefinition(CONTEXT_PACKAGE + "CustomConversionServiceFactoryBean"));
-			}
-		}
-		else {
-			BeanDefinition converterRegistrarBeanDefinition = registry
-					.getBeanDefinition(IntegrationContextUtils.CONVERTER_REGISTRAR_BEAN_NAME);
-			converters = (Set<BeanMetadataElement>) converterRegistrarBeanDefinition
-					.getConstructorArgumentValues()
-					.getIndexedArgumentValues()
-					.values()
-					.iterator()
-					.next()
-					.getValue();
+					new RootBeanDefinition(ConverterRegistrar.class, ConverterRegistrar::new));
 		}
 
-		converters.add(converterBeanDefinition); // NOSONAR never null
+		if (!registry.containsBeanDefinition(IntegrationUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME)) {
+			registry.registerBeanDefinition(IntegrationUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME,
+					new RootBeanDefinition(CustomConversionServiceFactoryBean.class,
+							CustomConversionServiceFactoryBean::new));
+		}
 	}
+
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -39,9 +39,7 @@ import org.springframework.util.ClassUtils;
 public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar {
 
 	static {
-		if (ClassUtils.isPresent("org.springframework.integration.dsl.support.Function",
-				IntegrationRegistrar.class.getClassLoader())) {
-
+		if (ClassUtils.isPresent("org.springframework.integration.dsl.support.Function", null)) {
 			throw new ApplicationContextException("Starting with Spring Integration 5.0, "
 					+ "the 'spring-integration-java-dsl' dependency is no longer needed; "
 					+ "the Java DSL has been merged into the core project. "

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ChainParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/ChainParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
 import org.springframework.beans.factory.support.ManagedList;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.IntegrationConfigUtils;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.handler.MessageHandlerChain;
 import org.springframework.util.StringUtils;
 import org.springframework.util.xml.DomUtils;
@@ -93,7 +94,7 @@ public class ChainParser extends AbstractConsumerEndpointParser {
 				}
 				if ("gateway".equals(child.getLocalName())) {
 					BeanDefinitionBuilder gwBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-							IntegrationConfigUtils.BASE_PACKAGE + ".gateway.RequestReplyMessageHandlerAdapter");
+							IntegrationContextUtils.BASE_PACKAGE + ".gateway.RequestReplyMessageHandlerAdapter");
 					gwBuilder.addConstructorArgValue(childBeanMetadata);
 					handlerList.add(gwBuilder.getBeanDefinition());
 				}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DefaultInboundChannelAdapterParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/DefaultInboundChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.beans.factory.support.ManagedMap;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.factory.xml.ParserContext;
 import org.springframework.integration.config.ExpressionFactoryBean;
-import org.springframework.integration.config.IntegrationConfigUtils;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.endpoint.ExpressionEvaluatingMessageSource;
 import org.springframework.integration.endpoint.MethodInvokingMessageSource;
 import org.springframework.integration.expression.DynamicExpression;
@@ -67,13 +67,13 @@ public class DefaultInboundChannelAdapterParser extends AbstractPollingInboundCh
 
 		if (!hasInnerDef && !hasRef && !hasExpression && !hasScriptElement && !hasExpressionElement) { // NOSONAR
 			parserContext.getReaderContext().error(
-				"Exactly one of the 'ref', 'expression', inner bean, <script> or <expression> is required.", element);
+					"Exactly one of the 'ref', 'expression', inner bean, <script> or <expression> is required.", element);
 		}
 		if (hasInnerDef) {
 			if (hasRef || hasExpression) {
 				parserContext.getReaderContext().error(
 						"Neither 'ref' nor 'expression' are permitted when an inner bean (<bean/>) is configured on "
-						+ "element " + IntegrationNamespaceUtils.createElementDescription(element) + ".", source);
+								+ "element " + IntegrationNamespaceUtils.createElementDescription(element) + ".", source);
 				return null;
 			}
 			if (hasMethod) {
@@ -87,13 +87,13 @@ public class DefaultInboundChannelAdapterParser extends AbstractPollingInboundCh
 			if (hasRef || hasMethod || hasExpression) {
 				parserContext.getReaderContext().error(
 						"Neither 'ref' and 'method' nor 'expression' are permitted when an inner script element is "
-						+ "configured on element "
-						+ IntegrationNamespaceUtils.createElementDescription(element) + ".", source);
+								+ "configured on element "
+								+ IntegrationNamespaceUtils.createElementDescription(element) + ".", source);
 				return null;
 			}
 			BeanDefinition scriptBeanDefinition = parserContext.getDelegate().parseCustomElement(scriptElement);
 			BeanDefinitionBuilder sourceBuilder = BeanDefinitionBuilder.genericBeanDefinition(
-					IntegrationConfigUtils.BASE_PACKAGE + ".scripting.ScriptExecutingMessageSource");
+					IntegrationContextUtils.BASE_PACKAGE + ".scripting.ScriptExecutingMessageSource");
 			sourceBuilder.addConstructorArgValue(scriptBeanDefinition);
 			parseHeaderExpressions(sourceBuilder, element, parserContext);
 			result = sourceBuilder.getBeanDefinition();
@@ -102,7 +102,7 @@ public class DefaultInboundChannelAdapterParser extends AbstractPollingInboundCh
 			if (hasRef || hasMethod) {
 				parserContext.getReaderContext().error(
 						"The 'ref' and 'method' attributes can't be used with 'expression' attribute or inner "
-						+ "<expression>.", element);
+								+ "<expression>.", element);
 				return null;
 			}
 			if (hasExpression & hasExpressionElement) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/IntegrationNamespaceUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -662,7 +662,7 @@ public abstract class IntegrationNamespaceUtils {
 		}
 		else if (hasExpression) {
 			BeanDefinitionBuilder adapterBuilder = BeanDefinitionBuilder
-					.genericBeanDefinition(IntegrationConfigUtils.BASE_PACKAGE + ".aggregator.ExpressionEvaluating"
+					.genericBeanDefinition(IntegrationContextUtils.BASE_PACKAGE + ".aggregator.ExpressionEvaluating"
 							+ adapterClass);
 			adapterBuilder.addConstructorArgValue(expression);
 			adapter = adapterBuilder.getBeanDefinition();
@@ -678,7 +678,7 @@ public abstract class IntegrationNamespaceUtils {
 			String unqualifiedClassName) {
 
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder
-				.genericBeanDefinition(IntegrationConfigUtils.BASE_PACKAGE + ".config." + unqualifiedClassName
+				.genericBeanDefinition(IntegrationContextUtils.BASE_PACKAGE + ".config." + unqualifiedClassName
 						+ "FactoryBean");
 		builder.addPropertyValue("target", ref);
 		if (StringUtils.hasText(method)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.expression.spel.support.SimpleEvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.integration.config.IntegrationConfigUtils;
 import org.springframework.integration.metadata.MetadataStore;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.scheduling.TaskScheduler;
@@ -48,6 +47,8 @@ import org.springframework.util.Assert;
  * @author Pierre Lakreb
  */
 public abstract class IntegrationContextUtils {
+
+	public static final String BASE_PACKAGE = "org.springframework.integration";
 
 	public static final String TASK_SCHEDULER_BEAN_NAME = "taskScheduler";
 
@@ -79,10 +80,10 @@ public abstract class IntegrationContextUtils {
 			"DefaultConfiguringBeanFactoryPostProcessor";
 
 	public static final String MESSAGING_ANNOTATION_POSTPROCESSOR_NAME =
-			IntegrationConfigUtils.BASE_PACKAGE + ".internalMessagingAnnotationPostProcessor";
+			BASE_PACKAGE + ".internalMessagingAnnotationPostProcessor";
 
 	public static final String PUBLISHER_ANNOTATION_POSTPROCESSOR_NAME =
-			IntegrationConfigUtils.BASE_PACKAGE + ".internalPublisherAnnotationBeanPostProcessor";
+			BASE_PACKAGE + ".internalPublisherAnnotationBeanPostProcessor";
 
 	public static final String INTEGRATION_CONFIGURATION_POST_PROCESSOR_BEAN_NAME =
 			"integrationConfigurationBeanFactoryPostProcessor";
@@ -181,6 +182,7 @@ public abstract class IntegrationContextUtils {
 	}
 
 	// TODO Revise in favor of 'IntegrationProperties' instance in the next 6.0 version
+
 	/**
 	 * @param beanFactory The bean factory.
 	 * @return the global {@link IntegrationContextUtils#INTEGRATION_GLOBAL_PROPERTIES_BEAN_NAME}

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphServer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphServer.java
@@ -54,7 +54,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.util.ClassUtils;
 
 /**
  * Builds the runtime object model graph.
@@ -497,7 +496,7 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 					? new ErrorCapableCompositeMessageHandlerNode(this.nodeId.incrementAndGet(), name, handler,
 					inputChannel, output, errors, innerHandlers)
 					: new CompositeMessageHandlerNode(this.nodeId.incrementAndGet(), name, handler,
-							inputChannel, output, innerHandlers);
+					inputChannel, output, innerHandlers);
 		}
 
 		MessageHandlerNode discardingHandler(String name, IntegrationConsumer consumer,
@@ -509,7 +508,7 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 					? new ErrorCapableDiscardingMessageHandlerNode(this.nodeId.incrementAndGet(), name, handler,
 					inputChannel, output, discards, errors)
 					: new DiscardingMessageHandlerNode(this.nodeId.incrementAndGet(), name, handler,
-							inputChannel, output, discards);
+					inputChannel, output, discards);
 		}
 
 		MessageHandlerNode routingHandler(String name, IntegrationConsumer consumer, MessageHandler handler,
@@ -525,7 +524,7 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 					? new ErrorCapableRoutingNode(this.nodeId.incrementAndGet(), name, handler,
 					inputChannel, output, errors, routes)
 					: new RoutingMessageHandlerNode(this.nodeId.incrementAndGet(), name, handler,
-							inputChannel, output, routes);
+					inputChannel, output, routes);
 		}
 
 		MessageHandlerNode recipientListRoutingHandler(String name, IntegrationConsumer consumer,
@@ -543,7 +542,7 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 					? new ErrorCapableRoutingNode(this.nodeId.incrementAndGet(), name, handler,
 					inputChannel, output, errors, routes)
 					: new RoutingMessageHandlerNode(this.nodeId.incrementAndGet(), name, handler,
-							inputChannel, output, routes);
+					inputChannel, output, routes);
 		}
 
 		void reset() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphServer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ import org.springframework.integration.router.RecipientListRouter.Recipient;
 import org.springframework.integration.router.RecipientListRouterManagement;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.integration.support.management.MappingMessageRouterManagement;
+import org.springframework.integration.support.management.micrometer.MicrometerMetricsCaptorRegistrar;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
@@ -105,8 +106,9 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 	 * @param additionalPropertiesCallback the {@link Function} to use for properties.
 	 * @since 5.1
 	 */
-	public void setAdditionalPropertiesCallback(
-			@Nullable Function<NamedComponent, Map<String, Object>> additionalPropertiesCallback) {
+	public void setAdditionalPropertiesCallback(@Nullable Function<NamedComponent,
+			Map<String, Object>> additionalPropertiesCallback) {
+
 		this.additionalPropertiesCallback = additionalPropertiesCallback;
 	}
 
@@ -158,8 +160,7 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 	}
 
 	private synchronized Graph buildGraph() {
-		if (micrometerEnhancer == null && ClassUtils.isPresent("io.micrometer.core.instrument.MeterRegistry",
-				this.applicationContext.getClassLoader())) {
+		if (micrometerEnhancer == null && MicrometerMetricsCaptorRegistrar.METER_REGISTRY_PRESENT) {
 			micrometerEnhancer = new MicrometerNodeEnhancer(this.applicationContext);
 		}
 		String implementationVersion = IntegrationGraphServer.class.getPackage().getImplementationVersion();

--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonNodeWrapperToJsonNodeConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonNodeWrapperToJsonNodeConverter.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.GenericConverter;
+import org.springframework.integration.config.IntegrationConverter;
 import org.springframework.integration.json.JsonPropertyAccessor.JsonNodeWrapper;
 import org.springframework.lang.Nullable;
 
@@ -37,6 +38,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  *
  * @since 5.5
  */
+@IntegrationConverter
 public class JsonNodeWrapperToJsonNodeConverter implements GenericConverter {
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/Jackson2JsonObjectMapper.java
@@ -64,20 +64,18 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
  */
 public class Jackson2JsonObjectMapper extends AbstractJacksonJsonObjectMapper<JsonNode, JsonParser, JavaType> {
 
-	private static final ClassLoader CLASS_LOADER = ClassUtils.getDefaultClassLoader();
-
 	private static final boolean JDK8_MODULE_PRESENT =
-			ClassUtils.isPresent("com.fasterxml.jackson.datatype.jdk8.Jdk8Module", CLASS_LOADER);
+			ClassUtils.isPresent("com.fasterxml.jackson.datatype.jdk8.Jdk8Module", null);
 
 	private static final boolean JAVA_TIME_MODULE_PRESENT =
-			ClassUtils.isPresent("com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", CLASS_LOADER);
+			ClassUtils.isPresent("com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", null);
 
 	private static final boolean JODA_MODULE_PRESENT =
-			ClassUtils.isPresent("com.fasterxml.jackson.datatype.joda.JodaModule", CLASS_LOADER);
+			ClassUtils.isPresent("com.fasterxml.jackson.datatype.joda.JodaModule", null);
 
 	private static final boolean KOTLIN_MODULE_PRESENT =
-			ClassUtils.isPresent("kotlin.Unit", CLASS_LOADER) &&
-					ClassUtils.isPresent("com.fasterxml.jackson.module.kotlin.KotlinModule", CLASS_LOADER);
+			ClassUtils.isPresent("kotlin.Unit", null) &&
+					ClassUtils.isPresent("com.fasterxml.jackson.module.kotlin.KotlinModule", null);
 
 	private final ObjectMapper objectMapper;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonPresent.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonPresent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,9 @@ import org.springframework.util.ClassUtils;
  */
 public final class JacksonPresent {
 
-	private static final ClassLoader CLASS_LOADER = ClassUtils.getDefaultClassLoader();
-
 	private static final boolean JACKSON_2_PRESENT =
-			ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", CLASS_LOADER) &&
-					ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", CLASS_LOADER);
+			ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", null) &&
+					ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", null);
 
 	public static boolean isJackson2Present() {
 		return JACKSON_2_PRESENT;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptorRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptorRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,13 @@ import io.micrometer.core.instrument.MeterRegistry;
  */
 public class MicrometerMetricsCaptorRegistrar implements ImportBeanDefinitionRegistrar {
 
-	private static final boolean METER_REGISTRY_PRESENT
-			= ClassUtils.isPresent("io.micrometer.core.instrument.MeterRegistry", ClassUtils.getDefaultClassLoader());
+	/**
+	 * A {@code boolean} flag to indicate if the
+	 * {@code io.micrometer.core.instrument.MeterRegistry} class is present in the
+	 * CLASSPATH to allow a {@link MicrometerMetricsCaptor} bean.
+	 */
+	public static final boolean METER_REGISTRY_PRESENT =
+			ClassUtils.isPresent("io.micrometer.core.instrument.MeterRegistry", null);
 
 	@Override
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/utils/IntegrationUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/utils/IntegrationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,7 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.ConversionService;
-import org.springframework.integration.config.IntegrationConfigUtils;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.context.NamedComponent;
@@ -49,7 +49,7 @@ public final class IntegrationUtils {
 
 	private static final Log LOGGER = LogFactory.getLog(IntegrationUtils.class);
 
-	private static final String INTERNAL_COMPONENT_PREFIX = '_' + IntegrationConfigUtils.BASE_PACKAGE;
+	private static final String INTERNAL_COMPONENT_PREFIX = '_' + IntegrationContextUtils.BASE_PACKAGE;
 
 	public static final String INTEGRATION_CONVERSION_SERVICE_BEAN_NAME = "integrationConversionService";
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/MapToObjectTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/MapToObjectTransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.support.GenericApplicationContext;
@@ -40,20 +40,21 @@ import org.springframework.messaging.Message;
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class MapToObjectTransformerTests {
 
-	private GenericApplicationContext context = TestUtils.createTestApplicationContext();
+	private final GenericApplicationContext context = TestUtils.createTestApplicationContext();
 
-	@Before
+	@BeforeEach
 	public void prepare() {
 		this.context.registerBeanDefinition(IntegrationUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME,
-				new RootBeanDefinition("org.springframework.integration.context.CustomConversionServiceFactoryBean"));
+				new RootBeanDefinition("org.springframework.integration.config.CustomConversionServiceFactoryBean"));
 		this.context.refresh();
 	}
 
-	@After
+	@AfterEach
 	public void terDown() {
 		this.context.close();
 	}
@@ -172,6 +173,7 @@ public class MapToObjectTransformerTests {
 		public void setAddress(Address address) {
 			this.address = address;
 		}
+
 	}
 
 	public static class Address {
@@ -185,6 +187,7 @@ public class MapToObjectTransformerTests {
 		public void setStreet(String street) {
 			this.street = street;
 		}
+
 	}
 
 	public class StringToAddressConverter implements Converter<String, Address> {
@@ -195,5 +198,7 @@ public class MapToObjectTransformerTests {
 			address.setStreet(source);
 			return address;
 		}
+
 	}
+
 }

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpContextUtils.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpContextUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,8 +45,7 @@ public final class HttpContextUtils {
 	 * e.g. {@code IntegrationGraphController}.
 	 */
 	public static final boolean WEB_MVC_PRESENT =
-			ClassUtils.isPresent("org.springframework.web.servlet.DispatcherServlet",
-					HttpContextUtils.class.getClassLoader());
+			ClassUtils.isPresent("org.springframework.web.servlet.DispatcherServlet", null);
 
 	/**
 	 * A {@code boolean} flag to indicate if the
@@ -55,8 +54,7 @@ public final class HttpContextUtils {
 	 * e.g. {@code IntegrationGraphController}.
 	 */
 	public static final boolean WEB_FLUX_PRESENT =
-			ClassUtils.isPresent("org.springframework.web.reactive.DispatcherHandler",
-					HttpContextUtils.class.getClassLoader());
+			ClassUtils.isPresent("org.springframework.web.reactive.DispatcherHandler", null);
 
 	/**
 	 * The name for the infrastructure
@@ -89,6 +87,7 @@ public final class HttpContextUtils {
 	 */
 	public static RequestMapping convertRequestMappingToAnnotation(
 			org.springframework.integration.http.inbound.RequestMapping requestMapping) {
+
 		if (ObjectUtils.isEmpty(requestMapping.getPathPatterns())) {
 			return null;
 		}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/BaseHttpInboundEndpoint.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/BaseHttpInboundEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,13 +56,9 @@ import org.springframework.validation.Validator;
  */
 public class BaseHttpInboundEndpoint extends MessagingGatewaySupport implements OrderlyShutdownCapable {
 
-	protected static final boolean JAXB_PRESENT =
-			ClassUtils.isPresent("javax.xml.bind.Binder",
-					BaseHttpInboundEndpoint.class.getClassLoader());
+	protected static final boolean JAXB_PRESENT = ClassUtils.isPresent("javax.xml.bind.Binder", null);
 
-	protected static final boolean ROME_TOOLS_PRESENT =
-			ClassUtils.isPresent("com.rometools.rome.feed.atom.Feed",
-					BaseHttpInboundEndpoint.class.getClassLoader());
+	protected static final boolean ROME_TOOLS_PRESENT = ClassUtils.isPresent("com.rometools.rome.feed.atom.Feed", null);
 
 	protected static final List<HttpMethod> NON_READABLE_BODY_HTTP_METHODS =
 			Arrays.asList(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.OPTIONS);

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +44,6 @@ import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.config.IntegrationConfigUtils;
 import org.springframework.integration.config.IntegrationManagementConfigurer;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.OrderlyShutdownCapable;
@@ -110,7 +109,7 @@ import org.springframework.util.ReflectionUtils;
 public class IntegrationMBeanExporter extends MBeanExporter
 		implements ApplicationContextAware, DestructionAwareBeanPostProcessor {
 
-	public static final String DEFAULT_DOMAIN = IntegrationConfigUtils.BASE_PACKAGE;
+	public static final String DEFAULT_DOMAIN = IntegrationContextUtils.BASE_PACKAGE;
 
 	private final IntegrationJmxAttributeSource attributeSource = new IntegrationJmxAttributeSource();
 
@@ -147,7 +146,7 @@ public class IntegrationMBeanExporter extends MBeanExporter
 
 	private String domain = DEFAULT_DOMAIN;
 
-	private String[] componentNamePatterns = {"*"};
+	private String[] componentNamePatterns = { "*" };
 
 	private volatile long shutdownDeadline;
 
@@ -744,7 +743,7 @@ public class IntegrationMBeanExporter extends MBeanExporter
 		String beanKey;
 		String name = endpoint.getComponentName();
 		String source;
-		if (name.startsWith('_' + IntegrationConfigUtils.BASE_PACKAGE)) {
+		if (name.startsWith('_' + IntegrationContextUtils.BASE_PACKAGE)) {
 			name = getInternalComponentName(name);
 			source = "internal";
 		}
@@ -798,7 +797,7 @@ public class IntegrationMBeanExporter extends MBeanExporter
 
 	private String getChannelBeanKey(String channel) {
 		String extra = "";
-		if (channel.startsWith(IntegrationConfigUtils.BASE_PACKAGE)) {
+		if (channel.startsWith(IntegrationContextUtils.BASE_PACKAGE)) {
 			extra = ",source=anonymous";
 		}
 		return String.format(this.domain + ":type=MessageChannel,name=%s%s" + getStaticNames(),
@@ -895,11 +894,11 @@ public class IntegrationMBeanExporter extends MBeanExporter
 		String managedType = source;
 		String managedName = name;
 
-		if (managedName != null && managedName.startsWith('_' + IntegrationConfigUtils.BASE_PACKAGE)) {
+		if (managedName != null && managedName.startsWith('_' + IntegrationContextUtils.BASE_PACKAGE)) {
 			managedName = getInternalComponentName(managedName);
 			managedType = "internal";
 		}
-		if (managedName != null && name.startsWith(IntegrationConfigUtils.BASE_PACKAGE)) {
+		if (managedName != null && name.startsWith(IntegrationContextUtils.BASE_PACKAGE)) {
 			MessageChannel inputChannel = endpoint.getInputChannel();
 			if (inputChannel != null) {
 				managedName = buildAnonymousManagedName(this.anonymousHandlerCounters, inputChannel);
@@ -937,7 +936,7 @@ public class IntegrationMBeanExporter extends MBeanExporter
 	}
 
 	private String getInternalComponentName(String name) {
-		return name.substring(('_' + IntegrationConfigUtils.BASE_PACKAGE).length() + 1);
+		return name.substring(('_' + IntegrationContextUtils.BASE_PACKAGE).length() + 1);
 	}
 
 	private IntegrationInboundManagement enhanceSourceMonitor(IntegrationInboundManagement source2) {
@@ -954,7 +953,7 @@ public class IntegrationMBeanExporter extends MBeanExporter
 		if (endpoint != null) {
 			endpointName = endpoint.getBeanName();
 		}
-		if (endpointName != null && endpointName.startsWith('_' + IntegrationConfigUtils.BASE_PACKAGE)) {
+		if (endpointName != null && endpointName.startsWith('_' + IntegrationContextUtils.BASE_PACKAGE)) {
 			endpointName = getInternalComponentName(endpointName);
 			source = "internal";
 		}
@@ -993,7 +992,7 @@ public class IntegrationMBeanExporter extends MBeanExporter
 		String managedType = source;
 		String managedName = name;
 
-		if (managedName != null && managedName.startsWith(IntegrationConfigUtils.BASE_PACKAGE)) {
+		if (managedName != null && managedName.startsWith(IntegrationContextUtils.BASE_PACKAGE)) {
 			Object target = endpoint;
 			if (endpoint instanceof Advised) {
 				TargetSource targetSource = ((Advised) endpoint).getTargetSource();

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
@@ -48,9 +48,7 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 
 	private static final Log LOGGER = LogFactory.getLog(WebSocketIntegrationConfigurationInitializer.class);
 
-	private static final boolean SERVLET_PRESENT =
-			ClassUtils.isPresent("javax.servlet.Servlet",
-					WebSocketIntegrationConfigurationInitializer.class.getClassLoader());
+	private static final boolean SERVLET_PRESENT = ClassUtils.isPresent("javax.servlet.Servlet", null);
 
 	private static final String WEB_SOCKET_HANDLER_MAPPING_BEAN_NAME = "integrationWebSocketHandlerMapping";
 

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/UnmarshallingTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/UnmarshallingTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,17 +58,20 @@ import org.springframework.xml.transform.StringSource;
  */
 public class UnmarshallingTransformer extends AbstractPayloadTransformer<Object, Object> {
 
+	private static final boolean MIME_MESSAGE_PRESENT =
+			ClassUtils.isPresent("org.springframework.ws.mime.MimeMessage", null);
+
 	private final Unmarshaller unmarshaller;
 
-	private volatile SourceFactory sourceFactory = new DomSourceFactory();
+	private SourceFactory sourceFactory = new DomSourceFactory();
 
-	private volatile boolean alwaysUseSourceFactory = false;
+	private boolean alwaysUseSourceFactory = false;
 
 	private MimeMessageUnmarshallerHelper mimeMessageUnmarshallerHelper;
 
 	public UnmarshallingTransformer(Unmarshaller unmarshaller) {
 		this.unmarshaller = unmarshaller;
-		if (ClassUtils.isPresent("org.springframework.ws.mime.MimeMessage", ClassUtils.getDefaultClassLoader())) {
+		if (MIME_MESSAGE_PRESENT) {
 			this.mimeMessageUnmarshallerHelper = new MimeMessageUnmarshallerHelper(unmarshaller);
 		}
 	}


### PR DESCRIPTION
* Add `BASE_PACKAGE` into an `IntegrationContextUtils`;
deprecate similar in the `IntegrationConfigUtils`.
This fixes a package tangle between `config` and `context`
* Move `ConverterRegistrar` and `CustomConversionServiceFactoryBean`
into a `config` package since they are package protected and
created their instances in the `IntegrationConverterInitializer`
functional way instead of reflection
* Use new `IntegrationContextUtils.BASE_PACKAGE` constant instead of
deprecated one
* Make `DefaultConfiguringBeanFactoryPostProcessor` `public` to
make it available for Spring Native `trigger` option in the `@NativeHint`
declaration
* Simplify logic around `JsonPath` to just a `ClassUtils.isPresent()`
* Move the `@IntegrationConverter` processing logic into the `ConverterRegistrar`
to avoid reflection via `BeanDefinition` ctor arg manipulation
* Move the reflection logic into a `ConverterParser` which, being a part of XML
configuration, is not going to be compatible with native any way
* Mark `JsonNodeWrapperToJsonNodeConverter` with an `@IntegrationConverter`
since it is not registered via reflection any more
* Expose `MicrometerMetricsCaptorRegistrar.METER_REGISTRY_PRESENT` and use
it in the `IntegrationGraphServer`
* Extract `UnmarshallingTransformer.MIME_MESSAGE_PRESENT` for less
reflection at runtime
* Use `null` for a `ClassLoader` arg in the `ClassUtils.isPresent()`
relying on the default one internally

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
