### PR TITLE
Make the reactive gateway example readable

### DIFF
--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -756,27 +756,51 @@ The following example shows how to create a gateway with Project Reactor:
 ----
 @MessagingGateway
 public interface TestGateway {
-
 	@Gateway(requestChannel = "promiseChannel")
 	Mono<Integer> multiply(Integer value);
-
-	}
-
-	    ...
-
+}
+----
+It's implementation looks like:
+====
+[source,java]
+----
+@Component
+public class MyServiceActivators {
 	@ServiceActivator(inputChannel = "promiseChannel")
 	public Integer multiply(Integer value) {
 			return value * 2;
 	}
+}
+----
 
-		...
-
-    Flux.just("1", "2", "3", "4", "5")
-            .map(Integer::parseInt)
-            .flatMap(this.testGateway::multiply)
-            .collectList()
-            .subscribe(integers -> ...);
-
+And the usage of it looks like this:
+====
+[source,java]
+----
+@Component
+public class MainFlow {
+  @Bean
+  public IntegrationFlow buildFlow() {
+     return IntegrationFlows.from(someReactiveMessageProducer)
+        .transform(someOperation)
+        .gateway(MyServiceActivators::multiply)
+        .get();
+  }
+}
+----
+Or within the Project Reactor DSL:
+[source,java]
+----
+@Component
+public class MainFlow {
+  @Bean
+  public IntegrationFlow buildFlow() {
+     return IntegrationFlows.from(someReactiveMessageProducer)
+        .transform(someOperation)
+        .bridge(e -> e.reactive(flux -> flux.flatMap(MyServiceActivators::multiply)))
+        .get();
+  }
+}
 ----
 ====
 


### PR DESCRIPTION
Relevant in general for the JavaDSL gateway usage. The `...` is super hard for new users to understand. I think it should be replaced with a real-world example in every usage.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
