### PR TITLE
Fix Websocket dynamic registration mapping order

### DIFF
--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
@@ -99,7 +99,12 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 
 				BeanDefinitionReaderUtils.registerWithGeneratedName(
 						new RootBeanDefinition(IntegrationDynamicWebSocketHandlerMapping.class,
-								IntegrationDynamicWebSocketHandlerMapping::new),
+								() -> {
+									IntegrationDynamicWebSocketHandlerMapping dynamicWebSocketHandlerMapping =
+											new IntegrationDynamicWebSocketHandlerMapping();
+									dynamicWebSocketHandlerMapping.setOrder(0);
+									return dynamicWebSocketHandlerMapping;
+								}),
 						registry);
 
 				BeanDefinitionBuilder enableWebSocketBuilder =

--- a/src/reference/asciidoc/web-sockets.adoc
+++ b/src/reference/asciidoc/web-sockets.adoc
@@ -430,3 +430,5 @@ dynamicServerFlow.destroy();
 
 NOTE: It is important to call `.addBean(serverWebSocketContainer)` on the dynamic flow registration to add the instance of `ServerWebSocketContainer` into an `ApplicationContext` for endpoint registration.
 When a dynamic flow registration is destroyed, the associated `ServerWebSocketContainer` instance is destroyed, too, as well as the respective endpoint registration, including URL path mappings.
+
+IMPORTANT: The dynamic Websocket endpoints can only be registered via Spring Integration mechanism: when regular Spring `@EnableWebsocket` is used, Spring Integration configuration backs off and no infrastructure for dynamic endpoints is registered.


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/67923303/dynamic-registration-of-websocket-output-adapter-is-not-working

By default the `AbstractHandlerMapping` comes with the `order = Ordered.LOWEST_PRECEDENCE` which sorts
added mappings to the end of chain.
At the same time Spring Boot registers a `SimpleUrlHandlerMapping` as a fallback for all not handled requests
leaving our own mapping behind consideration

* Add `order = 0` to the `IntegrationDynamicWebSocketHandlerMapping` bean registration to let it to be
consulted before `SimpleUrlHandlerMapping`
* Add a note into `web-sockets.adoc` that `@EnableWebsocket` would disable Spring Integration dynamic WebSocket
endpoints

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
