### PR TITLE
GH-3788 Support byte[] for JMS properties mapping

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,8 +57,9 @@ import org.springframework.util.StringUtils;
  */
 public class DefaultJmsHeaderMapper extends JmsHeaderMapper {
 
-	private static final List<Class<?>> SUPPORTED_PROPERTY_TYPES = Arrays.asList(new Class<?>[]{
-			Boolean.class, Byte.class, Double.class, Float.class, Integer.class, Long.class, Short.class, String.class });
+	private static final List<Class<?>> SUPPORTED_PROPERTY_TYPES =
+			Arrays.asList(Boolean.class, Byte.class, Double.class, Float.class, Integer.class, Long.class, Short.class,
+					String.class, byte[].class);
 
 
 	private static final Log LOGGER = LogFactory.getLog(DefaultJmsHeaderMapper.class);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3788

Some JMS vendors carry some important information in their JMS messages.
That information can be stored in the specific properties as `byte[]`.

* Add `byte[]` as a supported property type into a `DefaultJmsHeaderMapper`
* Verify `byte[]` property mapping and propagation via embedded ActiveMQ
broker.

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
