### PR TITLE
Fix deprecations around ListenableFuture

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -51,7 +51,6 @@ import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.util.concurrent.ListenableFuture;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -106,9 +105,9 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	}
 
 	/**
-	 * Allow async replies. If the handler reply is a {@link ListenableFuture}, send
-	 * the output when it is satisfied rather than sending the future as the result.
-	 * Ignored for return types other than {@link ListenableFuture}.
+	 * Allow async replies. If the handler reply is a {@link CompletableFuture} or {@link Publisher},
+	 * send the output when it is satisfied rather than sending the future as the result.
+	 * Ignored for return types other than {@link CompletableFuture} or {@link Publisher}.
 	 * @param async true to allow.
 	 * @since 4.3
 	 */
@@ -299,6 +298,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		return replyChannel;
 	}
 
+	@SuppressWarnings("deprecation")
 	private void doProduceOutput(Message<?> requestMessage, MessageHeaders requestHeaders, Object reply,
 			@Nullable Object replyChannelArg) {
 
@@ -307,7 +307,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 			replyChannel = getOutputChannel();
 		}
 
-		if (this.async && (reply instanceof ListenableFuture<?>
+		if (this.async && (reply instanceof org.springframework.util.concurrent.ListenableFuture<?>
 				|| reply instanceof CompletableFuture<?>
 				|| reply instanceof Publisher<?>)) {
 
@@ -351,13 +351,14 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		return builder;
 	}
 
+	@SuppressWarnings("deprecation")
 	private void asyncNonReactiveReply(Message<?> requestMessage, Object reply, @Nullable Object replyChannel) {
 		CompletableFuture<?> future;
 		if (reply instanceof CompletableFuture<?>) {
 			future = (CompletableFuture<?>) reply;
 		}
-		else if (reply instanceof ListenableFuture<?>) {
-			future = ((ListenableFuture<?>) reply).completable();
+		else if (reply instanceof org.springframework.util.concurrent.ListenableFuture<?>) {
+			future = ((org.springframework.util.concurrent.ListenableFuture<?>) reply).completable();
 		}
 		else {
 			Mono<?> reactiveReply;

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/GatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,6 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -403,7 +402,7 @@ public class GatewayParserTests {
 					.setCorrelationId(request.getHeaders().getId()).build();
 			Object payload = null;
 			if (request.getPayload().equals("futureSync")) {
-				payload = new AsyncResult<Message<?>>(reply);
+				payload = CompletableFuture.completedFuture(reply);
 			}
 			else if (request.getPayload().equals("flowCompletable")) {
 				payload = CompletableFuture.<String>completedFuture("SYNC_COMPLETABLE");
@@ -448,7 +447,7 @@ public class GatewayParserTests {
 		}
 
 		@Override
-		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@SuppressWarnings("unchecked")
 		public <T> Future<T> submit(Callable<T> task) {
 			try {
 				Future<?> result = super.submit(task);
@@ -462,7 +461,8 @@ public class GatewayParserTests {
 					modifiedMessage = MessageBuilder.fromMessage(message)
 							.setHeader("executor", this.beanName).build();
 				}
-				return new AsyncResult(modifiedMessage);
+
+				return (Future<T>) CompletableFuture.completedFuture(modifiedMessage);
 			}
 			catch (Exception e) {
 				throw new IllegalStateException("unexpected exception in testExecutor", e);

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -396,6 +396,7 @@ public class GatewayInterfaceTests {
 	 * performed the send() on gatewayThreadChannel.
 	 */
 	@Test
+	@SuppressWarnings("deprecation")
 	public void testExecs() throws Exception {
 		assertThat(TestUtils.getPropertyValue(execGatewayFB, "asyncExecutor")).isSameAs(exec);
 		assertThat(TestUtils.getPropertyValue(noExecGatewayFB, "asyncExecutor")).isNull();
@@ -420,6 +421,13 @@ public class GatewayInterfaceTests {
 		});
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(result2.get().getName()).startsWith("exec-");
+
+		org.springframework.util.concurrent.ListenableFuture<Thread> result3 =
+				this.execGateway.test3(Thread.currentThread());
+		final CountDownLatch latch1 = new CountDownLatch(1);
+		result3.addCallback(data -> latch1.countDown(), ex -> { });
+		assertThat(latch1.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(result3.get().getName()).startsWith("exec-");
 
 		/*
 		@IntegrationComponentScan(useDefaultFilters = false,
@@ -672,6 +680,10 @@ public class GatewayInterfaceTests {
 
 		@Gateway(requestChannel = "gatewayThreadChannel")
 		CompletableFuture<Thread> test2(Thread caller);
+
+		@Gateway(requestChannel = "gatewayThreadChannel")
+		@SuppressWarnings("deprecation")
+		org.springframework.util.concurrent.ListenableFuture<Thread> test3(Thread caller);
 
 	}
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageListenerContainerSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageListenerContainerSpec.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 
-import org.springframework.core.task.AsyncListenableTaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.integration.dsl.IntegrationComponentSpec;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.CommonErrorHandler;
@@ -157,12 +157,10 @@ public class KafkaMessageListenerContainerSpec<K, V>
 	 * Set the executor for threads that poll the consumer.
 	 * @param consumerTaskExecutor the executor
 	 * @return the spec.
-	 * @see ContainerProperties#setConsumerTaskExecutor(AsyncListenableTaskExecutor)
+	 * @see ContainerProperties#setListenerTaskExecutor(AsyncTaskExecutor)
 	 */
-	public KafkaMessageListenerContainerSpec<K, V> consumerTaskExecutor(
-			AsyncListenableTaskExecutor consumerTaskExecutor) {
-
-		this.target.getContainerProperties().setConsumerTaskExecutor(consumerTaskExecutor);
+	public KafkaMessageListenerContainerSpec<K, V> listenerTaskExecutor(AsyncTaskExecutor consumerTaskExecutor) {
+		this.target.getContainerProperties().setListenerTaskExecutor(consumerTaskExecutor);
 		return this;
 	}
 

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -105,8 +106,6 @@ import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -474,8 +473,7 @@ class KafkaProducerMessageHandlerTests {
 		given(pf.transactionCapable()).willReturn(true);
 		Producer producer = mock(Producer.class);
 		given(pf.createProducer(isNull())).willReturn(producer);
-		ListenableFuture future = mock(ListenableFuture.class);
-		willReturn(future).given(producer).send(any(ProducerRecord.class), any(Callback.class));
+		willReturn(mock(Future.class)).given(producer).send(any(ProducerRecord.class), any(Callback.class));
 		KafkaTemplate template = new KafkaTemplate(pf);
 		KafkaProducerMessageHandler handler = new KafkaProducerMessageHandler(template);
 		handler.setTopicExpression(new LiteralExpression("bar"));
@@ -517,7 +515,7 @@ class KafkaProducerMessageHandlerTests {
 		ConsumerFactory cf = mock(ConsumerFactory.class);
 		willReturn(mockConsumer).given(cf).createConsumer("group", "", null, KafkaTestUtils.defaultPropertyOverrides());
 		Producer producer = mock(Producer.class);
-		given(producer.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(producer.send(any(), any())).willReturn(mock(Future.class));
 		final CountDownLatch closeLatch = new CountDownLatch(2);
 		willAnswer(i -> {
 			closeLatch.countDown();
@@ -579,8 +577,7 @@ class KafkaProducerMessageHandlerTests {
 
 		};
 		pf.setTransactionIdPrefix("default.tx.id.");
-		ListenableFuture future = mock(ListenableFuture.class);
-		willReturn(future).given(producer).send(any(ProducerRecord.class), any(Callback.class));
+		willReturn(mock(Future.class)).given(producer).send(any(ProducerRecord.class), any(Callback.class));
 		KafkaTemplate template = new KafkaTemplate(pf);
 		template.setTransactionIdPrefix("overridden.tx.id.");
 		KafkaProducerMessageHandler handler = new KafkaProducerMessageHandler(template);
@@ -604,8 +601,7 @@ class KafkaProducerMessageHandlerTests {
 		ProducerFactory pf = mock(ProducerFactory.class);
 		given(pf.transactionCapable()).willReturn(true);
 		given(pf.createProducer(isNull())).willReturn(producer);
-		ListenableFuture future = mock(ListenableFuture.class);
-		willReturn(future).given(producer).send(any(ProducerRecord.class), any(Callback.class));
+		willReturn(mock(Future.class)).given(producer).send(any(ProducerRecord.class), any(Callback.class));
 		KafkaTemplate template = new KafkaTemplate(pf);
 		KafkaProducerMessageHandler handler = new KafkaProducerMessageHandler(template);
 		handler.setTopicExpression(new LiteralExpression("bar"));
@@ -655,7 +651,7 @@ class KafkaProducerMessageHandlerTests {
 		ConsumerFactory cf = mock(ConsumerFactory.class);
 		willReturn(mockConsumer).given(cf).createConsumer("group", "", null, KafkaTestUtils.defaultPropertyOverrides());
 		Producer producer = mock(Producer.class);
-		given(producer.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(producer.send(any(), any())).willReturn(mock(Future.class));
 		final CountDownLatch closeLatch = new CountDownLatch(2);
 		willAnswer(i -> {
 			closeLatch.countDown();
@@ -732,8 +728,7 @@ class KafkaProducerMessageHandlerTests {
 		ProducerFactory pf = mock(ProducerFactory.class);
 		Producer producer = mock(Producer.class);
 		given(pf.createProducer()).willReturn(producer);
-		ListenableFuture future = mock(ListenableFuture.class);
-		willReturn(future).given(producer).send(any(ProducerRecord.class), any(Callback.class));
+		willReturn(mock(Future.class)).given(producer).send(any(ProducerRecord.class), any(Callback.class));
 		KafkaTemplate template = new KafkaTemplate(pf);
 		KafkaProducerMessageHandler handler = new KafkaProducerMessageHandler(template);
 		handler.setTopicExpression(new LiteralExpression("bar"));
@@ -756,8 +751,7 @@ class KafkaProducerMessageHandlerTests {
 		ProducerFactory pf = mock(ProducerFactory.class);
 		Producer producer = mock(Producer.class);
 		given(pf.createProducer()).willReturn(producer);
-		ListenableFuture future = mock(ListenableFuture.class);
-		willReturn(future).given(producer).send(any(ProducerRecord.class), any(Callback.class));
+		willReturn(mock(Future.class)).given(producer).send(any(ProducerRecord.class), any(Callback.class));
 		KafkaTemplate template = new KafkaTemplate(pf);
 		KafkaProducerMessageHandler handler = new KafkaProducerMessageHandler(template);
 		handler.setTopicExpression(new LiteralExpression("bar"));
@@ -777,8 +771,7 @@ class KafkaProducerMessageHandlerTests {
 		ProducerFactory pf = mock(ProducerFactory.class);
 		Producer producer = mock(Producer.class);
 		given(pf.createProducer()).willReturn(producer);
-		ListenableFuture future = mock(ListenableFuture.class);
-		willReturn(future).given(producer).send(any(ProducerRecord.class), any(Callback.class));
+		willReturn(mock(Future.class)).given(producer).send(any(ProducerRecord.class), any(Callback.class));
 		KafkaTemplate template = new KafkaTemplate(pf);
 		RecordMessageConverter converter = mock(RecordMessageConverter.class);
 		ProducerRecord recordFromConverter = mock(ProducerRecord.class);

--- a/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/ReactorNettyTcpStompSessionManager.java
+++ b/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/ReactorNettyTcpStompSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,11 @@
 
 package org.springframework.integration.stomp;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.springframework.messaging.simp.stomp.ReactorNettyTcpStompClient;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandler;
-import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * The {@link ReactorNettyTcpStompClient} based {@link AbstractStompSessionManager} implementation.
@@ -37,8 +38,8 @@ public class ReactorNettyTcpStompSessionManager extends AbstractStompSessionMana
 	}
 
 	@Override
-	protected ListenableFuture<StompSession> doConnect(StompSessionHandler handler) {
-		return ((ReactorNettyTcpStompClient) this.stompClient).connect(getConnectHeaders(), handler);
+	protected CompletableFuture<StompSession> doConnect(StompSessionHandler handler) {
+		return ((ReactorNettyTcpStompClient) this.stompClient).connectAsync(getConnectHeaders(), handler);
 	}
 
 }

--- a/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/WebSocketStompSessionManager.java
+++ b/spring-integration-stomp/src/main/java/org/springframework/integration/stomp/WebSocketStompSessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@
 package org.springframework.integration.stomp;
 
 import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
 
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandler;
 import org.springframework.util.Assert;
-import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 
@@ -55,9 +55,9 @@ public class WebSocketStompSessionManager extends AbstractStompSessionManager {
 	}
 
 	@Override
-	protected ListenableFuture<StompSession> doConnect(StompSessionHandler handler) {
+	protected CompletableFuture<StompSession> doConnect(StompSessionHandler handler) {
 		return ((WebSocketStompClient) this.stompClient)
-				.connect(this.url, this.handshakeHeaders, getConnectHeaders(), handler, this.uriVariables);
+				.connectAsync(this.url, this.handshakeHeaders, getConnectHeaders(), handler, this.uriVariables);
 	}
 
 }

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/ClientWebSocketContainerTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/ClientWebSocketContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.http.HttpHeaders;
-import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.PingMessage;
 import org.springframework.web.socket.PongMessage;
@@ -72,12 +72,12 @@ public class ClientWebSocketContainerTests {
 		StandardWebSocketClient webSocketClient = new StandardWebSocketClient() {
 
 			@Override
-			protected ListenableFuture<WebSocketSession> doHandshakeInternal(WebSocketHandler webSocketHandler,
+			protected CompletableFuture<WebSocketSession> executeInternal(WebSocketHandler webSocketHandler,
 					HttpHeaders headers, URI uri, List<String> protocols, List<WebSocketExtension> extensions,
 					Map<String, Object> attributes) {
 
-				ListenableFuture<WebSocketSession> future =
-						super.doHandshakeInternal(webSocketHandler, headers, uri, protocols, extensions,
+				CompletableFuture<WebSocketSession> future =
+						super.executeInternal(webSocketHandler, headers, uri, protocols, extensions,
 								attributes);
 				if (failure.get()) {
 					future.cancel(true);

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/SimpleWebServiceOutboundGatewayTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/SimpleWebServiceOutboundGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.mock;
 import java.io.ByteArrayInputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -46,7 +47,6 @@ import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.FileCopyUtils;
-import org.springframework.util.concurrent.SettableListenableFuture;
 import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.WebServiceClientException;
@@ -142,13 +142,13 @@ public class SimpleWebServiceOutboundGatewayTests {
 		SimpleWebServiceOutboundGateway gateway = new SimpleWebServiceOutboundGateway(uri);
 		gateway.setBeanFactory(mock(BeanFactory.class));
 
-		final SettableListenableFuture<WebServiceMessage> requestFuture = new SettableListenableFuture<>();
+		final CompletableFuture<WebServiceMessage> requestFuture = new CompletableFuture<>();
 
 		ClientInterceptorAdapter interceptorAdapter = new ClientInterceptorAdapter() {
 
 			@Override
 			public boolean handleRequest(MessageContext messageContext) throws WebServiceClientException {
-				requestFuture.set(messageContext.getRequest());
+				requestFuture.complete(messageContext.getRequest());
 				return super.handleRequest(messageContext);
 			}
 
@@ -202,13 +202,13 @@ public class SimpleWebServiceOutboundGatewayTests {
 		SimpleWebServiceOutboundGateway gateway = new SimpleWebServiceOutboundGateway(uri);
 		gateway.setBeanFactory(mock(BeanFactory.class));
 
-		final SettableListenableFuture<WebServiceMessage> requestFuture = new SettableListenableFuture<>();
+		final CompletableFuture<WebServiceMessage> requestFuture = new CompletableFuture<>();
 
 		ClientInterceptorAdapter interceptorAdapter = new ClientInterceptorAdapter() {
 
 			@Override
 			public boolean handleRequest(MessageContext messageContext) throws WebServiceClientException {
-				requestFuture.set(messageContext.getRequest());
+				requestFuture.complete(messageContext.getRequest());
 				return super.handleRequest(messageContext);
 			}
 

--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -583,39 +583,13 @@ int finalResult =  result.get(1000, TimeUnit.SECONDS);
 
 For a more detailed example, see the https://github.com/spring-projects/spring-integration-samples/tree/main/intermediate/async-gateway[async-gateway] sample in the Spring Integration samples.
 
-===== `ListenableFuture`
-
-Starting with version 4.1, asynchronous gateway methods can also return `ListenableFuture` (introduced in Spring Framework 4.0).
-These return types let you provide a callback, which is invoked when the result is available (or an exception occurs).
-When the gateway detects this return type and the <<gateway-asynctaskexecutor,task executor>> is an `AsyncListenableTaskExecutor`, the executor's `submitListenable()` method is invoked.
-The following example shows how to use a `ListenableFuture`:
-
-====
-[source,java]
-----
-ListenableFuture<String> result = this.asyncGateway.async("something");
-result.addCallback(new ListenableFutureCallback<String>() {
-
-    @Override
-    public void onSuccess(String result) {
-        ...
-    }
-
-    @Override
-    public void onFailure(Throwable t) {
-        ...
-    }
-});
-----
-====
-
 [[gateway-asynctaskexecutor]]
 ===== `AsyncTaskExecutor`
 
 By default, the `GatewayProxyFactoryBean` uses `org.springframework.core.task.SimpleAsyncTaskExecutor` when submitting internal `AsyncInvocationTask` instances for any gateway method whose return type is a `Future`.
 However, the `async-executor` attribute in the `<gateway/>` element's configuration lets you provide a reference to any implementation of `java.util.concurrent.Executor` available within the Spring application context.
 
-The (default) `SimpleAsyncTaskExecutor` supports both `Future` and `ListenableFuture` return types, returning `FutureTask` or `ListenableFutureTask` respectively.
+The (default) `SimpleAsyncTaskExecutor` supports both `Future` and `CompletableFuture` return types.
 See <<gw-completable-future>>.
 Even though there is a default executor, it is often useful to provide an external one so that you can identify its threads in logs (when using XML, the thread name is based on the executor's bean name), as the following example shows:
 
@@ -670,6 +644,9 @@ There are two modes of operation when returning this type:
 
 * When the async executor is explicitly set to `null` and the return type is `CompletableFuture` or the return type is a subclass of `CompletableFuture`, the flow is invoked on the caller's thread.
 In this scenario, the downstream flow is expected to return a `CompletableFuture` of the appropriate type.
+
+NOTE: The `org.springframework.util.concurrent.ListenableFuture` has been deprecated starting with Spring Framework `6.0`.
+It is recommended now to migrate to the `CompletableFuture` which provides similar processing functionality.
 
 ====== Usage Scenarios
 
@@ -802,7 +779,7 @@ The calling thread continues, with `handleInvoice()` being called when the flow 
 
 ===== Downstream Flows Returning an Asynchronous Type
 
-As mentioned in the `ListenableFuture` section above, if you wish some downstream component to return a message with an async payload (`Future`, `Mono`, and others), you must explicitly set the async executor to `null` (or `""` when using XML configuration).
+As mentioned in the <<gateway-asynctaskexecutor>> section above, if you wish some downstream component to return a message with an async payload (`Future`, `Mono`, and others), you must explicitly set the async executor to `null` (or `""` when using XML configuration).
 The flow is then invoked on the caller thread and the result can be retrieved later.
 
 ===== `void` Return Type

--- a/src/reference/asciidoc/service-activator.adoc
+++ b/src/reference/asciidoc/service-activator.adoc
@@ -156,9 +156,9 @@ See <<./dsl.adoc#java-dsl-handle,Service Activators and the `.handle()` method>>
 
 The service activator is invoked by the calling thread.
 This is an upstream thread if the input channel is a `SubscribableChannel` or a poller thread for a `PollableChannel`.
-If the service returns a `ListenableFuture<?>`, the default action is to send that as the payload of the message sent to the output (or reply) channel.
+If the service returns a `CompletableFuture<?>`, the default action is to send that as the payload of the message sent to the output (or reply) channel.
 Starting with version 4.3, you can now set the `async` attribute to `true` (by using `setAsync(true)` when using Java configuration).
-If the service returns a `ListenableFuture<?>` when this the `async` attribute is set to `true`, the calling thread is released immediately and the reply message is sent on the thread (from within your service) that completes the future.
+If the service returns a `CompletableFuture<?>` when this the `async` attribute is set to `true`, the calling thread is released immediately and the reply message is sent on the thread (from within your service) that completes the future.
 This is particularly advantageous for long-running services that use a `PollableChannel`, because the poller thread is released to perform other services within the framework.
 
 If the service completes the future with an `Exception`, normal error processing occurs.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -52,6 +52,11 @@ The factory class will be removed in the future releases.
 
 See <<./dsl.adoc#java-dsl,Java DSL>> for more information.
 
+The `org.springframework.util.concurrent.ListenableFuture` has been deprecated starting with Spring Framework `6.0`.
+All Spring Integration async API has been migrated to the `CompletableFuture`.
+
+See <<./gateway.adoc#gw-completable-future, CompletableFuture support>> for more information.
+
 [[x6.0-http]]
 === HTTP Changes
 


### PR DESCRIPTION
SF has deprecated a `ListenableFuture` and API around it

* Migrate to `CompletableFuture` everywhere a `ListenableFuture` has been used
* Suppress a deprecation for `ListenableFuture` keeping the functionality until the next version
* Resolve deprecations nad removals from the latest Spring for Apache Kafka
* Fix documentation for the `ListenableFuture` in favor of `CompletableFuture`

NOTE: the AMQP module is left as is until `ListenableFuture` deprecation is resolved in Spring AMQP

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
