### PR TITLE
GH-3620: Fix Shared SFTP Session

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,11 +382,11 @@ public class DefaultSftpSessionFactory implements SessionFactory<LsEntry>, Share
 
 	@Override
 	public SftpSession getSession() {
-		JSchSessionWrapper jschSession = this.sharedJschSession;
 		SftpSession sftpSession;
 		if (this.sharedSessionLock != null) {
 			this.sharedSessionLock.lock();
 		}
+		JSchSessionWrapper jschSession = this.sharedJschSession;
 		try {
 			boolean freshJschSession = false;
 			if (jschSession == null || !jschSession.isConnected()) {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3620

Shared session field was captured outside of the lock, causing multiple sessions
in a multi-threaded environment.

**cherry-pick to 5.4.x, 5.3.x**
