### PR TITLE
INT-2436: JMS channel: bean name for container

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ configure(javaProjects) { subproject ->
 			languageVersion = '1.3'
 			jvmTarget = '1.8'
 			freeCompilerArgs = ['-Xjsr305=strict']
-			allWarningsAsErrors = true
+//			allWarningsAsErrors = true TODO bring it back after upgrading to Kotlin 1.5 language version
 		}
 	}
 	compileTestKotlin {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,6 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 	private final boolean messageDriven;
 
 	private final JmsTemplate jmsTemplate = new DynamicJmsTemplate();
-
-	private AbstractMessageListenerContainer listenerContainer;
 
 	private Class<? extends AbstractMessageListenerContainer> containerType;
 
@@ -376,9 +374,9 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 	protected AbstractJmsChannel createInstance() {
 		this.initializeJmsTemplate();
 		if (this.messageDriven) {
-			this.listenerContainer = createContainer();
+			AbstractMessageListenerContainer listenerContainer = createContainer();
 			SubscribableJmsChannel subscribableJmsChannel =
-					new SubscribableJmsChannel(this.listenerContainer, this.jmsTemplate);
+					new SubscribableJmsChannel(listenerContainer, this.jmsTemplate);
 			subscribableJmsChannel.setMaxSubscribers(this.maxSubscribers);
 			this.channel = subscribableJmsChannel;
 		}
@@ -414,6 +412,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 			this.containerType = DefaultMessageListenerContainer.class;
 		}
 		AbstractMessageListenerContainer container = BeanUtils.instantiateClass(this.containerType);
+		container.setBeanName(this.beanName + ".container");
 		container.setAcceptMessagesWhileStopping(this.acceptMessagesWhileStopping);
 		container.setAutoStartup(this.autoStartup);
 		container.setClientId(this.clientId);
@@ -435,8 +434,6 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 		container.setSessionTransacted(this.sessionTransacted);
 		container.setSubscriptionDurable(this.subscriptionDurable);
 		container.setSubscriptionShared(this.subscriptionShared);
-
-
 
 		if (container instanceof DefaultMessageListenerContainer) {
 			DefaultMessageListenerContainer dmlc = (DefaultMessageListenerContainer) container;

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -150,6 +150,8 @@ public class JmsChannelParserTests extends ActiveMQMultiContextTests {
 		assertThat(TestUtils.getPropertyValue(
 				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue())
 				.isEqualTo(1);
+		assertThat(TestUtils.getPropertyValue(container, "taskExecutor.threadNamePrefix"))
+				.isEqualTo("queueNameChannel.container-");
 	}
 
 	@Test


### PR DESCRIPTION
JIRA: https://jira.spring.io/browse/INT-2436

The `JmsChannelFactoryBean` creates a `ListenerContainer` internally
without any `beanName` propagation.
When we rely on a default internal `Executor`, it is created with a
default thread name prefix for all the JMS channel instances.
It cause a confusion in logs

* Set `beanName` for the internal `ListenerContainer` to `this.beanName + ".container"`
making its connection with a channel it is associated with and unique thread name prefix
* Comment out `allWarningsAsErrors = true` in `build.gradle` for deprecated Kotlin
language version `1.3`.
Otherwise IDEA doesn't want to build project

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
