### PR TITLE
Safely read message subject for debug message

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -551,11 +551,14 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 						this.selectorExpression.getValue(this.evaluationContext, message, Boolean.class))) {
 					filteredMessages.add(message);
 				}
-				else {
-					String subject = message.getSubject();
-					this.logger.debug(() ->
-							"Fetched email with subject '" + subject
-									+ "' will be discarded by the matching filter and will not be flagged as SEEN.");
+				else if (this.logger.isDebugEnabled()) {
+					try {
+						String subject = message.getSubject();
+						this.logger.debug("Fetched email with subject '" + subject
+										  + "' will be discarded by the matching filter and will not be flagged as SEEN.");
+					} catch (Exception e) {
+						this.logger.debug("Fetched email will be discarded by the matching filter and will not be flagged as SEEN.");
+					}
 				}
 			}
 			else {

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -557,8 +557,8 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 					}
 					else {
 						String subject = message.getSubject();
-						this.logger.debug("Fetched email with subject '" + subject
-										  + "' will be discarded by the matching filter and will not be flagged as SEEN.");
+						this.logger.debug("Fetched email with subject '" + subject +
+								"' will be discarded by the matching filter and will not be flagged as SEEN.");
 					}
 				}
 			}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -552,12 +552,13 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 					filteredMessages.add(message);
 				}
 				else if (this.logger.isDebugEnabled()) {
-					try {
+					if (message.isExpunged()) {
+						this.logger.debug("Expunged message received and will not be further processed.");
+					}
+					else {
 						String subject = message.getSubject();
 						this.logger.debug("Fetched email with subject '" + subject
 										  + "' will be discarded by the matching filter and will not be flagged as SEEN.");
-					} catch (Exception e) {
-						this.logger.debug("Fetched email will be discarded by the matching filter and will not be flagged as SEEN.");
 					}
 				}
 			}


### PR DESCRIPTION
If Spring Boot Integration Mail is connected to a Domino mail server via IMAP, it can happen from time to time that a message is expunged. This leads to a MessageRemovedException when calling IMAPMessage#getSubject. And although Debug is set to false this again leads to a MessageException and the whole integration flow stops.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
