### PR TITLE
Fix variable name typo in the redis.adoc

### DIFF
--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -785,9 +785,9 @@ public ReactiveRedisStreamMessageHandler reactiveValidatorMessageHandler(
         ReactiveRedisConnectionFactory reactiveRedisConnectionFactory) {
     ReactiveRedisStreamMessageHandler reactiveStreamMessageHandler =
         new ReactiveRedisStreamMessageHandler(reactiveRedisConnectionFactory, "myStreamKey"); <1>
-    reactiveRedisStreamMessageHandler.setSerializationContext(serializationContext); <2>
-    reactiveRedisStreamMessageHandler.setHashMapper(hashMapper); <3>
-    reactiveRedisStreamMessageHandler.setExtractPayload(true); <4>
+    reactiveStreamMessageHandler.setSerializationContext(serializationContext); <2>
+    reactiveStreamMessageHandler.setHashMapper(hashMapper); <3>
+    reactiveStreamMessageHandler.setExtractPayload(true); <4>
 }
 ----
 <1> Construct an instance of `ReactiveRedisStreamMessageHandler` using `ReactiveRedisConnectionFactory` and stream name to add records.

--- a/src/reference/asciidoc/redis.adoc
+++ b/src/reference/asciidoc/redis.adoc
@@ -788,6 +788,7 @@ public ReactiveRedisStreamMessageHandler reactiveValidatorMessageHandler(
     reactiveStreamMessageHandler.setSerializationContext(serializationContext); <2>
     reactiveStreamMessageHandler.setHashMapper(hashMapper); <3>
     reactiveStreamMessageHandler.setExtractPayload(true); <4>
+    return reactiveStreamMessageHandler;
 }
 ----
 <1> Construct an instance of `ReactiveRedisStreamMessageHandler` using `ReactiveRedisConnectionFactory` and stream name to add records.


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->

The example code of "the Redis Stream Outbound Channel Adapter" section has a typo.
