### PR TITLE
GH-3688: Fix WS DSL for proper values propagation

### DIFF
--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
@@ -158,8 +158,8 @@ public abstract class BaseWsOutboundGatewaySpec<
 	protected E assemble(E gateway) {
 		gateway.setUriVariableExpressions(this.uriVariableExpressions);
 		JavaUtils.INSTANCE
-				.acceptIfNotNull(this.headerMapper, gateway::setHeaderMapper);
-		gateway.setEncodingMode(this.encodingMode);
+				.acceptIfNotNull(this.headerMapper, gateway::setHeaderMapper)
+				.acceptIfNotNull(this.encodingMode, gateway::setEncodingMode);
 		gateway.setIgnoreEmptyResponses(this.ignoreEmptyResponses);
 		gateway.setRequestCallback(this.requestCallback);
 		return gateway;

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/MarshallingWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/MarshallingWsOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.ws.dsl;
 
 import java.util.Arrays;
 
+import org.springframework.integration.JavaUtils;
 import org.springframework.integration.ws.MarshallingWebServiceOutboundGateway;
 import org.springframework.oxm.Marshaller;
 import org.springframework.oxm.Unmarshaller;
@@ -141,9 +142,10 @@ public class MarshallingWsOutboundGatewaySpec extends
 		@Override
 		protected MarshallingWebServiceOutboundGateway assemble(MarshallingWebServiceOutboundGateway gateway) {
 			MarshallingWebServiceOutboundGateway assembled = super.assemble(gateway);
-			assembled.setFaultMessageResolver(this.faultMessageResolver);
-			assembled.setMessageSenders(this.messageSenders);
-			assembled.setInterceptors(this.gatewayInterceptors);
+			JavaUtils.INSTANCE
+					.acceptIfNotNull(this.faultMessageResolver, assembled::setFaultMessageResolver)
+					.acceptIfNotNull(this.messageSenders, assembled::setMessageSenders)
+					.acceptIfNotNull(this.gatewayInterceptors, assembled::setInterceptors);
 			return assembled;
 		}
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/SimpleWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/SimpleWsOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.ws.dsl;
 
 import java.util.Arrays;
 
+import org.springframework.integration.JavaUtils;
 import org.springframework.integration.ws.SimpleWebServiceOutboundGateway;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
@@ -100,7 +101,7 @@ public class SimpleWsOutboundGatewaySpec
 
 		protected SourceExtractor<?> sourceExtractor; // NOSONAR
 
-		private boolean extractPayload;
+		private boolean extractPayload = true;
 
 		/**
 		 * Configure a {@link SourceExtractor} to use.
@@ -181,9 +182,10 @@ public class SimpleWsOutboundGatewaySpec
 		@Override
 		protected SimpleWebServiceOutboundGateway assemble(SimpleWebServiceOutboundGateway gateway) {
 			SimpleWebServiceOutboundGateway assembled = super.assemble(gateway);
-			assembled.setFaultMessageResolver(this.faultMessageResolver);
-			assembled.setMessageSenders(this.messageSenders);
-			assembled.setInterceptors(this.gatewayInterceptors);
+			JavaUtils.INSTANCE
+					.acceptIfNotNull(this.faultMessageResolver, assembled::setFaultMessageResolver)
+					.acceptIfNotNull(this.messageSenders, assembled::setMessageSenders)
+					.acceptIfNotNull(this.gatewayInterceptors, assembled::setInterceptors);
 			assembled.setExtractPayload(this.extractPayload);
 			return assembled;
 		}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,6 @@ public class WsDslTests {
 						.marshaller(marshaller)
 						.unmarshaller(unmarshaller)
 						.messageFactory(messageFactory)
-						.encodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY)
 						.faultMessageResolver(faultMessageResolver)
 						.headerMapper(headerMapper)
 						.ignoreEmptyResponses(true)
@@ -172,7 +171,6 @@ public class WsDslTests {
 		MarshallingWebServiceOutboundGateway gateway =
 				Ws.marshallingOutboundGateway(template)
 						.uri(uri)
-						.encodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY)
 						.headerMapper(headerMapper)
 						.ignoreEmptyResponses(true)
 						.requestCallback(requestCallback)
@@ -182,6 +180,10 @@ public class WsDslTests {
 		assertThat(TestUtils.getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
 		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
 		assertThat(TestUtils.getPropertyValue(gateway, "uriVariableExpressions")).isEqualTo(uriVariableExpressions);
+		assertThat(
+				TestUtils.getPropertyValue(gateway, "uriFactory.encodingMode",
+						DefaultUriBuilderFactory.EncodingMode.class))
+				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.TEMPLATE_AND_VALUES);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3688

The `WebServiceTemplate` is populated with some defaults from its ctor.
We should rely on the target default template values as much as possible
and don't override them to `null` if end-user doesn't ask about that explicitly

* Fix `BaseWsOutboundGatewaySpec` extensions to populate values to the target gateway
only if they are not null - therefore provided by end-user
* If end-user wants them explicitly `null`, it is better to do that via
externally configured template.
See overloaded variants for DSL: `Ws.marshallingOutboundGateway(WebServiceTemplate)`
and `Ws.simpleOutboundGateway(WebServiceTemplate)`

**Cherry-pick to `5.4.x` & `5.3.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
