### PR TITLE
GH-3570: Disable the generation of the Gradle metadata

### DIFF
--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -1,6 +1,10 @@
 apply plugin: 'maven-publish'
 apply plugin: 'com.jfrog.artifactory'
 
+tasks.withType(GenerateModuleMetadata) {
+	enabled = false
+}
+
 publishing {
 	publications {
 		mavenJava(MavenPublication) {


### PR DESCRIPTION
Fixes spring-projects/spring-integration#3570

The module file with the Gradle metadata cannot be published on Maven
Central, which causes issues for some people using a repository manager such
as Artifactory. If it doesn't return a 404 HTTP status, the build fails
instead of ignoring the module.

This should probably be cherry-picked for `5.4.x` and `5.3.x` at least. Should I create other pull requests for those branches?