### PR TITLE
GH-3424: Refactor to use logging methods from LogAccessor

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,9 +93,7 @@ public class CorrelatingMessageBarrier extends AbstractMessageHandler implements
 		synchronized (lock) {
 			this.store.addMessagesToGroup(correlationKey, message);
 		}
-		if (logger.isDebugEnabled()) {
-			logger.debug(String.format("Handled message for key [%s]: %s.", correlationKey, message));
-		}
+		logger.debug(() -> String.format("Handled message for key [%s]: %s.", correlationKey, message));
 	}
 
 	private Object getLock(Object correlationKey) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelatingMessageBarrier.java
@@ -20,6 +20,7 @@ import java.util.Iterator;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.store.MessageGroup;
@@ -47,6 +48,7 @@ import org.springframework.messaging.Message;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @see AbstractCorrelatingMessageHandler
  */
@@ -93,7 +95,7 @@ public class CorrelatingMessageBarrier extends AbstractMessageHandler implements
 		synchronized (lock) {
 			this.store.addMessagesToGroup(correlationKey, message);
 		}
-		logger.debug(() -> String.format("Handled message for key [%s]: %s.", correlationKey, message));
+		logger.debug(LogMessage.format("Handled message for key [%s]: %s.", correlationKey, message));
 	}
 
 	private Object getLock(Object correlationKey) {
@@ -117,9 +119,7 @@ public class CorrelatingMessageBarrier extends AbstractMessageHandler implements
 					if (messages.hasNext()) {
 						nextMessage = messages.next();
 						this.store.removeMessagesFromGroup(key, nextMessage);
-						if (logger.isDebugEnabled()) {
-							logger.debug(String.format("Released message for key [%s]: %s.", key, nextMessage));
-						}
+						logger.debug(LogMessage.format("Released message for key [%s]: %s.", key, nextMessage));
 					}
 					else {
 						remove(key);

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.IntegrationPatternType;
 import org.springframework.integration.support.management.metrics.CounterFacade;
 import org.springframework.integration.support.management.metrics.MetricsCaptor;
@@ -36,6 +37,7 @@ import org.springframework.messaging.support.ExecutorChannelInterceptor;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  */
 public abstract class AbstractPollableChannel extends AbstractMessageChannel
 		implements PollableChannel, ExecutorChannelInterceptorAware {
@@ -99,10 +101,7 @@ public abstract class AbstractPollableChannel extends AbstractMessageChannel
 			else {
 				incrementReceiveCounter();
 				counted = true;
-
-				if (logger.isDebugEnabled()) {
-					logger.debug("postReceive on channel '" + this + "', message: " + message);
-				}
+				logger.debug(LogMessage.format("postReceive on channel '%s', message: %s", this, message));
 			}
 
 			if (interceptorStack != null && message != null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2020 the original author or authors.
+ * Copyright 2013-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -166,9 +166,7 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 			String name = this.uuid + id.incrementAndGet();
 			this.channels.put(name, new MessageChannelWrapper((MessageChannel) channel,
 					System.currentTimeMillis() + timeToLive));
-			if (logger.isDebugEnabled()) {
-				logger.debug("Registered " + channel + " as " + name);
-			}
+			logger.debug(() -> "Registered " + channel + " as " + name);
 			return name;
 		}
 		else {
@@ -187,8 +185,8 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 			else {
 				messageChannelWrapper = this.channels.get(name);
 			}
-			if (logger.isDebugEnabled() && messageChannelWrapper != null) {
-				logger.debug("Retrieved " + messageChannelWrapper.getChannel() + " with " + name);
+			if (messageChannelWrapper != null) {
+				logger.debug(() -> "Retrieved " + messageChannelWrapper.getChannel() + " with " + name);
 			}
 
 			return messageChannelWrapper == null ? null : messageChannelWrapper.getChannel();
@@ -211,17 +209,13 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 
 	@Override
 	public synchronized void run() {
-		if (logger.isTraceEnabled()) {
-			logger.trace("Reaper started; channels size=" + this.channels.size());
-		}
+		logger.trace(() -> "Reaper started; channels size=" + this.channels.size());
 		Iterator<Entry<String, MessageChannelWrapper>> iterator = this.channels.entrySet().iterator();
 		long now = System.currentTimeMillis();
 		while (iterator.hasNext()) {
 			Entry<String, MessageChannelWrapper> entry = iterator.next();
 			if (entry.getValue().getExpireAt() < now) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("Expiring " + entry.getKey() + " (" + entry.getValue().getChannel() + ")");
-				}
+				logger.debug(() -> "Expiring " + entry.getKey() + " (" + entry.getValue().getChannel() + ")");
 				iterator.remove();
 			}
 		}
@@ -229,9 +223,7 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 				getTaskScheduler()
 						.schedule(this, new Date(System.currentTimeMillis() + this.reaperDelay));
 
-		if (logger.isTraceEnabled()) {
-			logger.trace("Reaper completed; channels size=" + this.channels.size());
-		}
+		logger.trace(() -> "Reaper completed; channels size=" + this.channels.size());
 	}
 
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 3.0
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
@@ -180,8 +180,8 @@ public class PublishSubscribeChannel extends AbstractExecutorChannel implements 
 			dispatcherToUse.setMinSubscribers(this.minSubscribers);
 			this.dispatcher = dispatcherToUse;
 		}
-		else if (this.errorHandler != null && this.logger.isWarnEnabled()) {
-			this.logger.warn("The 'errorHandler' is ignored for the '" + getComponentName() +
+		else if (this.errorHandler != null) {
+			this.logger.warn(() -> "The 'errorHandler' is ignored for the '" + getComponentName() +
 					"' (an 'executor' is not provided) and exceptions will be thrown " +
 					"directly within the sending Thread");
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
@@ -34,6 +34,7 @@ import org.springframework.util.ErrorHandler;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  */
 public class PublishSubscribeChannel extends AbstractExecutorChannel implements BroadcastCapableChannel {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  * @author Kris Jacyna
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  */
 @IntegrationManagedResource
 public abstract class AbstractEndpoint extends IntegrationObjectSupport

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -155,9 +155,7 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 				this.active = true;
 				doStart();
 				this.running = true;
-				if (logger.isInfoEnabled()) {
-					logger.info("started " + this);
-				}
+				logger.info(() -> "started " + this);
 			}
 		}
 		finally {
@@ -173,9 +171,7 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 				this.active = false;
 				doStop();
 				this.running = false;
-				if (logger.isInfoEnabled()) {
-					logger.info("stopped " + this);
-				}
+				logger.info(() -> "stopped " + this);
 			}
 		}
 		finally {
@@ -191,9 +187,7 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 				this.active = false;
 				doStop(callback);
 				this.running = false;
-				if (logger.isInfoEnabled()) {
-					logger.info("stopped " + this);
-				}
+				logger.info(() -> "stopped " + this);
 			}
 			else {
 				callback.run();

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveStreamsConsumer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveStreamsConsumer.java
@@ -49,6 +49,7 @@ import reactor.core.publisher.Flux;
  * input channel and reactive consumption of messages from that channel.
  *
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 5.0
  */
@@ -90,7 +91,7 @@ public class ReactiveStreamsConsumer extends AbstractEndpoint implements Integra
 		this.inputChannel = inputChannel;
 
 		if (inputChannel instanceof NullChannel) {
-			logger.warn(() -> "The consuming from the NullChannel does not have any effects: " +
+			logger.warn("The consuming from the NullChannel does not have any effects: " +
 					"it doesn't forward messages sent to it. A NullChannel is the end of the flow.");
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveStreamsConsumer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/ReactiveStreamsConsumer.java
@@ -89,8 +89,8 @@ public class ReactiveStreamsConsumer extends AbstractEndpoint implements Integra
 		Assert.notNull(subscriber, "'subscriber' must not be null");
 		this.inputChannel = inputChannel;
 
-		if (inputChannel instanceof NullChannel && logger.isWarnEnabled()) {
-			logger.warn("The consuming from the NullChannel does not have any effects: " +
+		if (inputChannel instanceof NullChannel) {
+			logger.warn(() -> "The consuming from the NullChannel does not have any effects: " +
 					"it doesn't forward messages sent to it. A NullChannel is the end of the flow.");
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -78,6 +78,7 @@ import reactor.core.publisher.Sinks;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  */
 @IntegrationManagedResource
 public abstract class MessagingGatewaySupport extends AbstractEndpoint

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -529,9 +529,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 			}
 		}
 		catch (Throwable ex) { // NOSONAR (catch throwable)
-			if (logger.isDebugEnabled()) {
-				logger.debug("failure occurred in gateway sendAndReceive: " + ex.getMessage());
-			}
+			logger.debug(() -> "failure occurred in gateway sendAndReceive: " + ex.getMessage());
 			reply = ex;
 			if (sample != null) {
 				sample.stop(buildSendTimer(false, ex.getClass().getSimpleName()));
@@ -708,9 +706,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 	}
 
 	private Mono<Message<?>> handleSendError(Message<?> requestMessage, Throwable exception) {
-		if (logger.isDebugEnabled()) {
-			logger.debug("failure occurred in gateway sendAndReceiveReactive: " + exception.getMessage());
-		}
+		logger.debug(() -> "failure occurred in gateway sendAndReceiveReactive: " + exception.getMessage());
 		MessageChannel channel = getErrorChannel();
 		if (channel != null) {
 			ErrorMessage errorMessage = buildErrorMessage(requestMessage, exception);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReactiveMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReactiveMessageHandler.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.handler;
 
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.history.MessageHistory;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.ReactiveMessageHandler;
@@ -28,6 +29,7 @@ import reactor.core.publisher.Mono;
  *
  * @author David Turanski
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 5.3
  */
@@ -38,7 +40,7 @@ public abstract class AbstractReactiveMessageHandler extends MessageHandlerSuppo
 	public Mono<Void> handleMessage(final Message<?> message) {
 		Assert.notNull(message, "message must not be null");
 		if (isLoggingEnabled()) {
-			this.logger.debug(() -> this + " received message: " + message);
+			this.logger.debug(LogMessage.format("%s received message: %s", this, message));
 		}
 
 		final Message<?> messageToUse;
@@ -49,8 +51,8 @@ public abstract class AbstractReactiveMessageHandler extends MessageHandlerSuppo
 			messageToUse = message;
 		}
 		return handleMessageInternal(messageToUse)
-				.doOnError((ex) -> this.logger.error(ex, () ->
-						"An error occurred in message handler [" + this + "] on message [" + messageToUse + "]"));
+				.doOnError((ex) -> this.logger.error(ex,
+						LogMessage.format("An error occurred in message handler [%s] on message [%s]", this, messageToUse)));
 	}
 
 	protected abstract Mono<Void> handleMessageInternal(Message<?> message);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReactiveMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReactiveMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ public abstract class AbstractReactiveMessageHandler extends MessageHandlerSuppo
 	@Override
 	public Mono<Void> handleMessage(final Message<?> message) {
 		Assert.notNull(message, "message must not be null");
-		if (isLoggingEnabled() && this.logger.isDebugEnabled()) {
-			this.logger.debug(this + " received message: " + message);
+		if (isLoggingEnabled()) {
+			this.logger.debug(() -> this + " received message: " + message);
 		}
 
 		final Message<?> messageToUse;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -23,6 +23,7 @@ import org.aopalliance.aop.Advice;
 
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.factory.BeanClassLoaderAware;
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.IntegrationPatternType;
 import org.springframework.integration.handler.advice.HandleMessageAdvice;
 import org.springframework.lang.Nullable;
@@ -39,6 +40,7 @@ import org.springframework.util.ClassUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author David Liu
+ * @author Trung Pham
  */
 public abstract class AbstractReplyProducingMessageHandler extends AbstractMessageProducingHandler
 		implements BeanClassLoaderAware {
@@ -144,7 +146,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 					getComponentName() + "', and its 'requiresReply' property is set to true.");
 		}
 		else if (!isAsync()) {
-			logger.debug(() -> "handler '" + this + "' produced no reply for request Message: " + message);
+			logger.debug(LogMessage.format("handler '%s' produced no reply for request Message: %s", this, message));
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,8 +143,8 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 			throw new ReplyRequiredException(message, "No reply produced by handler '" +
 					getComponentName() + "', and its 'requiresReply' property is set to true.");
 		}
-		else if (!isAsync() && logger.isDebugEnabled()) {
-			logger.debug("handler '" + this + "' produced no reply for request Message: " + message);
+		else if (!isAsync()) {
+			logger.debug(() -> "handler '" + this + "' produced no reply for request Message: " + message);
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerChain.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerChain.java
@@ -65,6 +65,7 @@ import org.springframework.util.Assert;
  * @author Iwein Fuld
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  */
 public class MessageHandlerChain extends AbstractMessageProducingHandler
 		implements CompositeMessageHandler, ManageableLifecycle {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerChain.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerChain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,9 +182,7 @@ public class MessageHandlerChain extends AbstractMessageProducingHandler
 			if (!this.running) {
 				doStart();
 				this.running = true;
-				if (logger.isInfoEnabled()) {
-					logger.info("started " + this);
-				}
+				logger.info(() -> "started " + this);
 			}
 		}
 		finally {
@@ -199,9 +197,7 @@ public class MessageHandlerChain extends AbstractMessageProducingHandler
 			if (this.running) {
 				doStop();
 				this.running = false;
-				if (logger.isInfoEnabled()) {
-					logger.info("stopped " + this);
-				}
+				logger.info(() -> "stopped " + this);
 			}
 		}
 		finally {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,8 +73,8 @@ public class RequestHandlerCircuitBreakerAdvice extends AbstractRequestHandlerAd
 		}
 		try {
 			Object result = callback.execute();
-			if (logger.isDebugEnabled() && metadata.getFailures().get() > 0) {
-				logger.debug("Closing Circuit Breaker for " + target);
+			if (metadata.getFailures().get() > 0) {
+				logger.debug(() -> "Closing Circuit Breaker for " + target);
 			}
 			metadata.getFailures().set(0);
 			return result;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
@@ -30,6 +30,7 @@ import org.springframework.messaging.MessagingException;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 2.2
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -118,6 +118,7 @@ import org.springframework.util.StringUtils;
  * @author Soby Chacko
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 2.0
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -830,8 +830,8 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 					|| Lifecycle.class.isAssignableFrom(declaringClass))
 				&& ReflectionUtils.findMethod(Pausable.class, pausableMethod.getName(),
 						pausableMethod.getParameterTypes()) != null;
-		if (pausable && this.logger.isTraceEnabled()) {
-			this.logger.trace(pausableMethod + " is not considered a candidate method unless explicitly requested");
+		if (pausable) {
+			this.logger.trace(() -> pausableMethod + " is not considered a candidate method unless explicitly requested");
 		}
 		return pausable;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -230,9 +230,7 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	private void doSetChannelMappings(Map<String, String> newChannelMappings) {
 		Map<String, String> oldChannelMappings = this.channelMappings;
 		this.channelMappings = newChannelMappings;
-		if (logger.isDebugEnabled()) {
-			logger.debug("Channel mappings: " + oldChannelMappings + " replaced with: " + newChannelMappings);
-		}
+		logger.debug(() -> "Channel mappings: " + oldChannelMappings + " replaced with: " + newChannelMappings);
 	}
 
 	private MessageChannel resolveChannelForName(String channelName, Message<?> message) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.springframework.core.convert.ConversionService;
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.support.management.MappingMessageRouterManagement;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
@@ -47,6 +48,7 @@ import org.springframework.util.StringUtils;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 2.1
  */
@@ -230,7 +232,7 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	private void doSetChannelMappings(Map<String, String> newChannelMappings) {
 		Map<String, String> oldChannelMappings = this.channelMappings;
 		this.channelMappings = newChannelMappings;
-		logger.debug(() -> "Channel mappings: " + oldChannelMappings + " replaced with: " + newChannelMappings);
+		logger.debug(LogMessage.format("Channel mappings: %s replaced with: %s", oldChannelMappings, newChannelMappings));
 	}
 
 	private MessageChannel resolveChannelForName(String channelName, Message<?> message) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ClaimCheckOutTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ClaimCheckOutTransformer.java
@@ -18,6 +18,7 @@ package org.springframework.integration.transformer;
 
 import java.util.UUID;
 
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.IntegrationPattern;
 import org.springframework.integration.IntegrationPatternType;
 import org.springframework.integration.store.MessageStore;
@@ -34,6 +35,7 @@ import org.springframework.util.Assert;
  * @author Oleg Zhurakousky
  * @author Nick Spacek
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 2.0
  */
@@ -76,7 +78,7 @@ public class ClaimCheckOutTransformer extends AbstractTransformer implements Int
 		Message<?> retrievedMessage;
 		if (this.removeMessage) {
 			retrievedMessage = this.messageStore.removeMessage(id);
-			logger.debug(() -> "Removed Message with claim-check '" + id + "' from the MessageStore.");
+			logger.debug(LogMessage.format("Removed Message with claim-check '%s' from the MessageStore.", id));
 		}
 		else {
 			retrievedMessage = this.messageStore.getMessage(id);

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/ClaimCheckOutTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/ClaimCheckOutTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,9 +76,7 @@ public class ClaimCheckOutTransformer extends AbstractTransformer implements Int
 		Message<?> retrievedMessage;
 		if (this.removeMessage) {
 			retrievedMessage = this.messageStore.removeMessage(id);
-			if (logger.isDebugEnabled()) {
-				logger.debug("Removed Message with claim-check '" + id + "' from the MessageStore.");
-			}
+			logger.debug(() -> "Removed Message with claim-check '" + id + "' from the MessageStore.");
 		}
 		else {
 			retrievedMessage = this.messageStore.getMessage(id);

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -113,8 +113,8 @@ public class HeaderEnricher extends IntegrationObjectSupport implements Transfor
 			((BeanFactoryAware) this.messageProcessor).setBeanFactory(beanFactory);
 		}
 
-		if (!shouldOverwrite && !this.shouldSkipNulls && logger.isWarnEnabled()) {
-			logger.warn(getComponentName() +
+		if (!shouldOverwrite && !this.shouldSkipNulls) {
+			logger.warn(() -> getComponentName() +
 					" is configured to not overwrite existing headers. 'shouldSkipNulls = false' will have no effect");
 		}
 	}
@@ -192,13 +192,13 @@ public class HeaderEnricher extends IntegrationObjectSupport implements Transfor
 							messageBuilder.setHeader((String) key, entry.getValue());
 						}
 					}
-					else if (logger.isDebugEnabled()) {
-						logger.debug("ignoring value for non-String key: " + key);
+					else {
+						logger.debug(() -> "ignoring value for non-String key: " + key);
 					}
 				}
 			}
-			else if (logger.isDebugEnabled()) {
-				logger.debug("expected a Map result from processor, but received: " + result);
+			else {
+				logger.debug(() -> "expected a Map result from processor, but received: " + result);
 			}
 		}
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/HeaderEnricher.java
@@ -43,6 +43,7 @@ import org.springframework.messaging.MessageHeaders;
  * @author David Turanski
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Trung Pham
  */
 public class HeaderEnricher extends IntegrationObjectSupport implements Transformer, IntegrationPattern {
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -107,6 +107,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Tony Falabella
  * @author Alen Turkovic
+ * @author Trung Pham
  */
 public class FileWritingMessageHandler extends AbstractReplyProducingMessageHandler
 		implements ManageableLifecycle, MessageTriggerAction {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -588,8 +588,8 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 							+ "' timestamp on file: " + fileToReturn);
 				}
 			}
-			else if (this.logger.isWarnEnabled()) {
-				this.logger.warn("Could not set lastModified, header " + FileHeaders.SET_MODIFIED
+			else {
+				this.logger.warn(() -> "Could not set lastModified, header " + FileHeaders.SET_MODIFIED
 						+ " must be a Number, not " + (timestamp == null ? "null" : timestamp.getClass()));
 			}
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -29,6 +29,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.springframework.core.log.LogMessage;
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
@@ -51,6 +52,7 @@ import org.springframework.util.ObjectUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Lukas Gemela
+ * @author Trung Pham
  *
  * @since 4.3
  *
@@ -246,8 +248,8 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 
 	private void resetFilterIfNecessary(AbstractFileInfo<F> file) {
 		if (this.filter instanceof ResettableFileListFilter) {
-			this.logger.info(() -> "Removing the remote file '" + file +
-					"' from the filter for a subsequent transfer attempt");
+			this.logger.info(LogMessage.format("Removing the remote file '%s' from"
+					+ "the filterfor a subsequent transfer attempt", file));
 			((ResettableFileListFilter<F>) this.filter).remove(file.getFileInfo());
 		}
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,10 +246,8 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 
 	private void resetFilterIfNecessary(AbstractFileInfo<F> file) {
 		if (this.filter instanceof ResettableFileListFilter) {
-			if (this.logger.isInfoEnabled()) {
-				this.logger.info("Removing the remote file '" + file +
-						"' from the filter for a subsequent transfer attempt");
-			}
+			this.logger.info(() -> "Removing the remote file '" + file +
+					"' from the filter for a subsequent transfer attempt");
 			((ResettableFileListFilter<F>) this.filter).remove(file.getFileInfo());
 		}
 	}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/BaseHttpInboundEndpoint.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/BaseHttpInboundEndpoint.java
@@ -284,11 +284,11 @@ public class BaseHttpInboundEndpoint extends MessagingGatewaySupport implements 
 	}
 
 	private void validateSupportedMethods() {
-		if (this.requestPayloadType != null && logger.isWarnEnabled() &&
+		if (this.requestPayloadType != null &&
 				CollectionUtils.containsAny(NON_READABLE_BODY_HTTP_METHODS,
 						Arrays.asList(getRequestMapping().getMethods()))) {
 
-			logger.warn("The 'requestPayloadType' attribute will have no relevance for one " +
+			logger.warn(() -> "The 'requestPayloadType' attribute will have no relevance for one " +
 					"of the specified HTTP methods '" + NON_READABLE_BODY_HTTP_METHODS + "'");
 		}
 	}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/BaseHttpInboundEndpoint.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/BaseHttpInboundEndpoint.java
@@ -51,6 +51,7 @@ import org.springframework.validation.Validator;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Trung Pham
  *
  * @since 5.0
  */

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,17 +226,13 @@ public abstract class HttpRequestHandlingEndpointSupport extends BaseHttpInbound
 			try {
 				MultipartResolver resolver = beanFactory.getBean(
 						DispatcherServlet.MULTIPART_RESOLVER_BEAN_NAME, MultipartResolver.class);
-				if (logger.isDebugEnabled()) {
-					logger.debug("Using MultipartResolver [" + resolver + "]");
-				}
+				logger.debug(() -> "Using MultipartResolver [" + resolver + "]");
 				this.multipartResolver = resolver;
 			}
 			catch (NoSuchBeanDefinitionException e) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("Unable to locate MultipartResolver with name '"
-							+ DispatcherServlet.MULTIPART_RESOLVER_BEAN_NAME
-							+ "': no multipart request handling will be supported.");
-				}
+				logger.debug(() -> "Unable to locate MultipartResolver with name '"
+						+ DispatcherServlet.MULTIPART_RESOLVER_BEAN_NAME
+						+ "': no multipart request handling will be supported.");
 			}
 		}
 		if (this.messageConverters.size() == 0 || (this.mergeWithDefaultConverters && !this.convertersMerged)) {
@@ -397,27 +393,21 @@ public abstract class HttpRequestHandlingEndpointSupport extends BaseHttpInbound
 				(Map<?, ?>) servletRequest.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
 
 		if (!CollectionUtils.isEmpty(pathVariables)) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("Mapped path variables: " + pathVariables);
-			}
+			logger.debug(() -> "Mapped path variables: " + pathVariables);
 			evaluationContext.setVariable("pathVariables", pathVariables);
 		}
 
 		Map<?, ?> matrixVariables = (Map<?, ?>) servletRequest.getAttribute(HandlerMapping.MATRIX_VARIABLES_ATTRIBUTE);
 
 		if (!CollectionUtils.isEmpty(matrixVariables)) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("Mapped matrix variables: " + matrixVariables);
-			}
+			logger.debug(() -> "Mapped matrix variables: " + matrixVariables);
 			evaluationContext.setVariable("matrixVariables", matrixVariables);
 		}
 		return evaluationContext;
 	}
 
 	private Message<?> createServiceUnavailableResponse() {
-		if (logger.isDebugEnabled()) {
-			logger.debug("Endpoint is stopped; returning status " + HttpStatus.SERVICE_UNAVAILABLE);
-		}
+		logger.debug(() -> "Endpoint is stopped; returning status " + HttpStatus.SERVICE_UNAVAILABLE);
 		return getMessageBuilderFactory()
 				.withPayload("Endpoint is stopped")
 				.setHeader(HttpHeaders.STATUS_CODE, HttpStatus.SERVICE_UNAVAILABLE)

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -107,6 +107,7 @@ import org.springframework.web.servlet.HandlerMapping;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Biju Kunjummen
+ * @author Trung Pham
  *
  * @since 2.0
  */

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
@@ -34,6 +34,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 2.0
  *

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractClientConnectionFactory.java
@@ -177,9 +177,7 @@ public abstract class AbstractClientConnectionFactory extends AbstractConnection
 
 	private TcpConnectionSupport doObtain(boolean singleUse) {
 		TcpConnectionSupport connection;
-		if (logger.isDebugEnabled()) {
-			logger.debug("Opening new socket connection to " + getHost() + ":" + getPort());
-		}
+		logger.debug(() -> "Opening new socket connection to " + getHost() + ":" + getPort());
 
 		connection = buildNewConnection();
 		if (this.connectionTest != null && !this.connectionTest.test(connection)) {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageHandler.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageHandler.java
@@ -76,6 +76,7 @@ import org.springframework.util.LinkedCaseInsensitiveMap;
  *
  * @author Dave Syer
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 2.0
  */

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageHandler.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/JdbcMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -172,8 +172,8 @@ public class JdbcMessageHandler extends AbstractMessageHandler {
 	@Override
 	protected void handleMessageInternal(Message<?> message) {
 		List<? extends Map<String, Object>> keys = executeUpdateQuery(message, this.keysGenerated);
-		if (!keys.isEmpty() && logger.isDebugEnabled()) {
-			logger.debug("Generated keys: " + keys);
+		if (!keys.isEmpty()) {
+			logger.debug(() -> "Generated keys: " + keys);
 		}
 	}
 

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -32,6 +32,7 @@ import javax.sql.DataSource;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.core.log.LogAccessor;
+import org.springframework.core.log.LogMessage;
 import org.springframework.core.serializer.Deserializer;
 import org.springframework.core.serializer.Serializer;
 import org.springframework.core.serializer.support.SerializingConverter;
@@ -80,6 +81,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Meherzad Lahewala
+ * @author Trung Pham
  *
  * @since 2.2
  */
@@ -385,7 +387,7 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 		}
 
 		if (this.jdbcTemplate.getFetchSize() != 1) {
-			LOGGER.warn(() -> "The jdbcTemplate's fetch size is not 1. This may cause FIFO issues with Oracle databases.");
+			LOGGER.warn("The jdbcTemplate's fetch size is not 1. This may cause FIFO issues with Oracle databases.");
 		}
 
 		if (this.preparedStatementSetter == null) {
@@ -559,7 +561,7 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 				this.idCacheWriteLock.lock();
 				try {
 					boolean added = this.idCache.add(messageId);
-					LOGGER.debug(() -> String.format("Polled message with id '%s' added: '%s'.", messageId, added));
+					LOGGER.debug(() -> LogMessage.format("Polled message with id '%s' added: '%s'.", messageId, added));
 				}
 				finally {
 					this.idCacheWriteLock.unlock();
@@ -580,10 +582,10 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 
 		boolean result = updated != 0;
 		if (result) {
-			LOGGER.debug(() -> String.format("Message with id '%s' was deleted.", id));
+			LOGGER.debug(LogMessage.format("Message with id '%s' was deleted.", id));
 		}
 		else {
-			LOGGER.warn(() -> String.format("Message with id '%s' was not deleted.", id));
+			LOGGER.warn(LogMessage.format("Message with id '%s' was not deleted.", id));
 		}
 		return result;
 	}
@@ -598,7 +600,7 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 	 * @param messageId The message identifier.
 	 */
 	public void removeFromIdCache(String messageId) {
-		LOGGER.debug(() -> "Removing Message Id: " + messageId);
+		LOGGER.debug(LogMessage.format("Removing Message Id: %s", messageId));
 		this.idCacheWriteLock.lock();
 		try {
 			this.idCache.remove(messageId);

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -561,7 +561,7 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 				this.idCacheWriteLock.lock();
 				try {
 					boolean added = this.idCache.add(messageId);
-					LOGGER.debug(() -> LogMessage.format("Polled message with id '%s' added: '%s'.", messageId, added));
+					LOGGER.debug(LogMessage.format("Polled message with id '%s' added: '%s'.", messageId, added));
 				}
 				finally {
 					this.idCacheWriteLock.unlock();
@@ -600,7 +600,7 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 	 * @param messageId The message identifier.
 	 */
 	public void removeFromIdCache(String messageId) {
-		LOGGER.debug(LogMessage.format("Removing Message Id: %s", messageId));
+		LOGGER.debug(() -> "Removing Message Id: " + messageId);
 		this.idCacheWriteLock.lock();
 		try {
 			this.idCache.remove(messageId);

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -384,8 +384,8 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 			this.messageRowMapper = new MessageRowMapper(this.deserializer, this.lobHandler);
 		}
 
-		if (this.jdbcTemplate.getFetchSize() != 1 && LOGGER.isWarnEnabled()) {
-			LOGGER.warn("The jdbcTemplate's fetch size is not 1. This may cause FIFO issues with Oracle databases.");
+		if (this.jdbcTemplate.getFetchSize() != 1) {
+			LOGGER.warn(() -> "The jdbcTemplate's fetch size is not 1. This may cause FIFO issues with Oracle databases.");
 		}
 
 		if (this.preparedStatementSetter == null) {

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotificationPublishingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotificationPublishingMessageHandler.java
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 2.0
  */

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotificationPublishingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/NotificationPublishingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -124,9 +124,7 @@ public class NotificationPublishingMessageHandler extends AbstractMessageHandler
 		}
 		if (exporter != null) {
 			exporter.registerManagedResource(this.delegate, this.objectName);
-			if (this.logger.isInfoEnabled()) {
-				this.logger.info("Registered JMX notification publisher as MBean with ObjectName: " + this.objectName);
-			}
+			this.logger.info(() -> "Registered JMX notification publisher as MBean with ObjectName: " + this.objectName);
 		}
 	}
 

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/OperationInvokingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ import org.springframework.util.ObjectUtils;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 2.0
  */

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceivingMessageSource.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/MailReceivingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
@@ -34,6 +35,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Trung Pham
  */
 public class MailReceivingMessageSource extends AbstractMessageSource<Object> {
 
@@ -64,9 +66,7 @@ public class MailReceivingMessageSource extends AbstractMessageSource<Object> {
 				mailMessage = this.mailQueue.poll();
 			}
 			if (mailMessage != null) {
-				if (this.logger.isDebugEnabled()) {
-					this.logger.debug("received mail message [" + mailMessage + "]");
-				}
+				this.logger.debug(LogMessage.format("received mail message [%s]", mailMessage));
 				return mailMessage;
 			}
 		}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.mqtt.support.DefaultPahoMessageConverter;
 import org.springframework.integration.mqtt.support.MqttMessageConverter;
@@ -37,6 +38,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 4.0
  *
@@ -161,7 +163,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter extends MessagePro
 				throw new MessagingException("Topic '" + topic + "' is already subscribed.");
 			}
 			this.topics.add(topik);
-			logger.debug(() -> "Added '" + topic + "' to subscriptions.");
+			logger.debug(LogMessage.format("Added '%s' to subscriptions.", topic));
 		}
 		finally {
 			this.topicLock.unlock();
@@ -228,7 +230,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter extends MessagePro
 		try {
 			for (String t : topic) {
 				if (this.topics.remove(new Topic(t, 0))) {
-					logger.debug(() -> "Removed '" + t + "' from subscriptions.");
+					logger.debug(LogMessage.format("Removed '%s' from subscriptions.", t));
 				}
 			}
 		}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,9 +161,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter extends MessagePro
 				throw new MessagingException("Topic '" + topic + "' is already subscribed.");
 			}
 			this.topics.add(topik);
-			if (this.logger.isDebugEnabled()) {
-				logger.debug("Added '" + topic + "' to subscriptions.");
-			}
+			logger.debug(() -> "Added '" + topic + "' to subscriptions.");
 		}
 		finally {
 			this.topicLock.unlock();
@@ -229,8 +227,8 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter extends MessagePro
 		this.topicLock.lock();
 		try {
 			for (String t : topic) {
-				if (this.topics.remove(new Topic(t, 0)) && this.logger.isDebugEnabled()) {
-					logger.debug("Removed '" + t + "' from subscriptions.");
+				if (this.topics.remove(new Topic(t, 0))) {
+					logger.debug(() -> "Removed '" + t + "' from subscriptions.");
 				}
 			}
 		}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandler.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 
+import org.springframework.core.log.LogMessage;
 import org.springframework.data.redis.connection.RedisConnection;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.BoundSetOperations;
@@ -68,6 +69,7 @@ import org.springframework.util.NumberUtils;
  * @author Gary Russell
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Trung Pham
  *
  * @since 2.2
  */
@@ -464,8 +466,8 @@ public class RedisStoreWritingMessageHandler extends AbstractMessageHandler {
 	private boolean verifyAllMapValuesOfTypeNumber(Map<?, ?> map) {
 		for (Object value : map.values()) {
 			if (!(value instanceof Number)) {
-				this.logger.warn(() -> "failed to extract payload elements because '" +
-						value + "' is not of type Number");
+				this.logger.warn(LogMessage.format("failed to extract payload elements"
+						+ "because '%s' is not of type Number", value));
 				return false;
 			}
 		}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandler.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/RedisStoreWritingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2007-2019 the original author or authors.
+ * Copyright 2007-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -464,10 +464,8 @@ public class RedisStoreWritingMessageHandler extends AbstractMessageHandler {
 	private boolean verifyAllMapValuesOfTypeNumber(Map<?, ?> map) {
 		for (Object value : map.values()) {
 			if (!(value instanceof Number)) {
-				if (this.logger.isWarnEnabled()) {
-					this.logger.warn("failed to extract payload elements because '" +
-							value + "' is not of type Number");
-				}
+				this.logger.warn(() -> "failed to extract payload elements because '" +
+						value + "' is not of type Number");
 				return false;
 			}
 		}

--- a/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/inbound/StompInboundChannelAdapter.java
+++ b/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/inbound/StompInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,9 +137,7 @@ public class StompInboundChannelAdapter extends MessageProducerSupport implement
 			Arrays.stream(destination)
 					.filter(this.destinations::add)
 					.forEach(d -> {
-						if (this.logger.isDebugEnabled()) {
-							logger.debug("Subscribe to destination '" + d + "'.");
-						}
+						logger.debug(() -> "Subscribe to destination '" + d + "'.");
 						subscribeDestination(d);
 					});
 		}
@@ -160,17 +158,13 @@ public class StompInboundChannelAdapter extends MessageProducerSupport implement
 			Arrays.stream(destination)
 					.filter(this.destinations::remove)
 					.forEach(d -> {
-						if (this.logger.isDebugEnabled()) {
-							logger.debug("Removed '" + d + "' from subscriptions.");
-						}
+						logger.debug(() -> "Removed '" + d + "' from subscriptions.");
 						StompSession.Subscription subscription = this.subscriptions.get(d);
 						if (subscription != null) {
 							subscription.unsubscribe();
 						}
 						else {
-							if (this.logger.isDebugEnabled()) {
-								logger.debug("No subscription for destination '" + d + "'.");
-							}
+							logger.debug(() -> "No subscription for destination '" + d + "'.");
 						}
 					});
 		}
@@ -264,8 +258,8 @@ public class StompInboundChannelAdapter extends MessageProducerSupport implement
 			}
 			this.subscriptions.put(destination, subscription);
 		}
-		else if (logger.isWarnEnabled()) {
-			logger.warn("The StompInboundChannelAdapter [" + getComponentName() +
+		else {
+			logger.warn(() -> "The StompInboundChannelAdapter [" + getComponentName() +
 					"] ins't connected to StompSession. Check the state of [" + this.stompSessionManager + "]");
 		}
 	}

--- a/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/inbound/StompInboundChannelAdapter.java
+++ b/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/inbound/StompInboundChannelAdapter.java
@@ -28,6 +28,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.Lifecycle;
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.stomp.StompSessionManager;
@@ -63,6 +64,7 @@ import org.springframework.util.Assert;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Trung Pham
  *
  * @since 4.2
  */
@@ -137,7 +139,7 @@ public class StompInboundChannelAdapter extends MessageProducerSupport implement
 			Arrays.stream(destination)
 					.filter(this.destinations::add)
 					.forEach(d -> {
-						logger.debug(() -> "Subscribe to destination '" + d + "'.");
+						logger.debug(LogMessage.format("Subscribe to destination '%s'.", d));
 						subscribeDestination(d);
 					});
 		}
@@ -158,13 +160,13 @@ public class StompInboundChannelAdapter extends MessageProducerSupport implement
 			Arrays.stream(destination)
 					.filter(this.destinations::remove)
 					.forEach(d -> {
-						logger.debug(() -> "Removed '" + d + "' from subscriptions.");
+						logger.debug(LogMessage.format("Removed '%s' from subscriptions.", d));
 						StompSession.Subscription subscription = this.subscriptions.get(d);
 						if (subscription != null) {
 							subscription.unsubscribe();
 						}
 						else {
-							logger.debug(() -> "No subscription for destination '" + d + "'.");
+							logger.debug(LogMessage.format("No subscription for destination '%s'.", d));
 						}
 					});
 		}
@@ -251,7 +253,7 @@ public class StompInboundChannelAdapter extends MessageProducerSupport implement
 						eventPublisher.publishEvent(event);
 					}
 					else {
-						logger.error("The receipt [" + subscription.getReceiptId() + "] is lost for [" +
+						logger.error(() -> "The receipt [" + subscription.getReceiptId() + "] is lost for [" +
 								subscription.getSubscriptionId() + "] on destination [" + destination + "]");
 					}
 				});

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XsltPayloadTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XsltPayloadTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -270,10 +270,8 @@ public class XsltPayloadTransformer extends AbstractXmlTransformer implements Be
 			transformerFactory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "file,jar:file");
 		}
 		catch (@SuppressWarnings("unused") IllegalArgumentException ex) {
-			if (logger.isInfoEnabled()) {
-				logger.info("The '" + XMLConstants.ACCESS_EXTERNAL_STYLESHEET + "' property is not supported by "
-						+ transformerFactory.getClass().getCanonicalName());
-			}
+			logger.info(() -> "The '" + XMLConstants.ACCESS_EXTERNAL_STYLESHEET + "' property is not supported by "
+					+ transformerFactory.getClass().getCanonicalName());
 		}
 		return transformerFactory;
 	}
@@ -395,12 +393,10 @@ public class XsltPayloadTransformer extends AbstractXmlTransformer implements Be
 					transformer.setParameter(parameterName, value);
 				}
 				catch (Exception e) {
-					if (logger.isWarnEnabled()) {
-						logger.warn("Evaluation of header expression '"
-								+ expression.getExpressionString()
-								+ "' failed. The XSLT parameter '"
-								+ parameterName + "' will be skipped.");
-					}
+					logger.warn(() -> "Evaluation of header expression '"
+							+ expression.getExpressionString()
+							+ "' failed. The XSLT parameter '"
+							+ parameterName + "' will be skipped.");
 				}
 			}
 		}

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XsltPayloadTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/XsltPayloadTransformer.java
@@ -84,6 +84,7 @@ import org.springframework.xml.transform.TransformerFactoryUtils;
  * @author Artem Bilan
  * @author Mike Bazos
  * @author Gary Russell
+ * @author Trung Pham
  */
 public class XsltPayloadTransformer extends AbstractXmlTransformer implements BeanClassLoaderAware {
 

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpoint.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,31 +87,23 @@ public class PresenceListeningEndpoint extends AbstractXmppConnectionAwareEndpoi
 
 		@Override
 		public void entriesAdded(Collection<Jid> entries) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("entries added: " + StringUtils.collectionToCommaDelimitedString(entries));
-			}
+			logger.debug(() -> "entries added: " + StringUtils.collectionToCommaDelimitedString(entries));
 		}
 
 		@Override
 		public void entriesUpdated(Collection<Jid> entries) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("entries updated: " + StringUtils.collectionToCommaDelimitedString(entries));
-			}
+			logger.debug(() -> "entries updated: " + StringUtils.collectionToCommaDelimitedString(entries));
 		}
 
 		@Override
 		public void entriesDeleted(Collection<Jid> entries) {
-			if (logger.isDebugEnabled()) {
-				logger.debug("entries deleted: " + StringUtils.collectionToCommaDelimitedString(entries));
-			}
+			logger.debug(() -> "entries deleted: " + StringUtils.collectionToCommaDelimitedString(entries));
 		}
 
 		@Override
 		public void presenceChanged(Presence presence) {
 			if (presence != null) {
-				if (logger.isDebugEnabled()) {
-					logger.debug("presence changed: " + presence.getFrom() + " - " + presence);
-				}
+				logger.debug(() -> "presence changed: " + presence.getFrom() + " - " + presence);
 				sendMessage(PresenceListeningEndpoint.this.getMessageBuilderFactory().withPayload(presence).build());
 			}
 		}

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpoint.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpoint.java
@@ -38,6 +38,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Trung Pham
  *
  * @since 2.0
  */


### PR DESCRIPTION
Fixes spring-projects/spring-integration#3424

- Logging statements that test cases depend on are kept unchanged (or should I have revised the test cases too?)
- Some include non-final variables so we cannot use LogAcessor.debug(Supplier<? extends CharSequence>). It might be a good idea to have methods similar to LogMessage.format().
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
