### PR TITLE
GH-3643: Defer MeterRegistry bean dependency

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/EnableIntegrationManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/EnableIntegrationManagement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.Import;
-import org.springframework.integration.support.management.micrometer.MicrometerMetricsCaptorRegistrar;
+import org.springframework.integration.support.management.micrometer.MicrometerMetricsCaptorImportSelector;
 
 /**
  * Enables default configuring of management in Spring Integration components in an existing application.
@@ -39,7 +39,7 @@ import org.springframework.integration.support.management.micrometer.MicrometerM
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@Import({ MicrometerMetricsCaptorRegistrar.class, IntegrationManagementConfiguration.class })
+@Import({ MicrometerMetricsCaptorImportSelector.class, IntegrationManagementConfiguration.class })
 public @interface EnableIntegrationManagement {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphServer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphServer.java
@@ -48,7 +48,7 @@ import org.springframework.integration.router.RecipientListRouter.Recipient;
 import org.springframework.integration.router.RecipientListRouterManagement;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.integration.support.management.MappingMessageRouterManagement;
-import org.springframework.integration.support.management.micrometer.MicrometerMetricsCaptorRegistrar;
+import org.springframework.integration.support.management.micrometer.MicrometerMetricsCaptorConfiguration;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
@@ -159,7 +159,7 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 	}
 
 	private synchronized Graph buildGraph() {
-		if (micrometerEnhancer == null && MicrometerMetricsCaptorRegistrar.METER_REGISTRY_PRESENT) {
+		if (micrometerEnhancer == null && MicrometerMetricsCaptorConfiguration.METER_REGISTRY_PRESENT) {
 			micrometerEnhancer = new MicrometerNodeEnhancer(this.applicationContext);
 		}
 		String implementationVersion = IntegrationGraphServer.class.getPackage().getImplementationVersion();

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptorImportSelector.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptorImportSelector.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.support.management.micrometer;
+
+import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.type.AnnotationMetadata;
+
+/**
+ * An {@link ImportSelector} to conditionally add a {@link MicrometerMetricsCaptorConfiguration}
+ * bean when {@code io.micrometer.core.instrument.MeterRegistry} is present in classpath.
+ *
+ * @author Artem Bilan
+ *
+ * @since 5.5.5
+ */
+public class MicrometerMetricsCaptorImportSelector implements ImportSelector {
+
+	@Override
+	public String[] selectImports(AnnotationMetadata importingClassMetadata) {
+		if (MicrometerMetricsCaptorConfiguration.METER_REGISTRY_PRESENT) {
+			return new String[]{ MicrometerMetricsCaptorConfiguration.class.getName() };
+		}
+		else {
+			return new String[0];
+		}
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3643

The `ImportBeanDefinitionRegistrar` register its bean definition in the early phase.
It causes a problem with Spring Boot when an explicit `@EnableIntegrationManagement`
is declared: the `MeterRegistry` is provided later on via auto-configuration
and `MicrometerMetricsCaptor` has no knowledge about `MeterRegistry` at the
`ImportBeanDefinitionRegistrar` phase.

* Reworks `MicrometerMetricsCaptorRegistrar` to the `MicrometerMetricsCaptorConfiguration`
and use special conditional `MicrometerMetricsCaptorImportSelector` for that
`@EnableIntegrationManagement`.
This way a `MicrometerMetricsCaptor` `@Bean` consults `ObjectProvider<MeterRegistry>`
on its creating time and returns `null` if no `MeterRegistry` beans at all.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
