### PR TITLE
Use Global Embedded Kafka whenever possible

### DIFF
--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/channnel/ChannelTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/channnel/ChannelTests.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.channel.NullChannel;
@@ -44,8 +45,6 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ConsumerProperties;
 import org.springframework.kafka.support.KafkaHeaders;
-import org.springframework.kafka.test.EmbeddedKafkaBroker;
-import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
@@ -61,7 +60,6 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  *
  */
 @SpringJUnitConfig
-@EmbeddedKafka(topics = { "channel.1", "channel.2", "channel.3" }, partitions = 1)
 public class ChannelTests {
 
 	@Test
@@ -118,17 +116,18 @@ public class ChannelTests {
 	@Configuration
 	public static class Config {
 
-		@Autowired
-		private EmbeddedKafkaBroker broker;
+		@Value("${spring.global.embedded.kafka.brokers}")
+		String embeddedKafkaBrokers;
 
 		@Bean
 		public ProducerFactory<Integer, String> pf() {
-			return new DefaultKafkaProducerFactory<>(KafkaTestUtils.producerProps(this.broker));
+			return new DefaultKafkaProducerFactory<>(KafkaTestUtils.producerProps(this.embeddedKafkaBrokers));
 		}
 
 		@Bean
 		public ConsumerFactory<Integer, String> cf() {
-			Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("channelTests", "false", this.broker);
+			Map<String, Object> consumerProps =
+					KafkaTestUtils.consumerProps(this.embeddedKafkaBrokers, "channelTests", "false");
 			consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 			return new DefaultKafkaConsumerFactory<>(consumerProps);
 		}

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/AllXmlTests-context.xml
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/AllXmlTests-context.xml
@@ -3,14 +3,18 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:int="http://www.springframework.org/schema/integration"
 	   xmlns:int-kafka="http://www.springframework.org/schema/integration/kafka"
+	   xmlns:context="http://www.springframework.org/schema/context"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration/kafka https://www.springframework.org/schema/integration/kafka/spring-integration-kafka.xsd
-		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd">
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
+
+	<context:property-placeholder />
 
 	<bean id="cf" class="org.springframework.kafka.core.DefaultKafkaConsumerFactory">
 		<constructor-arg>
 			<map>
-				<entry key="bootstrap.servers" value="#{embeddedKafka.brokersAsString}"/>
+				<entry key="bootstrap.servers" value="${spring.global.embedded.kafka.brokers}"/>
 				<entry key="auto.offset.reset" value="earliest"/>
 				<entry key="key.deserializer" value="org.apache.kafka.common.serialization.StringDeserializer"/>
 				<entry key="value.deserializer" value="org.apache.kafka.common.serialization.StringDeserializer"/>
@@ -22,7 +26,7 @@
 	<bean id="pf" class="org.springframework.kafka.core.DefaultKafkaProducerFactory">
 		<constructor-arg>
 			<map>
-				<entry key="bootstrap.servers" value="#{embeddedKafka.brokersAsString}"/>
+				<entry key="bootstrap.servers" value="${spring.global.embedded.kafka.brokers}"/>
 				<entry key="key.serializer" value="org.apache.kafka.common.serialization.StringSerializer"/>
 				<entry key="value.serializer" value="org.apache.kafka.common.serialization.StringSerializer"/>
 			</map>

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/AllXmlTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/AllXmlTests.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.test.annotation.DirtiesContext;
@@ -36,7 +35,6 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @SpringJUnitConfig
 @DirtiesContext
-@EmbeddedKafka(topics = { "one", "two", "three", "four" })
 public class AllXmlTests {
 
 	@Autowired

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/ChannelParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/ChannelParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,16 +28,17 @@ import org.springframework.context.annotation.ImportResource;
 import org.springframework.integration.kafka.channel.PollableKafkaChannel;
 import org.springframework.integration.kafka.channel.SubscribableKafkaChannel;
 import org.springframework.integration.kafka.inbound.KafkaMessageSource;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.listener.ConsumerProperties;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 5.4
  *
@@ -65,17 +66,17 @@ public class ChannelParserTests {
 
 	@Test
 	void testParser() {
-		assertThat(KafkaTestUtils.getPropertyValue(this.ptp, "topic")).isEqualTo("ptpTopic");
-		assertThat(KafkaTestUtils.getPropertyValue(this.pubSub, "topic")).isEqualTo("pubSubTopic");
-		assertThat(KafkaTestUtils.getPropertyValue(this.ptp, "container")).isNotNull();
-		assertThat(KafkaTestUtils.getPropertyValue(this.pubSub, "container")).isNotNull();
-		assertThat(KafkaTestUtils.getPropertyValue(this.ptp, "template")).isSameAs(this.template);
-		assertThat(KafkaTestUtils.getPropertyValue(this.pubSub, "template")).isSameAs(this.template);
-		assertThat(KafkaTestUtils.getPropertyValue(this.pollable, "template")).isSameAs(this.template);
-		assertThat(KafkaTestUtils.getPropertyValue(this.pollable, "source")).isSameAs(this.source);
-		assertThat(KafkaTestUtils.getPropertyValue(this.ptp, "groupId")).isEqualTo("ptpGroup");
-		assertThat(KafkaTestUtils.getPropertyValue(this.pubSub, "groupId")).isEqualTo("pubSubGroup");
-		assertThat(KafkaTestUtils.getPropertyValue(this.pollable, "groupId")).isEqualTo("pollableGroup");
+		assertThat(TestUtils.getPropertyValue(this.ptp, "topic")).isEqualTo("ptpTopic");
+		assertThat(TestUtils.getPropertyValue(this.pubSub, "topic")).isEqualTo("pubSubTopic");
+		assertThat(TestUtils.getPropertyValue(this.ptp, "container")).isNotNull();
+		assertThat(TestUtils.getPropertyValue(this.pubSub, "container")).isNotNull();
+		assertThat(TestUtils.getPropertyValue(this.ptp, "template")).isSameAs(this.template);
+		assertThat(TestUtils.getPropertyValue(this.pubSub, "template")).isSameAs(this.template);
+		assertThat(TestUtils.getPropertyValue(this.pollable, "template")).isSameAs(this.template);
+		assertThat(TestUtils.getPropertyValue(this.pollable, "source")).isSameAs(this.source);
+		assertThat(TestUtils.getPropertyValue(this.ptp, "groupId")).isEqualTo("ptpGroup");
+		assertThat(TestUtils.getPropertyValue(this.pubSub, "groupId")).isEqualTo("pubSubGroup");
+		assertThat(TestUtils.getPropertyValue(this.pollable, "groupId")).isEqualTo("pollableGroup");
 	}
 
 	@Configuration

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceIntegrationTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceIntegrationTests.java
@@ -34,8 +34,6 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.ConsumerProperties;
-import org.springframework.kafka.test.EmbeddedKafkaBroker;
-import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
@@ -48,14 +46,14 @@ import org.springframework.messaging.support.GenericMessage;
  * @since 5.4
  *
  */
-@EmbeddedKafka(controlledShutdown = true, topics = MessageSourceIntegrationTests.TOPIC1, partitions = 1)
 class MessageSourceIntegrationTests {
 
 	static final String TOPIC1 = "MessageSourceIntegrationTests1";
 
 	@Test
-	void testSource(EmbeddedKafkaBroker embeddedKafka) throws Exception {
-		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testSource", "false", embeddedKafka);
+	void testSource() throws Exception {
+		String brokers = System.getProperty("spring.global.embedded.kafka.brokers");
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(brokers, "testSource", "false");
 		consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
 		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 		consumerProps.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, 42);
@@ -81,7 +79,7 @@ class MessageSourceIntegrationTests {
 
 		KafkaMessageSource<Integer, String> source = new KafkaMessageSource<>(consumerFactory, consumerProperties);
 
-		Map<String, Object> producerProps = KafkaTestUtils.producerProps(embeddedKafka);
+		Map<String, Object> producerProps = KafkaTestUtils.producerProps(brokers);
 		DefaultKafkaProducerFactory<Object, Object> producerFactory = new DefaultKafkaProducerFactory<>(producerProps);
 		KafkaTemplate<Object, Object> template = new KafkaTemplate<>(producerFactory);
 		template.setDefaultTopic(TOPIC1);

--- a/spring-integration-kafka/src/test/resources/junit-platform.properties
+++ b/spring-integration-kafka/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+spring.kafka.global.embedded.enabled = true
+spring.embedded.kafka.brokers.property=spring.global.embedded.kafka.brokers
+spring.kafka.embedded.partitions=1


### PR DESCRIPTION
For better test suite lifecycle (higher performance)
reuse one global embedded Kafka broker introduced in Spring for Apache Kafka `3.0`

Some tests have left with their own `EmbeddedKafkaBroker` definitions since they
rely on different partitions

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
