### PR TITLE
GH-3735: Don't mutate FeedEntryMS metadataKey

### DIFF
--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ public class FeedInboundChannelAdapterParserTests {
 				"FeedInboundChannelAdapterParserTests-file-context.xml", this.getClass());
 		SourcePollingChannelAdapter adapter = context.getBean("feedAdapter", SourcePollingChannelAdapter.class);
 		FeedEntryMessageSource source = (FeedEntryMessageSource) TestUtils.getPropertyValue(adapter, "source");
+		assertThat(TestUtils.getPropertyValue(source, "metadataKey")).isEqualTo("feedAdapter");
 		assertThat(TestUtils.getPropertyValue(source, "metadataStore")).isSameAs(context.getBean(MetadataStore.class));
 		SyndFeedInput syndFeedInput = TestUtils.getPropertyValue(source, "syndFeedInput", SyndFeedInput.class);
 		assertThat(syndFeedInput).isSameAs(context.getBean(SyndFeedInput.class));

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/dsl/FeedDslTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/dsl/FeedDslTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +18,12 @@ package org.springframework.integration.feed.dsl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.io.FileReader;
 import java.util.Properties;
 
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,7 +38,7 @@ import org.springframework.integration.metadata.PropertiesPersistingMetadataStor
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.rometools.rome.feed.synd.SyndEntry;
 
@@ -48,12 +47,12 @@ import com.rometools.rome.feed.synd.SyndEntry;
  *
  * @since 5.0
  */
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
 public class FeedDslTests {
 
-	@ClassRule
-	public static final TemporaryFolder tempFolder = new TemporaryFolder();
+	@TempDir
+	public static File tempFolder;
 
 	@Autowired
 	private PollableChannel entries;
@@ -80,12 +79,14 @@ public class FeedDslTests {
 		this.metadataStore.flush();
 
 		FileReader metadataStoreFile =
-				new FileReader(tempFolder.getRoot().getAbsolutePath() + "/metadata-store.properties");
+				new FileReader(tempFolder.getAbsolutePath() + "/metadata-store.properties");
 		Properties metadataStoreProperties = new Properties();
 		metadataStoreProperties.load(metadataStoreFile);
 		assertThat(metadataStoreProperties.isEmpty()).isFalse();
 		assertThat(metadataStoreProperties.size()).isEqualTo(1);
 		assertThat(metadataStoreProperties.containsKey("feedTest")).isTrue();
+
+		metadataStoreFile.close();
 	}
 
 	@Configuration
@@ -98,7 +99,7 @@ public class FeedDslTests {
 		@Bean
 		public MetadataStore metadataStore() {
 			PropertiesPersistingMetadataStore metadataStore = new PropertiesPersistingMetadataStore();
-			metadataStore.setBaseDirectory(tempFolder.getRoot().getAbsolutePath());
+			metadataStore.setBaseDirectory(tempFolder.getAbsolutePath());
 			return metadataStore;
 		}
 

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/inbound/FeedEntryMessageSourceTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/reference/asciidoc/feed.adoc
+++ b/src/reference/asciidoc/feed.adoc
@@ -46,7 +46,39 @@ It lets you subscribe to a particular URL.
 The following example shows a possible configuration:
 
 ====
-[source,xml]
+[source, java, role="primary"]
+.Java DSL
+----
+@Configuration
+@EnableIntegration
+public class ContextConfiguration {
+
+    @Value("org/springframework/integration/feed/sample.rss")
+    private Resource feedResource;
+
+    @Bean
+    public IntegrationFlow feedFlow() {
+        return IntegrationFlows
+                .from(Feed.inboundAdapter(this.feedResource, "feedTest")
+                                .preserveWireFeed(true),
+                        e -> e.poller(p -> p.fixedDelay(100)))
+                .channel(c -> c.queue("entries"))
+                .get();
+    }
+
+}
+----
+[source, java, role="secondary"]
+.Java
+----
+@Bean
+@InboundChannelAdapter(inputChannel = "fromFeed")
+public FeedEntryMessageSource feedEntrySource() {
+    return new FeedEntryMessageSource("https://feeds.bbci.co.uk/news/rss.xml", "metadataKey");
+}
+----
+[source, xml, role="secondary"]
+.XML
 ----
 <int-feed:inbound-channel-adapter id="feedAdapter"
         channel="feedChannel"
@@ -59,13 +91,13 @@ The following example shows a possible configuration:
 In the preceding configuration, we are subscribing to a URL identified by the `url` attribute.
 
 As news items are retrieved, they are converted to messages and sent to a channel identified by the `channel` attribute.
-The payload of each message is a `com.sun.syndication.feed.synd.SyndEntry` instance.
+The payload of each message is a `com.rometools.rome.feed.synd.SyndEntry` instance.
 Each one encapsulates various data about a news item (content, dates, authors, and other details).
 
 The inbound feed channel adapter is a polling consumer.
 That means that you must provide a poller configuration.
-However, one important thing you must understand with regard to a feed is that its inner workings are slightly different then most other polling consumers.
-When an inbound feed adapter is started, it does the first poll and receives a `com.sun.syndication.feed.synd.SyndEntryFeed` instance.
+However, one important thing you must understand with regard to a feed is that its inner workings are slightly different, then most other polling consumers.
+When an inbound feed adapter is started, it does the first poll and receives a `com.rometools.rome.feed.synd.SyndFeed` instance.
 That object contains multiple `SyndEntry` objects.
 Each entry is stored in the local entry queue and is released based on the value in the `max-messages-per-poll` attribute, such that each message contains a single entry.
 If, during retrieval of the entries from the entry queue, the queue has become empty, the adapter attempts to update the feed, thereby populating the queue with more entries (`SyndEntry` instances), if any are available.
@@ -77,8 +109,7 @@ Polling for a feed can result in entries that have already been processed ("`I a
 Spring Integration provides a convenient mechanism to eliminate the need to worry about duplicate entries.
 Each feed entry has a "`published date`" field.
 Every time a new `Message` is generated and sent, Spring Integration stores the value of the latest published date in an instance of the `MetadataStore` strategy (see <<./meta-data-store.adoc#metadata-store,Metadata Store>>).
-
-NOTE: The key used to persist the latest published date is the value of the (required) `id` attribute of the feed inbound channel adapter component plus the `feedUrl` (if any) from the adapter's configuration.
+The `metadataKey` is used to persist the latest published date.
 
 === Other Options
 
@@ -108,47 +139,6 @@ FeedEntryMessageSource feedEntrySource() {
 	        }
 	    };
     return new FeedEntryMessageSource(urlResource, "myKey");
-}
-----
-====
-
-[[feed-java-configuration]]
-=== Java DSL Configuration
-
-The following Spring Boot application shows an example of how to configure the inbound adapter with the Java DSL:
-
-====
-[source, java]
-----
-@SpringBootApplication
-public class FeedJavaApplication {
-
-    public static void main(String[] args) {
-        new SpringApplicationBuilder(FeedJavaApplication.class)
-            .web(false)
-            .run(args);
-    }
-
-    @Value("org/springframework/integration/feed/sample.rss")
-    private Resource feedResource;
-
-    @Bean
-    public MetadataStore metadataStore() {
-        PropertiesPersistingMetadataStore metadataStore = new PropertiesPersistingMetadataStore();
-        metadataStore.setBaseDirectory(tempFolder.getRoot().getAbsolutePath());
-        return metadataStore;
-    }
-
-    @Bean
-    public IntegrationFlow feedFlow() {
-        return IntegrationFlows
-                .from(Feed.inboundAdapter(this.feedResource, "feedTest")
-                                .metadataStore(metadataStore()),
-                        e -> e.poller(p -> p.fixedDelay(100)))
-                .channel(c -> c.queue("entries"))
-                .get();
-    }
-
 }
 ----
 ====


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3735

The `FeedEntryMessageSource` adds an url to the provided `metadataKey`
making it incompatible when we provide a `Resource`-based configuration.

* Remove adding of the url to the `metadataKey` making it rely only
on the provided value
* Remove internal `Comparator` for entries in favor of `Comparator.comparing()`
feature
* Improve some internal logic of the `PropertiesPersistingMetadataStore`
when it emits a false warning: cannot create dirs, but they are present
* Improve `feed.adoc`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
