### PR TITLE
Fix IntegrationMBeanExporter logic for endpoints

### DIFF
--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/ScatterGatherHandlerIntegrationTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/ScatterGatherHandlerIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -336,21 +336,9 @@ public class ScatterGatherHandlerIntegrationTests {
 			return new DirectChannel();
 		}
 
-		@Bean
-		@ServiceActivator(inputChannel = "serviceChannel2")
-		public MessageHandler service2() {
-			return new AbstractReplyProducingMessageHandler() {
-
-				{
-					setOutputChannel(gatherChannel());
-				}
-
-				@Override
-				protected Object handleRequestMessage(Message<?> requestMessage) {
-					return Math.random();
-				}
-
-			};
+		@ServiceActivator(inputChannel = "serviceChannel2", outputChannel = "gatherChannel")
+		public double service2() {
+			return Math.random();
 		}
 
 	}


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/72851234/error-in-startup-application-when-using-serviceactivator-in-spring-cloud-stream

The `MessagingAnnotationPostProcessor` register an `endpoint` bean for Messaging Annotation on POJO methods.
The `IntegrationMBeanExporter` post-process such a bean and registers respective MBean.
It does this not in optimal way scanning all the `IntegrationConsumer` beans for requested `MessageHandler`
which may cause a `BeanCurrentlyInCreationException`.

* Rework the logic of the `IntegrationMBeanExporter.postProcessAbstractEndpoint()` to propagate provided endpoint
for the monitor registration to bypass application context scanning for matched name.
* Swap `equals()` for `monitor` since an `extractTarget()` may return `null`
* Some other code clean in the `IntegrationMBeanExporter`
* Change one of the `@ServiceActivator` in the configuration for the `ScatterGatherHandlerIntegrationTests`
to POJO method.
However, this didn't fail for me with original code unlike in the sample application provided in the mentioned SO thread.

**Cherry-pick to `main`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
