### PR TITLE
Use bean CL for JdbcMessageStore.deserializer

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
@@ -29,6 +29,7 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.core.MethodIntrospector;
+import org.springframework.core.log.LogMessage;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
@@ -151,7 +152,14 @@ public class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFac
 						args[i] = message;
 					}
 					else {
-						args[i] = this.messageConverter.fromMessage(message, this.expectedType);
+						Object payload = this.messageConverter.fromMessage(message, this.expectedType);
+						if (payload == null && LOGGER.isWarnEnabled()) {
+							LOGGER.warn(LogMessage.format(
+									"The '%s' returned 'null' for the payload conversion from the " +
+											"'%s' and expected type '%s'.",
+									this.messageConverter, message, this.expectedType));
+						}
+						args[i] = payload;
 					}
 				}
 				else {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/converter/AllowListDeserializingConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/converter/AllowListDeserializingConverter.java
@@ -40,6 +40,9 @@ import org.springframework.util.PatternMatchUtils;
  * classes/packages are deserialized. If you receive data from untrusted sources, consider
  * adding trusted classes/packages using {@link #setAllowedPatterns(String...)} or
  * {@link #addAllowedPatterns(String...)}.
+ * <p>
+ * If a delegate deserializer is a {@link DefaultDeserializer}, only its {@link ClassLoader}
+ * is used for a {@link ConfigurableObjectInputStream} logic.
  *
  * @author Gary Russell
  * @author Mark Fisher
@@ -132,7 +135,13 @@ public class AllowListDeserializingConverter implements Converter<byte[], Object
 				return deserialize(byteStream);
 			}
 			else {
-				return this.deserializer.deserialize(byteStream);
+				Object result = this.deserializer.deserialize(byteStream);
+				/* Even if there is no knowledge what is the target deserialization algorithm
+				 and malicious code may be executed already, it is still better to fail
+				 with untrusted data rather than just let it pass downstream.
+				 */
+				checkAllowList(result.getClass());
+				return result;
 			}
 		}
 		catch (Exception ex) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.dsl;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.util.Date;
 import java.util.Objects;
 import java.util.function.Function;
 
@@ -32,6 +33,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.config.IntegrationConverter;
+import org.springframework.integration.core.GenericSelector;
 import org.springframework.integration.handler.GenericHandler;
 import org.springframework.integration.handler.LambdaMessageProcessor;
 import org.springframework.integration.transformer.GenericTransformer;
@@ -85,6 +87,24 @@ public class LambdaMessageProcessorTests {
 		assertThatExceptionOfType(ClassCastException.class)
 				.isThrownBy(() -> lmp.processMessage(testMessage));
 	}
+
+	@Test
+	public void testConversionToNull() {
+		LambdaMessageProcessor lmp = new LambdaMessageProcessor(
+				new GenericSelector<Date>() { // Must not be lambda
+
+					@Override
+					public boolean accept(Date payload) {
+						return payload == null;
+					}
+
+				}, Date.class);
+		lmp.setBeanFactory(this.beanFactory);
+		GenericMessage<String> testMessage = new GenericMessage<>("foo");
+		Object result = lmp.processMessage(testMessage);
+		assertThat(result).isEqualTo(Boolean.TRUE);
+	}
+
 
 	@Test
 	@Disabled("Until https://github.com/spring-projects/spring-integration/issues/3660")

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.condition.LongRunningTest;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.util.UUIDConverter;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
@@ -80,6 +81,10 @@ public class DelayerHandlerRescheduleIntegrationTests {
 		MessageChannel input = context.getBean("input", MessageChannel.class);
 		MessageGroupStore messageStore = context.getBean("messageStore", MessageGroupStore.class);
 
+		ClassLoader messageStoreDeserializerClassLoader =
+				TestUtils.getPropertyValue(messageStore, "deserializer.defaultDeserializerClassLoader",
+						ClassLoader.class);
+		assertThat(messageStoreDeserializerClassLoader).isSameAs(context.getClassLoader());
 		assertThat(messageStore.getMessageGroupCount()).isEqualTo(0);
 		Message<String> message1 = MessageBuilder.withPayload("test1").build();
 		input.send(message1);


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/72305387/spring-integration-delayer-starts-sending-null-message-payloads-when-switched

In some async use-cases (e.g. `DelayHandler`), the context classloader
might be different for the data to be deserialized from message store.

* Fix `JdbcMessageStore` to populate a bean `ClassLoader` into default
`AllowListDeserializingConverter` from the application context.
The provided `Deserializer` must ensure such a `ClassLoader` itself
* Add warning message to the `LambdaMessageProcessor` when converter
returns `null` for the payload it cannot convert to expected type.
Cannot be raised as error since some applications may already rely
on the `null` conversion result in their method arguments

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
