### PR TITLE
GH-2708: Make messaging annotations as repeatable

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregator.java
@@ -18,6 +18,7 @@ package org.springframework.integration.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -39,6 +40,7 @@ import org.springframework.messaging.handler.annotation.ValueConstants;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(Aggregators.class)
 public @interface Aggregator {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregators.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Aggregators.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeatable container for {@link Aggregator} annotations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+@Documented
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Aggregators {
+
+	Aggregator[] value();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeFrom.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeFrom.java
@@ -18,6 +18,7 @@ package org.springframework.integration.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -45,6 +46,7 @@ import org.springframework.messaging.handler.annotation.ValueConstants;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(BridgeFromRepeatable.class)
 public @interface BridgeFrom {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeFromRepeatable.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeFromRepeatable.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeatable container for {@link BridgeFrom} annotations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+@Documented
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BridgeFromRepeatable {
+
+	BridgeFrom[] value();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeTo.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeTo.java
@@ -18,6 +18,7 @@ package org.springframework.integration.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -50,6 +51,7 @@ import org.springframework.messaging.handler.annotation.ValueConstants;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(BridgeToRepeatable.class)
 public @interface BridgeTo {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeToRepeatable.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/BridgeToRepeatable.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeatable container for {@link BridgeTo} annotations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+@Documented
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface BridgeToRepeatable {
+
+	BridgeTo[] value();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filter.java
@@ -18,6 +18,7 @@ package org.springframework.integration.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -47,6 +48,7 @@ import org.springframework.messaging.handler.annotation.ValueConstants;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(Filters.class)
 public @interface Filter {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filters.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Filters.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeatable container for {@link Filter} annotations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+@Documented
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Filters {
+
+	Filter[] value();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapter.java
@@ -18,6 +18,7 @@ package org.springframework.integration.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -53,6 +54,7 @@ import org.springframework.messaging.handler.annotation.ValueConstants;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(InboundChannelAdapters.class)
 public @interface InboundChannelAdapter {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapters.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapters.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeatable container for {@link InboundChannelAdapter} annotations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+@Documented
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface InboundChannelAdapters {
+
+	InboundChannelAdapter[] value();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Router.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Router.java
@@ -18,6 +18,7 @@ package org.springframework.integration.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -50,6 +51,7 @@ import org.springframework.messaging.handler.annotation.ValueConstants;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(Routers.class)
 public @interface Router {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Routers.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Routers.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeatable container for {@link Router} annotations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+@Documented
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Routers {
+
+	Router[] value();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivator.java
@@ -18,6 +18,7 @@ package org.springframework.integration.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -48,6 +49,7 @@ import org.springframework.messaging.handler.annotation.ValueConstants;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(ServiceActivators.class)
 public @interface ServiceActivator {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivators.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/ServiceActivators.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeatable container for {@link ServiceActivator} annotations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+@Documented
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ServiceActivators {
+
+	ServiceActivator[] value();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitter.java
@@ -18,6 +18,7 @@ package org.springframework.integration.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -48,6 +49,7 @@ import org.springframework.messaging.handler.annotation.ValueConstants;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(Splitters.class)
 public @interface Splitter {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitters.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Splitters.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeatable container for {@link Splitter} annotations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+@Documented
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Splitters {
+
+	Splitter[] value();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Transformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Transformer.java
@@ -18,6 +18,7 @@ package org.springframework.integration.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -36,6 +37,7 @@ import org.springframework.messaging.handler.annotation.ValueConstants;
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
+@Repeatable(Transformers.class)
 public @interface Transformer {
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/Transformers.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/Transformers.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The repeatable container for {@link Transformer} annotations.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+@Documented
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Transformers {
+
+	Transformer[] value();
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorTests.java
@@ -298,6 +298,12 @@ public class MessagingAnnotationPostProcessorTests {
 		inputChannel.send(new GenericMessage<>("foo"));
 		Message<?> reply = outputChannel.receive(0);
 		assertThat(reply.getPayload()).isEqualTo("FOO");
+
+		MessageChannel inputChannel2 = context.getBean("inputChannel2", MessageChannel.class);
+		inputChannel2.send(new GenericMessage<>("test2"));
+		reply = outputChannel.receive(0);
+		assertThat(reply.getPayload()).isEqualTo("TEST2");
+
 		context.close();
 	}
 
@@ -386,6 +392,7 @@ public class MessagingAnnotationPostProcessorTests {
 	public static class TransformerAnnotationTestBean {
 
 		@Transformer(inputChannel = "inputChannel", outputChannel = "outputChannel")
+		@Transformer(inputChannel = "inputChannel2", outputChannel = "outputChannel")
 		public String transformBefore(String input) {
 			return input.toUpperCase();
 		}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -385,9 +385,9 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 
 		@Bean
 		@ServiceActivator(inputChannel = "skippedChannel")
-		@Splitter(inputChannel = "skippedChannel2")
+		@ServiceActivator(inputChannel = "skippedChannel2")
 		@Router(inputChannel = "skippedChannel3")
-		@Transformer(inputChannel = "skippedChannel4")
+		@Filter(inputChannel = "skippedChannel4")
 		@Filter(inputChannel = "skippedChannel5")
 		@Profile("foo")
 		public MessageHandler skippedMessageHandler() {
@@ -396,6 +396,7 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 		}
 
 		@Bean
+		@BridgeFrom("skippedChannel5")
 		@BridgeFrom("skippedChannel6")
 		@Profile("foo")
 		public MessageChannel skippedChannel1() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -251,6 +251,9 @@ public class EnableIntegrationTests {
 	private PollableChannel messageChannel;
 
 	@Autowired
+	private PollableChannel messageChannel2;
+
+	@Autowired
 	private PollableChannel fooChannel;
 
 	@Autowired
@@ -427,6 +430,12 @@ public class EnableIntegrationTests {
 		assertThat(this.fooChannel.receive(10)).isNull();
 
 		message = this.messageChannel.receive(10_000);
+		assertThat(message).isNotNull();
+		assertThat(message.getPayload()).isEqualTo("bar");
+		assertThat(message.getHeaders().containsKey("foo")).isTrue();
+		assertThat(message.getHeaders().get("foo")).isEqualTo("FOO");
+
+		message = this.messageChannel2.receive(10_000);
 		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isEqualTo("bar");
 		assertThat(message.getHeaders().containsKey("foo")).isTrue();
@@ -1163,6 +1172,11 @@ public class EnableIntegrationTests {
 		}
 
 		@Bean
+		public PollableChannel messageChannel2() {
+			return new QueueChannel();
+		}
+
+		@Bean
 		public QueueChannel numberChannel() {
 			QueueChannel channel = new QueueChannel();
 			channel.setDatatypes(Number.class);
@@ -1354,6 +1368,7 @@ public class EnableIntegrationTests {
 
 		@InboundChannelAdapter(value = "messageChannel", poller = @Poller(fixedDelay = "${poller.interval}",
 				maxMessagesPerPoll = "1"))
+		@InboundChannelAdapter(value = "messageChannel2", poller = @Poller(fixedDelay = "100"))
 		public Message<?> message() {
 			return MessageBuilder.withPayload("bar").setHeader("foo", "FOO").build();
 		}

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -301,7 +301,7 @@ public class ThingService {
 ----
 ====
 
-You can also use the  `@Headers` annotation to provide all of the message headers as a `Map`, as the following example shows:
+You can also use the  `@Headers` annotation to provide all the message headers as a `Map`, as the following example shows:
 
 ====
 [source,java]
@@ -354,7 +354,7 @@ The `MessageHandler` instances (`MessageSource` instances) are also eligible to 
 
 Starting with version 4.0, all messaging annotations provide `SmartLifecycle` options (`autoStartup` and `phase`) to allow endpoint lifecycle control on application context initialization.
 They default to `true` and `0`, respectively.
-To change the state of an endpoint (such as ` start()` or `stop()`), you can obtain a reference to the endpoint bean by using the `BeanFactory` (or autowiring) and invoke the methods.
+To change the state of an endpoint (such as `start()` or `stop()`), you can obtain a reference to the endpoint bean by using the `BeanFactory` (or autowiring) and invoke the methods.
 Alternatively, you can send a command message to the `Control Bus` (see <<./control-bus.adoc#control-bus,Control Bus>>).
 For these purposes, you should use the `beanName` mentioned earlier in the preceding paragraph.
 
@@ -379,6 +379,18 @@ Thing1 dependsOnSPCA(@Qualifier("someInboundAdapter") @Lazy SourcePollingChannel
 ----
 ====
 =====
+
+Starting with version 6.0, all the messaging annotations are `@Repeatable` now, so several of the same type can be declared on the same service method with the meaning to create as many endpoints as those annotations are repeated:
+====
+[source, java]
+----
+@Transformer(inputChannel = "inputChannel1", outputChannel = "outputChannel1")
+@Transformer(inputChannel = "inputChannel2", outputChannel = "outputChannel2")
+public String transform(String input) {
+    return input.toUpperCase();
+}
+----
+====
 
 [[configuration-using-poller-annotation]]
 ==== Using the `@Poller` Annotation

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -26,8 +26,10 @@ See <<./graphql.adoc#graphql,GraphQL Support>> for more information.
 [[x6.0-general]]
 === General Changes
 
-The messaging annotations don't require a poller attribute as an array of @Poller any more.
-See <<./configuration.adoc#configuration-using-poller-annotation,Using the @Poller Annotation>> for more information.
+The messaging annotations are now `@Repeatable` and the same type can be declared several times on the same service method.
+The messaging annotations don't require a `poller` attribute as an array of `@Poller` anymore.
+
+See <<./configuration.adoc#annotations,Annotation Support>> for more information.
 
 [[x6.0-http]]
 === HTTP Changes


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/2708

There are some requests to use the same service method for different input channels

* Make all the messaging annotations as `@Repeatable` with their
respective container annotations
* Modify `MessagingAnnotationPostProcessor` logic to deal with the mentioned repeatable
requirements

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
