### PR TITLE
GH-3843: propagate ErrorMessage.originalMes in MH

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/history/MessageHistory.java
@@ -107,10 +107,17 @@ public final class MessageHistory implements List<Properties>, Serializable {
 				message.getHeaders().put(HEADER_NAME, history);
 			}
 			else if (message instanceof ErrorMessage) {
+				ErrorMessage errorMessage = (ErrorMessage) message;
 				IntegrationMessageHeaderAccessor headerAccessor = new IntegrationMessageHeaderAccessor(message);
 				headerAccessor.setHeader(HEADER_NAME, history);
-				Throwable payload = ((ErrorMessage) message).getPayload();
-				ErrorMessage errorMessage = new ErrorMessage(payload, headerAccessor.toMessageHeaders());
+				Throwable payload = errorMessage.getPayload();
+				Message<?> originalMessage = errorMessage.getOriginalMessage();
+				if (originalMessage != null) {
+					errorMessage = new ErrorMessage(payload, headerAccessor.toMessageHeaders(), originalMessage);
+				}
+				else {
+					errorMessage = new ErrorMessage(payload, headerAccessor.toMessageHeaders());
+				}
 				message = (Message<T>) errorMessage;
 			}
 			else if (message instanceof AdviceMessage) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3843

The `MessageHistory.write()` is missing the `ErrorMessage.originalMessage`
on creating a new `ErrorMessage` with message history header

* Reuse an `ErrorMessage.originalMessage` for newly created `ErrorMessage`
after populating the message history header

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
