### PR TITLE
Clean up JdbcLockRegistry, ZookeeperLockRegistry cache automatically

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
@@ -106,8 +106,6 @@ public class DefaultConfiguringBeanFactoryPostProcessor
 	}
 
 
-	private ClassLoader classLoader;
-
 	private ConfigurableListableBeanFactory beanFactory;
 
 	private BeanDefinitionRegistry registry;
@@ -119,7 +117,6 @@ public class DefaultConfiguringBeanFactoryPostProcessor
 	public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
 		this.registry = registry;
 		this.beanFactory = (ConfigurableListableBeanFactory) registry;
-		this.classLoader = this.beanFactory.getBeanClassLoader();
 
 		registerBeanFactoryChannelResolver();
 		registerMessagePublishingErrorHandler();

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -68,7 +68,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry, RenewableLockReg
 
 				@Override
 				protected boolean removeEldestEntry(Entry<String, JdbcLock> eldest) {
-					return size() > JdbcLockRegistry.this.capacity;
+					return size() > JdbcLockRegistry.this.cacheCapacity;
 				}
 
 			};
@@ -77,7 +77,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry, RenewableLockReg
 
 	private Duration idleBetweenTries = Duration.ofMillis(DEFAULT_IDLE);
 
-	private int capacity = DEFAULT_CAPACITY;
+	private int cacheCapacity = DEFAULT_CAPACITY;
 
 	public JdbcLockRegistry(LockRepository client) {
 		this.client = client;
@@ -96,11 +96,11 @@ public class JdbcLockRegistry implements ExpirableLockRegistry, RenewableLockReg
 
 	/**
 	 * Set the capacity of cached locks.
-	 * @param capacity The capacity of cached lock, (default 100_000).
+	 * @param cacheCapacity The capacity of cached lock, (default 100_000).
 	 * @since 5.5.6
 	 */
-	public void cacheCapacity(int capacity) {
-		this.capacity = capacity;
+	public void setCacheCapacity(int cacheCapacity) {
+		this.cacheCapacity = cacheCapacity;
 	}
 
 	@Override

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -99,7 +99,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry, RenewableLockReg
 	 * @param capacity The capacity of cached lock, (default 100_000).
 	 * @since 5.5.6
 	 */
-	public void setCapacity(int capacity) {
+	public void cacheCapacity(int capacity) {
 		this.capacity = capacity;
 	}
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
@@ -325,7 +325,7 @@ public class JdbcLockRegistryTests {
 		final int THREAD_CNT = 4;
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 
 		for (int i = 0; i < KEY_CNT; i++) {
@@ -363,7 +363,7 @@ public class JdbcLockRegistryTests {
 		final int CAPACITY_CNT = THREAD_CNT;
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -408,7 +408,7 @@ public class JdbcLockRegistryTests {
 		final String REMAIN_DUMMY_LOCK_KEY = "foo:1";
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -452,14 +452,14 @@ public class JdbcLockRegistryTests {
 	@Test
 	public void setCapacityTest() {
 		final int CAPACITY_CNT = 4;
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 
 		registry.obtain("foo:1");
 		registry.obtain("foo:2");
 		registry.obtain("foo:3");
 
 		//capacity 4->3
-		registry.setCapacity(CAPACITY_CNT - 1);
+		registry.cacheCapacity(CAPACITY_CNT - 1);
 
 		registry.obtain("foo:4");
 
@@ -469,7 +469,7 @@ public class JdbcLockRegistryTests {
 															toUUID("foo:4"));
 
 		//capacity 3->4
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		registry.obtain("foo:5");
 		assertThat(getRegistryLocks(registry)).hasSize(4);
 		assertThat(getRegistryLocks(registry)).containsKeys(toUUID("foo:3"),

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
@@ -325,7 +325,7 @@ public class JdbcLockRegistryTests {
 		final int THREAD_CNT = 4;
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 
 		for (int i = 0; i < KEY_CNT; i++) {
@@ -363,7 +363,7 @@ public class JdbcLockRegistryTests {
 		final int CAPACITY_CNT = THREAD_CNT;
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -408,7 +408,7 @@ public class JdbcLockRegistryTests {
 		final String REMAIN_DUMMY_LOCK_KEY = "foo:1";
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -452,14 +452,14 @@ public class JdbcLockRegistryTests {
 	@Test
 	public void setCapacityTest() {
 		final int CAPACITY_CNT = 4;
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 
 		registry.obtain("foo:1");
 		registry.obtain("foo:2");
 		registry.obtain("foo:3");
 
 		//capacity 4->3
-		registry.cacheCapacity(CAPACITY_CNT - 1);
+		registry.setCacheCapacity(CAPACITY_CNT - 1);
 
 		registry.obtain("foo:4");
 
@@ -469,7 +469,7 @@ public class JdbcLockRegistryTests {
 															toUUID("foo:4"));
 
 		//capacity 3->4
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		registry.obtain("foo:5");
 		assertThat(getRegistryLocks(registry)).hasSize(4);
 		assertThat(getRegistryLocks(registry)).containsKeys(toUUID("foo:3"),
@@ -478,11 +478,11 @@ public class JdbcLockRegistryTests {
 	}
 
 	@SuppressWarnings("unchecked")
-	private Map<String, Lock> getRegistryLocks(JdbcLockRegistry registry) {
+	private static Map<String, Lock> getRegistryLocks(JdbcLockRegistry registry) {
 		return TestUtils.getPropertyValue(registry, "locks", Map.class);
 	}
 
-	private String toUUID(String key) {
+	private static String toUUID(String key) {
 		return UUIDConverter.getUUID(key).toString();
 	}
 }

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -99,7 +99,7 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 
 				@Override
 				protected boolean removeEldestEntry(Entry<String, RedisLock> eldest) {
-					return size() > RedisLockRegistry.this.capacity;
+					return size() > RedisLockRegistry.this.cacheCapacity;
 				}
 
 			};
@@ -114,7 +114,7 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 
 	private final long expireAfter;
 
-	private int capacity = DEFAULT_CAPACITY;
+	private int cacheCapacity = DEFAULT_CAPACITY;
 
 	/**
 	 * An {@link ExecutorService} to call {@link StringRedisTemplate#delete} in
@@ -168,11 +168,11 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 
 	/**
 	 * Set the capacity of cached locks.
-	 * @param capacity The capacity of cached lock, (default 100_000).
+	 * @param cacheCapacity The capacity of cached lock, (default 100_000).
 	 * @since 5.5.6
 	 */
-	public void cacheCapacity(int capacity) {
-		this.capacity = capacity;
+	public void setCacheCapacity(int cacheCapacity) {
+		this.cacheCapacity = cacheCapacity;
 	}
 
 	@Override

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -171,7 +171,7 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 	 * @param capacity The capacity of cached lock, (default 100_000).
 	 * @since 5.5.6
 	 */
-	public void setCapacity(int capacity) {
+	public void cacheCapacity(int capacity) {
 		this.capacity = capacity;
 	}
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
@@ -449,7 +449,7 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final RedisConnectionFactory connectionFactory = getConnectionFactoryForTest();
 		final RedisLockRegistry registry = new RedisLockRegistry(connectionFactory, this.registryKey, 10000);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 
 		for (int i = 0; i < KEY_CNT; i++) {
@@ -490,7 +490,7 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final RedisConnectionFactory connectionFactory = getConnectionFactoryForTest();
 		final RedisLockRegistry registry = new RedisLockRegistry(connectionFactory, this.registryKey, 10000);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -538,7 +538,7 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final RedisConnectionFactory connectionFactory = getConnectionFactoryForTest();
 		final RedisLockRegistry registry = new RedisLockRegistry(connectionFactory, this.registryKey, 10000);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -585,14 +585,14 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		final int CAPACITY_CNT = 4;
 		final RedisConnectionFactory connectionFactory = getConnectionFactoryForTest();
 		final RedisLockRegistry registry = new RedisLockRegistry(connectionFactory, this.registryKey, 10000);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 
 		registry.obtain("foo:1");
 		registry.obtain("foo:2");
 		registry.obtain("foo:3");
 
 		//capacity 4->3
-		registry.setCapacity(CAPACITY_CNT - 1);
+		registry.cacheCapacity(CAPACITY_CNT - 1);
 
 		registry.obtain("foo:4");
 
@@ -600,7 +600,7 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		assertThat(getRedisLockRegistryLocks(registry)).containsKeys("foo:2", "foo:3", "foo:4");
 
 		//capacity 3->4
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		registry.obtain("foo:5");
 		assertThat(TestUtils.getPropertyValue(registry, "locks", Map.class).size()).isEqualTo(4);
 		assertThat(getRedisLockRegistryLocks(registry)).containsKeys("foo:3", "foo:4", "foo:5");

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
@@ -449,7 +449,7 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final RedisConnectionFactory connectionFactory = getConnectionFactoryForTest();
 		final RedisLockRegistry registry = new RedisLockRegistry(connectionFactory, this.registryKey, 10000);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 
 		for (int i = 0; i < KEY_CNT; i++) {
@@ -490,7 +490,7 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final RedisConnectionFactory connectionFactory = getConnectionFactoryForTest();
 		final RedisLockRegistry registry = new RedisLockRegistry(connectionFactory, this.registryKey, 10000);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -538,7 +538,7 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final RedisConnectionFactory connectionFactory = getConnectionFactoryForTest();
 		final RedisLockRegistry registry = new RedisLockRegistry(connectionFactory, this.registryKey, 10000);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -585,14 +585,14 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		final int CAPACITY_CNT = 4;
 		final RedisConnectionFactory connectionFactory = getConnectionFactoryForTest();
 		final RedisLockRegistry registry = new RedisLockRegistry(connectionFactory, this.registryKey, 10000);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 
 		registry.obtain("foo:1");
 		registry.obtain("foo:2");
 		registry.obtain("foo:3");
 
 		//capacity 4->3
-		registry.cacheCapacity(CAPACITY_CNT - 1);
+		registry.setCacheCapacity(CAPACITY_CNT - 1);
 
 		registry.obtain("foo:4");
 
@@ -600,7 +600,7 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 		assertThat(getRedisLockRegistryLocks(registry)).containsKeys("foo:2", "foo:3", "foo:4");
 
 		//capacity 3->4
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		registry.obtain("foo:5");
 		assertThat(TestUtils.getPropertyValue(registry, "locks", Map.class).size()).isEqualTo(4);
 		assertThat(getRedisLockRegistryLocks(registry)).containsKeys("foo:3", "foo:4", "foo:5");
@@ -636,8 +636,7 @@ public class RedisLockRegistryTests extends RedisAvailableTests {
 	}
 
 	@SuppressWarnings("unchecked")
-	private Map<String, Lock> getRedisLockRegistryLocks(RedisLockRegistry registry) {
+	private static Map<String, Lock> getRedisLockRegistryLocks(RedisLockRegistry registry) {
 		return TestUtils.getPropertyValue(registry, "locks", Map.class);
 	}
-
 }

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
@@ -137,7 +137,7 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry, DisposableB
 	 * @param capacity The capacity of cached lock, (default 30_000).
 	 * @since 5.5.6
 	 */
-	public void setCapacity(int capacity) {
+	public void cacheCapacity(int capacity) {
 		this.capacity = capacity;
 	}
 

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
@@ -63,7 +63,7 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry, DisposableB
 
 				@Override
 				protected boolean removeEldestEntry(Entry<String, ZkLock> eldest) {
-					return size() > ZookeeperLockRegistry.this.capacity;
+					return size() > ZookeeperLockRegistry.this.cacheCapacity;
 				}
 
 			};
@@ -81,7 +81,7 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry, DisposableB
 
 	private boolean mutexTaskExecutorExplicitlySet;
 
-	private int capacity = DEFAULT_CAPACITY;
+	private int cacheCapacity = DEFAULT_CAPACITY;
 
 	/**
 	 * Construct a lock registry using the default {@link KeyToPathStrategy} which
@@ -134,11 +134,11 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry, DisposableB
 
 	/**
 	 * Set the capacity of cached locks.
-	 * @param capacity The capacity of cached lock, (default 30_000).
+	 * @param cacheCapacity The capacity of cached lock, (default 30_000).
 	 * @since 5.5.6
 	 */
-	public void cacheCapacity(int capacity) {
-		this.capacity = capacity;
+	public void setCacheCapacity(int cacheCapacity) {
+		this.cacheCapacity = cacheCapacity;
 	}
 
 	@Override

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -349,7 +349,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		final CountDownLatch maincountDownLatch = new CountDownLatch(KEY_CNT);
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 
 		for (int i = 0; i < KEY_CNT; i++) {
@@ -391,7 +391,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -438,7 +438,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -484,14 +484,14 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 	public void setCapacityTest() {
 		final int CAPACITY_CNT = 4;
 		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 
 		registry.obtain("foo:1");
 		registry.obtain("foo:2");
 		registry.obtain("foo:3");
 
 		//capacity 4->3
-		registry.cacheCapacity(CAPACITY_CNT - 1);
+		registry.setCacheCapacity(CAPACITY_CNT - 1);
 
 		registry.obtain("foo:4");
 
@@ -499,7 +499,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		assertThat(getRegistryLocks(registry)).containsKeys(toKey("foo:2"), toKey("foo:3"), toKey("foo:4"));
 
 		//capacity 3->4
-		registry.cacheCapacity(CAPACITY_CNT);
+		registry.setCacheCapacity(CAPACITY_CNT);
 		registry.obtain("foo:5");
 		assertThat(getRegistryLocks(registry)).hasSize(4);
 		assertThat(getRegistryLocks(registry)).containsKeys(toKey("foo:3"), toKey("foo:4"), toKey("foo:5"));
@@ -507,11 +507,11 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 	}
 
 	@SuppressWarnings("unchecked")
-	private Map<String, Lock> getRegistryLocks(ZookeeperLockRegistry registry) {
+	private static Map<String, Lock> getRegistryLocks(ZookeeperLockRegistry registry) {
 		return TestUtils.getPropertyValue(registry, "locks", Map.class);
 	}
 
-	private String toKey(String path) {
+	private static String toKey(String path) {
 		final String DEFAULT_ROOT = "/SpringIntegration-LockRegistry";
 		return DEFAULT_ROOT + "/" + path;
 	}

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -349,7 +349,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		final CountDownLatch maincountDownLatch = new CountDownLatch(KEY_CNT);
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 
 		for (int i = 0; i < KEY_CNT; i++) {
@@ -391,7 +391,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -438,7 +438,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
 		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
 
@@ -484,14 +484,14 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 	public void setCapacityTest() {
 		final int CAPACITY_CNT = 4;
 		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 
 		registry.obtain("foo:1");
 		registry.obtain("foo:2");
 		registry.obtain("foo:3");
 
 		//capacity 4->3
-		registry.setCapacity(CAPACITY_CNT - 1);
+		registry.cacheCapacity(CAPACITY_CNT - 1);
 
 		registry.obtain("foo:4");
 
@@ -499,7 +499,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		assertThat(getRegistryLocks(registry)).containsKeys(toKey("foo:2"), toKey("foo:3"), toKey("foo:4"));
 
 		//capacity 3->4
-		registry.setCapacity(CAPACITY_CNT);
+		registry.cacheCapacity(CAPACITY_CNT);
 		registry.obtain("foo:5");
 		assertThat(getRegistryLocks(registry)).hasSize(4);
 		assertThat(getRegistryLocks(registry)).containsKeys(toKey("foo:3"), toKey("foo:4"), toKey("foo:5"));

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
@@ -35,7 +38,8 @@ import org.springframework.messaging.MessagingException;
 
 /**
  * @author Gary Russell
- * @author Artem Bilan\
+ * @author Artem Bilan
+ * @author Unseok Kim
  *
  * @since 4.2
  *
@@ -336,4 +340,179 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		registry.destroy();
 	}
 
+	@Test
+	public void concurrentObtainCapacityTest() throws InterruptedException {
+		final int KEY_CNT = 50;
+		final int CAPACITY_CNT = 17;
+		final int THREAD_CNT = 4;
+
+		final CountDownLatch maincountDownLatch = new CountDownLatch(KEY_CNT);
+		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
+		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
+		registry.setCapacity(CAPACITY_CNT);
+		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
+
+		for (int i = 0; i < KEY_CNT; i++) {
+			int finalI = i;
+			executorService.submit(() -> {
+				countDownLatch.countDown();
+				try {
+					countDownLatch.await();
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				String keyId = "foo:" + finalI;
+				Lock obtain = registry.obtain(keyId);
+				maincountDownLatch.countDown();
+				obtain.lock();
+				obtain.unlock();
+			});
+		}
+		executorService.shutdown();
+		maincountDownLatch.await();
+		executorService.awaitTermination(5, TimeUnit.SECONDS);
+
+		//capacity limit test
+		assertThat(getRegistryLocks(registry)).hasSize(CAPACITY_CNT);
+
+
+		registry.expireUnusedOlderThan(-1000);
+		assertThat(getRegistryLocks(registry)).isEmpty();
+		registry.destroy();
+	}
+
+	@Test
+	public void concurrentObtainRemoveOrderTest() throws InterruptedException {
+		final int THREAD_CNT = 2;
+		final int DUMMY_LOCK_CNT = 3;
+
+		final int CAPACITY_CNT = THREAD_CNT;
+
+		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
+		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
+		registry.setCapacity(CAPACITY_CNT);
+		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
+		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
+
+		//Removed due to capcity limit
+		for (int i = 0; i < DUMMY_LOCK_CNT; i++) {
+			Lock obtainLock0 = registry.obtain("foo:" + i);
+			obtainLock0.lock();
+			obtainLock0.unlock();
+		}
+
+		for (int i = DUMMY_LOCK_CNT; i < THREAD_CNT + DUMMY_LOCK_CNT; i++) {
+			int finalI = i;
+			executorService.submit(() -> {
+				countDownLatch.countDown();
+				try {
+					countDownLatch.await();
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				String keyId = "foo:" + finalI;
+				remainLockCheckQueue.offer(toKey(keyId));
+				Lock obtain = registry.obtain(keyId);
+				obtain.lock();
+				obtain.unlock();
+			});
+		}
+
+		executorService.shutdown();
+		executorService.awaitTermination(5, TimeUnit.SECONDS);
+
+		assertThat(getRegistryLocks(registry)).containsKeys(
+				remainLockCheckQueue.toArray(new String[remainLockCheckQueue.size()]));
+		registry.destroy();
+	}
+
+	@Test
+	public void concurrentObtainAccessRemoveOrderTest() throws InterruptedException {
+		final int THREAD_CNT = 2;
+		final int DUMMY_LOCK_CNT = 3;
+
+		final int CAPACITY_CNT = THREAD_CNT + 1;
+		final String REMAIN_DUMMY_LOCK_KEY = "foo:1";
+
+		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
+		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
+		registry.setCapacity(CAPACITY_CNT);
+		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
+		final Queue<String> remainLockCheckQueue = new LinkedBlockingQueue<>();
+
+		//Removed due to capcity limit
+		for (int i = 0; i < DUMMY_LOCK_CNT; i++) {
+			Lock obtainLock0 = registry.obtain("foo:" + i);
+			obtainLock0.lock();
+			obtainLock0.unlock();
+		}
+
+		Lock obtainLock0 = registry.obtain(REMAIN_DUMMY_LOCK_KEY);
+		obtainLock0.lock();
+		obtainLock0.unlock();
+		remainLockCheckQueue.offer(toKey(REMAIN_DUMMY_LOCK_KEY));
+
+		for (int i = DUMMY_LOCK_CNT; i < THREAD_CNT + DUMMY_LOCK_CNT; i++) {
+			int finalI = i;
+			executorService.submit(() -> {
+				countDownLatch.countDown();
+				try {
+					countDownLatch.await();
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				String keyId = "foo:" + finalI;
+				remainLockCheckQueue.offer(toKey(keyId));
+				Lock obtain = registry.obtain(keyId);
+				obtain.lock();
+				obtain.unlock();
+			});
+		}
+
+		executorService.shutdown();
+		executorService.awaitTermination(5, TimeUnit.SECONDS);
+
+		assertThat(getRegistryLocks(registry)).containsKeys(
+				remainLockCheckQueue.toArray(new String[remainLockCheckQueue.size()]));
+		registry.destroy();
+	}
+
+	@Test
+	public void setCapacityTest() {
+		final int CAPACITY_CNT = 4;
+		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
+		registry.setCapacity(CAPACITY_CNT);
+
+		registry.obtain("foo:1");
+		registry.obtain("foo:2");
+		registry.obtain("foo:3");
+
+		//capacity 4->3
+		registry.setCapacity(CAPACITY_CNT - 1);
+
+		registry.obtain("foo:4");
+
+		assertThat(getRegistryLocks(registry)).hasSize(3);
+		assertThat(getRegistryLocks(registry)).containsKeys(toKey("foo:2"), toKey("foo:3"), toKey("foo:4"));
+
+		//capacity 3->4
+		registry.setCapacity(CAPACITY_CNT);
+		registry.obtain("foo:5");
+		assertThat(getRegistryLocks(registry)).hasSize(4);
+		assertThat(getRegistryLocks(registry)).containsKeys(toKey("foo:3"), toKey("foo:4"), toKey("foo:5"));
+		registry.destroy();
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Lock> getRegistryLocks(ZookeeperLockRegistry registry) {
+		return TestUtils.getPropertyValue(registry, "locks", Map.class);
+	}
+
+	private String toKey(String path) {
+		final String DEFAULT_ROOT = "/SpringIntegration-LockRegistry";
+		return DEFAULT_ROOT + "/" + path;
+	}
 }

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -1091,7 +1091,7 @@ So the time to live can be highly reduce and deployments can retake a lost lock 
 
 NOTE: The lock renewal can be done only if the lock is held by the current thread.
 
-String with version 5.5.6, the `JdbcLockRegistry` is support automatically clean up cache for JdbcLock in `JdbcLockRegistry.locks` via `JdbcLockRegistry.cacheCapacity()`.
+String with version 5.5.6, the `JdbcLockRegistry` is support automatically clean up cache for JdbcLock in `JdbcLockRegistry.locks` via `JdbcLockRegistry.setCacheCapacity()`.
 See its JavaDocs for more information.
 
 [[jdbc-metadata-store]]

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -1091,6 +1091,9 @@ So the time to live can be highly reduce and deployments can retake a lost lock 
 
 NOTE: The lock renewal can be done only if the lock is held by the current thread.
 
+String with version 5.5.6, the `JdbcLockRegistry` is support automatically clean up cache for JdbcLock in `JdbcLockRegistry.locks` via `JdbcLockRegistry.setCapacity()`.
+See its JavaDocs for more information.
+
 [[jdbc-metadata-store]]
 === JDBC Metadata Store
 

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -1091,7 +1091,7 @@ So the time to live can be highly reduce and deployments can retake a lost lock 
 
 NOTE: The lock renewal can be done only if the lock is held by the current thread.
 
-String with version 5.5.6, the `JdbcLockRegistry` is support automatically clean up cache for JdbcLock in `JdbcLockRegistry.locks` via `JdbcLockRegistry.setCapacity()`.
+String with version 5.5.6, the `JdbcLockRegistry` is support automatically clean up cache for JdbcLock in `JdbcLockRegistry.locks` via `JdbcLockRegistry.cacheCapacity()`.
 See its JavaDocs for more information.
 
 [[jdbc-metadata-store]]

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -884,5 +884,5 @@ You should set the expiry at a large enough value to prevent this condition, but
 
 Starting with version 5.0, the `RedisLockRegistry` implements `ExpirableLockRegistry`, which removes locks last acquired more than `age` ago and that are not currently locked.
 
-String with version 5.5.6, the `RedisLockRegistry` is support automatically clean up cache for redisLocks in `RedisLockRegistry.locks` via `RedisLockRegistry.cacheCapacity()`.
+String with version 5.5.6, the `RedisLockRegistry` is support automatically clean up cache for redisLocks in `RedisLockRegistry.locks` via `RedisLockRegistry.setCacheCapacity()`.
 See its JavaDocs for more information.

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -884,5 +884,5 @@ You should set the expiry at a large enough value to prevent this condition, but
 
 Starting with version 5.0, the `RedisLockRegistry` implements `ExpirableLockRegistry`, which removes locks last acquired more than `age` ago and that are not currently locked.
 
-String with version 5.5.6, the `RedisLockRegistry` is support automatically clean up cache for redisLocks in `RedisLockRegistry.locks` via `RedisLockRegistry.setCapacity()`.
+String with version 5.5.6, the `RedisLockRegistry` is support automatically clean up cache for redisLocks in `RedisLockRegistry.locks` via `RedisLockRegistry.cacheCapacity()`.
 See its JavaDocs for more information.

--- a/src/reference/asciidoc/zookeeper.adoc
+++ b/src/reference/asciidoc/zookeeper.adoc
@@ -84,7 +84,7 @@ public interface KeyToPathStrategy {
 If the strategy returns `true` from `isBounded`, unused locks do not need to be harvested.
 For unbounded strategies (such as the default), you need to periodically invoke `expireUnusedOlderThan(long age)` to remove old unused locks from memory.
 
-String with version 5.5.6, the `ZookeeperLockRegistry` is support automatically clean up cache for ZkLock in `ZookeeperLockRegistry.locks` via `ZookeeperLockRegistry.setCapacity()`.
+String with version 5.5.6, the `ZookeeperLockRegistry` is support automatically clean up cache for ZkLock in `ZookeeperLockRegistry.locks` via `ZookeeperLockRegistry.cacheCapacity()`.
 See its JavaDocs for more information.
 
 [[zk-leadership]]

--- a/src/reference/asciidoc/zookeeper.adoc
+++ b/src/reference/asciidoc/zookeeper.adoc
@@ -84,7 +84,7 @@ public interface KeyToPathStrategy {
 If the strategy returns `true` from `isBounded`, unused locks do not need to be harvested.
 For unbounded strategies (such as the default), you need to periodically invoke `expireUnusedOlderThan(long age)` to remove old unused locks from memory.
 
-String with version 5.5.6, the `ZookeeperLockRegistry` is support automatically clean up cache for ZkLock in `ZookeeperLockRegistry.locks` via `ZookeeperLockRegistry.cacheCapacity()`.
+String with version 5.5.6, the `ZookeeperLockRegistry` is support automatically clean up cache for ZkLock in `ZookeeperLockRegistry.locks` via `ZookeeperLockRegistry.setCacheCapacity()`.
 See its JavaDocs for more information.
 
 [[zk-leadership]]

--- a/src/reference/asciidoc/zookeeper.adoc
+++ b/src/reference/asciidoc/zookeeper.adoc
@@ -84,6 +84,9 @@ public interface KeyToPathStrategy {
 If the strategy returns `true` from `isBounded`, unused locks do not need to be harvested.
 For unbounded strategies (such as the default), you need to periodically invoke `expireUnusedOlderThan(long age)` to remove old unused locks from memory.
 
+String with version 5.5.6, the `ZookeeperLockRegistry` is support automatically clean up cache for ZkLock in `ZookeeperLockRegistry.locks` via `ZookeeperLockRegistry.setCapacity()`.
+See its JavaDocs for more information.
+
 [[zk-leadership]]
 === Zookeeper Leadership Event Handling
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3672

Currently, if you don't manually call expireUnusedOlderThan(), OutOfMemory can happen.
Therefore, I changed the code so that if the cache exceeds a setting capacity, it is automatically deleted.

### `JdbcLockRegistry`
default capacity : `100_000`, about 21MB
![image](https://user-images.githubusercontent.com/5335333/141319214-97283273-91cf-41cb-98fe-84c15900d7f0.png)


### `ZookeeperLockRegistry`
if default of capacity is `100_000`, about 83MB
![image](https://user-images.githubusercontent.com/5335333/141319331-021da283-22b3-4160-bb42-6ee7198555a0.png)

if default of capacity is `30_000`, about 25MB
![image](https://user-images.githubusercontent.com/5335333/141319409-d64b4890-ed4f-4069-9b60-6d8a8c7ad11d.png)

because `ZookeeperLockRegistry` default of capacity  is `30_000`