### PR TITLE
GH-3826: Fix SimplePool for resizing from MAX

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/SimplePool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class SimplePool<T> implements Pool<T> {
 
 	protected final Log logger = LogFactory.getLog(getClass()); // NOSONAR final
 
-	private final Semaphore permits = new Semaphore(0);
+	private final PoolSemaphore permits = new PoolSemaphore(0);
 
 	private final AtomicInteger poolSize = new AtomicInteger();
 
@@ -56,11 +56,11 @@ public class SimplePool<T> implements Pool<T> {
 
 	private long waitTimeout = Long.MAX_VALUE;
 
-	private final BlockingQueue<T> available = new LinkedBlockingQueue<T>();
+	private final BlockingQueue<T> available = new LinkedBlockingQueue<>();
 
-	private final Set<T> allocated = Collections.synchronizedSet(new HashSet<T>());
+	private final Set<T> allocated = Collections.synchronizedSet(new HashSet<>());
 
-	private final Set<T> inUse = Collections.synchronizedSet(new HashSet<T>());
+	private final Set<T> inUse = Collections.synchronizedSet(new HashSet<>());
 
 	private final PoolItemCallback<T> callback;
 
@@ -105,21 +105,27 @@ public class SimplePool<T> implements Pool<T> {
 			this.permits.release(delta);
 		}
 		else {
-			while (delta < 0) {
-				if (!this.permits.tryAcquire()) {
-					break;
-				}
+			this.permits.reducePermits(-delta);
+
+			int inUseSize = this.inUse.size();
+			int newPoolSize = Math.max(poolSize, inUseSize);
+			this.poolSize.set(newPoolSize);
+
+			for (int i = this.available.size(); i > newPoolSize - inUseSize; i--) {
 				T item = this.available.poll();
 				if (item != null) {
 					doRemoveItem(item);
 				}
-				this.poolSize.decrementAndGet();
-				delta++;
+				else {
+					break;
+				}
 			}
-		}
-		if (delta < 0 && this.logger.isDebugEnabled()) {
-			this.logger.debug(String.format("Pool is overcommitted by %d; items will be removed when returned",
-					-delta));
+
+			int inUseDelta = poolSize - inUseSize;
+			if (inUseDelta < 0 && this.logger.isDebugEnabled()) {
+				this.logger.debug(String.format("Pool is overcommitted by %d; items will be removed when returned",
+						-inUseDelta));
+			}
 		}
 	}
 
@@ -264,6 +270,19 @@ public class SimplePool<T> implements Pool<T> {
 	public synchronized void close() {
 		this.closed = true;
 		removeAllIdleItems();
+	}
+
+	private static class PoolSemaphore extends Semaphore {
+
+		public PoolSemaphore(int permits) {
+			super(permits);
+		}
+
+		@Override
+		public void reducePermits(int reduction) { // NOSONAR increases visibility
+			super.reducePermits(reduction);
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3826

By default, the `SimplePool` is used with an `Integer.MAX_VALUE` pool size.
There is a performance degradation in the `setPoolSize()` when we try to
decrease the pool size: the `while` for `permits.tryAcquire()` is too long
close to the current `Integer.MAX_VALUE` pool size

* Revise the logic in the `setPoolSize()` to use `Semaphore.reducePermits()`
instead of the loop.
* Change the calculation for a new pool size for the current pool state:
or it is a size of a new request, or iti s equal to the `inUse.size()`.
It will be reduced on subsequent `releaseItem()` calls
* Reduce the number of `available` according a new pool size based on the `inUse`.
So, if `inUse > newPoolSize`, the `available` is cleared.
Otherewise, it is reduced to the number which would give `newPoolSize` together
with the `inUse` size

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
