### PR TITLE
Fix breaking change for PersistentFileListFilter

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractPersistentAcceptOnceFileListFilter.java
@@ -180,6 +180,11 @@ public abstract class AbstractPersistentAcceptOnceFileListFilter<F> extends Abst
 		}
 	}
 
+	@Override
+	protected boolean isDirectory(F file) {
+		return false;
+	}
+
 	protected abstract long modified(F file);
 
 	protected abstract String fileName(F file);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/PersistentAcceptOnceFileListFilterTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/PersistentAcceptOnceFileListFilterTests.java
@@ -111,11 +111,6 @@ public class PersistentAcceptOnceFileListFilterTests extends AcceptOnceFileListF
 						return file;
 					}
 
-					@Override
-					protected boolean isDirectory(String file) {
-						return false;
-					}
-
 				};
 		doTestRollback(filter);
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -345,19 +345,19 @@ public class StreamingInboundTests {
 			}
 			try {
 				Session<String> session = mock(Session.class);
-				willReturn(new String[] { "/foo/foo", "/foo/bar" }).given(session).list("/foo");
+				willReturn(new String[]{ "/foo/foo", "/foo/bar" }).given(session).list("/foo");
 				ByteArrayInputStream foo = new ByteArrayInputStream("foo\nbar".getBytes());
 				ByteArrayInputStream bar = new ByteArrayInputStream("baz\nqux".getBytes());
 				willReturn(foo).given(session).readRaw("/foo/foo");
 				willReturn(bar).given(session).readRaw("/foo/bar");
 
-				willReturn(new String[] { "/bar/foo", "/bar/bar" }).given(session).list("/bar");
+				willReturn(new String[]{ "/bar/foo", "/bar/bar" }).given(session).list("/bar");
 				ByteArrayInputStream foo2 = new ByteArrayInputStream("foo\r\nbar".getBytes());
 				ByteArrayInputStream bar2 = new ByteArrayInputStream("baz\r\nqux".getBytes());
 				willReturn(foo2).given(session).readRaw("/bar/foo");
 				willReturn(bar2).given(session).readRaw("/bar/bar");
 
-				willReturn(new String[] { "/bad/file1", "/bad/file2" }).given(session).list("/bad");
+				willReturn(new String[]{ "/bad/file1", "/bad/file2" }).given(session).list("/bad");
 				willThrow(new IOException("No file")).given(session).readRaw("/bad/file1");
 				willThrow(new IOException("No file")).given(session).readRaw("/bad/file2");
 
@@ -388,11 +388,6 @@ public class StreamingInboundTests {
 		@Override
 		protected String fileName(String file) {
 			return file;
-		}
-
-		@Override
-		protected boolean isDirectory(String file) {
-			return false;
 		}
 
 	}


### PR DESCRIPTION
The `AbstractPersistentAcceptOnceFileListFilter`
extends now an `AbstractDirectoryAwareFileListFilter`
and makes all the implementors to implement its `isDirectory()` method.
This is a breaking change in the point release which makes implementations
outside of the core project not compilable

The regression after: https://github.com/spring-projects/spring-integration/issues/3488
Related fix in the Spring Cloud GCP: https://github.com/spring-cloud/spring-cloud-gcp/pull/2654

* Implement an `isDirectory()` in the `AbstractPersistentAcceptOnceFileListFilter`
to let other implementations do not worry during upgrade

**Cherry-pick to `5.4.x` & `5.3.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
