### PR TITLE
GH-3697: Various lifecycle fixed for MQTT v5 CAs

### DIFF
--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
@@ -56,7 +56,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * @author Gary Russell
  * @author Artem Bilan
  *
- * @since 4.0
+ * @since 5.5.5
  *
  */
 @SpringJUnitConfig
@@ -164,8 +164,7 @@ public class Mqttv5BackToBackTests implements MosquittoContainerTest {
 			messageProducer.setMessageConverter(mqttStringToBytesConverter());
 			messageProducer.setManualAcks(true);
 
-			return IntegrationFlows.from(
-							messageProducer)
+			return IntegrationFlows.from(messageProducer)
 					.channel(c -> c.queue("fromMqttChannel"))
 					.get();
 		}

--- a/src/reference/asciidoc/mqtt.adoc
+++ b/src/reference/asciidoc/mqtt.adoc
@@ -495,3 +495,6 @@ public IntegrationFlow mqttInFlow() {
 IMPORTANT: The `org.springframework.integration.mqtt.support.MqttMessageConverter` cannot be used with the `Mqttv5PahoMessageDrivenChannelAdapter` since its contract is aimed only for the MQTT v3 protocol.
 
 See more information in the `Mqttv5PahoMessageDrivenChannelAdapter` javadocs and its superclass.
+
+IMPORTANT: It is recommended to have the `MqttConnectionOptions#setAutomaticReconnect(boolean)` set to true to let an internal `IMqttAsyncClient` instance to handle reconnects.
+Otherwise, only the manual restart of these channel adapters can handle reconnects, e.g. via `MqttConnectionFailedEvent` handling on disconnection.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3697
SO: https://stackoverflow.com/questions/70374046/spring-integration-mqtt-failed-to-start-app-when-the-network-is-disconnected

* Add `mqttClient.disconnect()` to `Mqttv5PahoMessageDrivenChannelAdapter.doStop()` - the `doStart()` does `connect()`
* Add `Mqttv5PahoMessageDrivenChannelAdapter.destroy()` impl to close `mqttClient`
* Fix `Mqttv5PahoMessageHandler.doStart()` to not re-throw an exception on connection.
Emit an `MqttConnectionFailedEvent` and log error instead
* Fix `Mqttv5PahoMessageHandler.destroy()` to call `mqttClient.close(true)` for better resources clean up
* Improve MQTT v5 components Javadocs and add a reconnect note into `mqtt.adoc`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
