### PR TITLE
Update RedisLockRegistry default capacity value

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -80,7 +80,7 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 
 	private static final long DEFAULT_EXPIRE_AFTER = 60000L;
 
-	private static final int DEFAULT_CAPACITY = 1_000_000;
+	private static final int DEFAULT_CAPACITY = 100_000;
 
 	private static final String OBTAIN_LOCK_SCRIPT =
 			"local lockClientId = redis.call('GET', KEYS[1])\n" +
@@ -168,7 +168,7 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 
 	/**
 	 * Set the capacity of cached locks.
-	 * @param capacity The capacity of cached lock, (default 1_000_000).
+	 * @param capacity The capacity of cached lock, (default 100_000).
 	 * @since 5.5.6
 	 */
 	public void setCapacity(int capacity) {


### PR DESCRIPTION
@artembilan
 
I found that the default was calculated incorrectly.
I'm sorry, but could you please reflect the default value?
(1,000,000 -> 100,000)

Is it better to proceed after registering as an issue?

CAPACITY = 100,000
![image](https://user-images.githubusercontent.com/5335333/141296181-89a3b864-1179-45fd-9cd3-ded2382b6936.png)


CAPACITY = 1,000,000
![image](https://user-images.githubusercontent.com/5335333/141296191-29002a89-1017-4d76-8c01-95080d77fafb.png)
