### PR TITLE
Move IntegrationDsl from .kt to .java

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationDsl.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationDsl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,27 @@
  * limitations under the License.
  */
 
-package org.springframework.integration.dsl
+package org.springframework.integration.dsl;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import kotlin.DslMarker;
 
 /**
- * The Kotlin [DslMarker] annotation for classes used in scope of DSL, including all the Java DSL classes.
+ * The Kotlin {@link DslMarker} annotation for classes used in scope of DSL, including all the Java DSL classes.
  *
  * @author Artem Bilan
  *
  * @since 5.5.8
  */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS)
+@Documented
 @DslMarker
-annotation class IntegrationDsl
+public @interface IntegrationDsl {
+
+}


### PR DESCRIPTION
Turns out Eclipse Kotlin plugin is not perfect at the moment,
and it causes some code parsing problems in the editor.

* Move Kotlin annotation to Java to mitigate normal source code flow:
 Java to Kotlin, not opposite

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
