### PR TITLE
GH-3652 Do not try to delete non-existing file in FileExistMode.REPLACE

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -73,6 +73,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Mauro Molinari
  *
  * @since 2.1
  */
@@ -1110,9 +1111,9 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		FileExistsMode existsMode = this.fileExistsMode;
 		boolean appending = FileExistsMode.APPEND.equals(existsMode);
 		boolean exists = localFile.exists();
-		boolean replacing = FileExistsMode.REPLACE.equals(existsMode)
-				|| (exists && FileExistsMode.REPLACE_IF_MODIFIED.equals(existsMode)
-				&& localFile.lastModified() != getModified(fileInfo));
+		boolean replacing = exists && (FileExistsMode.REPLACE.equals(existsMode)
+				|| (FileExistsMode.REPLACE_IF_MODIFIED.equals(existsMode)
+				&& localFile.lastModified() != getModified(fileInfo)));
 		if (!exists || appending || replacing) {
 			OutputStream outputStream;
 			String tempFileName = localFile.getAbsolutePath() + this.remoteFileTemplate.getTemporaryFileSuffix();


### PR DESCRIPTION
Fixes spring-projects/spring-integration#3652

`testAll` task passes (except for `org.springframework.integration.xml.transformer.jaxbmarshaling.JaxbMarshallingIntegrationTests.testFileUnlockedAfterUnmarshallingFailure()`, which fails in my Italian-speaking system because the exception message is localized ;-)).

I don't know if it's worth to think of a possible (and viable) test case to test this change...