### PR TITLE
GH-3685: Share MQTT connection across components

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParser.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,6 @@ public class MqttMessageDrivenChannelAdapterParser extends AbstractChannelAdapte
 		builder.addPropertyReference("outputChannel", channelName);
 		IntegrationNamespaceUtils.setReferenceIfAttributeDefined(builder, element, "error-channel");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "qos");
-		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "recovery-interval");
 		IntegrationNamespaceUtils.setValueIfAttributeDefined(builder, element, "manual-acks");
 
 		return builder.getBeanDefinition();

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -19,6 +19,8 @@ package org.springframework.integration.mqtt.core;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.util.Assert;
 
 /**
@@ -28,9 +30,11 @@ import org.springframework.util.Assert;
  *
  * @since 6.0
  */
-public abstract class AbstractMqttClientManager<T> implements ClientManager<T> {
+public abstract class AbstractMqttClientManager<T> implements ClientManager<T>, ApplicationEventPublisherAware {
 
-	protected final Log logger = LogFactory.getLog(this.getClass());
+	protected final Log logger = LogFactory.getLog(this.getClass()); // NOSONAR
+
+	private ApplicationEventPublisher applicationEventPublisher;
 
 	private boolean manualAcks;
 
@@ -38,9 +42,31 @@ public abstract class AbstractMqttClientManager<T> implements ClientManager<T> {
 
 	private final String clientId;
 
+	volatile T client;
+
 	AbstractMqttClientManager(String clientId) {
 		Assert.notNull(clientId, "'clientId' is required");
 		this.clientId = clientId;
+	}
+
+	protected void setManualAcks(boolean manualAcks) {
+		this.manualAcks = manualAcks;
+	}
+
+	protected String getUrl() {
+		return this.url;
+	}
+
+	protected void setUrl(String url) {
+		this.url = url;
+	}
+
+	protected String getClientId() {
+		return this.clientId;
+	}
+
+	protected ApplicationEventPublisher getApplicationEventPublisher() {
+		return this.applicationEventPublisher;
 	}
 
 	@Override
@@ -48,20 +74,18 @@ public abstract class AbstractMqttClientManager<T> implements ClientManager<T> {
 		return this.manualAcks;
 	}
 
-	public void setManualAcks(boolean manualAcks) {
-		this.manualAcks = manualAcks;
+	@Override
+	public T getClient() {
+		return this.client;
 	}
 
-	public String getUrl() {
-		return this.url;
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		Assert.notNull(applicationEventPublisher, "'applicationEventPublisher' cannot be null");
+		this.applicationEventPublisher = applicationEventPublisher;
 	}
 
-	public void setUrl(String url) {
-		this.url = url;
+	public synchronized boolean isRunning() {
+		return this.client != null;
 	}
-
-	public String getClientId() {
-		return this.clientId;
-	}
-
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -16,20 +16,24 @@
 
 package org.springframework.integration.mqtt.core;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import org.springframework.util.Assert;
 
 public abstract class AbstractMqttClientManager<T> implements ClientManager<T> {
+
+	protected final Log logger = LogFactory.getLog(this.getClass());
 
 	private boolean manualAcks;
 
 	private String url;
 
-	private String clientId;
+	private final String clientId;
 
-	AbstractMqttClientManager(String url, String clientId) {
+	AbstractMqttClientManager(String clientId) {
 		Assert.notNull(clientId, "'clientId' is required");
 		this.clientId = clientId;
-		this.url = url;
 	}
 
 	@Override
@@ -53,7 +57,4 @@ public abstract class AbstractMqttClientManager<T> implements ClientManager<T> {
 		return this.clientId;
 	}
 
-	public void setClientId(String clientId) {
-		this.clientId = clientId;
-	}
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mqtt.core;
+
+import org.springframework.util.Assert;
+
+public abstract class AbstractMqttClientManager<T> implements ClientManager<T> {
+
+	private boolean manualAcks;
+
+	private String url;
+
+	private String clientId;
+
+	AbstractMqttClientManager(String url, String clientId) {
+		Assert.notNull(clientId, "'clientId' is required");
+		this.clientId = clientId;
+		this.url = url;
+	}
+
+	@Override
+	public boolean isManualAcks() {
+		return this.manualAcks;
+	}
+
+	public void setManualAcks(boolean manualAcks) {
+		this.manualAcks = manualAcks;
+	}
+
+	public String getUrl() {
+		return this.url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public String getClientId() {
+		return this.clientId;
+	}
+
+	public void setClientId(String clientId) {
+		this.clientId = clientId;
+	}
+}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -30,6 +30,9 @@ import org.springframework.integration.mqtt.inbound.AbstractMqttMessageDrivenCha
 import org.springframework.util.Assert;
 
 /**
+ * Abstract class for MQTT client managers which can be a base for any common v3/v5 client manager implementation.
+ * Contains some basic utility  and implementation-agnostic fields and methods.
+ *
  * @param <T> MQTT client type
  * @param <C> MQTT connection options type (v5 or v3)
  *
@@ -43,7 +46,7 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 
 	private static final int DEFAULT_MANAGER_PHASE = 0;
 
-	private final Set<ConnectCallback> connectCallbacks;
+	private final Set<ConnectCallback> connectCallbacks = Collections.synchronizedSet(new HashSet<>());
 
 	private final String clientId;
 
@@ -62,7 +65,6 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 	AbstractMqttClientManager(String clientId) {
 		Assert.notNull(clientId, "'clientId' is required");
 		this.clientId = clientId;
-		this.connectCallbacks = Collections.synchronizedSet(new HashSet<>());
 	}
 
 	protected void setManualAcks(boolean manualAcks) {

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -35,12 +35,13 @@ import org.springframework.util.Assert;
  *
  * @param <T> MQTT client type
  * @param <C> MQTT connection options type (v5 or v3)
+ * @param <P> MQTT client persistence type (for v5 or v3)
  *
  * @author Artem Vozhdayenko
  *
  * @since 6.0
  */
-public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T, C>, ApplicationEventPublisherAware {
+public abstract class AbstractMqttClientManager<T, C, P> implements ClientManager<T, C>, ApplicationEventPublisherAware {
 
 	protected final Log logger = LogFactory.getLog(this.getClass()); // NOSONAR
 
@@ -56,11 +57,13 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
+	private P persistence;
+
 	private String url;
 
-	private volatile T client;
-
 	private String beanName;
+
+	private volatile T client;
 
 	AbstractMqttClientManager(String clientId) {
 		Assert.notNull(clientId, "'clientId' is required");
@@ -89,6 +92,18 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 
 	protected synchronized void setClient(T client) {
 		this.client = client;
+	}
+
+	protected P getPersistence() {
+		return this.persistence;
+	}
+
+	/**
+	 * Set client persistence if some specific impl is required for topics QoS.
+	 * @param persistence persistence implementation to use for te client
+	 */
+	public void setPersistence(P persistence) {
+		this.persistence = persistence;
 	}
 
 	protected Set<ConnectCallback> getCallbacks() {
@@ -149,7 +164,7 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 	}
 
 	/**
-	 * Sets the phase of component autostart in {@link SmartLifecycle}.
+	 * Set the phase of component autostart in {@link SmartLifecycle}.
 	 * If the custom one is required, note that for the correct behavior it should be less than phase of
 	 * {@link AbstractMqttMessageDrivenChannelAdapter} implementations.
 	 * @see #getPhase

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -16,37 +16,49 @@
 
 package org.springframework.integration.mqtt.core;
 
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.integration.mqtt.inbound.AbstractMqttMessageDrivenChannelAdapter;
 import org.springframework.util.Assert;
 
 /**
  * @param <T> MQTT client type
+ * @param <C> MQTT connection options type (v5 or v3)
  *
  * @author Artem Vozhdayenko
  *
  * @since 6.0
  */
-public abstract class AbstractMqttClientManager<T> implements ClientManager<T>, ApplicationEventPublisherAware {
+public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T, C>, ApplicationEventPublisherAware {
 
 	protected final Log logger = LogFactory.getLog(this.getClass()); // NOSONAR
 
-	private ApplicationEventPublisher applicationEventPublisher;
-
-	private boolean manualAcks;
-
-	private String url;
+	private final Set<ConnectCallback> connectCallbacks;
 
 	private final String clientId;
 
-	volatile T client;
+	private boolean manualAcks;
+
+	private ApplicationEventPublisher applicationEventPublisher;
+
+	private String url;
+
+	private volatile T client;
+
+	private String beanName;
 
 	AbstractMqttClientManager(String clientId) {
 		Assert.notNull(clientId, "'clientId' is required");
 		this.clientId = clientId;
+		this.connectCallbacks = Collections.synchronizedSet(new HashSet<>());
 	}
 
 	protected void setManualAcks(boolean manualAcks) {
@@ -69,6 +81,14 @@ public abstract class AbstractMqttClientManager<T> implements ClientManager<T>, 
 		return this.applicationEventPublisher;
 	}
 
+	protected synchronized void setClient(T client) {
+		this.client = client;
+	}
+
+	protected Set<ConnectCallback> getCallbacks() {
+		return Collections.unmodifiableSet(this.connectCallbacks);
+	}
+
 	@Override
 	public boolean isManualAcks() {
 		return this.manualAcks;
@@ -85,7 +105,39 @@ public abstract class AbstractMqttClientManager<T> implements ClientManager<T>, 
 		this.applicationEventPublisher = applicationEventPublisher;
 	}
 
+	@Override
+	public void setBeanName(String name) {
+		this.beanName = name;
+	}
+
+	@Override
+	public String getBeanName() {
+		return this.beanName;
+	}
+
+	/**
+	 * The phase of component autostart in {@link SmartLifecycle}.
+	 * If the custom one is required, note that for the correct behavior it should be less than phase of
+	 * {@link AbstractMqttMessageDrivenChannelAdapter} implementations.
+	 * @return {@link SmartLifecycle} autostart phase
+	 */
+	@Override
+	public int getPhase() {
+		return 0;
+	}
+
+	@Override
+	public void addCallback(ConnectCallback connectCallback) {
+		this.connectCallbacks.add(connectCallback);
+	}
+
+	@Override
+	public boolean removeCallback(ConnectCallback connectCallback) {
+		return this.connectCallbacks.remove(connectCallback);
+	}
+
 	public synchronized boolean isRunning() {
 		return this.client != null;
 	}
+
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -21,6 +21,13 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.util.Assert;
 
+/**
+ * @param <T> MQTT client type
+ *
+ * @author Artem Vozhdayenko
+ *
+ * @since 6.0
+ */
 public abstract class AbstractMqttClientManager<T> implements ClientManager<T> {
 
 	protected final Log logger = LogFactory.getLog(this.getClass());

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -41,9 +41,13 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 
 	protected final Log logger = LogFactory.getLog(this.getClass()); // NOSONAR
 
+	private static final int DEFAULT_MANAGER_PHASE = 0;
+
 	private final Set<ConnectCallback> connectCallbacks;
 
 	private final String clientId;
+
+	private int phase = DEFAULT_MANAGER_PHASE;
 
 	private boolean manualAcks;
 
@@ -86,7 +90,7 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 	}
 
 	protected Set<ConnectCallback> getCallbacks() {
-		return Collections.unmodifiableSet(this.connectCallbacks);
+		return this.connectCallbacks;
 	}
 
 	@Override
@@ -119,11 +123,13 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 	 * The phase of component autostart in {@link SmartLifecycle}.
 	 * If the custom one is required, note that for the correct behavior it should be less than phase of
 	 * {@link AbstractMqttMessageDrivenChannelAdapter} implementations.
+	 * The default phase is {@link #DEFAULT_MANAGER_PHASE}.
 	 * @return {@link SmartLifecycle} autostart phase
+	 * @see #setPhase
 	 */
 	@Override
 	public int getPhase() {
-		return 0;
+		return this.phase;
 	}
 
 	@Override
@@ -138,6 +144,16 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 
 	public synchronized boolean isRunning() {
 		return this.client != null;
+	}
+
+	/**
+	 * Sets the phase of component autostart in {@link SmartLifecycle}.
+	 * If the custom one is required, note that for the correct behavior it should be less than phase of
+	 * {@link AbstractMqttMessageDrivenChannelAdapter} implementations.
+	 * @see #getPhase
+	 */
+	public void setPhase(int phase) {
+		this.phase = phase;
 	}
 
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -24,15 +24,29 @@ import org.springframework.context.SmartLifecycle;
  * Using this manager in multiple MQTT integrations will preserve a single connection.
  *
  * @param <T> MQTT client type
+ * @param <C> MQTT connection options type (v5 or v3)
  *
  * @author Artem Vozhdayenko
  *
  * @since 6.0
  */
-public interface ClientManager<T> extends SmartLifecycle {
+public interface ClientManager<T, C> extends SmartLifecycle, MqttComponent<C> {
 
 	T getClient();
 
 	boolean isManualAcks();
+
+	void addCallback(ConnectCallback connectCallback);
+
+	boolean removeCallback(ConnectCallback connectCallback);
+
+	/**
+	 * A contract for a custom callback if needed by a usage.
+	 */
+	interface ConnectCallback {
+
+		void connectComplete(boolean isReconnect);
+
+	}
 
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -18,6 +18,17 @@ package org.springframework.integration.mqtt.core;
 
 import org.springframework.context.SmartLifecycle;
 
+/**
+ * A utility abstraction over MQTT client which can be used in any MQTT-related component
+ * without need to handle generic client callbacks, reconnects etc.
+ * Using this manager in multiple MQTT integrations will preserve a single connection.
+ *
+ * @param <T> MQTT client type
+ *
+ * @author Artem Vozhdayenko
+ *
+ * @since 6.0
+ */
 public interface ClientManager<T> extends SmartLifecycle {
 
 	T getClient();

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -16,10 +16,12 @@
 
 package org.springframework.integration.mqtt.core;
 
-import org.springframework.integration.support.management.ManageableLifecycle;
+import org.springframework.context.SmartLifecycle;
 
-public interface ClientManager<T> extends ManageableLifecycle {
+public interface ClientManager<T> extends SmartLifecycle {
 
 	T getClient();
+
+	boolean isManualAcks();
 
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mqtt.core;
+
+import org.springframework.integration.support.management.ManageableLifecycle;
+
+public interface ClientManager<T> extends ManageableLifecycle {
+
+	T getClient();
+
+}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -42,6 +42,9 @@ public interface ClientManager<T, C> extends SmartLifecycle, MqttComponent<C> {
 
 	/**
 	 * A contract for a custom callback if needed by a usage.
+	 *
+	 * @see org.eclipse.paho.mqttv5.client.MqttCallback#connectComplete
+	 * @see org.eclipse.paho.client.mqttv3.MqttCallbackExtended#connectComplete
 	 */
 	interface ConnectCallback {
 

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
@@ -82,8 +82,6 @@ public class Mqttv3ClientManager extends AbstractMqttClientManager<IMqttAsyncCli
 			getClient().connect(options).waitForCompletion(options.getConnectionTimeout());
 		}
 		catch (MqttException e) {
-			logger.error("could not start client manager, client_id=" + getClientId(), e);
-
 			// See GH-3822
 			if (getConnectionInfo().isAutomaticReconnect()) {
 				try {
@@ -97,6 +95,9 @@ public class Mqttv3ClientManager extends AbstractMqttClientManager<IMqttAsyncCli
 				var applicationEventPublisher = getApplicationEventPublisher();
 				if (applicationEventPublisher != null) {
 					applicationEventPublisher.publishEvent(new MqttConnectionFailedEvent(this, e));
+				}
+				else {
+					logger.error("could not start client manager, client_id=" + getClientId(), e);
 				}
 			}
 		}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mqtt.core;
+
+import java.time.Instant;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.paho.client.mqttv3.IMqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.IMqttDeliveryToken;
+import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
+import org.eclipse.paho.client.mqttv3.MqttCallback;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import org.springframework.integration.context.IntegrationObjectSupport;
+import org.springframework.integration.support.management.ManageableLifecycle;
+
+public class Mqttv3ClientManager extends IntegrationObjectSupport implements ClientManager<IMqttAsyncClient>,
+		ManageableLifecycle, MqttCallback {
+
+	private AtomicReference<ScheduledFuture<?>> scheduledReconnect;
+
+	private final MqttConnectOptions connectOptions;
+
+	private final String clientId;
+
+	private IMqttAsyncClient client;
+
+	public Mqttv3ClientManager(MqttConnectOptions connectOptions, String clientId) throws MqttException {
+		this.connectOptions = connectOptions;
+		this.client = new MqttAsyncClient(connectOptions.getServerURIs()[0], clientId);
+		this.client.setCallback(this);
+		this.clientId = clientId;
+	}
+
+	@Override
+	public IMqttAsyncClient getClient() {
+		return client;
+	}
+
+	@Override
+	public void start() {
+		if (this.client == null) {
+			try {
+				this.client = new MqttAsyncClient(this.connectOptions.getServerURIs()[0], this.clientId);
+			}
+			catch (MqttException e) {
+				throw new IllegalStateException("could not start client manager", e);
+			}
+			this.client.setCallback(this);
+		}
+		try {
+			connect();
+		}
+		catch (MqttException e) {
+			logger.error(e, "could not start client manager, scheduling reconnect, client_id=" +
+					this.client.getClientId());
+			scheduleReconnect();
+		}
+	}
+
+	@Override
+	public void stop() {
+		if (this.client == null) {
+			return;
+		}
+		try {
+			this.client.disconnectForcibly(this.connectOptions.getConnectionTimeout());
+		}
+		catch (MqttException e) {
+			logger.error(e, "could not disconnect from the client");
+		}
+		finally {
+			try {
+				this.client.close();
+			}
+			catch (MqttException e) {
+				logger.error(e, "could not close the client");
+			}
+			this.client = null;
+		}
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.client != null;
+	}
+
+	private synchronized void connect() throws MqttException {
+		if (this.client == null) {
+			logger.error("could not connect on a null client reference");
+			return;
+		}
+		MqttConnectOptions options = Mqttv3ClientManager.this.connectOptions;
+		this.client.connect(options).waitForCompletion(options.getConnectionTimeout());
+	}
+
+	@Override
+	public synchronized void connectionLost(Throwable cause) {
+		logger.error(cause, "connection lost, scheduling reconnect, client_id=" + this.client.getClientId());
+		scheduleReconnect();
+	}
+
+	private void scheduleReconnect() {
+		if (this.scheduledReconnect.get() != null) {
+			this.scheduledReconnect.get().cancel(false);
+		}
+		this.scheduledReconnect.set(getTaskScheduler().schedule(() -> {
+			try {
+				connect();
+				this.scheduledReconnect.set(null);
+			}
+			catch (MqttException e) {
+				logger.error(e, "could not reconnect");
+				scheduleReconnect();
+			}
+		}, Instant.now().plusSeconds(10)));
+	}
+
+	@Override
+	public void messageArrived(String topic, MqttMessage message) {
+		// not this manager concern
+	}
+
+	@Override
+	public void deliveryComplete(IMqttDeliveryToken token) {
+		// nor this manager concern
+	}
+}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -83,9 +83,19 @@ public class Mqttv5ClientManager extends AbstractMqttClientManager<IMqttAsyncCli
 		catch (MqttException e) {
 			logger.error("could not start client manager, client_id=" + getClientId(), e);
 
-			var applicationEventPublisher = getApplicationEventPublisher();
-			if (applicationEventPublisher != null) {
-				applicationEventPublisher.publishEvent(new MqttConnectionFailedEvent(this, e));
+			if (getConnectionInfo().isAutomaticReconnect()) {
+				try {
+					getClient().reconnect();
+				}
+				catch (MqttException re) {
+					logger.error("MQTT client failed to connect. Never happens.", re);
+				}
+			}
+			else {
+				var applicationEventPublisher = getApplicationEventPublisher();
+				if (applicationEventPublisher != null) {
+					applicationEventPublisher.publishEvent(new MqttConnectionFailedEvent(this, e));
+				}
 			}
 		}
 	}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -81,8 +81,6 @@ public class Mqttv5ClientManager extends AbstractMqttClientManager<IMqttAsyncCli
 					.waitForCompletion(this.connectionOptions.getConnectionTimeout());
 		}
 		catch (MqttException e) {
-			logger.error("could not start client manager, client_id=" + getClientId(), e);
-
 			if (getConnectionInfo().isAutomaticReconnect()) {
 				try {
 					getClient().reconnect();
@@ -95,6 +93,9 @@ public class Mqttv5ClientManager extends AbstractMqttClientManager<IMqttAsyncCli
 				var applicationEventPublisher = getApplicationEventPublisher();
 				if (applicationEventPublisher != null) {
 					applicationEventPublisher.publishEvent(new MqttConnectionFailedEvent(this, e));
+				}
+				else {
+					logger.error("could not start client manager, client_id=" + getClientId(), e);
 				}
 			}
 		}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mqtt.core;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.eclipse.paho.mqttv5.client.IMqttAsyncClient;
+import org.eclipse.paho.mqttv5.client.IMqttToken;
+import org.eclipse.paho.mqttv5.client.MqttAsyncClient;
+import org.eclipse.paho.mqttv5.client.MqttCallback;
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.MqttDisconnectResponse;
+import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
+
+import org.springframework.util.Assert;
+
+public class Mqttv5ClientManager extends AbstractMqttClientManager<IMqttAsyncClient> implements MqttCallback {
+
+	private final Log logger = LogFactory.getLog(this.getClass());
+
+	private final MqttConnectionOptions connectionOptions;
+
+	private volatile IMqttAsyncClient client;
+
+	public Mqttv5ClientManager(MqttConnectionOptions connectionOptions, String url, String clientId) {
+		super(url, clientId);
+		Assert.notNull(connectionOptions, "'connectionOptions' is required");
+		if (url == null) {
+			Assert.notEmpty(connectionOptions.getServerURIs(), "'serverURIs' must be provided in the 'MqttConnectionOptions'");
+		}
+		this.connectionOptions = connectionOptions;
+	}
+
+	@Override
+	public IMqttAsyncClient getClient() {
+		return this.client;
+	}
+
+	@Override
+	public synchronized void start() {
+		if (this.client == null) {
+			try {
+				this.client = new MqttAsyncClient(getUrl(), getClientId());
+				this.client.setManualAcks(isManualAcks());
+				this.client.setCallback(this);
+			}
+			catch (MqttException e) {
+				throw new IllegalStateException("could not start client manager", e);
+			}
+		}
+		try {
+			this.client.connect(this.connectionOptions)
+					.waitForCompletion(this.connectionOptions.getConnectionTimeout());
+		}
+		catch (MqttException e) {
+			this.logger.error("could not start client manager, client_id=" + this.client.getClientId(), e);
+		}
+	}
+
+	@Override
+	public synchronized void stop() {
+		if (this.client == null) {
+			return;
+		}
+
+		try {
+			this.client.disconnectForcibly(this.connectionOptions.getConnectionTimeout());
+		}
+		catch (MqttException e) {
+			this.logger.error("could not disconnect from the client", e);
+		}
+		finally {
+			try {
+				this.client.close();
+			}
+			catch (MqttException e) {
+				this.logger.error("could not close the client", e);
+			}
+			this.client = null;
+		}
+	}
+
+	@Override
+	public synchronized boolean isRunning() {
+		return this.client != null;
+	}
+
+	@Override
+	public void messageArrived(String topic, MqttMessage message) {
+		// not this manager concern
+	}
+
+	@Override
+	public void deliveryComplete(IMqttToken token) {
+		// not this manager concern
+	}
+
+	@Override
+	public void connectComplete(boolean reconnect, String serverURI) {
+		if (this.logger.isInfoEnabled()) {
+			this.logger.info("MQTT connect complete to " + serverURI);
+		}
+		// probably makes sense to use custom callbacks in the future
+	}
+
+	@Override
+	public void authPacketArrived(int reasonCode, MqttProperties properties) {
+		// not this manager concern
+	}
+
+	@Override
+	public void disconnected(MqttDisconnectResponse disconnectResponse) {
+		if (this.logger.isInfoEnabled()) {
+			this.logger.info("MQTT disconnected" + disconnectResponse);
+		}
+	}
+
+	@Override
+	public void mqttErrorOccurred(MqttException exception) {
+		this.logger.error("MQTT error occurred", exception);
+	}
+
+}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -26,6 +26,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.log.LogMessage;
 import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.mqtt.core.ClientManager;
 import org.springframework.integration.mqtt.support.MqttMessageConverter;
 import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
@@ -38,6 +39,8 @@ import org.springframework.util.Assert;
 /**
  * Abstract class for MQTT Message-Driven Channel Adapters.
  *
+ * @param <T> MQTT Client type
+ *
  * @author Gary Russell
  * @author Artem Bilan
  * @author Trung Pham
@@ -48,7 +51,7 @@ import org.springframework.util.Assert;
  */
 @ManagedResource
 @IntegrationManagedResource
-public abstract class AbstractMqttMessageDrivenChannelAdapter extends MessageProducerSupport
+public abstract class AbstractMqttMessageDrivenChannelAdapter<T> extends MessageProducerSupport
 		implements ApplicationEventPublisherAware {
 
 	/**
@@ -70,6 +73,8 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter extends MessagePro
 
 	private MqttMessageConverter converter;
 
+	protected ClientManager<T> clientManager;
+
 	protected final Lock topicLock = new ReentrantLock(); // NOSONAR
 
 	public AbstractMqttMessageDrivenChannelAdapter(@Nullable String url, String clientId, String... topic) {
@@ -87,6 +92,15 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter extends MessagePro
 	public void setConverter(MqttMessageConverter converter) {
 		Assert.notNull(converter, "'converter' cannot be null");
 		this.converter = converter;
+	}
+
+	public void setClientManager(ClientManager<T> clientManager) {
+		Assert.notNull(clientManager, "'clientManager' cannot be null");
+		this.clientManager = clientManager;
+	}
+
+	public ClientManager<T> getClientManager() {
+		return this.clientManager;
 	}
 
 	/**

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -195,7 +195,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T> extends Message
 	}
 
 	protected boolean isManualAcks() {
-		return this.manualAcks;
+		return this.clientManager == null ? this.manualAcks : this.clientManager.isManualAcks();
 	}
 
 	/**

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -54,7 +54,7 @@ import org.springframework.util.Assert;
 @ManagedResource
 @IntegrationManagedResource
 public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends MessageProducerSupport
-		implements ApplicationEventPublisherAware {
+		implements ApplicationEventPublisherAware, ClientManager.ConnectCallback {
 
 	/**
 	 * The default completion timeout in milliseconds.
@@ -78,8 +78,6 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 	private ApplicationEventPublisher applicationEventPublisher;
 
 	private MqttMessageConverter converter;
-
-	private ClientManager.ConnectCallback clientManagerConnectCallback;
 
 	public AbstractMqttMessageDrivenChannelAdapter(@Nullable String url, String clientId, String... topic) {
 		Assert.hasText(clientId, "'clientId' cannot be null or empty");
@@ -116,15 +114,6 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 	@Nullable
 	protected ClientManager<T, C> getClientManager() {
 		return this.clientManager;
-	}
-
-	@Nullable
-	protected ClientManager.ConnectCallback getClientManagerCallback() {
-		return this.clientManagerConnectCallback;
-	}
-
-	protected void setClientManagerCallback(ClientManager.ConnectCallback clientManagerConnectCallback) {
-		this.clientManagerConnectCallback = clientManagerConnectCallback;
 	}
 
 	/**

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -95,7 +95,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 		this.clientId = null;
 	}
 
-	private Set<Topic> initTopics(String[] topic) {
+	private static Set<Topic> initTopics(String[] topic) {
 		Assert.notNull(topic, "'topics' cannot be null");
 		Assert.noNullElements(topic, "'topics' cannot have null elements");
 		final Set<Topic> initialTopics = new LinkedHashSet<>();
@@ -182,6 +182,22 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 		}
 		finally {
 			this.topicLock.unlock();
+		}
+	}
+
+	@Override
+	protected void onInit() {
+		super.onInit();
+		if (this.clientManager != null) {
+			this.clientManager.addCallback(this);
+		}
+	}
+
+	@Override
+	public void destroy() {
+		super.destroy();
+		if (this.clientManager != null) {
+			this.clientManager.removeCallback(this);
 		}
 	}
 

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -60,9 +60,9 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T> extends Message
 	 */
 	public static final long DEFAULT_COMPLETION_TIMEOUT = 30_000L;
 
-	private String url;
+	private final String url;
 
-	private String clientId;
+	private final String clientId;
 
 	private final Set<Topic> topics;
 
@@ -74,7 +74,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T> extends Message
 
 	private MqttMessageConverter converter;
 
-	protected ClientManager<T> clientManager;
+	private final ClientManager<T> clientManager;
 
 	protected final Lock topicLock = new ReentrantLock(); // NOSONAR
 
@@ -83,12 +83,15 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T> extends Message
 		this.url = url;
 		this.clientId = clientId;
 		this.topics = initTopics(topic);
+		this.clientManager = null;
 	}
 
 	AbstractMqttMessageDrivenChannelAdapter(ClientManager<T> clientManager, String... topic) {
 		Assert.notNull(clientManager, "'clientManager' cannot be null");
 		this.clientManager = clientManager;
 		this.topics = initTopics(topic);
+		this.url = null;
+		this.clientId = null;
 	}
 
 	private Set<Topic> initTopics(String[] topic) {
@@ -107,7 +110,8 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T> extends Message
 		this.converter = converter;
 	}
 
-	public ClientManager<T> getClientManager() {
+	@Nullable
+	protected ClientManager<T> getClientManager() {
 		return this.clientManager;
 	}
 
@@ -155,6 +159,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T> extends Message
 		return this.url;
 	}
 
+	@Nullable
 	protected String getClientId() {
 		return this.clientId;
 	}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -168,11 +168,6 @@ public class MqttPahoMessageDrivenChannelAdapter
 			pahoMessageConverter.setBeanFactory(getBeanFactory());
 			setConverter(pahoMessageConverter);
 		}
-
-		var clientManager = getClientManager();
-		if (clientManager != null) {
-			clientManager.addCallback(this);
-		}
 	}
 
 	@Override
@@ -228,11 +223,7 @@ public class MqttPahoMessageDrivenChannelAdapter
 	@Override
 	public void destroy() {
 		super.destroy();
-		var clientManager = getClientManager();
-		if (clientManager != null) {
-			clientManager.removeCallback(this);
-		}
-		else {
+		if (getClientManager() == null) {
 			try {
 				this.client.close();
 			}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -90,6 +90,16 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 	private volatile ConsumerStopAction consumerStopAction;
 
 	/**
+	 * Use this constructor when you don't need additional {@link MqttConnectOptions}.
+	 * @param url The URL.
+	 * @param clientId The client id.
+	 * @param topic The topic(s).
+	 */
+	public MqttPahoMessageDrivenChannelAdapter(String url, String clientId, String... topic) {
+		this(url, clientId, new DefaultMqttPahoClientFactory(), topic);
+	}
+
+	/**
 	 * Use this constructor for a single url (although it may be overridden if the server
 	 * URI(s) are provided by the {@link MqttConnectOptions#getServerURIs()} provided by
 	 * the {@link MqttPahoClientFactory}).
@@ -121,15 +131,14 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 		this.clientFactory = clientFactory;
 	}
 
-
 	/**
-	 * Use this constructor when you don't need additional {@link MqttConnectOptions}.
-	 * @param url The URL.
-	 * @param clientId The client id.
+	 * Use this constructor when you need to use a single {@link ClientManager}
+	 * (for instance, to reuse an MQTT connection).
+	 * @param clientManager The client manager.
 	 * @param topic The topic(s).
 	 */
-	public MqttPahoMessageDrivenChannelAdapter(String url, String clientId, String... topic) {
-		this(url, clientId, new DefaultMqttPahoClientFactory(), topic);
+	public MqttPahoMessageDrivenChannelAdapter(ClientManager<IMqttAsyncClient> clientManager, String... topic) {
+		this(clientManager, new MqttConnectOptions(), topic);
 	}
 
 	/**
@@ -146,16 +155,6 @@ public class MqttPahoMessageDrivenChannelAdapter extends AbstractMqttMessageDriv
 		var factory = new DefaultMqttPahoClientFactory();
 		factory.setConnectionOptions(connectOptions);
 		this.clientFactory = factory;
-	}
-
-	/**
-	 * Use this constructor when you need to use a single {@link ClientManager}
-	 * (for instance, to reuse an MQTT connection).
-	 * @param clientManager The client manager.
-	 * @param topic The topic(s).
-	 */
-	public MqttPahoMessageDrivenChannelAdapter(ClientManager<IMqttAsyncClient> clientManager, String... topic) {
-		this(clientManager, new MqttConnectOptions(), topic);
 	}
 
 	/**

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -71,7 +71,7 @@ import org.springframework.util.Assert;
  * @since 5.5.5
  *
  */
-public class Mqttv5PahoMessageDrivenChannelAdapter extends AbstractMqttMessageDrivenChannelAdapter
+public class Mqttv5PahoMessageDrivenChannelAdapter extends AbstractMqttMessageDrivenChannelAdapter<IMqttAsyncClient>
 		implements MqttCallback, MqttComponent<MqttConnectionOptions> {
 
 	private final MqttConnectionOptions connectionOptions;
@@ -90,7 +90,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter extends AbstractMqttMessageDr
 	public Mqttv5PahoMessageDrivenChannelAdapter(String url, String clientId, String... topic) {
 		super(url, clientId, topic);
 		this.connectionOptions = new MqttConnectionOptions();
-		this.connectionOptions.setServerURIs(new String[]{ url });
+		this.connectionOptions.setServerURIs(new String[] {url});
 		this.connectionOptions.setAutomaticReconnect(true);
 	}
 

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -111,6 +111,16 @@ public class Mqttv5PahoMessageDrivenChannelAdapter extends AbstractMqttMessageDr
 
 	/**
 	 * Use this constructor when you need to use a single {@link ClientManager}
+	 * (for instance, to reuse an MQTT connection).
+	 * @param clientManager The client manager.
+	 * @param topic The topic(s).
+	 */
+	public Mqttv5PahoMessageDrivenChannelAdapter(ClientManager<IMqttAsyncClient> clientManager, String... topic) {
+		this(buildDefaultConnectionOptions(null), clientManager, topic);
+	}
+
+	/**
+	 * Use this constructor when you need to use a single {@link ClientManager}
 	 * (for instance, to reuse an MQTT connection) and a specific {@link MqttConnectionOptions}.
 	 * @param connectionOptions The connection options.
 	 * @param clientManager The client manager.
@@ -126,16 +136,6 @@ public class Mqttv5PahoMessageDrivenChannelAdapter extends AbstractMqttMessageDr
 					"Otherwise the current channel adapter restart should be used explicitly, " +
 					"e.g. via handling 'MqttConnectionFailedEvent' on client disconnection.");
 		}
-	}
-
-	/**
-	 * Use this constructor when you need to use a single {@link ClientManager}
-	 * (for instance, to reuse an MQTT connection).
-	 * @param clientManager The client manager.
-	 * @param topic The topic(s).
-	 */
-	public Mqttv5PahoMessageDrivenChannelAdapter(ClientManager<IMqttAsyncClient> clientManager, String... topic) {
-		this(buildDefaultConnectionOptions(null), clientManager, topic);
 	}
 
 	private static MqttConnectionOptions buildDefaultConnectionOptions(@Nullable String url) {

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -331,11 +331,9 @@ public class Mqttv5PahoMessageDrivenChannelAdapter extends AbstractMqttMessageDr
 
 	@Override
 	public void connectComplete(boolean reconnect, String serverURI) {
-		if (reconnect) {
-			return;
+		if (!reconnect) {
+			subscribeToAll();
 		}
-
-		subscribeToAll();
 	}
 
 	@Override

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Artem Vozhdayenko
  *
  * @since 4.0
  *
@@ -63,9 +64,9 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 
 	private final AtomicBoolean running = new AtomicBoolean();
 
-	private final String url;
+	private String url;
 
-	private final String clientId;
+	private String clientId;
 
 	private long completionTimeout = DEFAULT_COMPLETION_TIMEOUT;
 
@@ -95,6 +96,11 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 		Assert.hasText(clientId, "'clientId' cannot be null or empty");
 		this.url = url;
 		this.clientId = clientId;
+	}
+
+	AbstractMqttMessageHandler(ClientManager<T> clientManager) {
+		Assert.notNull(clientManager, "'clientManager' cannot be null or empty");
+		this.clientManager = clientManager;
 	}
 
 	@Override
@@ -299,11 +305,6 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 
 	protected ClientManager<T> getClientManager() {
 		return this.clientManager;
-	}
-
-	public void setClientManager(ClientManager<T> clientManager) {
-		Assert.notNull(clientManager, "'clientManager' cannot be null");
-		this.clientManager = clientManager;
 	}
 
 	@Override

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
@@ -64,9 +64,9 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 
 	private final AtomicBoolean running = new AtomicBoolean();
 
-	private String url;
+	private final String url;
 
-	private String clientId;
+	private final String clientId;
 
 	private long completionTimeout = DEFAULT_COMPLETION_TIMEOUT;
 
@@ -90,17 +90,20 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 
 	private int clientInstance;
 
-	protected ClientManager<T> clientManager;
+	private final ClientManager<T> clientManager;
 
 	public AbstractMqttMessageHandler(@Nullable String url, String clientId) {
 		Assert.hasText(clientId, "'clientId' cannot be null or empty");
 		this.url = url;
 		this.clientId = clientId;
+		this.clientManager = null;
 	}
 
 	AbstractMqttMessageHandler(ClientManager<T> clientManager) {
 		Assert.notNull(clientManager, "'clientManager' cannot be null or empty");
 		this.clientManager = clientManager;
+		this.url = null;
+		this.clientId = null;
 	}
 
 	@Override
@@ -253,6 +256,7 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 		return this.url;
 	}
 
+	@Nullable
 	public String getClientId() {
 		return this.clientId;
 	}
@@ -303,6 +307,7 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 		return this.disconnectCompletionTimeout;
 	}
 
+	@Nullable
 	protected ClientManager<T> getClientManager() {
 		return this.clientManager;
 	}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
@@ -103,6 +103,7 @@ public abstract class AbstractMqttMessageHandler<T, C> extends AbstractMessageHa
 	public AbstractMqttMessageHandler(ClientManager<T, C> clientManager) {
 		Assert.notNull(clientManager, "'clientManager' cannot be null or empty");
 		this.clientManager = clientManager;
+		clientManager.getConnectionInfo();
 		this.url = null;
 		this.clientId = null;
 	}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.expression.Expression;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.integration.handler.ExpressionEvaluatingMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
+import org.springframework.integration.mqtt.core.ClientManager;
 import org.springframework.integration.mqtt.support.MqttHeaders;
 import org.springframework.integration.mqtt.support.MqttMessageConverter;
 import org.springframework.integration.support.management.ManageableLifecycle;
@@ -36,13 +37,15 @@ import org.springframework.util.Assert;
 /**
  * Abstract class for MQTT outbound channel adapters.
  *
+ * @param <T> MQTT Client type
+ *
  * @author Gary Russell
  * @author Artem Bilan
  *
  * @since 4.0
  *
  */
-public abstract class AbstractMqttMessageHandler extends AbstractMessageHandler
+public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandler
 		implements ManageableLifecycle, ApplicationEventPublisherAware {
 
 	/**
@@ -85,6 +88,8 @@ public abstract class AbstractMqttMessageHandler extends AbstractMessageHandler
 	private ApplicationEventPublisher applicationEventPublisher;
 
 	private int clientInstance;
+
+	protected ClientManager<T> clientManager;
 
 	public AbstractMqttMessageHandler(@Nullable String url, String clientId) {
 		Assert.hasText(clientId, "'clientId' cannot be null or empty");
@@ -290,6 +295,15 @@ public abstract class AbstractMqttMessageHandler extends AbstractMessageHandler
 
 	protected long getDisconnectCompletionTimeout() {
 		return this.disconnectCompletionTimeout;
+	}
+
+	protected ClientManager<T> getClientManager() {
+		return this.clientManager;
+	}
+
+	public void setClientManager(ClientManager<T> clientManager) {
+		Assert.notNull(clientManager, "'clientManager' cannot be null");
+		this.clientManager = clientManager;
 	}
 
 	@Override

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/AbstractMqttMessageHandler.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  * Abstract class for MQTT outbound channel adapters.
  *
  * @param <T> MQTT Client type
+ * @param <C> MQTT connection options type (v5 or v3)
  *
  * @author Gary Russell
  * @author Artem Bilan
@@ -46,7 +47,7 @@ import org.springframework.util.Assert;
  * @since 4.0
  *
  */
-public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandler
+public abstract class AbstractMqttMessageHandler<T, C> extends AbstractMessageHandler
 		implements ManageableLifecycle, ApplicationEventPublisherAware {
 
 	/**
@@ -67,6 +68,8 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 	private final String url;
 
 	private final String clientId;
+
+	private final ClientManager<T, C> clientManager;
 
 	private long completionTimeout = DEFAULT_COMPLETION_TIMEOUT;
 
@@ -90,8 +93,6 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 
 	private int clientInstance;
 
-	private final ClientManager<T> clientManager;
-
 	public AbstractMqttMessageHandler(@Nullable String url, String clientId) {
 		Assert.hasText(clientId, "'clientId' cannot be null or empty");
 		this.url = url;
@@ -99,7 +100,7 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 		this.clientManager = null;
 	}
 
-	AbstractMqttMessageHandler(ClientManager<T> clientManager) {
+	public AbstractMqttMessageHandler(ClientManager<T, C> clientManager) {
 		Assert.notNull(clientManager, "'clientManager' cannot be null or empty");
 		this.clientManager = clientManager;
 		this.url = null;
@@ -308,7 +309,7 @@ public abstract class AbstractMqttMessageHandler<T> extends AbstractMessageHandl
 	}
 
 	@Nullable
-	protected ClientManager<T> getClientManager() {
+	protected ClientManager<T, C> getClientManager() {
 		return this.clientManager;
 	}
 

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
@@ -24,6 +24,7 @@ import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.integration.mqtt.core.ClientManager;
 import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
 import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
 import org.springframework.integration.mqtt.core.MqttPahoComponent;
@@ -48,6 +49,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Artem Vozhdayenko
  *
  * @since 4.0
  *
@@ -95,6 +97,28 @@ public class MqttPahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyn
 	 */
 	public MqttPahoMessageHandler(String url, String clientId) {
 		this(url, clientId, new DefaultMqttPahoClientFactory());
+	}
+
+	/**
+	 * Use this constructor when you need to use a single {@link ClientManager}
+	 * (for instance, to reuse an MQTT connection) and a specific {@link MqttConnectOptions}.
+	 * @param clientManager The client manager.
+	 * @param connectOptions The connection options.
+	 */
+	public MqttPahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager, MqttConnectOptions connectOptions) {
+		super(clientManager);
+		var factory = new DefaultMqttPahoClientFactory();
+		factory.setConnectionOptions(connectOptions);
+		this.clientFactory = factory;
+	}
+
+	/**
+	 * Use this constructor when you need to use a single {@link ClientManager}
+	 * (for instance, to reuse an MQTT connection).
+	 * @param clientManager The client manager.
+	 */
+	public MqttPahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager) {
+		this(clientManager, new MqttConnectOptions());
 	}
 
 	/**

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
@@ -54,7 +54,7 @@ import org.springframework.util.Assert;
  * @since 4.0
  *
  */
-public class MqttPahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyncClient>
+public class MqttPahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyncClient, MqttConnectOptions>
 		implements MqttCallback, MqttPahoComponent {
 
 	private final MqttPahoClientFactory clientFactory;
@@ -103,21 +103,12 @@ public class MqttPahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyn
 	 * Use this constructor when you need to use a single {@link ClientManager}
 	 * (for instance, to reuse an MQTT connection).
 	 * @param clientManager The client manager.
+	 * @since 6.0
 	 */
-	public MqttPahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager) {
-		this(clientManager, new MqttConnectOptions());
-	}
-
-	/**
-	 * Use this constructor when you need to use a single {@link ClientManager}
-	 * (for instance, to reuse an MQTT connection) and a specific {@link MqttConnectOptions}.
-	 * @param clientManager The client manager.
-	 * @param connectOptions The connection options.
-	 */
-	public MqttPahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager, MqttConnectOptions connectOptions) {
+	public MqttPahoMessageHandler(ClientManager<IMqttAsyncClient, MqttConnectOptions> clientManager) {
 		super(clientManager);
 		var factory = new DefaultMqttPahoClientFactory();
-		factory.setConnectionOptions(connectOptions);
+		factory.setConnectionOptions(clientManager.getConnectionInfo());
 		this.clientFactory = factory;
 	}
 

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,8 @@ import org.springframework.util.Assert;
  * @since 4.0
  *
  */
-public class MqttPahoMessageHandler extends AbstractMqttMessageHandler implements MqttCallback, MqttPahoComponent {
+public class MqttPahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyncClient>
+		implements MqttCallback, MqttPahoComponent {
 
 	private final MqttPahoClientFactory clientFactory;
 
@@ -169,6 +170,11 @@ public class MqttPahoMessageHandler extends AbstractMqttMessageHandler implement
 	}
 
 	private synchronized IMqttAsyncClient checkConnection() throws MqttException {
+		var theClientManager = getClientManager();
+		if (theClientManager != null) {
+			return theClientManager.getClient();
+		}
+
 		if (this.client != null && !this.client.isConnected()) {
 			this.client.setCallback(null);
 			this.client.close();

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/MqttPahoMessageHandler.java
@@ -66,6 +66,15 @@ public class MqttPahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyn
 	private volatile IMqttAsyncClient client;
 
 	/**
+	 * Use this constructor when you don't need additional {@link MqttConnectOptions}.
+	 * @param url The URL.
+	 * @param clientId The client id.
+	 */
+	public MqttPahoMessageHandler(String url, String clientId) {
+		this(url, clientId, new DefaultMqttPahoClientFactory());
+	}
+
+	/**
 	 * Use this constructor for a single url (although it may be overridden if the server
 	 * URI(s) are provided by the {@link MqttConnectOptions#getServerURIs()} provided by
 	 * the {@link MqttPahoClientFactory}).
@@ -91,12 +100,12 @@ public class MqttPahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyn
 	}
 
 	/**
-	 * Use this constructor when you don't need additional {@link MqttConnectOptions}.
-	 * @param url The URL.
-	 * @param clientId The client id.
+	 * Use this constructor when you need to use a single {@link ClientManager}
+	 * (for instance, to reuse an MQTT connection).
+	 * @param clientManager The client manager.
 	 */
-	public MqttPahoMessageHandler(String url, String clientId) {
-		this(url, clientId, new DefaultMqttPahoClientFactory());
+	public MqttPahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager) {
+		this(clientManager, new MqttConnectOptions());
 	}
 
 	/**
@@ -110,15 +119,6 @@ public class MqttPahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyn
 		var factory = new DefaultMqttPahoClientFactory();
 		factory.setConnectionOptions(connectOptions);
 		this.clientFactory = factory;
-	}
-
-	/**
-	 * Use this constructor when you need to use a single {@link ClientManager}
-	 * (for instance, to reuse an MQTT connection).
-	 * @param clientManager The client manager.
-	 */
-	public MqttPahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager) {
-		this(clientManager, new MqttConnectOptions());
 	}
 
 	/**

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
@@ -57,7 +57,7 @@ import org.springframework.util.Assert;
  *
  * @since 5.5.5
  */
-public class Mqttv5PahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyncClient>
+public class Mqttv5PahoMessageHandler extends AbstractMqttMessageHandler<IMqttAsyncClient, MqttConnectionOptions>
 		implements MqttCallback, MqttComponent<MqttConnectionOptions> {
 
 	private final MqttConnectionOptions connectionOptions;
@@ -83,14 +83,15 @@ public class Mqttv5PahoMessageHandler extends AbstractMqttMessageHandler<IMqttAs
 		this.connectionOptions = connectionOptions;
 	}
 
-	public Mqttv5PahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager) {
-		this(clientManager, buildDefaultConnectionOptions(null));
-	}
-
-	public Mqttv5PahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager,
-			MqttConnectionOptions connectionOptions) {
+	/**
+	 * Use this constructor when you need to use a single {@link ClientManager}
+	 * (for instance, to reuse an MQTT connection).
+	 * @param clientManager The client manager.
+	 * @since 6.0
+	 */
+	public Mqttv5PahoMessageHandler(ClientManager<IMqttAsyncClient, MqttConnectionOptions> clientManager) {
 		super(clientManager);
-		this.connectionOptions = connectionOptions;
+		this.connectionOptions = clientManager.getConnectionInfo();
 	}
 
 	private static MqttConnectionOptions buildDefaultConnectionOptions(@Nullable String url) {

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
@@ -83,14 +83,14 @@ public class Mqttv5PahoMessageHandler extends AbstractMqttMessageHandler<IMqttAs
 		this.connectionOptions = connectionOptions;
 	}
 
+	public Mqttv5PahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager) {
+		this(clientManager, buildDefaultConnectionOptions(null));
+	}
+
 	public Mqttv5PahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager,
 			MqttConnectionOptions connectionOptions) {
 		super(clientManager);
 		this.connectionOptions = connectionOptions;
-	}
-
-	public Mqttv5PahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager) {
-		this(clientManager, buildDefaultConnectionOptions(null));
 	}
 
 	private static MqttConnectionOptions buildDefaultConnectionOptions(@Nullable String url) {

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
@@ -168,11 +168,11 @@ public class Mqttv5PahoMessageHandler extends AbstractMqttMessageHandler<IMqttAs
 	protected void doStart() {
 		try {
 			var clientManager = getClientManager();
-			if (this.mqttClient != null) {
-				this.mqttClient.connect(this.connectionOptions).waitForCompletion(getCompletionTimeout());
-			}
-			else if (clientManager != null) {
+			if (clientManager != null) {
 				this.mqttClient = clientManager.getClient();
+			}
+			else {
+				this.mqttClient.connect(this.connectionOptions).waitForCompletion(getCompletionTimeout());
 			}
 		}
 		catch (MqttException ex) {
@@ -183,7 +183,7 @@ public class Mqttv5PahoMessageHandler extends AbstractMqttMessageHandler<IMqttAs
 	@Override
 	protected void doStop() {
 		try {
-			if (this.mqttClient != null) {
+			if (getClientManager() == null) {
 				this.mqttClient.disconnect().waitForCompletion(getDisconnectCompletionTimeout());
 			}
 		}
@@ -196,7 +196,7 @@ public class Mqttv5PahoMessageHandler extends AbstractMqttMessageHandler<IMqttAs
 	public void destroy() {
 		super.destroy();
 		try {
-			if (this.mqttClient != null) {
+			if (getClientManager() == null) {
 				this.mqttClient.close(true);
 			}
 		}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
@@ -95,8 +95,7 @@ public class Mqttv5PahoMessageHandler extends AbstractMqttMessageHandler<IMqttAs
 	}
 
 	private static MqttConnectionOptions buildDefaultConnectionOptions(@Nullable String url) {
-		final MqttConnectionOptions connectionOptions;
-		connectionOptions = new MqttConnectionOptions();
+		var connectionOptions = new MqttConnectionOptions();
 		if (url != null) {
 			connectionOptions.setServerURIs(new String[]{ url });
 		}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/outbound/Mqttv5PahoMessageHandler.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.mapping.HeaderMapper;
+import org.springframework.integration.mqtt.core.ClientManager;
 import org.springframework.integration.mqtt.core.MqttComponent;
 import org.springframework.integration.mqtt.event.MqttConnectionFailedEvent;
 import org.springframework.integration.mqtt.event.MqttMessageDeliveredEvent;
@@ -52,6 +53,7 @@ import org.springframework.util.Assert;
  *
  * @author Artem Bilan
  * @author Lucas Bowler
+ * @author Artem Vozhdayenko
  *
  * @since 5.5.5
  */
@@ -73,14 +75,32 @@ public class Mqttv5PahoMessageHandler extends AbstractMqttMessageHandler<IMqttAs
 
 	public Mqttv5PahoMessageHandler(String url, String clientId) {
 		super(url, clientId);
-		this.connectionOptions = new MqttConnectionOptions();
-		this.connectionOptions.setServerURIs(new String[]{ url });
-		this.connectionOptions.setAutomaticReconnect(true);
+		this.connectionOptions = buildDefaultConnectionOptions(url);
 	}
 
 	public Mqttv5PahoMessageHandler(MqttConnectionOptions connectionOptions, String clientId) {
 		super(obtainServerUrlFromOptions(connectionOptions), clientId);
 		this.connectionOptions = connectionOptions;
+	}
+
+	public Mqttv5PahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager,
+			MqttConnectionOptions connectionOptions) {
+		super(clientManager);
+		this.connectionOptions = connectionOptions;
+	}
+
+	public Mqttv5PahoMessageHandler(ClientManager<IMqttAsyncClient> clientManager) {
+		this(clientManager, buildDefaultConnectionOptions(null));
+	}
+
+	private static MqttConnectionOptions buildDefaultConnectionOptions(@Nullable String url) {
+		final MqttConnectionOptions connectionOptions;
+		connectionOptions = new MqttConnectionOptions();
+		if (url != null) {
+			connectionOptions.setServerURIs(new String[]{ url });
+		}
+		connectionOptions.setAutomaticReconnect(true);
+		return connectionOptions;
 	}
 
 

--- a/spring-integration-mqtt/src/main/resources/org/springframework/integration/mqtt/config/spring-integration-mqtt.xsd
+++ b/spring-integration-mqtt/src/main/resources/org/springframework/integration/mqtt/config/spring-integration-mqtt.xsd
@@ -66,15 +66,6 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
-			<xsd:attribute name="recovery-interval" type="xsd:string" default="10000">
-				<xsd:annotation>
-					<xsd:documentation><![CDATA[
-						The time in milliseconds to wait between reconnection attempts.
-	 					Defaults to 10 seconds.
-					]]>
-					</xsd:documentation>
-				</xsd:annotation>
-			</xsd:attribute>
 			<xsd:attribute name="error-channel" type="xsd:string">
 				<xsd:annotation>
 					<xsd:appinfo>

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mqtt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
+import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
+import org.springframework.integration.mqtt.core.Mqttv3ClientManager;
+import org.springframework.integration.mqtt.core.Mqttv5ClientManager;
+import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
+import org.springframework.integration.mqtt.inbound.Mqttv5PahoMessageDrivenChannelAdapter;
+import org.springframework.integration.mqtt.outbound.MqttPahoMessageHandler;
+import org.springframework.integration.mqtt.outbound.Mqttv5PahoMessageHandler;
+import org.springframework.integration.mqtt.support.MqttHeaders;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+/**
+ * @author Artem Vozhdayenko
+ */
+class ClientManagerBackToBackTests implements MosquittoContainerTest {
+
+	static final String SHARED_CLIENT_ID = "shared-client-id";
+
+	public static final String TOPIC_NAME = "test-topic";
+
+	@Test
+	void testSameV3ClientIdWorksForPubAndSub() {
+		testSubscribeAndPublish(Mqttv3Config.class);
+	}
+
+	@Test
+	void testSameV5ClientIdWorksForPubAndSub() {
+		testSubscribeAndPublish(Mqttv5Config.class);
+	}
+
+	private void testSubscribeAndPublish(Class<?> configClass) {
+		try (var ctx = new AnnotationConfigApplicationContext(configClass)) {
+			// given
+			var input = ctx.getBean("mqttOutFlow.input", MessageChannel.class);
+			var output = ctx.getBean("fromMqttChannel", PollableChannel.class);
+			String testPayload = "foo";
+
+			// when
+			input.send(MessageBuilder.withPayload(testPayload).setHeader(MqttHeaders.TOPIC, TOPIC_NAME).build());
+			Message<?> receive = output.receive(10_000);
+
+			// then
+			assertThat(receive).isNotNull();
+			assertThat(receive.getPayload()).isEqualTo(testPayload);
+		}
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class Mqttv3Config {
+
+		@Bean
+		public TaskScheduler taskScheduler() {
+			return new ThreadPoolTaskScheduler();
+		}
+
+		@Bean
+		public Mqttv3ClientManager mqttv3ClientManager(MqttPahoClientFactory pahoClientFactory) {
+			return new Mqttv3ClientManager(pahoClientFactory, SHARED_CLIENT_ID);
+		}
+
+		@Bean
+		public MqttPahoClientFactory pahoClientFactory() {
+			var pahoClientFactory = new DefaultMqttPahoClientFactory();
+			MqttConnectOptions connectionOptions = new MqttConnectOptions();
+			connectionOptions.setServerURIs(new String[]{ MosquittoContainerTest.mqttUrl() });
+			pahoClientFactory.setConnectionOptions(connectionOptions);
+			return pahoClientFactory;
+		}
+
+		@Bean
+		public IntegrationFlow mqttOutFlow(MqttPahoClientFactory pahoClientFactory,
+				Mqttv3ClientManager mqttv3ClientManager) {
+
+			var mqttHandler = new MqttPahoMessageHandler(SHARED_CLIENT_ID, pahoClientFactory);
+			mqttHandler.setClientManager(mqttv3ClientManager);
+			return f -> f.handle(mqttHandler);
+		}
+
+		@Bean
+		public IntegrationFlow mqttInFlow(MqttPahoClientFactory pahoClientFactory,
+				Mqttv3ClientManager mqttv3ClientManager) {
+
+			var mqttAdapter = new MqttPahoMessageDrivenChannelAdapter(SHARED_CLIENT_ID, pahoClientFactory, TOPIC_NAME);
+			mqttAdapter.setClientManager(mqttv3ClientManager);
+			return IntegrationFlow.from(mqttAdapter)
+					.channel(c -> c.queue("fromMqttChannel"))
+					.get();
+		}
+
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class Mqttv5Config {
+
+		@Bean
+		public TaskScheduler taskScheduler() {
+			return new ThreadPoolTaskScheduler();
+		}
+
+		@Bean
+		public Mqttv5ClientManager mqttv5ClientManager() {
+			return new Mqttv5ClientManager(MosquittoContainerTest.mqttUrl(), SHARED_CLIENT_ID);
+		}
+
+		@Bean
+		public IntegrationFlow mqttOutFlow(Mqttv5ClientManager mqttv5ClientManager) {
+			var mqttHandler = new Mqttv5PahoMessageHandler(MosquittoContainerTest.mqttUrl(), SHARED_CLIENT_ID);
+			mqttHandler.setClientManager(mqttv5ClientManager); // todo: add into ctor
+			return f -> f.handle(mqttHandler);
+		}
+
+		@Bean
+		public IntegrationFlow mqttInFlow(Mqttv5ClientManager mqttv5ClientManager) {
+			var mqttAdapter = new Mqttv5PahoMessageDrivenChannelAdapter(MosquittoContainerTest.mqttUrl(), SHARED_CLIENT_ID, TOPIC_NAME);
+			mqttAdapter.setClientManager(mqttv5ClientManager);
+			return IntegrationFlow.from(mqttAdapter)
+					.channel(c -> c.queue("fromMqttChannel"))
+					.get();
+		}
+
+	}
+
+}

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -32,8 +32,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
-import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
 import org.springframework.integration.mqtt.core.Mqttv3ClientManager;
 import org.springframework.integration.mqtt.core.Mqttv5ClientManager;
 import org.springframework.integration.mqtt.event.MqttSubscribedEvent;
@@ -115,18 +113,11 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		}
 
 		@Bean
-		public Mqttv3ClientManager mqttv3ClientManager(MqttPahoClientFactory pahoClientFactory) {
-			return new Mqttv3ClientManager(pahoClientFactory, "client-manager-client-id-v3");
-		}
-
-		@Bean
-		public MqttPahoClientFactory pahoClientFactory() {
-			var pahoClientFactory = new DefaultMqttPahoClientFactory();
+		public Mqttv3ClientManager mqttv3ClientManager() {
 			MqttConnectOptions connectionOptions = new MqttConnectOptions();
 			connectionOptions.setServerURIs(new String[]{ MosquittoContainerTest.mqttUrl() });
 			connectionOptions.setAutomaticReconnect(true);
-			pahoClientFactory.setConnectionOptions(connectionOptions);
-			return pahoClientFactory;
+			return new Mqttv3ClientManager(connectionOptions, "client-manager-client-id-v3");
 		}
 
 		@Bean
@@ -162,18 +153,11 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		}
 
 		@Bean
-		public Mqttv3ClientManager mqttv3ClientManager(MqttPahoClientFactory pahoClientFactory) {
-			return new Mqttv3ClientManager(pahoClientFactory, "client-manager-client-id-v3-reconnect");
-		}
-
-		@Bean
-		public MqttPahoClientFactory pahoClientFactory() {
-			var pahoClientFactory = new DefaultMqttPahoClientFactory();
+		public Mqttv3ClientManager mqttv3ClientManager() {
 			MqttConnectOptions connectionOptions = new MqttConnectOptions();
 			connectionOptions.setServerURIs(new String[]{ MosquittoContainerTest.mqttUrl() });
 			connectionOptions.setAutomaticReconnect(true);
-			pahoClientFactory.setConnectionOptions(connectionOptions);
-			return pahoClientFactory;
+			return new Mqttv3ClientManager(connectionOptions, "client-manager-client-id-v3-reconnect");
 		}
 
 		@Bean

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -43,7 +43,6 @@ import org.springframework.integration.mqtt.outbound.MqttPahoMessageHandler;
 import org.springframework.integration.mqtt.outbound.Mqttv5PahoMessageHandler;
 import org.springframework.integration.mqtt.support.MqttHeaders;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.condition.LongRunningTest;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
@@ -52,7 +51,6 @@ import org.springframework.messaging.PollableChannel;
  * @author Artem Vozhdayenko
  * @since 6.0
  */
-@LongRunningTest
 class ClientManagerBackToBackTests implements MosquittoContainerTest {
 
 	@Test

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -18,50 +18,62 @@ package org.springframework.integration.mqtt;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
+
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.mqtt.core.DefaultMqttPahoClientFactory;
 import org.springframework.integration.mqtt.core.MqttPahoClientFactory;
 import org.springframework.integration.mqtt.core.Mqttv3ClientManager;
 import org.springframework.integration.mqtt.core.Mqttv5ClientManager;
+import org.springframework.integration.mqtt.event.MqttSubscribedEvent;
 import org.springframework.integration.mqtt.inbound.MqttPahoMessageDrivenChannelAdapter;
 import org.springframework.integration.mqtt.inbound.Mqttv5PahoMessageDrivenChannelAdapter;
 import org.springframework.integration.mqtt.outbound.MqttPahoMessageHandler;
 import org.springframework.integration.mqtt.outbound.Mqttv5PahoMessageHandler;
 import org.springframework.integration.mqtt.support.MqttHeaders;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.condition.LongRunningTest;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 /**
  * @author Artem Vozhdayenko
+ * @since 6.0
  */
+@LongRunningTest
 class ClientManagerBackToBackTests implements MosquittoContainerTest {
-
-	static final String SHARED_CLIENT_ID = "shared-client-id";
-
-	public static final String TOPIC_NAME = "test-topic";
 
 	@Test
 	void testSameV3ClientIdWorksForPubAndSub() {
-		testSubscribeAndPublish(Mqttv3Config.class);
+		testSubscribeAndPublish(Mqttv3Config.class, Mqttv3Config.TOPIC_NAME);
 	}
 
 	@Test
 	void testSameV5ClientIdWorksForPubAndSub() {
-		testSubscribeAndPublish(Mqttv5Config.class);
+		testSubscribeAndPublish(Mqttv5Config.class, Mqttv5Config.TOPIC_NAME);
 	}
 
-	private void testSubscribeAndPublish(Class<?> configClass) {
+	@Test
+	void testV3ClientManagerReconnect() {
+		testSubscribeAndPublish(Mqttv3ConfigWithDisconnect.class, Mqttv3ConfigWithDisconnect.TOPIC_NAME);
+	}
+
+	@Test
+	void testV5ClientManagerReconnect() {
+		testSubscribeAndPublish(Mqttv5ConfigWithDisconnect.class, Mqttv5ConfigWithDisconnect.TOPIC_NAME);
+	}
+
+	private void testSubscribeAndPublish(Class<?> configClass, String topicName) {
 		try (var ctx = new AnnotationConfigApplicationContext(configClass)) {
 			// given
 			var input = ctx.getBean("mqttOutFlow.input", MessageChannel.class);
@@ -69,12 +81,18 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 			String testPayload = "foo";
 
 			// when
-			input.send(MessageBuilder.withPayload(testPayload).setHeader(MqttHeaders.TOPIC, TOPIC_NAME).build());
-			Message<?> receive = output.receive(10_000);
+			input.send(MessageBuilder.withPayload(testPayload).setHeader(MqttHeaders.TOPIC, topicName).build());
+			Message<?> receive = output.receive(20_000);
 
 			// then
 			assertThat(receive).isNotNull();
-			assertThat(receive.getPayload()).isEqualTo(testPayload);
+			Object payload = receive.getPayload();
+			if (payload instanceof String sp) {
+				assertThat(sp).isEqualTo(testPayload);
+			}
+			else {
+				assertThat(payload).isEqualTo(testPayload.getBytes(StandardCharsets.UTF_8));
+			}
 		}
 	}
 
@@ -82,14 +100,11 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 	@EnableIntegration
 	public static class Mqttv3Config {
 
-		@Bean
-		public TaskScheduler taskScheduler() {
-			return new ThreadPoolTaskScheduler();
-		}
+		static final String TOPIC_NAME = "test-topic-v3";
 
 		@Bean
 		public Mqttv3ClientManager mqttv3ClientManager(MqttPahoClientFactory pahoClientFactory) {
-			return new Mqttv3ClientManager(pahoClientFactory, SHARED_CLIENT_ID);
+			return new Mqttv3ClientManager(pahoClientFactory, "client-manager-client-id-v3");
 		}
 
 		@Bean
@@ -97,26 +112,59 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 			var pahoClientFactory = new DefaultMqttPahoClientFactory();
 			MqttConnectOptions connectionOptions = new MqttConnectOptions();
 			connectionOptions.setServerURIs(new String[]{ MosquittoContainerTest.mqttUrl() });
+			connectionOptions.setAutomaticReconnect(true);
 			pahoClientFactory.setConnectionOptions(connectionOptions);
 			return pahoClientFactory;
 		}
 
 		@Bean
-		public IntegrationFlow mqttOutFlow(MqttPahoClientFactory pahoClientFactory,
-				Mqttv3ClientManager mqttv3ClientManager) {
-
-			var mqttHandler = new MqttPahoMessageHandler(SHARED_CLIENT_ID, pahoClientFactory);
-			mqttHandler.setClientManager(mqttv3ClientManager);
-			return f -> f.handle(mqttHandler);
+		public IntegrationFlow mqttOutFlow(Mqttv3ClientManager mqttv3ClientManager) {
+			return f -> f.handle(new MqttPahoMessageHandler(mqttv3ClientManager));
 		}
 
 		@Bean
-		public IntegrationFlow mqttInFlow(MqttPahoClientFactory pahoClientFactory,
-				Mqttv3ClientManager mqttv3ClientManager) {
+		public IntegrationFlow mqttInFlow(Mqttv3ClientManager mqttv3ClientManager) {
+			return IntegrationFlow.from(new MqttPahoMessageDrivenChannelAdapter(mqttv3ClientManager, TOPIC_NAME))
+					.channel(c -> c.queue("fromMqttChannel"))
+					.get();
+		}
 
-			var mqttAdapter = new MqttPahoMessageDrivenChannelAdapter(SHARED_CLIENT_ID, pahoClientFactory, TOPIC_NAME);
-			mqttAdapter.setClientManager(mqttv3ClientManager);
-			return IntegrationFlow.from(mqttAdapter)
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class Mqttv3ConfigWithDisconnect {
+
+		static final String TOPIC_NAME = "test-topic-v3-reconnect";
+
+		@Bean
+		public ClientV3Disconnector disconnector(Mqttv3ClientManager mqttv3ClientManager) {
+			return new ClientV3Disconnector(mqttv3ClientManager);
+		}
+
+		@Bean
+		public Mqttv3ClientManager mqttv3ClientManager(MqttPahoClientFactory pahoClientFactory) {
+			return new Mqttv3ClientManager(pahoClientFactory, "client-manager-client-id-v3-reconnect");
+		}
+
+		@Bean
+		public MqttPahoClientFactory pahoClientFactory() {
+			var pahoClientFactory = new DefaultMqttPahoClientFactory();
+			MqttConnectOptions connectionOptions = new MqttConnectOptions();
+			connectionOptions.setServerURIs(new String[]{ MosquittoContainerTest.mqttUrl() });
+			connectionOptions.setAutomaticReconnect(true);
+			pahoClientFactory.setConnectionOptions(connectionOptions);
+			return pahoClientFactory;
+		}
+
+		@Bean
+		public IntegrationFlow mqttOutFlow() {
+			return f -> f.handle(new MqttPahoMessageHandler(MosquittoContainerTest.mqttUrl(), "old-client-v3"));
+		}
+
+		@Bean
+		public IntegrationFlow mqttInFlow(Mqttv3ClientManager mqttv3ClientManager) {
+			return IntegrationFlow.from(new MqttPahoMessageDrivenChannelAdapter(mqttv3ClientManager, TOPIC_NAME))
 					.channel(c -> c.queue("fromMqttChannel"))
 					.get();
 		}
@@ -127,30 +175,93 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 	@EnableIntegration
 	public static class Mqttv5Config {
 
-		@Bean
-		public TaskScheduler taskScheduler() {
-			return new ThreadPoolTaskScheduler();
-		}
+		static final String TOPIC_NAME = "test-topic-v5";
 
 		@Bean
 		public Mqttv5ClientManager mqttv5ClientManager() {
-			return new Mqttv5ClientManager(MosquittoContainerTest.mqttUrl(), SHARED_CLIENT_ID);
+			return new Mqttv5ClientManager(MosquittoContainerTest.mqttUrl(), "client-manager-client-id-v5");
 		}
 
 		@Bean
 		public IntegrationFlow mqttOutFlow(Mqttv5ClientManager mqttv5ClientManager) {
-			var mqttHandler = new Mqttv5PahoMessageHandler(MosquittoContainerTest.mqttUrl(), SHARED_CLIENT_ID);
-			mqttHandler.setClientManager(mqttv5ClientManager); // todo: add into ctor
-			return f -> f.handle(mqttHandler);
+			return f -> f.handle(new Mqttv5PahoMessageHandler(mqttv5ClientManager));
 		}
 
 		@Bean
 		public IntegrationFlow mqttInFlow(Mqttv5ClientManager mqttv5ClientManager) {
-			var mqttAdapter = new Mqttv5PahoMessageDrivenChannelAdapter(MosquittoContainerTest.mqttUrl(), SHARED_CLIENT_ID, TOPIC_NAME);
-			mqttAdapter.setClientManager(mqttv5ClientManager);
-			return IntegrationFlow.from(mqttAdapter)
+			return IntegrationFlow.from(new Mqttv5PahoMessageDrivenChannelAdapter(mqttv5ClientManager, TOPIC_NAME))
 					.channel(c -> c.queue("fromMqttChannel"))
 					.get();
+		}
+
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class Mqttv5ConfigWithDisconnect {
+
+		static final String TOPIC_NAME = "test-topic-v5-reconnect";
+
+		@Bean
+		public ClientV5Disconnector disconnector(Mqttv5ClientManager mqttv5ClientManager) {
+			return new ClientV5Disconnector(mqttv5ClientManager);
+		}
+
+		@Bean
+		public Mqttv5ClientManager mqttv5ClientManager() {
+			return new Mqttv5ClientManager(MosquittoContainerTest.mqttUrl(), "client-manager-client-id-v5-reconnect");
+		}
+
+		@Bean
+		public IntegrationFlow mqttOutFlow(Mqttv5ClientManager mqttv5ClientManager) {
+			return f -> f.handle(new Mqttv5PahoMessageHandler(MosquittoContainerTest.mqttUrl(), "old-client-v5"));
+		}
+
+		@Bean
+		public IntegrationFlow mqttInFlow(Mqttv5ClientManager mqttv5ClientManager) {
+			return IntegrationFlow.from(new Mqttv5PahoMessageDrivenChannelAdapter(mqttv5ClientManager, TOPIC_NAME))
+					.channel(c -> c.queue("fromMqttChannel"))
+					.get();
+		}
+
+	}
+
+	public static class ClientV3Disconnector {
+
+		private final Mqttv3ClientManager clientManager;
+
+		ClientV3Disconnector(Mqttv3ClientManager clientManager) {
+			this.clientManager = clientManager;
+		}
+
+		@EventListener
+		public void handleSubscribedEvent(MqttSubscribedEvent e) {
+			try {
+				this.clientManager.getClient().disconnectForcibly();
+			}
+			catch (MqttException ex) {
+				throw new IllegalStateException("could not disconnect the client!");
+			}
+		}
+
+	}
+
+	public static class ClientV5Disconnector {
+
+		private final Mqttv5ClientManager clientManager;
+
+		ClientV5Disconnector(Mqttv5ClientManager clientManager) {
+			this.clientManager = clientManager;
+		}
+
+		@EventListener
+		public void handleSubscribedEvent(MqttSubscribedEvent e) {
+			try {
+				this.clientManager.getClient().disconnectForcibly();
+			}
+			catch (org.eclipse.paho.mqttv5.common.MqttException ex) {
+				throw new IllegalStateException("could not disconnect the client!");
+			}
 		}
 
 	}

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
@@ -102,6 +102,7 @@ import org.springframework.util.ReflectionUtils;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Artem Vozhdayenko
  *
  * @since 4.0
  *
@@ -221,9 +222,7 @@ public class MqttAdapterTests {
 		var deliveryToken = mock(MqttDeliveryToken.class);
 		given(client.publish(anyString(), any(MqttMessage.class))).willReturn(deliveryToken);
 
-		var handler = new MqttPahoMessageHandler("foo", "bar",
-				new DefaultMqttPahoClientFactory());
-		handler.setClientManager(clientManager);
+		var handler = new MqttPahoMessageHandler(clientManager);
 		handler.setDefaultTopic("mqtt-foo");
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
@@ -254,9 +253,7 @@ public class MqttAdapterTests {
 		given(client.subscribe(any(String[].class), any(int[].class), any()))
 				.willReturn(subscribeToken);
 
-		var adapter = new MqttPahoMessageDrivenChannelAdapter("foo", "bar",
-				new DefaultMqttPahoClientFactory(), "mqtt-foo");
-		adapter.setClientManager(clientManager);
+		var adapter = new MqttPahoMessageDrivenChannelAdapter(clientManager, "mqtt-foo");
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.initialize();
 		adapter.setTaskScheduler(taskScheduler);

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackAutomaticReconnectTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackAutomaticReconnectTests.java
@@ -17,17 +17,16 @@
 package org.springframework.integration.mqtt;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
-import java.net.UnknownHostException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.paho.mqttv5.client.IMqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.client.MqttConnectionOptionsBuilder;
-import org.eclipse.paho.mqttv5.common.MqttException;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
@@ -42,7 +41,6 @@ import org.springframework.integration.mqtt.support.MqttHeaders;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
-import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -73,23 +71,13 @@ public class Mqttv5BackToBackAutomaticReconnectTests implements MosquittoContain
 
 	@Test
 	public void testReconnectionWhenFirstConnectionFails() throws InterruptedException {
-		Message<String> testMessage =
-				MessageBuilder.withPayload("testPayload")
-						.setHeader(MqttHeaders.TOPIC, "siTest")
-						.build();
-
-		assertThatExceptionOfType(MessageHandlingException.class)
-				.isThrownBy(() -> this.mqttOutFlowInput.send(testMessage))
-				.withCauseExactlyInstanceOf(MqttException.class)
-				.withRootCauseExactlyInstanceOf(UnknownHostException.class);
-
-		connectionOptions.setServerURIs(new String[]{ MosquittoContainerTest.mqttUrl() });
-
 		assertThat(this.config.subscribeLatch.await(10, TimeUnit.SECONDS)).isTrue();
 
-		this.mqttOutFlowInput.send(testMessage);
+		this.mqttOutFlowInput.send(MessageBuilder.withPayload("testPayload")
+				.setHeader(MqttHeaders.TOPIC, "siTest")
+				.build());
 
-		Message<?> receive = this.fromMqttChannel.receive(10_000);
+		Message<?> receive = this.fromMqttChannel.receive(20_000);
 
 		assertThat(receive).isNotNull();
 	}
@@ -104,7 +92,7 @@ public class Mqttv5BackToBackAutomaticReconnectTests implements MosquittoContain
 		@Bean
 		public MqttConnectionOptions mqttConnectOptions() {
 			return new MqttConnectionOptionsBuilder()
-					.serverURI("wss://badMqttUrl")
+					.serverURI(MosquittoContainerTest.mqttUrl())
 					.automaticReconnect(true)
 					.connectionTimeout(1)
 					.build();
@@ -120,19 +108,48 @@ public class Mqttv5BackToBackAutomaticReconnectTests implements MosquittoContain
 
 
 		@Bean
-		public IntegrationFlow mqttInFlow() {
-			Mqttv5PahoMessageDrivenChannelAdapter messageProducer =
-					new Mqttv5PahoMessageDrivenChannelAdapter(mqttConnectOptions(), "mqttv5SIin", "siTest");
-			messageProducer.setPayloadType(String.class);
-
-			return IntegrationFlow.from(messageProducer)
+		public IntegrationFlow mqttInFlow(Mqttv5PahoMessageDrivenChannelAdapter mqttAdapter) {
+			mqttAdapter.setPayloadType(String.class);
+			return IntegrationFlow.from(mqttAdapter)
 					.channel(c -> c.queue("fromMqttChannel"))
 					.get();
 		}
 
-		@EventListener(MqttSubscribedEvent.class)
-		void mqttEvents() {
+		@Bean
+		public Mqttv5PahoMessageDrivenChannelAdapter mqttAdapter() {
+			return new Mqttv5PahoMessageDrivenChannelAdapter(mqttConnectOptions(), "mqttv5SIin", "siTest");
+		}
+
+		@EventListener
+		void mqttEvents(MqttSubscribedEvent e) {
 			this.subscribeLatch.countDown();
+		}
+
+		@Bean
+		public ClientV5Disconnector disconnector(Mqttv5PahoMessageDrivenChannelAdapter mqttAdapter) {
+			return new ClientV5Disconnector(mqttAdapter);
+		}
+
+	}
+
+	public static class ClientV5Disconnector {
+
+		private final Mqttv5PahoMessageDrivenChannelAdapter mqttAdapter;
+
+		ClientV5Disconnector(Mqttv5PahoMessageDrivenChannelAdapter mqttAdapter) {
+			this.mqttAdapter = mqttAdapter;
+		}
+
+		@EventListener
+		public void handleSubscribedEvent(MqttSubscribedEvent e) {
+			// not ideal, but no idea what can be the better way of disconnecting the client
+			try {
+				((IMqttAsyncClient) new DirectFieldAccessor(mqttAdapter).getPropertyValue("mqttClient"))
+						.disconnect();
+			}
+			catch (Exception ex) {
+				throw new IllegalStateException("could not disconnect the client!");
+			}
 		}
 
 	}

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests-context.xml
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests-context.xml
@@ -16,7 +16,6 @@
 		client-id="foo"
 		url="tcp://localhost:1883"
 		client-factory="clientFactory"
-		recovery-interval="5000"
 		channel="out" />
 
 	<int-mqtt:message-driven-channel-adapter id="noTopicsAdapterDefaultCF"

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,6 @@ public class MqttMessageDrivenChannelAdapterParserTests {
 		assertThat(TestUtils.getPropertyValue(noTopicsAdapter, "topics", Collection.class).size()).isEqualTo(0);
 		assertThat(TestUtils.getPropertyValue(noTopicsAdapter, "outputChannel")).isSameAs(out);
 		assertThat(TestUtils.getPropertyValue(noTopicsAdapter, "clientFactory")).isSameAs(clientFactory);
-		assertThat(TestUtils.getPropertyValue(this.noTopicsAdapter, "recoveryInterval")).isEqualTo(5000);
 		assertThat(TestUtils.getPropertyValue(this.noTopicsAdapter, "manualAcks", Boolean.class)).isTrue();
 	}
 


### PR DESCRIPTION
Fixes spring-projects/spring-integration#3685

Introduce some initial design.
Add a new interface `MqttClientManager` which will manage clients and
connections.
Use this manager in v3 topic adapter and message handler.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
