### PR TITLE
GH-3797: Improve batch processing in the framework

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,21 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 	@Override
 	protected boolean isExpireGroupsUponCompletion() {
 		return this.expireGroupsUponCompletion;
+	}
+
+	/**
+	 * Check an {@link Iterable} result for split possibility on the output production:
+	 * the items of the collection have to be instances of {@link Message}
+	 * or {@link org.springframework.integration.support.AbstractIntegrationMessageBuilder}
+	 * and {@link #getOutputProcessor()} has to be a {@link SimpleMessageGroupProcessor}.
+	 * Otherwise, a single reply message is emitted with the whole {@link Iterable} as its payload.
+	 * @param reply the {@link Iterable} result to check for split possibility.
+	 * @return true if the {@link Iterable} result has to be split into individual messages.
+	 * @since 6.0
+	 */
+	@Override
+	protected boolean shouldSplitOutput(Iterable<?> reply) {
+		return getOutputProcessor() instanceof SimpleMessageGroupProcessor && super.shouldSplitOutput(reply);
 	}
 
 	/**

--- a/src/reference/asciidoc/aggregator.adoc
+++ b/src/reference/asciidoc/aggregator.adoc
@@ -143,9 +143,9 @@ It returns the collection of messages from the group, which, as indicated earlie
 
 This lets the aggregator work as a message barrier, where arriving messages are held until the release strategy fires and the group is released as a sequence of individual messages.
 
-Starting with version 6.0, a splitting behaviour, described above, works only for a mentioned `SimpleMessageGroupProcessor`.
-Otherwise, with any other `MessageGroupProcessor` implementation which returns a `Collection<Message>`, only a single reply message is emitted with the whole collection of messages as its payload.
-Such a logic is dictated with a canonical purpose of an aggregator - collect request messages by some key and produce a single grouped message.
+Starting with version 6.0, the splitting behaviour, described above, works only if the group processor is a `SimpleMessageGroupProcessor`.
+Otherwise, with any other `MessageGroupProcessor` implementation that returns a `Collection<Message>`, only a single reply message is emitted with the whole collection of messages as its payload.
+Such logic is dictated by the canonical purpose of an aggregator - collect request messages by some key and produce a single grouped message.
 
 ===== `ReleaseStrategy`
 

--- a/src/reference/asciidoc/aggregator.adoc
+++ b/src/reference/asciidoc/aggregator.adoc
@@ -132,8 +132,6 @@ Consequently, the `Collection<Message>` variable in the POJO is cleared too, if 
 If you wish to simply release that collection as-is for further processing, you must build a new `Collection` (for example, `new ArrayList<Message>(messages)`).
 Starting with version 4.3, the framework no longer copies the messages to a new collection, to avoid undesired extra object creation.
 
-If the `processMessageGroup` method of the `MessageGroupProcessor` returns a collection, it must be a collection of `Message<?>` objects.
-In this case, the messages are individually released.
 Prior to version 4.2, it was not possible to provide a `MessageGroupProcessor` by using XML configuration.
 Only POJO methods could be used for aggregation.
 Now, if the framework detects that the referenced (or inner) bean implements `MessageProcessor`, it is used as the aggregator's output processor.
@@ -144,6 +142,10 @@ Also, since version 4.2, a `SimpleMessageGroupProcessor` is provided.
 It returns the collection of messages from the group, which, as indicated earlier, causes the released messages to be sent individually.
 
 This lets the aggregator work as a message barrier, where arriving messages are held until the release strategy fires and the group is released as a sequence of individual messages.
+
+Starting with version 6.0, a splitting behaviour, described above, works only for a mentioned `SimpleMessageGroupProcessor`.
+Otherwise, with any other `MessageGroupProcessor` implementation which returns a `Collection<Message>`, only a single reply message is emitted with the whole collection of messages as its payload.
+Such a logic is dictated with a canonical purpose of an aggregator - collect request messages by some key and produce a single grouped message.
 
 ===== `ReleaseStrategy`
 

--- a/src/reference/asciidoc/error-handling.adoc
+++ b/src/reference/asciidoc/error-handling.adoc
@@ -62,7 +62,7 @@ It is recommended to use that `MessagePublishingErrorHandler` for any custom `ta
 A registered `integrationMessagePublishingErrorHandler` bean can be used in this case.
 
 To enable global error handling, register a handler on that channel.
-For example, you can configure Spring Integration's `ErrorMessageExceptionTypeRouter` as the handler of an endpoint that is subscribed to the 'errorChannel'.
+For example, you can configure Spring Integration's `ErrorMessageExceptionTypeRouter` as the handler of an endpoint that is subscribed to the `errorChannel`.
 That router can then spread the error messages across multiple channels, based on the `Exception` type.
 
 Starting with version 4.3.10, Spring Integration provides the `ErrorMessagePublisher` and the `ErrorMessageStrategy`.
@@ -85,5 +85,7 @@ Including a resource and source of the bean definition helps to determine possib
 
 Starting with version 5.4.3, the default error channel is configured with the property `requireSubscribers = true` to not silently ignore messages when there are no subscribers on this channel (e.g. when application context is stopped).
 In this case a `MessageDispatchingException` is thrown which may lend on the client callback of the inbound channel adapter to negatively acknowledge (or roll back) an original message in the source system for redelivery or other future consideration.
-To restore the previous behavior (ignore non dispatched error messages), the global integration property `spring.integration.channels.error.requireSubscribers` must be set to `false`.
+To restore the previous behavior (ignore non-dispatched error messages), the global integration property `spring.integration.channels.error.requireSubscribers` must be set to `false`.
 See <<./configuration.adoc#global-properties,Global Properties>> and <<./channel.adoc#channel-configuration-pubsubchannel,`PublishSubscribeChannel` Configuration>> (if you configure a global `errorChannel` manually) for more information.
+
+See also https://github.com/spring-projects/spring-integration-samples/tree/main/intermediate/errorhandling[Error Handling Sample] for more information.

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -284,7 +284,7 @@ It lets you specify a `MessagePreparedStatementSetter` bean reference.
 ==== Batch Update
 
 Starting with version 5.1, the `JdbcMessageHandler` performs a `JdbcOperations.batchUpdate()` if the payload of the request message is an `Iterable` instance.
-Each element of the `Iterable` is wrapped to a `Message` with the headers from the request message.
+Each element of the `Iterable` is wrapped to a `Message` with the headers from the request message if such an element is not a `Message` already.
 In the case of regular `SqlParameterSourceFactory`-based configuration these messages are used to build an `SqlParameterSource[]` for an argument used in the mentioned `JdbcOperations.batchUpdate()` function.
 When a `MessagePreparedStatementSetter` configuration is applied, a `BatchPreparedStatementSetter` variant is used to iterate over those messages for each item and the provided `MessagePreparedStatementSetter` is called against them.
 The batch update is not supported when `keysGenerated` mode is selected.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -43,6 +43,10 @@ For convenience, the XML and Java DSL for Scatter-Gather, based on the `Recipien
 
 See <<./scatter-gather.adoc#scatter-gather,Scatter-Gather>> for more information.
 
+The `AggregatingMessageHandler` now does not split the `Collection<Message<?>>` result of the `MessageGroupProcessor` (excluding `SimpleMessageGroupProcessor`) on the output, but emits a single message containing this whole collection as a payload.
+
+See <<./aggregator.adoc#aggregator,Aggregator>> for more information.
+
 [[x6.0-http]]
 === HTTP Changes
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -43,7 +43,7 @@ For convenience, the XML and Java DSL for Scatter-Gather, based on the `Recipien
 
 See <<./scatter-gather.adoc#scatter-gather,Scatter-Gather>> for more information.
 
-The `AggregatingMessageHandler` now does not split the `Collection<Message<?>>` result of the `MessageGroupProcessor` (excluding `SimpleMessageGroupProcessor`) on the output, but emits a single message containing this whole collection as a payload.
+The `AggregatingMessageHandler` now does not split a `Collection<Message<?>>` result of the `MessageGroupProcessor` (unless it is a `SimpleMessageGroupProcessor`) on the output, but emits a single message containing this whole collection as a payload.
 
 See <<./aggregator.adoc#aggregator,Aggregator>> for more information.
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3797

* Handle `Message` items of the `Iterable` payload properly in the `JdbcMessageHandler`.
Otherwise, they've been wrapped into an extra `Message`
* Produce a single message with a `Collection<Message<?>>` payload in the `AggregatingMessageHandler`
when the `getOutputProcessor()` is not an instance of `SimpleMessageGroupProcessor`
* Mention these changes in docs
* Point to the error handling sample from docs

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
