### PR TITLE
Fix a mistake in a sentence about EIP components and BeanPostProcessor

### DIFF
--- a/src/reference/asciidoc/overview.adoc
+++ b/src/reference/asciidoc/overview.adoc
@@ -595,7 +595,7 @@ Its main implementations are:
 * `EventDrivenConsumer`, used when we subscribe to a `SubscribableChannel` to listen for messages.
 * `PollingConsumer`, used when we poll for messages from a `PollableChannel`.
 
-When you use messaging annotations or the Java DSL, you need to worry about these components, because the Framework automatically produces them with appropriate annotations and `BeanPostProcessor` implementations.
+When you use messaging annotations or the Java DSL, you don't need to worry about these components, because the Framework automatically produces them with appropriate annotations and `BeanPostProcessor` implementations.
 When building components manually, you should use the `ConsumerEndpointFactoryBean` to help determine the target `AbstractEndpoint` consumer implementation to create, based on the provided `inputChannel` property.
 
 On the other hand, the `ConsumerEndpointFactoryBean` delegates to an another first class citizen in the Framework - `org.springframework.messaging.MessageHandler`.


### PR DESCRIPTION
A minor fix for a wrong sentence in the docs.
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
