### PR TITLE
GH-3700: Fix to retry until expiration time

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -359,35 +359,38 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 		}
 
 		private boolean subscribeLock(long time) throws ExecutionException, InterruptedException {
+			if (obtainLock()) {
+				return true;
+			}
+
+			if (!RedisLockRegistry.this.redisMessageListenerContainer.isRunning()) {
+				RedisLockRegistry.this.redisMessageListenerContainer.afterPropertiesSet();
+				RedisLockRegistry.this.redisMessageListenerContainer.start();
+			}
+
 			final long expiredTime = System.currentTimeMillis() + time;
 			while (time == -1 || expiredTime >= System.currentTimeMillis()) {
-				if (!obtainLock()) {
-					if (!RedisLockRegistry.this.redisMessageListenerContainer.isRunning()) {
-						RedisLockRegistry.this.redisMessageListenerContainer.afterPropertiesSet();
-						RedisLockRegistry.this.redisMessageListenerContainer.start();
+				try {
+					Future<String> future =
+							RedisLockRegistry.this.unlockNotifyMessageListener.subscribeLock(this.lockKey);
+					//DCL
+					if (obtainLock()) {
+						return true;
 					}
 					try {
-						Future<String> future =
-								RedisLockRegistry.this.unlockNotifyMessageListener.subscribeLock(this.lockKey);
-						//DCL
-						if (!obtainLock()) {
-							try {
-								//if short expireAfter key expire for ttl, no receive unlock msg
-								long waitTime = time >= 0 ? time : RedisLockRegistry.this.expireAfter;
-								future.get(waitTime, TimeUnit.MILLISECONDS);
-							}
-							catch (TimeoutException ignore) {
-							}
-							if (!obtainLock()) {
-								continue;
-							}
-						}
+						//if short expireAfter key expire for ttl, no receive unlock msg
+						long waitTime = time >= 0 ? time : RedisLockRegistry.this.expireAfter;
+						future.get(waitTime, TimeUnit.MILLISECONDS);
 					}
-					finally {
-						RedisLockRegistry.this.unlockNotifyMessageListener.unSubscribeLock(this.lockKey);
+					catch (TimeoutException ignore) {
+					}
+					if (obtainLock()) {
+						return true;
 					}
 				}
-				return true;
+				finally {
+					RedisLockRegistry.this.unlockNotifyMessageListener.unSubscribeLock(this.lockKey);
+				}
 			}
 			return false;
 		}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -359,6 +359,7 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 		}
 
 		private boolean subscribeLock(long time) throws ExecutionException, InterruptedException {
+			final long expiredTime = System.currentTimeMillis() + time;
 			if (obtainLock()) {
 				return true;
 			}
@@ -367,8 +368,6 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 				RedisLockRegistry.this.redisMessageListenerContainer.afterPropertiesSet();
 				RedisLockRegistry.this.redisMessageListenerContainer.start();
 			}
-
-			final long expiredTime = System.currentTimeMillis() + time;
 			while (time == -1 || expiredTime >= System.currentTimeMillis()) {
 				try {
 					Future<String> future =


### PR DESCRIPTION
https://github.com/spring-projects/spring-integration/issues/3700

Fixed a case where lock acquisition attempt was abandoned earlier than expected time

If a vm uses tryLock() and another vm unlock it, it will wake up with an unlock message and try to acquire the lock, but if it fails(the other vm obtain lock), vm will return false.


<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
