### PR TITLE
Fix ZeroMQ components initialization

### DIFF
--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/channel/ZeroMqChannel.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/channel/ZeroMqChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ public class ZeroMqChannel extends AbstractMessageChannel implements Subscribabl
 										? SocketType.PAIR
 										: (this.pubSub ? SocketType.PUB : SocketType.PUSH))
 				))
-				.doOnNext(this.sendSocketConfigurer)
+				.doOnNext((socket) -> this.sendSocketConfigurer.accept(socket))
 				.doOnNext((socket) ->
 						socket.connect(this.connectSendUrl != null
 								? this.connectSendUrl
@@ -184,7 +184,7 @@ public class ZeroMqChannel extends AbstractMessageChannel implements Subscribabl
 								this.connectSubscribeUrl == null
 										? SocketType.PAIR
 										: (this.pubSub ? SocketType.SUB : SocketType.PULL))))
-				.doOnNext(this.subscribeSocketConfigurer)
+				.doOnNext((socket) -> this.subscribeSocketConfigurer.accept(socket))
 				.doOnNext((socket) -> {
 					if (this.connectSubscribeUrl != null) {
 						if (this.pubSub) {
@@ -213,7 +213,7 @@ public class ZeroMqChannel extends AbstractMessageChannel implements Subscribabl
 							return Mono.empty();
 						})
 						.publishOn(Schedulers.parallel())
-						.map(this.messageMapper::toMessage)
+						.map((data) -> this.messageMapper.toMessage(data))
 						.doOnError((error) -> logger.error(error,
 								() -> "Error processing ZeroMQ message in the " + this))
 						.repeatWhenEmpty((repeat) ->

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class ZeroMqMessageHandler extends AbstractReactiveMessageHandler {
 		this.socketMono =
 				Mono.just(context.createSocket(socketType))
 						.publishOn(this.publisherScheduler)
-						.doOnNext(this.socketConfigurer)
+						.doOnNext((socket) -> this.socketConfigurer.accept(socket))
 						.doOnNext((socket) -> socket.connect(connectUrl))
 						.cache()
 						.publishOn(this.publisherScheduler);

--- a/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandlerTests.java
+++ b/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandlerTests.java
@@ -21,6 +21,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.mock;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.zeromq.SocketType;
@@ -32,10 +34,13 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.json.EmbeddedJsonHeadersMessageMapper;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.zeromq.ZeroMqProxy;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.ByteArrayMessageConverter;
 import org.springframework.messaging.support.GenericMessage;
+
+import reactor.core.publisher.Mono;
 
 /**
  * @author Artem Bilan
@@ -59,7 +64,13 @@ public class ZeroMqMessageHandlerTests {
 
 		ZeroMqMessageHandler messageHandler = new ZeroMqMessageHandler(CONTEXT, socketAddress);
 		messageHandler.setBeanFactory(mock(BeanFactory.class));
+		messageHandler.setSocketConfigurer(s -> s.setZapDomain("global"));
 		messageHandler.afterPropertiesSet();
+
+		@SuppressWarnings("unchecked")
+		Mono<ZMQ.Socket> socketMono = TestUtils.getPropertyValue(messageHandler, "socketMono", Mono.class);
+		ZMQ.Socket socketInUse = socketMono.block(Duration.ofSeconds(10));
+		assertThat(socketInUse.getZapDomain()).isEqualTo("global");
 
 		Message<?> testMessage = new GenericMessage<>("test");
 		messageHandler.handleMessage(testMessage).subscribe();


### PR DESCRIPTION
SO: https://stackoverflow.com/questions/67214907/zeromq-with-spring-spring-integration-zeromq

The `Mono` is created in several places in ZeroMQ components from their constructors.
That leads to the reactive stream to be configured just after ctor, which will ignore
any changes to the options which are used from that `Mono` definition.
For example this code `.doOnNext(this.sendSocketConfigurer)` is done once during
reactive stream definition.

* Fix all the ZeroMQ components to defer usage of the options which could be changed
after ctor initialization
* Cover affected option changes in the tests

**Cherry-pick to `5.4.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
