### PR TITLE
GH-2750: Deprecate container spec errorHandler

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageListenerContainerSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageListenerContainerSpec.java
@@ -87,7 +87,9 @@ public class KafkaMessageListenerContainerSpec<K, V>
 	 * @param errorHandler the {@link org.springframework.kafka.listener.ErrorHandler}.
 	 * @return the spec.
 	 * @see org.springframework.kafka.listener.ErrorHandler
+	 * @deprecated - will be replaced in 6.0 with {@code CommonErrorHandler}.
 	 */
+	@Deprecated
 	public KafkaMessageListenerContainerSpec<K, V> errorHandler(GenericErrorHandler<?> errorHandler) {
 		this.target.setGenericErrorHandler(errorHandler);
 		return this;


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3750

**5.5.x only; removed in 6.0**

