### PR TITLE
Use spring-asciidoctor-backends

### DIFF
--- a/gradle/docs.gradle
+++ b/gradle/docs.gradle
@@ -1,31 +1,17 @@
 ext {
-	docResourcesVersion = '0.2.5'
-	blockSwitchVersion = '0.5.0'
+	backendVersion = '0.0.3'
 }
 
 configurations {
-	docs
-	asciidoctorExt
+	asciidoctorExtensions
 }
 
 dependencies {
-	docs "io.spring.docresources:spring-doc-resources:${docResourcesVersion}@zip"
-	asciidoctorExt "io.spring.asciidoctor:spring-asciidoctor-extensions-block-switch:$blockSwitchVersion"
-}
-
-task prepareAsciidocBuild(type: Sync) {
-	dependsOn configurations.docs
-	from {
-		configurations.docs.collect { zipTree(it) }
-	}
-	duplicatesStrategy = DuplicatesStrategy.INCLUDE
-	from 'src/reference/asciidoc/'
-	into "$buildDir/asciidoc"
+	asciidoctorExtensions "io.spring.asciidoctor.backends:spring-asciidoctor-backends:$backendVersion"
 }
 
 task checkAsciidocLinks {
-	dependsOn prepareAsciidocBuild
-	inputs.dir("$buildDir/asciidoc")
+	inputs.dir("src/reference/asciidoc/")
 	doLast {
 		def errors = new ArrayList<>();
 		errors.add('*** Anchor reference errors found:')
@@ -71,10 +57,9 @@ asciidoctorPdf {
 	}
 
 	baseDirFollowsSourceFile()
-	configurations 'asciidoctorExt'
 
 	asciidoctorj {
-		sourceDir "$buildDir/asciidoc"
+		sourceDir "src/reference/asciidoc/"
 		inputs.dir(sourceDir)
 		sources {
 			include 'index-single.adoc'
@@ -119,9 +104,12 @@ asciidoctor {
 		jvmArgs '--add-opens', 'java.base/sun.nio.ch=ALL-UNNAMED', '--add-opens', 'java.base/java.io=ALL-UNNAMED'
 	}
 	baseDirFollowsSourceFile()
-	configurations 'asciidoctorExt'
-	sourceDir "$buildDir/asciidoc"
+	configurations 'asciidoctorExtensions'
+	sourceDir "src/reference/asciidoc/"
 	inputs.dir(sourceDir)
+	outputOptions {
+		backends "spring-html"
+	}
 	resources {
 		from(sourceDir) {
 			include 'images/*', 'css/**', 'js/**'

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -127,7 +127,6 @@ public MessageHandler handler() {
                                   tx-size=""                      <25>
                                   consumers-per-queue             <26>
                                   batch-mode="MESSAGES"/>         <27>
-----
 
 <1> The unique ID for this adapter.
 Optional.
@@ -221,7 +220,7 @@ See the https://docs.spring.io/spring-amqp/reference/html/[Spring AMQP Reference
 When set to `MESSAGES` (default), the payload is a `List<Message<?>>` where each message has headers mapped from the incoming AMQP `Message` and the payload is the converted `body`.
 When set to `EXTRACT_PAYLOADS`, the payload is a `List<?>` where the elements are converted from the AMQP `Message` body.
 `EXTRACT_PAYLOADS_WITH_HEADERS` is similar to `EXTRACT_PAYLOADS` but, in addition, the headers from each message are mapped from the `MessageProperties` into a `List<Map<String, Object>` at the corresponding index; the header name is `AmqpInboundChannelAdapter.CONSOLIDATED_HEADERS`.
-
+----
 ====
 
 [NOTE]

--- a/src/reference/asciidoc/message-history.adoc
+++ b/src/reference/asciidoc/message-history.adoc
@@ -16,12 +16,14 @@ To enable message history, you need only define the `message-history` element (o
 
 ====
 [source, java, role="primary"]
+.Java
 ----
 @Configuration
 @EnableIntegration
 @EnableMessageHistory
 ----
 [source, xml, role="secondary"]
+.XML
 ----
 <int:message-history/>
 ----
@@ -35,6 +37,7 @@ Consider the following configuration example:
 
 ====
 [source, java, role="primary"]
+.Java
 ----
 @MessagingGateway(defaultRequestChannel = "bridgeInChannel")
 public interface SampleGateway {
@@ -50,6 +53,7 @@ HeaderEnricher sampleEnricher() {
 }
 ----
 [source, xml, role="secondary"]
+.XML
 ----
 <int:gateway id="sampleGateway"
     service-interface="org.springframework.integration.history.sample.SampleGateway"
@@ -94,12 +98,14 @@ The following example shows how to do so:
 
 ====
 [source, java, role="primary"]
+.Java
 ----
 @Configuration
 @EnableIntegration
 @EnableMessageHistory("*Gateway", "sample*", "aName")
 ----
 [source, xml, role="secondary"]
+.XML
 ----
 <int:message-history tracked-components="*Gateway, sample*, aName"/>
 ----


### PR DESCRIPTION
rather than spring-doc-resources, which is to be retired.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
