### PR TITLE
GH-3578: Fix JdbcMessageStore.getMessageGroup()

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -391,10 +391,10 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 																		fluxSink.complete();
 																	}
 																})
-																.limitRequest(
-																		this.maxMessagesPerPoll < 0
+																.take(this.maxMessagesPerPoll < 0
 																				? Long.MAX_VALUE
-																				: this.maxMessagesPerPoll);
+																				: this.maxMessagesPerPoll,
+																		true);
 													}
 												})
 												.subscribeOn(Schedulers.fromExecutor(this.taskExecutor))

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,7 @@ public class MessageGroupMetadata implements Serializable {
 
 	private static final long serialVersionUID = 1L;
 
-	private List<UUID> messageIds = new LinkedList<>();
+	private final List<UUID> messageIds = new LinkedList<>();
 
 	private long timestamp;
 
@@ -52,8 +52,7 @@ public class MessageGroupMetadata implements Serializable {
 
 	private volatile String condition;
 
-	private MessageGroupMetadata() {
-		//For Jackson deserialization
+	public MessageGroupMetadata() {
 	}
 
 	public MessageGroupMetadata(MessageGroup messageGroup) {
@@ -79,7 +78,7 @@ public class MessageGroupMetadata implements Serializable {
 		return !this.messageIds.contains(messageId) && this.messageIds.add(messageId);
 	}
 
-	void setLastModified(long lastModified) {
+	public void setLastModified(long lastModified) {
 		this.lastModified = lastModified;
 	}
 
@@ -107,7 +106,7 @@ public class MessageGroupMetadata implements Serializable {
 		return new LinkedList<UUID>(this.messageIds);
 	}
 
-	void complete() {
+	public void complete() {
 		this.complete = true;
 	}
 
@@ -123,11 +122,15 @@ public class MessageGroupMetadata implements Serializable {
 		return this.timestamp;
 	}
 
+	public void setTimestamp(long timestamp) {
+		this.timestamp = timestamp;
+	}
+
 	public int getLastReleasedMessageSequenceNumber() {
 		return this.lastReleasedMessageSequenceNumber;
 	}
 
-	void setLastReleasedMessageSequenceNumber(int lastReleasedMessageSequenceNumber) {
+	public void setLastReleasedMessageSequenceNumber(int lastReleasedMessageSequenceNumber) {
 		this.lastReleasedMessageSequenceNumber = lastReleasedMessageSequenceNumber;
 	}
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3578

The `JdbcTemplate.queryForMap()` extract values for columns to the closer target driver types.
For example H2 and Derby return `Long` for `BIGINT`.
Oracle for its `NUMBER(19,0)` returns `BigInteger`.
This makes the code in the `JdbcMessageStore.getMessageGroup()`
not platform independent.

* Fix `JdbcMessageStore` to map `ResultSet` to the `MessageGroupMetadata`
directly.
Mostly reinstating the previous behavior
* For that reason expose a default ctor for `MessageGroupMetadata`
and extract some setters to make code in the `JdbcMessageStore` more cleaner.
* This opens for us a possibility to implement a `MessageGroupStore.getGroupMetadata(groupId)`
for `JdbcMessageStore`
* Fix deprecation for `Flux.limitRequest()`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
