### PR TITLE
GH-3675: Restore nativeHeaders for WebSocketInChA

### DIFF
--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
@@ -63,6 +63,8 @@ import org.springframework.web.socket.messaging.StompSubProtocolHandler;
 import org.springframework.web.socket.messaging.SubProtocolHandler;
 
 /**
+ * The {@link MessageProducerSupport} for inbound WebSocket messages.
+ *
  * @author Artem Bilan
  *
  * @since 4.1
@@ -356,7 +358,6 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 	}
 
 	private void produceMessage(Message<?> message, SimpMessageHeaderAccessor headerAccessor) {
-		headerAccessor.removeHeader(SimpMessageHeaderAccessor.NATIVE_HEADERS);
 		Object payload = this.messageConverter.fromMessage(message, this.payloadType.get());
 		Assert.state(payload != null,
 				() -> "The message converter '" + this.messageConverter +

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/outbound/WebSocketOutboundMessageHandlerTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/outbound/WebSocketOutboundMessageHandlerTests.java
@@ -46,7 +46,6 @@ import org.springframework.web.socket.client.standard.StandardWebSocketClient;
 import org.springframework.web.socket.messaging.StompSubProtocolHandler;
 import org.springframework.web.socket.messaging.SubProtocolHandler;
 import org.springframework.web.socket.sockjs.client.SockJsClient;
-import org.springframework.web.socket.sockjs.client.Transport;
 import org.springframework.web.socket.sockjs.client.WebSocketTransport;
 
 /**
@@ -101,7 +100,7 @@ public class WebSocketOutboundMessageHandlerTests {
 
 		@Bean
 		public WebSocketClient webSocketClient() {
-			return new SockJsClient(Collections.<Transport>singletonList(new WebSocketTransport(new StandardWebSocketClient())));
+			return new SockJsClient(Collections.singletonList(new WebSocketTransport(new StandardWebSocketClient())));
 		}
 
 		@Bean

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/server/WebSocketServerTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/server/WebSocketServerTests.java
@@ -134,6 +134,7 @@ public class WebSocketServerTests {
 		assertThat(received).isNotNull();
 		StompHeaderAccessor stompHeaderAccessor = StompHeaderAccessor.wrap(received);
 		assertThat(stompHeaderAccessor.getMessageType()).isEqualTo(StompCommand.MESSAGE.getMessageType());
+		assertThat(stompHeaderAccessor.getNativeHeader(StompHeaderAccessor.STOMP_MESSAGE_ID_HEADER)).isNotNull();
 
 		Object receivedPayload = received.getPayload();
 		assertThat(receivedPayload).isInstanceOf(String.class);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3675

The `WebSocketInboundChannelAdapter` removes a `SimpMessageHeaderAccessor.NATIVE_HEADERS`
from headers used to create an outbound message.
Turns out not all native headers are mapped by the `StompHeaderAccessor`
to the top-level header entries.

**Cherry-pick to `5.4.x` & `5.3.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
