### PR TITLE
GH-3711: Fix HTTP handler for content type header

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,8 +118,8 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 
 	/**
 	 * Set the encoding mode to use.
-	 * By default this is set to {@link DefaultUriBuilderFactory.EncodingMode#TEMPLATE_AND_VALUES}.
-	 * For more complicated scenarios consider to configure an {@link org.springframework.web.util.UriTemplateHandler}
+	 * By default, this is set to {@link DefaultUriBuilderFactory.EncodingMode#TEMPLATE_AND_VALUES}.
+	 * For more complicated scenarios consider configuring an {@link org.springframework.web.util.UriTemplateHandler}
 	 * on an externally provided {@link org.springframework.web.client.RestTemplate}.
 	 * @param encodingMode the mode to use for uri encoding
 	 * @since 5.3
@@ -151,7 +151,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 	/**
 	 * Specify whether the outbound message's payload should be extracted
 	 * when preparing the request body.
-	 * Otherwise the Message instance itself is serialized.
+	 * Otherwise, the Message instance itself is serialized.
 	 * The default value is {@code true}.
 	 * @param extractPayload true if the payload should be extracted.
 	 */
@@ -189,7 +189,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 
 	/**
 	 * Specify the expected response type for the REST request.
-	 * Otherwise it is null and an empty {@link ResponseEntity} is returned from HTTP client.
+	 * Otherwise, it is null and an empty {@link ResponseEntity} is returned from HTTP client.
 	 * To take advantage of the HttpMessageConverters
 	 * registered on this adapter, provide a different type).
 	 * @param expectedResponseType The expected type.
@@ -378,8 +378,8 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 							: resolveContentType(payload);
 			httpHeaders.setContentType(contentType);
 		}
-		if ((MediaType.APPLICATION_FORM_URLENCODED.equals(httpHeaders.getContentType()) ||
-				MediaType.MULTIPART_FORM_DATA.equals(httpHeaders.getContentType()))
+		if ((MediaType.APPLICATION_FORM_URLENCODED.equalsTypeAndSubtype(httpHeaders.getContentType()) ||
+				MediaType.MULTIPART_FORM_DATA.equalsTypeAndSubtype(httpHeaders.getContentType()))
 				&& !(payload instanceof MultiValueMap)) {
 
 			Assert.isInstanceOf(Map.class, payload,
@@ -471,8 +471,7 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 				if (value.getClass().isArray()) {
 					value = CollectionUtils.arrayToList(value);
 				}
-				if (value instanceof Collection) {
-					Collection<?> cValues = (Collection<?>) value;
+				if (value instanceof Collection<?> cValues) {
 					for (Object cValue : cValues) {
 						if (cValue != null && !(cValue instanceof String)) {
 							return true;

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests-context.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans:beans
-	xmlns="http://www.springframework.org/schema/integration/http"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:beans="http://www.springframework.org/schema/beans"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xmlns:util="http://www.springframework.org/schema/util"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		xmlns="http://www.springframework.org/schema/integration/http"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns:beans="http://www.springframework.org/schema/beans"
+		xmlns:int="http://www.springframework.org/schema/integration"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http.xsd
-		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
-		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<inbound-gateway path="/test" request-channel="testChannel"
 					 payload-expression="T(org.springframework.web.context.request.RequestContextHolder).requestAttributes.request.queryString"/>
@@ -25,15 +23,14 @@
 	</int:channel>
 
 	<inbound-gateway path="/testmp" request-channel="testChannelmp"
-					 merge-with-default-converters="false"
-					 message-converters="converters"
-					 request-payload-type="byte[]" />
+					 message-converters="formHttpMessageConverter"/>
 
-	<util:list id="converters">
-		<beans:bean class="org.springframework.http.converter.ByteArrayHttpMessageConverter" />
-		<beans:bean class="org.springframework.http.converter.StringHttpMessageConverter" />
-		<beans:bean class="org.springframework.http.converter.json.MappingJackson2HttpMessageConverter" />
-	</util:list>
+	<beans:bean id="formHttpMessageConverter"
+				class="org.springframework.integration.http.converter.MultipartAwareFormHttpMessageConverter">
+		<beans:property name="multipartFileReader">
+			<beans:bean class="org.springframework.integration.http.multipart.SimpleMultipartFileReader"/>
+		</beans:property>
+	</beans:bean>
 
 	<int:channel id="testChannelmp"/>
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3711

The `contentType` header may come with parameter in its media type.

* Fix `AbstractHttpRequestExecutingMessageHandler` to use `equalsTypeAndSubtype()`
ignoring params
* Some other code clean up in the `AbstractHttpRequestExecutingMessageHandler`
* Ensure in the `HttpRequestExecutingMessageHandlerTests.simpleStringKeyStringValueFormData()`
that provided `contentType` header is handled properly
* Fix `HttpProxyScenarioTests.testHttpMultipartProxyScenario()` for mislead multi-part form
handling

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
