### PR TITLE
Set FTPSClient property once

### DIFF
--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/DefaultFtpsSessionFactory.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/DefaultFtpsSessionFactory.java
@@ -150,7 +150,6 @@ public class DefaultFtpsSessionFactory extends AbstractFtpSessionFactory<FTPSCli
 			.acceptIfNotNull(this.protocols, ftpsClient::setEnabledProtocols)
 			.acceptIfNotNull(this.sessionCreation, ftpsClient::setEnabledSessionCreation)
 			.acceptIfNotNull(this.useClientMode, ftpsClient::setUseClientMode)
-			.acceptIfNotNull(this.sessionCreation, ftpsClient::setEnabledSessionCreation)
 			.acceptIfNotNull(this.keyManager, ftpsClient::setKeyManager)
 			.acceptIfNotNull(this.needClientAuth, ftpsClient::setNeedClientAuth)
 			.acceptIfNotNull(this.wantsClientAuth, ftpsClient::setWantClientAuth);


### PR DESCRIPTION
The sessionCreation property was being set twice by accident.

@pivotal-cla This is an Obvious Fix
