### PR TITLE
GH-3804: Migrate SMB unit tests to Testcontainers

### DIFF
--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbTestSupport.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbTestSupport.java
@@ -52,12 +52,10 @@ public class SmbTestSupport extends RemoteFileTestSupport {
 
 	private static final String INNER_SHARE_DIR = "/tmp";
 
-	// Configuration details can be found at https://hub.docker.com/r/dperson/samba
-	private static final GenericContainer<?> SMB_CONTAINER = new GenericContainer<>("dperson/samba:latest")
-			.withExposedPorts(445)
-			.withEnv("USER", USERNAME + ";" + PASSWORD)
+	private static final GenericContainer<?> SMB_CONTAINER = new GenericContainer<>("elswork/samba:4.15.5")
 			.withTmpFs(Map.of(INNER_SHARE_DIR, "rw"))
-			.withEnv("SHARE", SHARE_AND_DIR + ";" + INNER_SHARE_DIR + ";yes;no;no;all;none");
+			.withCommand("-u", "1000:1000:" + USERNAME + ":" + USERNAME + ":" + PASSWORD, "-s", SHARE_AND_DIR + ":" + INNER_SHARE_DIR + ":rw:" + USERNAME)
+			.withExposedPorts(445);
 
 	private static SmbSessionFactory smbSessionFactory;
 


### PR DESCRIPTION
Instead of manual SMB server setup and preparation, make it all
automated using convenient Testcontainers library and a bit of extra
code executed before tests.

More detailed,
* Change `localhost` to `127.0.0.1` for a proper integration with
docker container
* A few new config values to support container environment, like tmpFs,
share permissions and a dynamic port value
* Introduce Testcontainers API for container management
* Few configuration changes to support docker container usage
* Automatic dirs and files layout creation in `@BeforeAll`
* A few bugfixes where the assertion has not been done actually
* Couple of small changes related to assertions readability as well

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
