### PR TITLE
Spring Issue: 28032 Distributed lock fix

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
@@ -165,10 +165,12 @@ public class DefaultLockRepository implements LockRepository, InitializingBean {
 	@Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.SERIALIZABLE)
 	@Override
 	public boolean acquire(String lock) {
+		/*
 		if (this.template.update(this.updateQuery, this.id, new Date(), this.region, lock, this.id,
 				new Date(System.currentTimeMillis() - this.ttl)) > 0) {
 			return true;
 		}
+		*/
 		try {
 			return this.template.update(this.insertQuery, this.region, lock, this.id, new Date()) > 0;
 		}

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
@@ -165,7 +165,8 @@ public class DefaultLockRepository implements LockRepository, InitializingBean {
 	@Transactional(propagation = Propagation.REQUIRES_NEW, isolation = Isolation.SERIALIZABLE)
 	@Override
 	public boolean acquire(String lock) {
-		/*
+		/* Distributed lock allows 2nd process to acquire lock on lockKey inspite of being locked by 1st process.
+		Commenting out below logic will prevent 2nd process to acquire lock
 		if (this.template.update(this.updateQuery, this.id, new Date(), this.region, lock, this.id,
 				new Date(System.currentTimeMillis() - this.ttl)) > 0) {
 			return true;


### PR DESCRIPTION
org.springframework.integration:spring-integration-jdbc. Distributed lock allows 2nd process to acquire lock on lockKey inspite of being locked by 1st process

Detailed spring issue can be found here - spring-projects/spring-integration#3724
