### PR TITLE
Fix SIK module for latest SK compatibility

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/channel/DispatcherHasNoSubscribersTests.java
@@ -77,7 +77,7 @@ public class DispatcherHasNoSubscribersTests {
 		amqpChannel.setBeanFactory(mock(BeanFactory.class));
 		amqpChannel.afterPropertiesSet();
 
-		MessageListener listener = (MessageListener) container.getMessageListener();
+		MessageListener listener = container.getMessageListener();
 
 		assertThatExceptionOfType(MessageDeliveryException.class)
 				.isThrownBy(() -> listener.onMessage(new Message("Hello world!".getBytes())))
@@ -101,7 +101,7 @@ public class DispatcherHasNoSubscribersTests {
 		amqpChannel.afterPropertiesSet();
 
 		List<String> logList = insertMockLoggerInListener(amqpChannel);
-		MessageListener listener = (MessageListener) container.getMessageListener();
+		MessageListener listener = container.getMessageListener();
 		listener.onMessage(new Message("Hello world!".getBytes()));
 		verifyLogReceived(logList);
 	}

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -39,6 +39,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -309,13 +310,14 @@ class KafkaProducerMessageHandlerTests {
 
 		final RuntimeException fooException = new RuntimeException("foo");
 
-		handler = new KafkaProducerMessageHandler<>(new KafkaTemplate<Integer, String>(producerFactory) {
+		handler = new KafkaProducerMessageHandler<>(new KafkaTemplate<>(producerFactory) {
 
 			@Override
-			protected ListenableFuture<SendResult<Integer, String>> doSend(
+			protected CompletableFuture<SendResult<Integer, String>> doSend(
 					ProducerRecord<Integer, String> producerRecord) {
-				SettableListenableFuture<SendResult<Integer, String>> future = new SettableListenableFuture<>();
-				future.setException(fooException);
+
+				CompletableFuture<SendResult<Integer, String>> future = new CompletableFuture<>();
+				future.completeExceptionally(fooException);
 				return future;
 			}
 


### PR DESCRIPTION
Spring for Apache Kafka does not produce `ListenableFuture` anymore.

* Rework `KafkaProducerMessageHandler` to deal with the `CompletableFuture` from now on
* Add support for `CompletableFuture` replies handling into `AbstractMessageProducingHandler`
* Remove redundant cast in the `DispatcherHasNoSubscribersTests`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
