### PR TITLE
GH-3734: Support MessageHistory on Kafka deser

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.integration.support.json;
 
 import java.io.IOException;
+import java.io.Serial;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -50,6 +51,20 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
  *
  */
 public final class JacksonJsonUtils {
+
+	/**
+	 * The packages to trust on JSON deserialization by default.
+	 */
+	public static final List<String> DEFAULT_TRUSTED_PACKAGES =
+			List.of(
+					"java.util",
+					"java.lang",
+					"org.springframework.messaging.support",
+					"org.springframework.integration.support",
+					"org.springframework.integration.message",
+					"org.springframework.integration.store",
+					"org.springframework.integration.history"
+			);
 
 	private JacksonJsonUtils() {
 	}
@@ -99,17 +114,16 @@ public final class JacksonJsonUtils {
 
 	/**
 	 * An implementation of {@link ObjectMapper.DefaultTypeResolverBuilder}
-	 * that wraps a default {@link TypeIdResolver} to the {@link AllowlistTypeIdResolver}.
+	 * that wraps a default {@link TypeIdResolver} to the {@link AllowListTypeIdResolver}.
 	 *
 	 * @author Rob Winch
 	 * @author Artem Bilan
 	 * @author Filip Hanik
 	 * @author Gary Russell
-	 *
-	 * @since 4.3.11
 	 */
 	private static final class AllowListTypeResolverBuilder extends ObjectMapper.DefaultTypeResolverBuilder {
 
+		@Serial
 		private static final long serialVersionUID = 1L;
 
 		private final String[] trustedPackages;
@@ -133,8 +147,9 @@ public final class JacksonJsonUtils {
 				JavaType baseType,
 				PolymorphicTypeValidator subtypeValidator,
 				Collection<NamedType> subtypes, boolean forSer, boolean forDeser) {
+
 			TypeIdResolver result = super.idResolver(config, baseType, subtypeValidator, subtypes, forSer, forDeser);
-			return new AllowlistTypeIdResolver(result, this.trustedPackages);
+			return new AllowListTypeIdResolver(result, this.trustedPackages);
 		}
 
 	}
@@ -146,27 +161,14 @@ public final class JacksonJsonUtils {
 	 *
 	 * @author Rob Winch
 	 * @author Artem Bilan
-	 *
-	 * @since 4.3.11
 	 */
-	private static final class AllowlistTypeIdResolver implements TypeIdResolver {
-
-		private static final List<String> TRUSTED_PACKAGES =
-				Arrays.asList(
-						"java.util",
-						"java.lang",
-						"org.springframework.messaging.support",
-						"org.springframework.integration.support",
-						"org.springframework.integration.message",
-						"org.springframework.integration.store",
-						"org.springframework.integration.history"
-				);
+	private static final class AllowListTypeIdResolver implements TypeIdResolver {
 
 		private final TypeIdResolver delegate;
 
-		private final Set<String> trustedPackages = new LinkedHashSet<>(TRUSTED_PACKAGES);
+		private final Set<String> trustedPackages = new LinkedHashSet<>(DEFAULT_TRUSTED_PACKAGES);
 
-		AllowlistTypeIdResolver(TypeIdResolver delegate, String... trustedPackages) {
+		AllowListTypeIdResolver(TypeIdResolver delegate, String... trustedPackages) {
 			this.delegate = delegate;
 			if (trustedPackages != null) {
 				for (String trustedPackage : trustedPackages) {

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/SubscribableKafkaChannel.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/SubscribableKafkaChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.integration.dispatcher.MessageDispatcher;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
 import org.springframework.integration.dispatcher.UnicastingDispatcher;
+import org.springframework.integration.support.json.JacksonJsonUtils;
 import org.springframework.integration.support.management.ManageableSmartLifecycle;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.KafkaOperations;
@@ -29,6 +30,10 @@ import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
+import org.springframework.kafka.support.JacksonPresent;
+import org.springframework.kafka.support.converter.MessagingMessageConverter;
+import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.util.Assert;
@@ -48,6 +53,8 @@ public class SubscribableKafkaChannel extends AbstractKafkaChannel implements Su
 	private static final int DEFAULT_PHASE = Integer.MAX_VALUE / 2; // same as MessageProducerSupport
 
 	private final KafkaListenerContainerFactory<?> factory;
+
+	private final IntegrationRecordMessageListener recordListener = new IntegrationRecordMessageListener();
 
 	private MessageDispatcher dispatcher;
 
@@ -71,6 +78,24 @@ public class SubscribableKafkaChannel extends AbstractKafkaChannel implements Su
 		super(template, channelTopic);
 		Assert.notNull(factory, "'factory' cannot be null");
 		this.factory = factory;
+
+		if (JacksonPresent.isJackson2Present()) {
+			var messageConverter = new MessagingMessageConverter();
+			var headerMapper = new DefaultKafkaHeaderMapper();
+			headerMapper.addTrustedPackages(JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES.toArray(new String[0]));
+			messageConverter.setHeaderMapper(headerMapper);
+			this.recordListener.setMessageConverter(messageConverter);
+		}
+	}
+
+
+	/**
+	 * Set the {@link RecordMessageConverter} to the listener.
+	 * @param messageConverter the converter.
+	 * @since 6.0
+	 */
+	public void setMessageConverter(RecordMessageConverter messageConverter) {
+		this.recordListener.setMessageConverter(messageConverter);
 	}
 
 	@Override
@@ -113,7 +138,7 @@ public class SubscribableKafkaChannel extends AbstractKafkaChannel implements Su
 		String groupId = getGroupId();
 		ContainerProperties containerProperties = this.container.getContainerProperties();
 		containerProperties.setGroupId(groupId != null ? groupId : getBeanName());
-		containerProperties.setMessageListener(new IntegrationRecordMessageListener());
+		containerProperties.setMessageListener(this.recordListener);
 	}
 
 	protected MessageDispatcher createDispatcher() {

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
@@ -51,12 +51,15 @@ import org.springframework.integration.acks.AcknowledgmentCallbackFactory;
 import org.springframework.integration.core.Pausable;
 import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
+import org.springframework.integration.support.json.JacksonJsonUtils;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ConsumerAwareRebalanceListener;
 import org.springframework.kafka.listener.ConsumerProperties;
 import org.springframework.kafka.listener.LoggingCommitCallback;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
+import org.springframework.kafka.support.JacksonPresent;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.kafka.support.LogIfLevelEnabled;
@@ -233,6 +236,12 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object> impl
 		this.assignTimeout =
 				Duration.ofMillis(Math.max(this.pollTimeout.toMillis() * 20, MIN_ASSIGN_TIMEOUT)); // NOSONAR - magic
 		this.commitTimeout = consumerProperties.getSyncCommitTimeout();
+
+		if (JacksonPresent.isJackson2Present()) {
+			DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper();
+			headerMapper.addTrustedPackages(JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES.toArray(new String[0]));
+			((MessagingMessageConverter) this.messageConverter).setHeaderMapper(headerMapper);
+		}
 	}
 
 	/**

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests.java
@@ -156,8 +156,6 @@ class KafkaMessageDrivenChannelAdapterParserTests {
 
 		messageListener = containerProps.getMessageListener();
 		assertThat(messageListener.getClass().getName()).contains("$IntegrationRecordMessageListener");
-
-		assertThat(adapter).extracting("doFilterInRetry").isEqualTo(Boolean.TRUE);
 	}
 
 }

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/InboundGatewayTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/InboundGatewayTests.java
@@ -29,8 +29,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -53,6 +51,7 @@ import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.ContainerTestUtils;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
@@ -76,38 +75,32 @@ import org.springframework.retry.support.RetryTemplate;
  * @since 5.4
  *
  */
+@EmbeddedKafka(controlledShutdown = true,
+		topics = { InboundGatewayTests.topic1,
+				InboundGatewayTests.topic2,
+				InboundGatewayTests.topic3,
+				InboundGatewayTests.topic4,
+				InboundGatewayTests.topic5,
+				InboundGatewayTests.topic6,
+				InboundGatewayTests.topic7 })
 class InboundGatewayTests {
 
-	private static String topic1 = "testTopic1";
+	static final String topic1 = "testTopic1";
 
-	private static String topic2 = "testTopic2";
+	static final String topic2 = "testTopic2";
 
-	private static String topic3 = "testTopic3";
+	static final String topic3 = "testTopic3";
 
-	private static String topic4 = "testTopic4";
+	static final String topic4 = "testTopic4";
 
-	private static String topic5 = "testTopic5";
+	static final String topic5 = "testTopic5";
 
-	private static String topic6 = "testTopic6";
+	static final String topic6 = "testTopic6";
 
-	private static String topic7 = "testTopic7";
-
-	private static EmbeddedKafkaBroker embeddedKafka;
-
-	@BeforeAll
-	static void setup() {
-		embeddedKafka = new EmbeddedKafkaBroker(1, true,
-				topic1, topic2, topic3, topic4, topic5, topic6, topic7);
-		embeddedKafka.afterPropertiesSet();
-	}
-
-	@AfterAll
-	static void tearDown() {
-		embeddedKafka.destroy();
-	}
+	static final String topic7 = "testTopic7";
 
 	@Test
-	void testInbound() throws Exception {
+	void testInbound(EmbeddedKafkaBroker embeddedKafka) throws Exception {
 		Map<String, Object> consumerProps =
 				KafkaTestUtils.consumerProps("replyHandler1", "false", embeddedKafka);
 		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
@@ -199,7 +192,7 @@ class InboundGatewayTests {
 	}
 
 	@Test
-	void testInboundErrorRecover() {
+	void testInboundErrorRecover(EmbeddedKafkaBroker embeddedKafka) {
 		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("replyHandler2", "false", embeddedKafka);
 		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 		ConsumerFactory<Integer, String> cf2 = new DefaultKafkaConsumerFactory<>(consumerProps);
@@ -278,7 +271,7 @@ class InboundGatewayTests {
 	}
 
 	@Test
-	void testInboundRetryErrorRecover() {
+	void testInboundRetryErrorRecover(EmbeddedKafkaBroker embeddedKafka) {
 		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("replyHandler3", "false", embeddedKafka);
 		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 		ConsumerFactory<Integer, String> cf2 = new DefaultKafkaConsumerFactory<>(consumerProps);
@@ -362,7 +355,7 @@ class InboundGatewayTests {
 	}
 
 	@Test
-	void testInboundRetryErrorRecoverWithoutRecocveryCallback() throws Exception {
+	void testInboundRetryErrorRecoverWithoutRecoveryCallback(EmbeddedKafkaBroker embeddedKafka) throws Exception {
 		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("replyHandler4", "false", embeddedKafka);
 		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 		ConsumerFactory<Integer, String> cf2 = new DefaultKafkaConsumerFactory<>(consumerProps);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3734

The `MessageHistory` is not in the trusted packages of the `DefaultKafkaHeaderMapper`
therefore it fails when `MessageHistory.read()` is performed.

* Configure default `DefaultKafkaHeaderMapper` in the `SubscribableKafkaChannel`,
`KafkaInboundGateway`, `KafkaMessageDrivenChannelAdapter` and `KafkaMessageSource`
to also trust packages exposed via `JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES`
which include a `MessageHistory`, too.

* Verify in some integration Kafka tests to be sure that `MessageHistory` is
deserialized properly in the transferred headers
* Rework some tests to use `@EmbeddedKafka` instead of `@BeforeAll/@AfterAll`

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
