### PR TITLE
GH-3827: Fix RemoteFile GET STREAM session leak

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -673,6 +673,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 						.setHeader(IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE, session);
 			}
 			catch (IOException e) {
+				session.close();
 				throw new MessageHandlingException(requestMessage,
 						"Error handling message in the [" + this
 								+ "]. Failed to get the remote file [" + remoteFilePath + "] as a stream", e);

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests-context.xml
@@ -191,7 +191,13 @@
 							  auto-create-directory="true"
 							  remote-file-separator="/"	/>
 
-	<int-sftp:outbound-gateway session-factory="sftpSessionFactory"
+	<bean id="cachingSessionFactory" class="org.springframework.integration.file.remote.session.CachingSessionFactory">
+		<constructor-arg name="sessionFactory" ref="sftpSessionFactory"/>
+		<constructor-arg name="sessionCacheSize" value="1"/>
+		<property name="sessionWaitTimeout" value="100"/>
+	</bean>
+
+	<int-sftp:outbound-gateway session-factory="cachingSessionFactory"
 							  request-channel="inboundGetStream"
 							  command="get"
 							  command-options="-stream"


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3827

The `AbstractRemoteFileOutboundGateway.doGet()` for a `STREAM` option
does not close the `session` in case of error.
This may lead to some leaks or exhausted caches

* Close `session` in the `catch()` of the `AbstractRemoteFileOutboundGateway.doGet()`
* Adjust the `SftpServerOutboundTests` to configure a `CachingSessionFactory`
for the `testStream()` to verify there is no leaks attempting to
`GET STREAM` non-existing remote file twice

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
