### PR TITLE
GH-3601: Bring AMQP byte code compatibility back

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -123,6 +123,11 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 
 	private BatchMode batchMode = BatchMode.MESSAGES;
 
+	// TODO Remove in 6.0
+	public AmqpInboundChannelAdapter(AbstractMessageListenerContainer listenerContainer) {
+		this((MessageListenerContainer) listenerContainer);
+	}
+
 	/**
 	 * Construct an instance using the provided container.
 	 * @param listenerContainer the container.

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -101,12 +101,23 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 		this(listenerContainer, new RabbitTemplate(listenerContainer.getConnectionFactory()), false);
 	}
 
+	// TODO Remove in 6.0
+	/**
+	 * Construct {@link AmqpInboundGateway} based on the provided {@link AbstractMessageListenerContainer}
+	 * to receive request messages and {@link AmqpTemplate} to send replies.
+	 * @param listenerContainer the {@link MessageListenerContainer} to receive AMQP messages.
+	 * @param amqpTemplate the {@link AmqpTemplate} to send reply messages.
+	 * @since 4.2
+	 */
+	public AmqpInboundGateway(AbstractMessageListenerContainer listenerContainer, AmqpTemplate amqpTemplate) {
+		this((MessageListenerContainer) listenerContainer, amqpTemplate);
+	}
+
 	/**
 	 * Construct {@link AmqpInboundGateway} based on the provided {@link MessageListenerContainer}
 	 * to receive request messages and {@link AmqpTemplate} to send replies.
 	 * @param listenerContainer the {@link MessageListenerContainer} to receive AMQP messages.
 	 * @param amqpTemplate the {@link AmqpTemplate} to send reply messages.
-	 * @since 4.2
 	 */
 	public AmqpInboundGateway(MessageListenerContainer listenerContainer, AmqpTemplate amqpTemplate) {
 		this(listenerContainer, amqpTemplate, true);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3601

The issue https://github.com/spring-projects/spring-integration/issues/3584
has introduced a regression when old constructor with an
`AbstractMessageListenerContainer` was removed in favor of just
`MessageListenerContainer`.
But with that change all the dependant projects must be recompiled,
which is not a case when Spring Cloud was not released against the
latest Spring Boot.

**Cherry-pick to `5.4.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
