### PR TITLE
RedisLockRegistry, add automatically deleted for redisLock

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -383,7 +383,6 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 			}
 			finally {
 				this.localLock.unlock();
-
 			}
 		}
 

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -884,5 +884,5 @@ You should set the expiry at a large enough value to prevent this condition, but
 
 Starting with version 5.0, the `RedisLockRegistry` implements `ExpirableLockRegistry`, which removes locks last acquired more than `age` ago and that are not currently locked.
 
-String with version 5.5.6, the `RedisLockRegistry` is support automatically clean up cache for redisLocks in `RedisLockRegistry.locks` via `RedisLockRegistry.capacity`.
-`capacity` field can be modified via setters, The default is 1,000,000.
+String with version 5.5.6, the `RedisLockRegistry` is support automatically clean up cache for redisLocks in `RedisLockRegistry.locks` via `RedisLockRegistry.setCapacity()`.
+See its JavaDocs for more information.

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -883,3 +883,6 @@ However, the resources protected by such a lock may have been compromised, so su
 You should set the expiry at a large enough value to prevent this condition, but set it low enough that the lock can be recovered after a server failure in a reasonable amount of time.
 
 Starting with version 5.0, the `RedisLockRegistry` implements `ExpirableLockRegistry`, which removes locks last acquired more than `age` ago and that are not currently locked.
+
+String with version 5.5.6, the `RedisLockRegistry` is support automatically clean up cache for redisLocks in `RedisLockRegistry.locks` via `RedisLockRegistry.capacity`.
+`capacity` field can be modified via setters, The default is 1,000,000.


### PR DESCRIPTION
Resolves #3655

Currently, if you don't manually call `expireUnusedOlderThan()`, OutOfMemory can happen.


Therefore, I changed the code so that if the cache exceeds a setting capacity, it is automatically deleted.

default of capacity occupies about 25 MB.
(`locks` size is 1_000_000)


When reading, multiple threads can access it through readLock.
It is controlled through writeLock only when writing.

I added a queue .
Because it is effective in removing the oldest items

