### PR TITLE
Really reuse Testcontainers

### DIFF
--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlContainerTest.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlContainerTest.java
@@ -16,12 +16,16 @@
 
 package org.springframework.integration.jdbc.mysql;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
  * The base contract for JUnit tests based on the container for MqSQL.
+ * The Testcontainers 'reuse' option must be disabled,so, Ryuk container is started
+ * and will clean all the containers up from this test suite after JVM exit.
+ * Since the MqSQL container instance is shared via static property, it is going to be
+ * started only once per JVM, therefore the target Docker container is reused automatically.
  *
  * @author Artem Bilan
  *
@@ -30,9 +34,12 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 public interface MySqlContainerTest {
 
-	@Container
-	MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>("mysql").withReuse(true);
+	MySQLContainer<?> MY_SQL_CONTAINER = new MySQLContainer<>("mysql:8.0.29-oracle");
 
+	@BeforeAll
+	static void startContainer() {
+		MY_SQL_CONTAINER.start();
+	}
 
 	static String getDriverClassName() {
 		return MY_SQL_CONTAINER.getDriverClassName();

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MosquittoContainerTest.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MosquittoContainerTest.java
@@ -16,11 +16,16 @@
 
 package org.springframework.integration.mqtt;
 
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 /**
+ * The base contract for JUnit tests based on the container for MQTT Mosquitto broker.
+ * The Testcontainers 'reuse' option must be disabled,so, Ryuk container is started
+ * and will clean all the containers up from this test suite after JVM exit.
+ * Since the Mosquitto container instance is shared via static property, it is going to be
+ * started only once per JVM, therefore the target Docker container is reused automatically.
  *
  * @author Artem Bilan
  *
@@ -29,13 +34,15 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @Testcontainers(disabledWithoutDocker = true)
 public interface MosquittoContainerTest {
 
-	@Container
 	GenericContainer<?> MOSQUITTO_CONTAINER =
 			new GenericContainer<>("eclipse-mosquitto:2.0.12")
 					.withCommand("mosquitto -c /mosquitto-no-auth.conf")
-					.withReuse(true)
 					.withExposedPorts(1883);
 
+	@BeforeAll
+	static void startContainer() {
+		MOSQUITTO_CONTAINER.start();
+	}
 
 	static String mqttUrl() {
 		return "tcp://localhost:" + MOSQUITTO_CONTAINER.getFirstMappedPort();


### PR DESCRIPTION
The `withReuse(true)` and `testcontainers.reuse.enable=true` don't work together with `@Container`.
The JUnit extension gathers those containers and stop them in the end of test class unconditionally.

* Remove `@Container` annotation usage
* Use `@BeforeAll` and `GenericContainer.start()` manually
This way the container ensures to reuse existing running container and don't start a fresh one.
Since the container instance is stored in a `static` property, it is really started only once.
The rest tests in a suite just reuse that existing container.
Ryuk container will take care about their stopping and removal eventually afte JVM exit.

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
