### PR TITLE
Remove SocketUtils usage

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/MulticastRule.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/MulticastRule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import org.junit.runners.model.Statement;
 import org.springframework.integration.ip.util.SocketTestUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
-import org.springframework.util.SocketUtils;
 
 /**
  * @author Artem Bilan
@@ -76,7 +75,7 @@ public class MulticastRule extends TestWatcher {
 		}
 		try {
 			MulticastSocket socket = new MulticastSocket();
-			socket.joinGroup(new InetSocketAddress(this.group, SocketUtils.findAvailableUdpPort()), nic);
+			socket.joinGroup(new InetSocketAddress(this.group, 0), nic);
 			socket.close();
 		}
 		catch (Exception e) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,6 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.rule.Log4j2LevelAdjuster;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.SubscribableChannel;
-import org.springframework.util.SocketUtils;
 
 /**
  *
@@ -284,8 +283,7 @@ public class UdpChannelAdapterTests {
 			}
 
 		}
-		DatagramSocket datagramSocket =
-				new DatagramSocket(SocketUtils.findAvailableUdpPort(), inetAddress);
+		DatagramSocket datagramSocket = new DatagramSocket(0, inetAddress);
 		datagramSocket.send(packet);
 		datagramSocket.close();
 

--- a/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/client/StompServerIntegrationTests.java
+++ b/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/client/StompServerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.junit.jupiter.api.AfterAll;
@@ -57,7 +58,6 @@ import org.springframework.messaging.simp.stomp.ReactorNettyTcpStompClient;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
-import org.springframework.util.SocketUtils;
 
 /**
  * @author Artem Bilan
@@ -73,7 +73,6 @@ public class StompServerIntegrationTests {
 
 	@BeforeAll
 	public static void setup() throws Exception {
-		int port = SocketUtils.findAvailableTcpPort(61613);
 		ConfigurationImpl configuration =
 				new ConfigurationImpl()
 						.setName("embedded-server")
@@ -81,14 +80,14 @@ public class StompServerIntegrationTests {
 						.setSecurityEnabled(false)
 						.setJMXManagementEnabled(false)
 						.setJournalDatasync(false)
-						.addAcceptorConfiguration("stomp", "tcp://127.0.0.1:" + port)
+						.addAcceptorConfiguration("stomp", "tcp://127.0.0.1:" + TransportConstants.DEFAULT_STOMP_PORT)
 						.addAddressesSetting("#",
 								new AddressSettings()
 										.setDeadLetterAddress(SimpleString.toSimpleString("dla"))
 										.setExpiryAddress(SimpleString.toSimpleString("expiry")));
 		broker.setConfiguration(configuration).start();
 
-		stompClient = new ReactorNettyTcpStompClient("127.0.0.1", port);
+		stompClient = new ReactorNettyTcpStompClient("127.0.0.1", TransportConstants.DEFAULT_STOMP_PORT);
 		stompClient.setMessageConverter(new PassThruMessageConverter());
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.afterPropertiesSet();

--- a/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterParserTests-context.xml
+++ b/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterParserTests-context.xml
@@ -9,9 +9,7 @@
 		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<bean id="socketUtils" class="org.springframework.util.SocketUtils" />
-
-	<int-syslog:inbound-channel-adapter id="foo" port="#{socketUtils.findAvailableUdpPort(1514)}" />
+	<int-syslog:inbound-channel-adapter id="foo" port="0" />
 
 	<int-syslog:inbound-channel-adapter id="foobar" channel="foo" port="1514" auto-startup="false" />
 
@@ -42,7 +40,7 @@
 	<bean id="converter"
 		class="org.springframework.integration.syslog.config.SyslogReceivingChannelAdapterParserTests$PassThruConverter" />
 
-	<int-syslog:inbound-channel-adapter id="bar" protocol="tcp" port="#{socketUtils.findAvailableTcpPort(1514)}" />
+	<int-syslog:inbound-channel-adapter id="bar" protocol="tcp" port="0" />
 
 	<int:channel id="bar">
 		<int:queue/>

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/ZeroMqProxy.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/ZeroMqProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -212,7 +212,7 @@ public class ZeroMqProxy implements InitializingBean, SmartLifecycle, BeanNameAw
 
 	/**
 	 * Return the address an {@code inproc} control socket is bound or null if this proxy has not been started yet.
-	 * @return the the address for control socket or null
+	 * @return the address for control socket or null
 	 */
 	@Nullable
 	public String getControlAddress() {
@@ -222,7 +222,7 @@ public class ZeroMqProxy implements InitializingBean, SmartLifecycle, BeanNameAw
 	/**
 	 * Return the address an {@code inproc} capture socket is bound or null if this proxy has not been started yet
 	 * or {@link #captureAddress} is false.
-	 * @return the the address for capture socket or null
+	 * @return the address for capture socket or null
 	 */
 	@Nullable
 	public String getCaptureAddress() {

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMq.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.zeromq.dsl;
+
+import java.util.function.Supplier;
 
 import org.zeromq.SocketType;
 import org.zeromq.ZContext;
@@ -53,6 +55,18 @@ public final class ZeroMq {
 	 * @return the spec.
 	 */
 	public static ZeroMqMessageHandlerSpec outboundChannelAdapter(ZContext context, String connectUrl) {
+		return outboundChannelAdapter(context, () -> connectUrl);
+	}
+
+	/**
+	 * Create an instance of {@link ZeroMqMessageHandlerSpec} for the provided {@link ZContext}
+	 * and connection URL supplier.
+	 * @param context the {@link ZContext} to use.
+	 * @param connectUrl the supplier for URL to connect a ZeroMq socket to.
+	 * @return the spec.
+	 * @since 5.5.9
+	 */
+	public static ZeroMqMessageHandlerSpec outboundChannelAdapter(ZContext context, Supplier<String> connectUrl) {
 		return new ZeroMqMessageHandlerSpec(context, connectUrl);
 	}
 
@@ -65,6 +79,21 @@ public final class ZeroMq {
 	 * @return the spec.
 	 */
 	public static ZeroMqMessageHandlerSpec outboundChannelAdapter(ZContext context, String connectUrl,
+			SocketType socketType) {
+
+		return new ZeroMqMessageHandlerSpec(context, connectUrl, socketType);
+	}
+
+	/**
+	 * Create an instance of {@link ZeroMqMessageHandlerSpec} for the provided {@link ZContext},
+	 * connection URL supplier and {@link SocketType}.
+	 * @param context the {@link ZContext} to use.
+	 * @param connectUrl the supplier for URL to connect a ZeroMq socket to.
+	 * @param socketType the {@link SocketType} for ZeroMq socket.
+	 * @return the spec.
+	 * @since 5.5.9
+	 */
+	public static ZeroMqMessageHandlerSpec outboundChannelAdapter(ZContext context, Supplier<String> connectUrl,
 			SocketType socketType) {
 
 		return new ZeroMqMessageHandlerSpec(context, connectUrl, socketType);

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageHandlerSpec.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.zeromq.dsl;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.zeromq.SocketType;
 import org.zeromq.ZContext;
@@ -47,8 +48,19 @@ public class ZeroMqMessageHandlerSpec
 	 * @param connectUrl the URL to connect the socket to.
 	 */
 	protected ZeroMqMessageHandlerSpec(ZContext context, String connectUrl) {
+		this(context, () -> connectUrl);
+	}
+
+	/**
+	 * Create an instance based on the provided {@link ZContext} and connection string supplier.
+	 * @param context the {@link ZContext} to use for creating sockets.
+	 * @param connectUrl the supplier for URL to connect the socket to.
+	 * @since 5.5.9
+	 */
+	protected ZeroMqMessageHandlerSpec(ZContext context, Supplier<String> connectUrl) {
 		super(new ZeroMqMessageHandler(context, connectUrl));
 	}
+
 
 	/**
 	 * Create an instance based on the provided {@link ZContext}, connection string and {@link SocketType}.
@@ -58,6 +70,17 @@ public class ZeroMqMessageHandlerSpec
 	 *    only {@link SocketType#PAIR}, {@link SocketType#PUB} and {@link SocketType#PUSH} are supported.
 	 */
 	protected ZeroMqMessageHandlerSpec(ZContext context, String connectUrl, SocketType socketType) {
+		this(context, () -> connectUrl, socketType);
+	}
+
+	/**
+	 * Create an instance based on the provided {@link ZContext}, connection string supplier and {@link SocketType}.
+	 * @param context the {@link ZContext} to use for creating sockets.
+	 * @param connectUrl the supplier for URL to connect the socket to.
+	 * @param socketType the {@link SocketType} to use;
+	 *    only {@link SocketType#PAIR}, {@link SocketType#PUB} and {@link SocketType#PUSH} are supported.
+	 */
+	protected ZeroMqMessageHandlerSpec(ZContext context, Supplier<String> connectUrl, SocketType socketType) {
 		super(new ZeroMqMessageHandler(context, connectUrl, socketType));
 	}
 

--- a/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandlerTests.java
+++ b/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,6 +71,7 @@ public class ZeroMqMessageHandlerTests {
 		Mono<ZMQ.Socket> socketMono = TestUtils.getPropertyValue(messageHandler, "socketMono", Mono.class);
 		ZMQ.Socket socketInUse = socketMono.block(Duration.ofSeconds(10));
 		assertThat(socketInUse.getZapDomain()).isEqualTo("global");
+		messageHandler.start();
 
 		Message<?> testMessage = new GenericMessage<>("test");
 		messageHandler.handleMessage(testMessage).subscribe();
@@ -99,6 +100,7 @@ public class ZeroMqMessageHandlerTests {
 				new FunctionExpression<Message<?>>((message) -> message.getHeaders().get("topic")));
 		messageHandler.setMessageMapper(new EmbeddedJsonHeadersMessageMapper());
 		messageHandler.afterPropertiesSet();
+		messageHandler.start();
 
 		Message<?> testMessage = MessageBuilder.withPayload("test").setHeader("topic", "testTopic").build();
 
@@ -137,6 +139,7 @@ public class ZeroMqMessageHandlerTests {
 		messageHandler.setBeanFactory(mock(BeanFactory.class));
 		messageHandler.setMessageConverter(new ByteArrayMessageConverter());
 		messageHandler.afterPropertiesSet();
+		messageHandler.start();
 
 		Message<?> testMessage = new GenericMessage<>("test".getBytes());
 		messageHandler.handleMessage(testMessage).subscribe();

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -69,56 +69,6 @@ The `createTestApplicationContext()` factory method produces a `TestApplicationC
 
 See the https://docs.spring.io/spring-integration/api/org/springframework/integration/test/util/TestUtils.html[Javadoc] of other `TestUtils` methods for more information about this class.
 
-==== Using the `SocketUtils` Class
-
-The https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/SocketUtils.html[`SocketUtils` class] provides several methods that select one or more random ports for exposing server-side components without conflicts, as the following example shows:
-
-====
-[source,xml]
-----
-<bean id="socketUtils" class="org.springframework.util.SocketUtils" />
-
-<int-syslog:inbound-channel-adapter id="syslog"
-            channel="sysLogs"
-            port="#{socketUtils.findAvailableUdpPort(1514)}" />
-
-<int:channel id="sysLogs">
-    <int:queue/>
-</int:channel>
-----
-====
-
-The following example shows how the preceding configuration is used from the unit test:
-
-====
-[source,java]
-----
-@Autowired @Qualifier("syslog.adapter")
-private UdpSyslogReceivingChannelAdapter adapter;
-
-@Autowired
-private PollableChannel sysLogs;
-
-@Test
-public void testSimplestUdp() throws Exception {
-    int port = TestUtils.getPropertyValue(adapter1, "udpAdapter.port", Integer.class);
-    byte[] buf = "<157>JUL 26 22:08:35 WEBERN TESTING[70729]: TEST SYSLOG MESSAGE".getBytes("UTF-8");
-    DatagramPacket packet = new DatagramPacket(buf, buf.length,
-                              new InetSocketAddress("localhost", port));
-    DatagramSocket socket = new DatagramSocket();
-    socket.send(packet);
-    socket.close();
-    Message<?> message = foo.receive(10000);
-    assertNotNull(message);
-}
-----
-====
-
-NOTE: This technique is not foolproof.
-Some other process could be allocated the "`free`" port before your test opens it.
-It is generally more preferable to use server port `0`, let the operating system select the port for you, and then discover the selected port in your test.
-We have converted most framework tests to use this preferred technique.
-
 ==== Using `OnlyOnceTrigger`
 
 https://docs.spring.io/spring-integration/api/org/springframework/integration/test/util/OnlyOnceTrigger.html[`OnlyOnceTrigger`] is useful for polling endpoints when you need to produce only one test message and verify the behavior without impacting other period messages.


### PR DESCRIPTION
* Remove usage of non-stable `org.springframework.util.SocketUtils`
* Replace it with `0` for those tests where it is possible to select OS port
* Remove the mentioning of the `SocketUtils` from the `testing.adoc`
* Use `TransportConstants.DEFAULT_STOMP_PORT` for `StompServerIntegrationTests`.
We may disable this test in the future for CI if it is not going to be stable
* Introduce `Supplier<String> connectUrl` variants for `ZeroMqMessageHandler`
to let it defer connection evaluation until subscription to the socket `Mono`
in the `ZeroMqMessageHandler`.
* Move connection logic in the `ZeroMqMessageHandler` to `Lifecycle.start()`

Related to https://github.com/spring-projects/spring-framework/issues/28054

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
