### PR TITLE
Fix dynamic Websocket endpoints for SockJS

### DIFF
--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/ServerWebSocketContainer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/ServerWebSocketContainer.java
@@ -22,7 +22,6 @@ import org.springframework.context.Lifecycle;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.integration.util.JavaUtils;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.socket.WebSocketHandler;
@@ -134,6 +133,13 @@ public class ServerWebSocketContainer extends IntegrationWebSocketContainer
 		this.sockJsServiceOptions = sockJsServiceOptions;
 	}
 
+	/**
+	 * Configure a {@link TaskScheduler} for SockJS fallback service.
+	 * This is an alternative for default SockJS service scheduler
+	 * when Websocket endpoint (this server container) is registered at runtime.
+	 * @param sockJsTaskScheduler the {@link TaskScheduler} for SockJS fallback service.
+	 * @since 5.5.1
+	 */
 	public void setSockJsTaskScheduler(TaskScheduler sockJsTaskScheduler) {
 		this.sockJsTaskScheduler = sockJsTaskScheduler;
 	}

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/IntegrationDynamicWebSocketHandlerMapping.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/IntegrationDynamicWebSocketHandlerMapping.java
@@ -16,14 +16,23 @@
 
 package org.springframework.integration.websocket.config;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
+import org.springframework.http.server.PathContainer;
+import org.springframework.http.server.RequestPath;
 import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.handler.AbstractHandlerMapping;
+import org.springframework.web.servlet.handler.AbstractUrlHandlerMapping;
+import org.springframework.web.util.ServletRequestPathUtils;
+import org.springframework.web.util.pattern.PathPattern;
+import org.springframework.web.util.pattern.PathPatternParser;
 
 /**
  * The {@link AbstractHandlerMapping} implementation for dynamic WebSocket endpoint registrations in Spring Integration.
@@ -34,23 +43,60 @@ import org.springframework.web.servlet.handler.AbstractHandlerMapping;
  *
  * @since 5.5
  */
-class IntegrationDynamicWebSocketHandlerMapping extends AbstractHandlerMapping {
+class IntegrationDynamicWebSocketHandlerMapping extends AbstractUrlHandlerMapping {
 
 	private final Map<String, HttpRequestHandler> handlerMap = new HashMap<>();
+
+	private final Map<PathPattern, HttpRequestHandler> pathPatternHandlerMap = new LinkedHashMap<>();
 
 	@Override
 	protected Object getHandlerInternal(HttpServletRequest request) {
 		String lookupPath = initLookupPath(request);
 		HttpRequestHandler httpRequestHandler = this.handlerMap.get(lookupPath);
+		if (httpRequestHandler == null && usesPathPatterns()) {
+			RequestPath path = ServletRequestPathUtils.getParsedRequestPath(request);
+			return lookupByPattern(path);
+		}
 		return httpRequestHandler != null ? new HandlerExecutionChain(httpRequestHandler) : null;
+	}
+
+	private Object lookupByPattern(RequestPath path) {
+		List<PathPattern> matches = null;
+		for (PathPattern pattern : this.pathPatternHandlerMap.keySet()) {
+			if (pattern.matches(path.pathWithinApplication())) {
+				matches = (matches != null ? matches : new ArrayList<>());
+				matches.add(pattern);
+			}
+		}
+		if (matches == null) {
+			return null;
+		}
+		if (matches.size() > 1) {
+			matches.sort(PathPattern.SPECIFICITY_COMPARATOR);
+			if (logger.isTraceEnabled()) {
+				logger.trace("Matching patterns " + matches);
+			}
+		}
+		PathPattern pattern = matches.get(0);
+		HttpRequestHandler handler = this.pathPatternHandlerMap.get(pattern);
+		PathContainer pathWithinMapping = pattern.extractPathWithinPattern(path.pathWithinApplication());
+		return buildPathExposingHandler(handler, pattern.getPatternString(), pathWithinMapping.value(), null);
 	}
 
 	void registerHandler(String path, HttpRequestHandler httpHandler) {
 		this.handlerMap.put(path, httpHandler);
+		PathPatternParser patternParser = getPatternParser();
+		if (patternParser != null) {
+			this.pathPatternHandlerMap.put(patternParser.parse(path), httpHandler);
+		}
 	}
 
 	void unregisterHandler(String path) {
 		this.handlerMap.remove(path);
+		PathPatternParser patternParser = getPatternParser();
+		if (patternParser != null) {
+			this.pathPatternHandlerMap.remove(patternParser.parse(path));
+		}
 	}
 
 }

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/IntegrationServletWebSocketHandlerRegistry.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/IntegrationServletWebSocketHandlerRegistry.java
@@ -26,6 +26,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.integration.websocket.ServerWebSocketContainer;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.HttpRequestHandler;
@@ -46,9 +47,13 @@ import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistra
 class IntegrationServletWebSocketHandlerRegistry extends ServletWebSocketHandlerRegistry
 		implements ApplicationContextAware, DestructionAwareBeanPostProcessor {
 
+	private final ThreadLocal<IntegrationDynamicWebSocketHandlerRegistration> currentRegistration = new ThreadLocal<>();
+
 	private final Map<WebSocketHandler, List<String>> dynamicRegistrations = new HashMap<>();
 
 	private ApplicationContext applicationContext;
+
+	private TaskScheduler sockJsTaskScheduler;
 
 	private volatile IntegrationDynamicWebSocketHandlerMapping dynamicHandlerMapping;
 
@@ -60,15 +65,10 @@ class IntegrationServletWebSocketHandlerRegistry extends ServletWebSocketHandler
 		this.applicationContext = applicationContext;
 	}
 
-
 	@Override
-	protected boolean requiresTaskScheduler() { // NOSONAR visibility
-		return super.requiresTaskScheduler();
-	}
-
-	@Override
-	protected void setTaskScheduler(TaskScheduler scheduler) { // NOSONAR visibility
+	protected void setTaskScheduler(TaskScheduler scheduler) {
 		super.setTaskScheduler(scheduler);
+		this.sockJsTaskScheduler = scheduler;
 	}
 
 	@Override
@@ -85,15 +85,7 @@ class IntegrationServletWebSocketHandlerRegistry extends ServletWebSocketHandler
 			IntegrationDynamicWebSocketHandlerRegistration registration =
 					new IntegrationDynamicWebSocketHandlerRegistration();
 			registration.addHandler(handler, paths);
-			MultiValueMap<HttpRequestHandler, String> mappings = registration.getMapping();
-			for (Map.Entry<HttpRequestHandler, List<String>> entry : mappings.entrySet()) {
-				HttpRequestHandler httpHandler = entry.getKey();
-				List<String> patterns = entry.getValue();
-				this.dynamicRegistrations.put(handler, patterns);
-				for (String pattern : patterns) {
-					this.dynamicHandlerMapping.registerHandler(pattern, httpHandler);
-				}
-			}
+			this.currentRegistration.set(registration);
 			return registration;
 		}
 		else {
@@ -102,9 +94,24 @@ class IntegrationServletWebSocketHandlerRegistry extends ServletWebSocketHandler
 	}
 
 	@Override
-	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 		if (this.dynamicHandlerMapping != null && bean instanceof ServerWebSocketContainer) {
-			((ServerWebSocketContainer) bean).registerWebSocketHandlers(this);
+			ServerWebSocketContainer serverWebSocketContainer = (ServerWebSocketContainer) bean;
+			if (serverWebSocketContainer.getSockJsTaskScheduler() == null) {
+				serverWebSocketContainer.setSockJsTaskScheduler(this.sockJsTaskScheduler);
+			}
+			serverWebSocketContainer.registerWebSocketHandlers(this);
+			IntegrationDynamicWebSocketHandlerRegistration registration = this.currentRegistration.get();
+			this.currentRegistration.remove();
+			MultiValueMap<HttpRequestHandler, String> mappings = registration.getMapping();
+			for (Map.Entry<HttpRequestHandler, List<String>> entry : mappings.entrySet()) {
+				HttpRequestHandler httpHandler = entry.getKey();
+				List<String> patterns = entry.getValue();
+				this.dynamicRegistrations.put(registration.handler, patterns);
+				for (String pattern : patterns) {
+					this.dynamicHandlerMapping.registerHandler(pattern, httpHandler);
+				}
+			}
 		}
 		return bean;
 	}
@@ -132,6 +139,15 @@ class IntegrationServletWebSocketHandlerRegistry extends ServletWebSocketHandler
 
 	private static final class IntegrationDynamicWebSocketHandlerRegistration
 			extends ServletWebSocketHandlerRegistration {
+
+		private WebSocketHandler handler;
+
+		@Override
+		public WebSocketHandlerRegistration addHandler(WebSocketHandler handler, String... paths) {
+			// The IntegrationWebSocketContainer comes only with a single WebSocketHandler
+			this.handler = handler;
+			return super.addHandler(handler, paths);
+		}
 
 		MultiValueMap<HttpRequestHandler, String> getMapping() {
 			return getMappings();

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/IntegrationServletWebSocketHandlerRegistry.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/IntegrationServletWebSocketHandlerRegistry.java
@@ -26,7 +26,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.integration.websocket.ServerWebSocketContainer;
 import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.HttpRequestHandler;

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
@@ -35,6 +35,7 @@ import org.springframework.util.ClassUtils;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.socket.config.annotation.DelegatingWebSocketConfiguration;
 import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.util.pattern.PathPatternParser;
 
 /**
  * The WebSocket Integration infrastructure {@code beanFactory} initializer.
@@ -102,6 +103,7 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 								() -> {
 									IntegrationDynamicWebSocketHandlerMapping dynamicWebSocketHandlerMapping =
 											new IntegrationDynamicWebSocketHandlerMapping();
+									dynamicWebSocketHandlerMapping.setPatternParser(new PathPatternParser());
 									dynamicWebSocketHandlerMapping.setOrder(0);
 									return dynamicWebSocketHandlerMapping;
 								}),
@@ -143,9 +145,7 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 						.values()
 						.forEach(configurer -> configurer.registerWebSocketHandlers(this.registry));
 			}
-			if (this.registry.requiresTaskScheduler()) {
-				this.registry.setTaskScheduler(this.sockJsTaskScheduler);
-			}
+			this.registry.setTaskScheduler(this.sockJsTaskScheduler);
 			return this.registry.getHandlerMapping();
 		}
 

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/dsl/WebSocketDslTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/dsl/WebSocketDslTests.java
@@ -69,7 +69,8 @@ public class WebSocketDslTests {
 		IntegrationFlowContext serverIntegrationFlowContext = serverContext.getBean(IntegrationFlowContext.class);
 		ServerWebSocketContainer serverWebSocketContainer =
 				new ServerWebSocketContainer("/dynamic")
-						.setHandshakeHandler(serverContext.getBean(HandshakeHandler.class));
+						.setHandshakeHandler(serverContext.getBean(HandshakeHandler.class))
+						.withSockJs();
 
 		WebSocketInboundChannelAdapter webSocketInboundChannelAdapter =
 				new WebSocketInboundChannelAdapter(serverWebSocketContainer);
@@ -88,7 +89,7 @@ public class WebSocketDslTests {
 
 		// Dynamic client flow
 		ClientWebSocketContainer clientWebSocketContainer =
-				new ClientWebSocketContainer(this.webSocketClient, this.server.getWsBaseUrl() + "/dynamic");
+				new ClientWebSocketContainer(this.webSocketClient, this.server.getWsBaseUrl() + "/dynamic/websocket");
 		clientWebSocketContainer.setAutoStartup(true);
 		WebSocketOutboundMessageHandler webSocketOutboundMessageHandler =
 				new WebSocketOutboundMessageHandler(clientWebSocketContainer);


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/67971467/registration-of-dynamic-websocket-at-application-initialization-time-and-at-runt

The SockJS wrapper for dynamic endpoint is not initialized properly.
Technically we just don't map to the SockJS service if such one is requested from the `ServerWebSocketContainer` configuration

* Postpone the path mapping for the target endpoint until after the `ServerWebSocketContainer` applies all the options
into its registration to expose.
* Fix `ServerWebSocketContainer` to propagate a default `TaskScheduler` for underlying SockJS Service on the endpoint
* Fix `IntegrationDynamicWebSocketHandlerMapping` to deal with path patterns as well,  which is the case for the mentioned SockJS wrapper:
the SockJS Service is able to handle the rest of the path according its setting and request requirements

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
