### PR TITLE
Close mail folder if no messages to produce

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.ObjectUtils;
 
 /**
  * Base class for {@link MailReceiver} implementations.
@@ -362,6 +363,7 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 	public Object[] receive() throws jakarta.mail.MessagingException {
 		this.folderReadLock.lock(); // NOSONAR - guarded with the getReadHoldCount()
 		try {
+			Object[] messagesToReturn = null;
 			try {
 				Folder folderToCheck = getFolder();
 				if (folderToCheck == null || !folderToCheck.isOpen()) {
@@ -375,10 +377,11 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 						this.folderWriteLock.unlock();
 					}
 				}
-				return convertMessagesIfNecessary(searchAndFilterMessages());
+				messagesToReturn = convertMessagesIfNecessary(searchAndFilterMessages());
+				return messagesToReturn;
 			}
 			finally {
-				if (this.autoCloseFolder) {
+				if (this.autoCloseFolder || ObjectUtils.isEmpty(messagesToReturn)) {
 					closeFolder();
 				}
 			}

--- a/src/reference/asciidoc/mail.adoc
+++ b/src/reference/asciidoc/mail.adoc
@@ -140,6 +140,9 @@ This functionality is enabled with this combination of options: no `headerMapper
 The `MimeMessage` is present as the payload of the Spring message produced.
 In this case, the only header populated is the mentioned above `IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE` for the folder which must be closed when processing of the `MimeMessage` is complete.
 
+Starting with version 5.5.11, the folder is closed automatically after `AbstractMailReceiver.receive()` if no messages received or all of them are filtered out independently of the `autoCloseFolder` flag.
+In this case there is nothing to produce downstream for possible logic around `IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE` header.
+
 [[mail-mapping]]
 === Inbound Mail Message Mapping
 


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/71667731/spring-integration-mimemessage-gmail-folder-is-not-open-exception

If no mail messages pulled from the folder or all of them are filtered out,
there is nothing to produce downstream.
Therefore, always close the folder in the end of `AbstractMailReceiver.receive()`
when no messages and even if `autoCloseFolder == false`

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
