### PR TITLE
GH-3509: Fix regression in TcpNetServerConnectionFactory

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNetServerConnectionFactory.java
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Mário Dias
  *
  * @since 2.0
  *
@@ -180,7 +181,11 @@ public class TcpNetServerConnectionFactory extends AbstractServerConnectionFacto
 				setSocketAttributes(socket);
 				TcpConnectionSupport connection = this.tcpNetConnectionSupport.createNewConnection(socket, true,
 						isLookupHost(), getApplicationEventPublisher(), getComponentName());
-				connection = wrapConnection(connection);
+				TcpConnectionSupport wrapped = wrapConnection(connection);
+				if (!wrapped.equals(connection)) {
+					connection.setSenders(getSenders());
+					connection = wrapped;
+				}
 				initializeConnection(connection, socket);
 				getTaskExecutor().execute(connection);
 				harvestClosedConnections();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
@@ -1199,7 +1199,6 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		}
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testInterceptedConnection() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
@@ -1229,7 +1228,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		socket.close();
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(connection.get()).isInstanceOf(HelloWorldInterceptor.class);
-		await().untilAsserted(() -> handler.getConnections().isEmpty());
+		await().untilAsserted(() -> assertThat(handler.getConnections()).isEmpty());
 		scf.stop();
 	}
 
@@ -1258,7 +1257,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
 		socket.close();
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-		await().untilAsserted(() -> handler.getConnections().isEmpty());
+		await().untilAsserted(() -> assertThat(handler.getConnections()).isEmpty());
 		scf.stop();
 	}
 


### PR DESCRIPTION
This pull request fixes a regression introduced in https://github.com/spring-projects/spring-integration/commit/a2081137f6bab38c892dba379928ce87e68e59df on `TcpNetServerConnectionFactory`, re-triggering #3509

Fix intercepted tcp connector cleanup tests.
Add missing logic to call `setSenders` on wrapped connection.
