### PR TITLE
GH-3567: Retry for TransactionSystemException in JdbcLockRegistry

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -32,6 +32,7 @@ import org.springframework.dao.TransientDataAccessException;
 import org.springframework.integration.support.locks.ExpirableLockRegistry;
 import org.springframework.integration.support.locks.RenewableLockRegistry;
 import org.springframework.integration.util.UUIDConverter;
+import org.springframework.transaction.TransactionSystemException;
 import org.springframework.transaction.TransactionTimedOutException;
 import org.springframework.util.Assert;
 
@@ -52,6 +53,7 @@ import org.springframework.util.Assert;
  * @author Alexandre Strubel
  * @author Stefan Vassilev
  * @author Olivier Hubaut
+ * @author Fran Aranda
  *
  * @since 4.3
  */
@@ -149,7 +151,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry, RenewableLockReg
 					}
 					break;
 				}
-				catch (TransientDataAccessException | TransactionTimedOutException e) {
+				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
 					// try again
 				}
 				catch (InterruptedException e) {
@@ -183,7 +185,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry, RenewableLockReg
 					}
 					break;
 				}
-				catch (TransientDataAccessException | TransactionTimedOutException e) {
+				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
 					// try again
 				}
 				catch (InterruptedException ie) {
@@ -227,7 +229,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry, RenewableLockReg
 					}
 					return acquired;
 				}
-				catch (TransientDataAccessException | TransactionTimedOutException e) {
+				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
 					// try again
 				}
 				catch (Exception e) {
@@ -260,7 +262,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry, RenewableLockReg
 						this.mutex.delete(this.path);
 						return;
 					}
-					catch (TransientDataAccessException | TransactionTimedOutException e) {
+					catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
 						// try again
 					}
 					catch (Exception e) {
@@ -294,7 +296,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry, RenewableLockReg
 					}
 					return renewed;
 				}
-				catch (TransientDataAccessException | TransactionTimedOutException e) {
+				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
 					// try again
 				}
 				catch (Exception e) {

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryDelegateTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryDelegateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.transaction.TransactionTimedOutException;
 
 /**
  * @author Olivier Hubaut
+ * @author Fran Aranda
  *
  * @since 5.2.11
  */


### PR DESCRIPTION
Fixes spring-projects/spring-integration#3567

Including in the catch blocks also the `TransactionSystemException` so the `JdbcLockRegistry` will be able to retry when facing these kind of errors:
```
Caused by: org.springframework.dao.CannotAcquireLockException: Failed to lock mutex at 04c819b6-efaa-4077-bdf9-3ee236d675b3; nested exception is org.springframework.transaction.TransactionSystemException: Could not commit JPA transaction; nested exception is javax.persistence.RollbackException: Exception [EclipseLink-4002] (Eclipse Persistence Services - 2.7.7.v20200504-69f2c2b80d): org.eclipse.persistence.exceptions.DatabaseException
Internal Exception: org.postgresql.util.PSQLException: ERROR: could not serialize access due to read/write dependencies among transactions
  Detail: Reason code: Canceled on identification as a pivot, during commit attempt.
  Hint: The transaction might succeed if retried.
```


