### PR TITLE
GH-3713: TCP: Fix Intercepted Sender List

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2001-2021 the original author or authors.
+ * Copyright 2001-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,9 +199,7 @@ public abstract class TcpConnectionSupport implements TcpConnection {
 				outerListener = nextListener;
 			}
 			outerListener.close();
-			for (TcpSender sender : getSenders()) {
-				sender.removeDeadConnection(outerListener);
-			}
+			outerListener.removeDeadConnection(outerListener);
 			if (isException) {
 				// ensure physical close in case the interceptor did not close
 				this.close();
@@ -337,6 +335,7 @@ public abstract class TcpConnectionSupport implements TcpConnection {
 	 * @return the listener
 	 */
 	@Override
+	@Nullable
 	public TcpListener getListener() {
 		if (this.needsTest && this.testListener != null) {
 			this.needsTest = false;


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3713

https://github.com/spring-projects/spring-integration/issues/3326 added support
for multiple `TcpSenders`. However, when connections are intercepted, the sender
list was not properly chained through the interceptors.

- override `registerSenders` and properly capture the real senders in the last
  interceptor and intermediate interceptors
- this ensures that `addNewConnection` is called on each interceptor
- when removing dead connections, use the (possibly intercepted) connection sender
  list insted of the factory's raw sender list.

**cherry-pick to 5.5.x**
