### PR TITLE
GH-3694: Resolve circular dep in PublisherAnnBPP

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.beans.factory.SmartInitializingSingleton;
 
 /**
  * Post-processes beans that contain the
@@ -40,7 +41,7 @@ import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
  */
 @SuppressWarnings("serial")
 public class PublisherAnnotationBeanPostProcessor extends AbstractBeanFactoryAwareAdvisingPostProcessor
-		implements BeanNameAware, InitializingBean {
+		implements BeanNameAware, SmartInitializingSingleton {
 
 	private String defaultChannelName;
 
@@ -74,7 +75,7 @@ public class PublisherAnnotationBeanPostProcessor extends AbstractBeanFactoryAwa
 	}
 
 	@Override
-	public void afterPropertiesSet() {
+	public void afterSingletonsInstantiated() {
 		try {
 			this.beanFactory.getBean(PublisherAnnotationBeanPostProcessor.class);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationBeanPostProcessor.java
@@ -20,7 +20,6 @@ import org.springframework.aop.framework.autoproxy.AbstractBeanFactoryAwareAdvis
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanNameAware;
-import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3694

* Move check for `PublisherAnnotationBeanPostProcessor` bean into the
`SmartInitializingSingleton.afterSingletonsInstantiated()` to break a circular dependency revealed
in the `InitializingBean.afterPropertiesSet()`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
