### PR TITLE
Introduce high-level API for flows composition

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/ConsumerEndpointFactoryBean.java
@@ -137,6 +137,10 @@ public class ConsumerEndpointFactoryBean
 		}
 	}
 
+	public MessageHandler getHandler() {
+		return this.handler;
+	}
+
 	public void setInputChannel(MessageChannel inputChannel) {
 		this.inputChannel = inputChannel;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -2918,6 +2918,18 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	}
 
 	/**
+	 * Finish this flow with delegation to other {@link IntegrationFlow} instance.
+	 * @param other the {@link IntegrationFlow} to compose with.
+	 * @return The {@link IntegrationFlow} instance based on this definition.
+	 * @since 5.5.4
+	 */
+	public IntegrationFlow to(IntegrationFlow other) {
+		MessageChannel otherFlowInputChannel = obtainInputChannelFromFlow(other);
+		return channel(otherFlowInputChannel)
+				.get();
+	}
+
+	/**
 	 * Represent an Integration Flow as a Reactive Streams {@link Publisher} bean.
 	 * @param <T> the expected {@code payload} type
 	 * @return the Reactive Streams {@link Publisher}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.dsl;
+
+import java.util.Map;
 
 import org.springframework.messaging.MessageChannel;
 
@@ -89,6 +91,15 @@ public interface IntegrationFlow {
 	 * @since 5.0.4
 	 */
 	default MessageChannel getInputChannel() {
+		return null;
+	}
+
+	/**
+	 * Return a map of integration components managed by this flow (if any).
+	 * @return the map of integration components managed by this flow.
+	 * @since 5.5.4
+	 */
+	default Map<Object, String> getIntegrationComponents() {
 		return null;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.dsl;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -77,6 +78,10 @@ public abstract class IntegrationFlowAdapter implements IntegrationFlow, Managea
 	public MessageChannel getInputChannel() {
 		assertTargetIntegrationFlow();
 		return this.targetIntegrationFlow.getInputChannel();
+	}
+
+	@Override public Map<Object, String> getIntegrationComponents() {
+		return this.targetIntegrationFlow.getIntegrationComponents();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
@@ -344,8 +344,9 @@ public final class IntegrationFlows {
 
 	/**
 	 * Start the flow with a composition from the {@link IntegrationFlow}.
-	 * @param other the {@link IntegrationFlow} to composition from.
+	 * @param other the {@link IntegrationFlow} from which to compose.
 	 * @return new {@link IntegrationFlowBuilder}.
+	 * @since 5.5.4
 	 */
 	@SuppressWarnings("overloads")
 	public static IntegrationFlowBuilder from(IntegrationFlow other) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlows.java
@@ -335,6 +335,7 @@ public final class IntegrationFlows {
 	 * @param publisher the {@link Publisher} to subscribe to.
 	 * @return new {@link IntegrationFlowBuilder}.
 	 */
+	@SuppressWarnings("overloads")
 	public static IntegrationFlowBuilder from(Publisher<? extends Message<?>> publisher) {
 		FluxMessageChannel reactiveChannel = new FluxMessageChannel();
 		reactiveChannel.subscribeTo(publisher);
@@ -346,6 +347,7 @@ public final class IntegrationFlows {
 	 * @param other the {@link IntegrationFlow} to composition from.
 	 * @return new {@link IntegrationFlowBuilder}.
 	 */
+	@SuppressWarnings("overloads")
 	public static IntegrationFlowBuilder from(IntegrationFlow other) {
 		Map<Object, String> integrationComponents = other.getIntegrationComponents();
 		Assert.notNull(integrationComponents, () ->

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -321,6 +321,7 @@ public class IntegrationFlowBeanPostProcessor
 					new NameMatchMethodPointcutAdvisor(new IntegrationFlowLifecycleAdvice(target));
 			integrationFlowAdvice.setMappedNames(
 					"getInputChannel",
+					"getIntegrationComponents",
 					"start",
 					"stop",
 					"isRunning",

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowLifecycleAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowLifecycleAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,6 +73,12 @@ class IntegrationFlowLifecycleAdvice implements MethodInterceptor {
 			result = invocation.proceed();
 			if (result == null) {
 				result = this.delegate.getInputChannel();
+			}
+		}
+		else if ("getIntegrationComponents".equals(method)) {
+			result = invocation.proceed();
+			if (result == null) {
+				result = this.delegate.getIntegrationComponents();
 			}
 		}
 		else {

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/composition/IntegrationFlowCompositionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/composition/IntegrationFlowCompositionTests.java
@@ -121,7 +121,7 @@ public class IntegrationFlowCompositionTests {
 
 	@Test
 	void testInvalidStartFlowForComposition() {
-		IntegrationFlow startFlow = f -> f.handle(m -> {});
+		IntegrationFlow startFlow = f -> f.handle(m -> { });
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> IntegrationFlows.from(startFlow))

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/composition/IntegrationFlowCompositionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/composition/IntegrationFlowCompositionTests.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.dsl.composition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.IntegrationFlows;
+import org.springframework.integration.dsl.Pollers;
+import org.springframework.integration.scheduling.PollerMetadata;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 5.5.4
+ */
+@SpringJUnitConfig
+@DirtiesContext
+public class IntegrationFlowCompositionTests {
+
+	@Autowired
+	IntegrationFlow templateFlow;
+
+	@Autowired
+	@Qualifier("mainFlow.input")
+	DirectChannel mainFlowInput;
+
+	@Autowired
+	QueueChannel otherFlowResultChannel;
+
+	@Test
+	void testToOperator() {
+		this.mainFlowInput.send(new GenericMessage<>("hello"));
+		Message<?> receive = this.otherFlowResultChannel.receive(10_000);
+		assertThat(receive).isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("HELLO from other flow");
+	}
+
+	@Autowired
+	@Qualifier("requestReplyMainFlow.input")
+	DirectChannel requestReplyMainFlowInput;
+
+	@Test
+	void testToWithRequestReply() {
+		QueueChannel replyChannel = new QueueChannel();
+		this.requestReplyMainFlowInput.send(
+				MessageBuilder.withPayload("TEST")
+						.setReplyChannel(replyChannel)
+						.build());
+		Message<?> receive = replyChannel.receive(10_000);
+		assertThat(receive).isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("Reply for: test");
+	}
+
+	@Autowired
+	QueueChannel compositionMainFlowResult;
+
+	@Test
+	void testFromComposition() {
+		Message<?> receive = this.compositionMainFlowResult.receive(10_000);
+		assertThat(receive).isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("TEST DATA");
+
+		receive = this.compositionMainFlowResult.receive(10_000);
+		assertThat(receive).isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("TEST DATA");
+	}
+
+	@Autowired
+	@Qualifier("firstFlow.input")
+	DirectChannel firstFlowInput;
+
+	@Autowired
+	QueueChannel lastFlowResult;
+
+	@Test
+	void testFromToComposition() {
+		this.firstFlowInput.send(new GenericMessage<>("start"));
+
+		Message<?> receive = this.lastFlowResult.receive(10_000);
+		assertThat(receive).isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("start, and first flow, and middle flow, and last flow");
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean(PollerMetadata.DEFAULT_POLLER)
+		PollerMetadata defaultPoller() {
+			return Pollers.fixedDelay(100).get();
+		}
+
+		@Bean
+		IntegrationFlow mainFlow(IntegrationFlow otherFlow) {
+			return f -> f
+					.<String, String>transform(String::toUpperCase)
+					.to(otherFlow);
+		}
+
+		@Bean
+		IntegrationFlow otherFlow() {
+			return f -> f
+					.<String, String>transform(p -> p + " from other flow")
+					.channel(c -> c.queue("otherFlowResultChannel"));
+		}
+
+		@Bean
+		IntegrationFlow requestReplyMainFlow(IntegrationFlow templateFlow) {
+			return f -> f
+					.<String, String>transform(String::toLowerCase)
+					.to(templateFlow);
+		}
+
+		@Bean
+		IntegrationFlow templateFlow() {
+			return f -> f
+					.<String, String>transform("Reply for: "::concat);
+		}
+
+		@Bean
+		IntegrationFlow templateSourceFlow() {
+			return IntegrationFlows.fromSupplier(() -> "test data")
+					.channel("sourceChannel")
+					.get();
+		}
+
+		@Bean
+		IntegrationFlow compositionMainFlow(IntegrationFlow templateSourceFlow) {
+			return IntegrationFlows.from(templateSourceFlow)
+					.<String, String>transform(String::toUpperCase)
+					.channel(c -> c.queue("compositionMainFlowResult"))
+					.get();
+		}
+
+		@Bean
+		IntegrationFlow firstFlow() {
+			return f -> f
+					.<String, String>transform(p -> p + ", and first flow");
+		}
+
+		@Bean
+		IntegrationFlow middleFlow(IntegrationFlow firstFlow, IntegrationFlow lastFlow) {
+			return IntegrationFlows.from(firstFlow)
+					.<String, String>transform(p -> p + ", and middle flow")
+					.to(lastFlow);
+		}
+
+		@Bean
+		IntegrationFlow lastFlow() {
+			return f -> f
+					.<String, String>transform(p -> p + ", and last flow")
+					.channel(c -> c.queue("lastFlowResult"));
+		}
+
+	}
+
+}

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -1378,3 +1378,8 @@ public IntegrationFlow customFlowDefinition() {
 }
 ----
 ====
+
+[[integration-flows-composition]]
+=== Integration Flows Composition
+
+TBD

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -1382,4 +1382,54 @@ public IntegrationFlow customFlowDefinition() {
 [[integration-flows-composition]]
 === Integration Flows Composition
 
-TBD
+With a `MessageChannel` abstraction as a first class citizen in Spring Integration the composition of integration flows was always assumed.
+The input channel of any endpoint in the flow can be used to send messages from any other endpoint and not only from the one which has this channel as an output.
+Furthermore, with a `@MessagingGateway` contract, Content Enricher components, composite endpoints like a `<chain>`, and now with `IntegrationFlow` beans (e.g. `IntegrationFlowAdapter`), it is straightforward enough to distribute a business logic between shorter, reusable parts.
+Only what is needed for the final composition is a knowledge about a `MessageChannel` to send to or receive from.
+
+Starting with version `5.5.4`, to abstract more from `MessageChannel` and hide implementation details from end-user, the `IntegrationFlows` introduces a `from(IntegrationFlow)` factory method to allow starting the current `IntegrationFlow` from the output of an existing flow:
+
+====
+[source,java]
+----
+@Bean
+IntegrationFlow templateSourceFlow() {
+    return IntegrationFlows.fromSupplier(() -> "test data")
+            .channel("sourceChannel")
+            .get();
+}
+
+@Bean
+IntegrationFlow compositionMainFlow(IntegrationFlow templateSourceFlow) {
+    return IntegrationFlows.from(templateSourceFlow)
+            .<String, String>transform(String::toUpperCase)
+            .channel(c -> c.queue("compositionMainFlowResult"))
+            .get();
+}
+----
+====
+
+On the other hand,  the `IntegrationFlowDefinition` has added a `to(IntegrationFlow)` terminal operator to continue the current flow at the input channel of some other flow:
+
+====
+[source,java]
+----
+@Bean
+IntegrationFlow mainFlow(IntegrationFlow otherFlow) {
+    return f -> f
+            .<String, String>transform(String::toUpperCase)
+            .to(otherFlow);
+}
+
+@Bean
+IntegrationFlow otherFlow() {
+    return f -> f
+            .<String, String>transform(p -> p + " from other flow")
+            .channel(c -> c.queue("otherFlowResultChannel"));
+}
+----
+====
+
+The composition in the middle of the flow is simply achievable with an existing `gateway(IntegrationFlow)` EIP-method.
+This way we can build flows any complexity composing them from more simpler, reusable logical blocks.
+For example, you may have some library of `IntegrationFlow` beans as dependency and there is just enough to have their configuration classes imported to the final project and autowired for your `IntegrationFlow` definitions.

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -1382,12 +1382,12 @@ public IntegrationFlow customFlowDefinition() {
 [[integration-flows-composition]]
 === Integration Flows Composition
 
-With a `MessageChannel` abstraction as a first class citizen in Spring Integration the composition of integration flows was always assumed.
+With the `MessageChannel` abstraction as a first class citizen in Spring Integration, the composition of integration flows was always assumed.
 The input channel of any endpoint in the flow can be used to send messages from any other endpoint and not only from the one which has this channel as an output.
-Furthermore, with a `@MessagingGateway` contract, Content Enricher components, composite endpoints like a `<chain>`, and now with `IntegrationFlow` beans (e.g. `IntegrationFlowAdapter`), it is straightforward enough to distribute a business logic between shorter, reusable parts.
-Only what is needed for the final composition is a knowledge about a `MessageChannel` to send to or receive from.
+Furthermore, with a `@MessagingGateway` contract, Content Enricher components, composite endpoints like a `<chain>`, and now with `IntegrationFlow` beans (e.g. `IntegrationFlowAdapter`), it is straightforward enough to distribute the business logic between shorter, reusable parts.
+All that is needed for the final composition is knowledge about a `MessageChannel` to send to or receive from.
 
-Starting with version `5.5.4`, to abstract more from `MessageChannel` and hide implementation details from end-user, the `IntegrationFlows` introduces a `from(IntegrationFlow)` factory method to allow starting the current `IntegrationFlow` from the output of an existing flow:
+Starting with version `5.5.4`, to abstract more from `MessageChannel` and hide implementation details from the end-user, the `IntegrationFlows` introduces the `from(IntegrationFlow)` factory method to allow starting the current `IntegrationFlow` from the output of an existing flow:
 
 ====
 [source,java]
@@ -1431,5 +1431,5 @@ IntegrationFlow otherFlow() {
 ====
 
 The composition in the middle of the flow is simply achievable with an existing `gateway(IntegrationFlow)` EIP-method.
-This way we can build flows any complexity composing them from more simpler, reusable logical blocks.
-For example, you may have some library of `IntegrationFlow` beans as dependency and there is just enough to have their configuration classes imported to the final project and autowired for your `IntegrationFlow` definitions.
+This way we can build flows with any complexity by composing them from simpler, reusable logical blocks.
+For example, you may add a library of `IntegrationFlow` beans as a dependency and it is just enough to have their configuration classes imported to the final project and autowired for your `IntegrationFlow` definitions.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -49,8 +49,9 @@ See <<./message-store.adoc#message-group-condition,Message Group Condition>> for
 
 [[x5.5-integration-flows-composition]]
 ==== Integration Flows Composition
-The new `IntegrationFlows.from(IntegrationFlow)` factory has been added to let to start the current `IntegrationFlow` from existing one.
-On the other side, the `IntegrationFlowDefinition` has added a `to(IntegrationFlow)` terminal operator to continue the current flow in some other existing.
+
+The new `IntegrationFlows.from(IntegrationFlow)` factory method has been added to allow starting the current `IntegrationFlow` from the output of an existing flow.
+In addition, the `IntegrationFlowDefinition` has added a `to(IntegrationFlow)` terminal operator to continue the current flow at the input channel of some other flow.
 See <<./dsl.adoc#integration-flows-composition,Integration Flows Composition>> for more information.
 
 [[x5.5-amqp]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -47,6 +47,12 @@ See <<./aggregator.adoc#aggregator,Aggregator>> for more information.
 The `MessageGroup` abstraction can be supplied with a `condition` to evaluate later on to make a decision for the group.
 See <<./message-store.adoc#message-group-condition,Message Group Condition>> for more information.
 
+[[x5.5-integration-flows-composition]]
+==== Integration Flows Composition
+The new `IntegrationFlows.from(IntegrationFlow)` factory has been added to let to start the current `IntegrationFlow` from existing one.
+On the other side, the `IntegrationFlowDefinition` has added a `to(IntegrationFlow)` terminal operator to continue the current flow in some other existing.
+See <<./dsl.adoc#integration-flows-composition,Integration Flows Composition>> for more information.
+
 [[x5.5-amqp]]
 ==== AMQP Changes
 


### PR DESCRIPTION
For better end-user experience and more smooth integration logic
decomposition and distribution introduce an `IntegrationFlows.from(IntegrationFlow)`
to let to start the current flow from existing one.
On the other hand introduce an `BaseIntegrationFlowDefinition.to(IntegrationFlow)`
to let to continue the flow logic in the other existing one.
This way we can extract some templating logic into separate `IntegrationFlow` definitions
allowing at the same time to decompose a complex flow definition into logical reusable parts

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
