### PR TITLE
Make sure DefaultLockRepository always use new transaction

### DIFF
--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/DefaultLockRepositoryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/DefaultLockRepositoryTests.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.jdbc.lock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.sql.Connection;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.transaction.annotation.Isolation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+/**
+ * @author Ruslan Stelmachenko
+ *
+ * @since 5.5.7
+ */
+@SpringJUnitConfig(locations = "JdbcLockRegistryTests-context.xml")
+@DirtiesContext
+public class DefaultLockRepositoryTests {
+
+	@Autowired
+	private LockRepository client;
+
+	@BeforeEach
+	public void clear() {
+		this.client.close();
+	}
+
+	@Transactional
+	@Test
+	public void testNewTransactionIsStartedWhenTransactionIsAlreadyActive() {
+		// Make sure a transaction is active
+		assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isTrue();
+
+		TransactionSynchronization transactionSynchronization = spy(TransactionSynchronization.class);
+		TransactionSynchronizationManager.registerSynchronization(transactionSynchronization);
+
+		this.client.acquire("foo"); // 1
+		this.client.renew("foo"); // 2
+		this.client.delete("foo"); // 3
+		this.client.isAcquired("foo"); // 4
+		this.client.deleteExpired(); // 5
+		this.client.close(); // 6
+
+		// Make sure a transaction is still active
+		assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isTrue();
+		// And was suspended for each invocation of @Transactional methods of DefaultLockRepository,
+		// that confirms that these methods were called in a separate transaction each.
+		verify(transactionSynchronization, times(6)).suspend();
+	}
+
+	@Transactional(isolation = Isolation.REPEATABLE_READ)
+	@Test
+	public void testIsAcquiredFromRepeatableReadTransaction() {
+		// Make sure a transaction with REPEATABLE_READ isolation level is active
+		assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isTrue();
+		assertThat(TransactionSynchronizationManager.getCurrentTransactionIsolationLevel())
+				.isEqualTo(Connection.TRANSACTION_REPEATABLE_READ);
+
+		this.client.acquire("foo");
+		assertThat(this.client.isAcquired("foo")).isTrue();
+
+		this.client.delete("foo");
+		assertThat(this.client.isAcquired("foo")).isFalse();
+	}
+
+}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
@@ -18,9 +18,6 @@ package org.springframework.integration.jdbc.lock;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 import java.util.Map;
 import java.util.Queue;
@@ -45,9 +42,6 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.util.UUIDConverter;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * @author Dave Syer
@@ -481,35 +475,6 @@ public class JdbcLockRegistryTests {
 		assertThat(getRegistryLocks(registry)).containsKeys(toUUID("foo:3"),
 															toUUID("foo:4"),
 															toUUID("foo:5"));
-	}
-
-	@Transactional
-	@Test
-	public void testNewTransactionIsStartedWhenTransactionIsAlreadyActive() {
-		// Make sure a transaction is active
-		assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isTrue();
-
-		TransactionSynchronization transactionSynchronization = spy(TransactionSynchronization.class);
-		TransactionSynchronizationManager.registerSynchronization(transactionSynchronization);
-
-		Lock lock = this.registry.obtain("foo");
-		lock.lock(); // 1
-		try {
-			this.registry.renewLock("foo"); // 2
-		}
-		finally {
-			lock.unlock(); // 3
-		}
-		assertThat(TestUtils.getPropertyValue(this.registry, "locks", Map.class).size()).isEqualTo(1);
-		this.registry.expireUnusedOlderThan(-1000); // 4
-		this.client.deleteExpired(); // 5
-		this.client.close(); // 6
-
-		// Make sure a transaction is still active
-		assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isTrue();
-		// And was suspended for each invocation of @Transactional methods of DefaultLockRepository,
-		// that confirms that these methods were called in a separate transaction each.
-		verify(transactionSynchronization, times(6)).suspend();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
@@ -500,7 +500,8 @@ public class JdbcLockRegistryTests {
 		finally {
 			lock.unlock(); // 3
 		}
-		this.registry.expireUnusedOlderThan(0); // 4
+		assertThat(TestUtils.getPropertyValue(this.registry, "locks", Map.class).size()).isEqualTo(1);
+		this.registry.expireUnusedOlderThan(-1000); // 4
 		this.client.deleteExpired(); // 5
 		this.client.close(); // 6
 


### PR DESCRIPTION
If a transaction is already active while JdbcLockRegistry uses
DefaultLockRepository to acquire/release a lock, the repository
must execute SQL queries in a separate transaction to prevent
problems with blocking, deadlocking etc.

It also allows to properly follow transaction isolation level that
is set on some methods of DefaultLockRepository.

Previously all methods of DefaultLockRepository supported the current
transaction if there are any. Now all methods will always create new
transaction on each call.

Fixes #3683 