### PR TITLE
Fix pattern how `Lock.unlock()` is used

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -537,18 +537,18 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		boolean noOutput = true;
 		try {
 			lock.lockInterruptibly();
+			try {
+				noOutput = processMessageForGroup(message, correlationKey, groupIdUuid, lock);
+			}
+			finally {
+				if (noOutput || !this.releaseLockBeforeSend) {
+					lock.unlock();
+				}
+			}
 		}
 		catch (InterruptedException e) {
 			Thread.currentThread().interrupt();
 			throw new MessageHandlingException(message, "Interrupted getting lock in the [" + this + ']', e);
-		}
-		try {
-			noOutput = processMessageForGroup(message, correlationKey, groupIdUuid, lock);
-		}
-		finally {
-			if (noOutput || !this.releaseLockBeforeSend) {
-				lock.unlock();
-			}
 		}
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -600,7 +600,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 	/**
 	 * Retrieves the File instance from the {@link FileHeaders#ORIGINAL_FILE}
 	 * header if available. If the value is not a File instance or a String
-	 * representation of a file path, this will return <code>null</code>.
+	 * representation of a file path, this will return {@code null}.
 	 */
 	private File retrieveOriginalFileFromHeader(Message<?> message) {
 		Object value = message.getHeaders().get(FileHeaders.ORIGINAL_FILE);
@@ -1076,14 +1076,14 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 				catch (IOException e) {
 					// ignore
 				}
+				finally {
+					this.lock.unlock();
+				}
 				return true;
 			}
 			catch (InterruptedException e1) {
 				Thread.currentThread().interrupt();
 				return false;
-			}
-			finally {
-				this.lock.unlock();
 			}
 		}
 
@@ -1175,6 +1175,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 		@Override
 		public boolean shouldFlush(String fileAbsolutePath, long firstWrite, long lastWrite,
 				Message<?> triggerMessage) {
+
 			Pattern pattern;
 			if (triggerMessage.getPayload() instanceof String) {
 				pattern = Pattern.compile((String) triggerMessage.getPayload());


### PR DESCRIPTION
Related to https://build.spring.io/browse/INT-MAIN-84/

The `lock.unlock()` must be called in the `finally` block of the
nested `try..catch`, not in the outer which may just fail on `lock.lockInterruptibly()`
in which case there is just not going to be anything we can `unlock()` in the end

**Cherry-pick to `5.4.x` & `5.3.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
