### PR TITLE
GH-3614: JPA outbound components delete in batch

### DIFF
--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/core/JpaExecutor.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/core/JpaExecutor.java
@@ -190,11 +190,9 @@ public class JpaExecutor implements InitializingBean, BeanFactoryAware {
 	 * @param nativeQuery The provided SQL query must neither be null nor empty.
 	 */
 	public void setNativeQuery(String nativeQuery) {
-
 		Assert.isTrue(this.namedQuery == null && this.jpaQuery == null, "You can define only one of the "
 				+ "properties 'jpaQuery', 'nativeQuery', 'namedQuery'");
 		Assert.hasText(nativeQuery, "nativeQuery must neither be null nor empty.");
-
 		this.nativeQuery = nativeQuery;
 	}
 
@@ -204,10 +202,8 @@ public class JpaExecutor implements InitializingBean, BeanFactoryAware {
 	 * @param namedQuery Must neither be null nor empty
 	 */
 	public void setNamedQuery(String namedQuery) {
-
 		Assert.isTrue(this.jpaQuery == null && this.nativeQuery == null, "You can define only one of the "
 				+ "properties 'jpaQuery', 'nativeQuery', 'namedQuery'");
-
 		Assert.hasText(namedQuery, "namedQuery must neither be null nor empty.");
 		this.namedQuery = namedQuery;
 	}
@@ -453,7 +449,12 @@ public class JpaExecutor implements InitializingBean, BeanFactoryAware {
 			case MERGE:
 				return this.jpaOperations.merge(payload, this.flushSize, this.clearOnFlush); // NOSONAR
 			case DELETE:
-				this.jpaOperations.delete(payload);
+				if (payload instanceof Iterable) {
+					this.jpaOperations.deleteInBatch((Iterable<?>) payload);
+				}
+				else {
+					this.jpaOperations.delete(payload);
+				}
 				if (this.flush) {
 					this.jpaOperations.flush();
 				}

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayTests-context.xml
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/JpaOutboundGatewayTests-context.xml
@@ -24,6 +24,7 @@
 	<int:gateway default-reply-channel="studentReplyChannel"
 			service-interface="org.springframework.integration.jpa.outbound.StudentService" default-reply-timeout="3000">
 		<int:method name="deleteStudent"            request-channel="deleteStudentChannel" />
+		<int:method name="deleteStudents"            request-channel="deleteStudentChannel" />
 		<int:method name="getStudent"               request-channel="getStudentChannel"    />
 		<int:method name="getStudentWithException"  request-channel="getStudentEndpointWithExceptionChannel"/>
 		<int:method name="getStudentWithParameters" request-channel="getStudentWithParametersChannel"/>

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/StudentService.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/outbound/StudentService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.messaging.handler.annotation.Payload;
 /**
  * @author Amol Nayak
  * @author Artem Bilan
+ *
  * @since 2.2
  */
 public interface StudentService {
@@ -33,7 +34,10 @@ public interface StudentService {
 	StudentDomain getStudentWithException(Long id);
 
 	StudentDomain getStudent(Long id);
+
 	StudentDomain deleteStudent(StudentDomain student);
+
+	List<StudentDomain> deleteStudents(List<StudentDomain> students);
 
 	@Payload("new java.util.Date()")
 	List<StudentDomain> getAllStudents();

--- a/src/reference/asciidoc/jpa.adoc
+++ b/src/reference/asciidoc/jpa.adoc
@@ -501,6 +501,8 @@ NOTE: As of Spring Integration 3.0, payloads to `PERSIST` or `MERGE` can also be
 In that case, each object returned by the `Iterable` is treated as an entity and persisted or merged using the underlying `EntityManager`.
 Null values returned by the iterator are ignored.
 
+NOTE: Starting with version 5.5.4, the `JpaOutboundGateway` with a `PersistMode.DELETE` can accept an `Iterable` payload to perform batch removal persistent operation for the provided entities.
+
 [[jpa-using-jpaql]]
 ==== Using JPA Query Language (JPA QL)
 

--- a/src/reference/asciidoc/jpa.adoc
+++ b/src/reference/asciidoc/jpa.adoc
@@ -501,7 +501,7 @@ NOTE: As of Spring Integration 3.0, payloads to `PERSIST` or `MERGE` can also be
 In that case, each object returned by the `Iterable` is treated as an entity and persisted or merged using the underlying `EntityManager`.
 Null values returned by the iterator are ignored.
 
-NOTE: Starting with version 5.5.4, the `JpaOutboundGateway` with a `PersistMode.DELETE` can accept an `Iterable` payload to perform batch removal persistent operation for the provided entities.
+NOTE: Starting with version 5.5.4, the `JpaOutboundGateway`, with a `JpaExecutor` configured with  `PersistMode.DELETE`, can accept an `Iterable` payload to perform a batch removal persistent operation for the provided entities.
 
 [[jpa-using-jpaql]]
 ==== Using JPA Query Language (JPA QL)

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -100,3 +100,10 @@ See <<./mongodb.adoc#mongodb,MongoDb Support>> for more information.
 The WebSocket channel adapters based on `ServerWebSocketContainer` can now be registered and removed at runtime.
 
 See <<./web-sockets.adoc#web-sockets,WebSockets Support>> for more information.
+
+[[x5.5-jpa]]
+==== JPA Changes
+
+The `JpaOutboundGateway` supports now an `Iterable` message payload for a `PersistMode.DELETE`.
+
+See <<./jpa.adoc#jpa-outbound-channel-adapter,Outbound Channel Adapter>> for more information.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -104,6 +104,6 @@ See <<./web-sockets.adoc#web-sockets,WebSockets Support>> for more information.
 [[x5.5-jpa]]
 ==== JPA Changes
 
-The `JpaOutboundGateway` supports now an `Iterable` message payload for a `PersistMode.DELETE`.
+The `JpaOutboundGateway` now supports an `Iterable` message payload for a `PersistMode.DELETE`.
 
 See <<./jpa.adoc#jpa-outbound-channel-adapter,Outbound Channel Adapter>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3614

Add an `Iterable` payload support for the
`JpaExecutor.executeOutboundJpaOperationOnPersistentMode(Message<?>)`
and `DELETE` persist mode

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
