### PR TITLE
GH-3647: Use remoteDirExpression in MV command

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -42,6 +42,7 @@ import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
+import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessagingException;
@@ -156,6 +157,10 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 		Assert.notNull(remoteDirectoryExpression, "remoteDirectoryExpression must not be null");
 		this.directoryExpressionProcessor =
 				new ExpressionEvaluatingMessageProcessor<>(remoteDirectoryExpression, String.class);
+	}
+
+	public MessageProcessor<String> getDirectoryExpressionProcessor() {
+		return this.directoryExpressionProcessor;
 	}
 
 	/**

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -43,6 +43,7 @@ import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessagingException;
@@ -159,6 +160,11 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 				new ExpressionEvaluatingMessageProcessor<>(remoteDirectoryExpression, String.class);
 	}
 
+	/**
+	 * Return the processor for remote directory SpEL expression if any.
+	 * @return the processor for remote directory SpEL expression.
+	 */
+	@Nullable
 	public MessageProcessor<String> getDirectoryExpressionProcessor() {
 		return this.directoryExpressionProcessor;
 	}

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -1247,7 +1247,7 @@ The `file_remoteDirectory` header provides the remote directory, and the `file_r
 
 ==== Using the `mv` Command
 
-The `mv` command moves files
+The `mv` command moves files.
 
 The `mv` command has no options.
 
@@ -1258,6 +1258,10 @@ If necessary, any necessary remote directories are created.
 The payload of the result message is `Boolean.TRUE`.
 The `file_remoteDirectory` header provides the original remote directory, and `file_remoteFile` header provides the file name.
 The new path is in the `file_renameTo` header.
+
+Starting with version 5.5.6, the `remoteDirectoryExpression` can be used in the `mv` command for convenience.
+If "`from`" file is not a full file path, the result of `remoteDirectoryExpression` is used as the remote directory.
+Same applies for "`to`" file, for example if the task is just to rename a remote file in some directory.
 
 ==== Additional Information about FTP Outbound Gateway Commands
 

--- a/src/reference/asciidoc/ftp.adoc
+++ b/src/reference/asciidoc/ftp.adoc
@@ -1260,8 +1260,8 @@ The `file_remoteDirectory` header provides the original remote directory, and `f
 The new path is in the `file_renameTo` header.
 
 Starting with version 5.5.6, the `remoteDirectoryExpression` can be used in the `mv` command for convenience.
-If "`from`" file is not a full file path, the result of `remoteDirectoryExpression` is used as the remote directory.
-Same applies for "`to`" file, for example if the task is just to rename a remote file in some directory.
+If the "`from`" file is not a full file path, the result of `remoteDirectoryExpression` is used as the remote directory.
+The same applies for the "`to`" file, for example, if the task is just to rename a remote file in some directory.
 
 ==== Additional Information about FTP Outbound Gateway Commands
 

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -1215,8 +1215,8 @@ The the `file_remoteDirectory` header holds the original remote directory, and t
 The `file_renameTo` header holds the new path.
 
 Starting with version 5.5.6, the `remoteDirectoryExpression` can be used in the `mv` command for convenience.
-If "`from`" file is not a full file path, the result of `remoteDirectoryExpression` is used as the remote directory.
-Same applies for "`to`" file, for example if the task is just to rename a remote file in some directory.
+If the "`from`" file is not a full file path, the result of `remoteDirectoryExpression` is used as the remote directory.
+The same applies for the "`to`" file, for example, if the task is just to rename a remote file in some directory.
 
 ==== Additional Command Information
 

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -1214,6 +1214,10 @@ The payload of the result message is `Boolean.TRUE`.
 The the `file_remoteDirectory` header holds the original remote directory, and the `file_remoteFile` header holds the filename.
 The `file_renameTo` header holds the new path.
 
+Starting with version 5.5.6, the `remoteDirectoryExpression` can be used in the `mv` command for convenience.
+If "`from`" file is not a full file path, the result of `remoteDirectoryExpression` is used as the remote directory.
+Same applies for "`to`" file, for example if the task is just to rename a remote file in some directory.
+
 ==== Additional Command Information
 
 The `get` and `mget` commands support the `local-filename-generator-expression` attribute.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -92,6 +92,8 @@ For this reason, the property is `false` by default; this may change in a future
 
 The `FileInboundChannelAdapterSpec` has now a convenient `recursive(boolean)` option instead of requiring an explicit reference to the `RecursiveDirectoryScanner`.
 
+The `remoteDirectoryExpression` can now be used in the `mv` command for convenience.
+
 [[x5.5-mongodb]]
 ==== MongoDb Changes
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3647

To simplify a source and renameTo remote file expressions, the `remoteDirectoryExpression`
is consulted now, when they are not full paths.
This is useful when we want just to rename a remote file in some dir

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
