### PR TITLE
GH-3844: Rework messaging annotation with @Bean

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceIntegrationTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpMessageSourceIntegrationTests.java
@@ -22,12 +22,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.aopalliance.intercept.MethodInterceptor;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.Queue;
@@ -36,7 +33,7 @@ import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
-import org.springframework.amqp.rabbit.junit.BrokerRunning;
+import org.springframework.amqp.rabbit.junit.RabbitAvailable;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -59,7 +56,7 @@ import org.springframework.integration.support.AbstractIntegrationMessageBuilder
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Gary Russell
@@ -67,23 +64,24 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @since 5.0.1
  *
  */
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
+@RabbitAvailable({
+		AmqpMessageSourceIntegrationTests.DSL_QUEUE,
+		AmqpMessageSourceIntegrationTests.INTERCEPT_QUEUE,
+		AmqpMessageSourceIntegrationTests.DLQ,
+		AmqpMessageSourceIntegrationTests.NOAUTOACK_QUEUE })
 public class AmqpMessageSourceIntegrationTests {
 
-	private static final String DSL_QUEUE = "AmqpMessageSourceIntegrationTests";
+	static final String DSL_QUEUE = "AmqpMessageSourceIntegrationTests";
 
-	private static final String QUEUE_WITH_DLQ = "AmqpMessageSourceIntegrationTests.withDLQ";
+	static final String QUEUE_WITH_DLQ = "AmqpMessageSourceIntegrationTests.withDLQ";
 
-	private static final String DLQ = QUEUE_WITH_DLQ + ".dlq";
+	static final String DLQ = QUEUE_WITH_DLQ + ".dlq";
 
-	private static final String INTERCEPT_QUEUE = "AmqpMessageSourceIntegrationTests.channel";
+	static final String INTERCEPT_QUEUE = "AmqpMessageSourceIntegrationTests.channel";
 
-	private static final String NOAUTOACK_QUEUE = "AmqpMessageSourceIntegrationTests.noAutoAck";
-
-	@ClassRule
-	public static BrokerRunning brokerRunning = BrokerRunning.isRunningWithEmptyQueues(DSL_QUEUE, INTERCEPT_QUEUE, DLQ,
-			NOAUTOACK_QUEUE);
+	static final String NOAUTOACK_QUEUE = "AmqpMessageSourceIntegrationTests.noAutoAck";
 
 	@Autowired
 	private Config config;
@@ -91,7 +89,7 @@ public class AmqpMessageSourceIntegrationTests {
 	@Autowired
 	private ConfigurableApplicationContext context;
 
-	@Before
+	@BeforeEach
 	public void before() {
 		RabbitAdmin admin = new RabbitAdmin(this.config.connectionFactory());
 		Queue queue = QueueBuilder.nonDurable(QUEUE_WITH_DLQ)
@@ -103,14 +101,9 @@ public class AmqpMessageSourceIntegrationTests {
 		this.context.start();
 	}
 
-	@After
+	@AfterEach
 	public void after() {
 		this.context.stop();
-	}
-
-	@AfterClass
-	public static void afterClass() {
-		brokerRunning.removeTestQueues(QUEUE_WITH_DLQ);
 	}
 
 	@Test
@@ -256,7 +249,7 @@ public class AmqpMessageSourceIntegrationTests {
 
 		@Bean
 		public ConnectionFactory connectionFactory() {
-			return new CachingConnectionFactory(brokerRunning.getConnectionFactory());
+			return new CachingConnectionFactory("localhost");
 		}
 
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IdempotentReceiverAutoProxyCreatorInitializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IdempotentReceiverAutoProxyCreatorInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,8 +95,7 @@ public class IdempotentReceiverAutoProxyCreatorInitializer implements Integratio
 			List<Map<String, String>> idempotentEndpointsMapping, String beanName, BeanDefinition beanDefinition)
 			throws LinkageError {
 
-		if (beanDefinition.getSource() instanceof MethodMetadata) {
-			MethodMetadata beanMethod = (MethodMetadata) beanDefinition.getSource();
+		if (beanDefinition.getSource() instanceof MethodMetadata beanMethod) {
 			String annotationType = IdempotentReceiver.class.getName();
 			if (beanMethod.isAnnotated(annotationType)) { // NOSONAR never null
 				Object value = beanMethod.getAnnotationAttributes(annotationType).get("value"); // NOSONAR
@@ -120,13 +119,7 @@ public class IdempotentReceiverAutoProxyCreatorInitializer implements Integratio
 
 					String endpoint = beanName;
 					if (!MessageHandler.class.isAssignableFrom(returnType)) {
-						/*
-						   MessageHandler beans, populated from @Bean methods, have a complex id,
-						   including @Configuration bean name, method name and the Messaging annotation name.
-						   The following pattern matches the bean name, regardless of the annotation name.
-						*/
-						endpoint = beanDefinition.getFactoryBeanName() + "." + beanName +
-								".*" + IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX;
+						endpoint = beanName + ".*" + IntegrationConfigUtils.HANDLER_ALIAS_SUFFIX;
 					}
 
 					String[] interceptors = (String[]) value;

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/RouterFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.config;
 import java.util.Map;
 
 import org.springframework.expression.Expression;
+import org.springframework.integration.JavaUtils;
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.handler.AbstractMessageProducingHandler;
 import org.springframework.integration.router.AbstractMappingMessageRouter;
@@ -49,6 +50,10 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 
 	private String defaultOutputChannelName;
 
+	private String prefix;
+
+	private String suffix;
+
 	private Boolean resolutionRequired;
 
 	private Boolean applySequence;
@@ -61,6 +66,14 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 
 	public void setDefaultOutputChannelName(String defaultOutputChannelName) {
 		this.defaultOutputChannelName = defaultOutputChannelName;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public void setSuffix(String suffix) {
+		this.suffix = suffix;
 	}
 
 	public void setResolutionRequired(Boolean resolutionRequired) {
@@ -106,7 +119,7 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 
 	@Override
 	protected MessageHandler createExpressionEvaluatingHandler(Expression expression) {
-		return this.configureRouter(new ExpressionEvaluatingRouter(expression));
+		return configureRouter(new ExpressionEvaluatingRouter(expression));
 	}
 
 	protected AbstractMappingMessageRouter createMethodInvokingRouter(Object targetObject, String targetMethodName) {
@@ -116,34 +129,25 @@ public class RouterFactoryBean extends AbstractStandardMessageHandlerFactoryBean
 	}
 
 	protected AbstractMessageRouter configureRouter(AbstractMessageRouter router) {
-		if (this.defaultOutputChannel != null) {
-			router.setDefaultOutputChannel(this.defaultOutputChannel);
-		}
-		if (this.defaultOutputChannelName != null) {
-			router.setDefaultOutputChannelName(this.defaultOutputChannelName);
-		}
-		if (getSendTimeout() != null) {
-			router.setSendTimeout(getSendTimeout());
-		}
-		if (this.applySequence != null) {
-			router.setApplySequence(this.applySequence);
-		}
-		if (this.ignoreSendFailures != null) {
-			router.setIgnoreSendFailures(this.ignoreSendFailures);
-		}
+		JavaUtils.INSTANCE
+				.acceptIfNotNull(this.defaultOutputChannel, router::setDefaultOutputChannel)
+				.acceptIfNotNull(this.defaultOutputChannelName, router::setDefaultOutputChannelName)
+				.acceptIfNotNull(getSendTimeout(), router::setSendTimeout)
+				.acceptIfNotNull(this.applySequence, router::setApplySequence)
+				.acceptIfNotNull(this.ignoreSendFailures, router::setIgnoreSendFailures);
+
 		if (router instanceof AbstractMappingMessageRouter) {
-			this.configureMappingRouter((AbstractMappingMessageRouter) router);
+			configureMappingRouter((AbstractMappingMessageRouter) router);
 		}
 		return router;
 	}
 
 	protected void configureMappingRouter(AbstractMappingMessageRouter router) {
-		if (this.channelMappings != null) {
-			router.setChannelMappings(this.channelMappings);
-		}
-		if (this.resolutionRequired != null) {
-			router.setResolutionRequired(this.resolutionRequired);
-		}
+		JavaUtils.INSTANCE
+				.acceptIfNotNull(this.channelMappings, router::setChannelMappings)
+				.acceptIfNotNull(this.resolutionRequired, router::setResolutionRequired)
+				.acceptIfHasText(this.prefix, router::setPrefix)
+				.acceptIfHasText(this.suffix, router::setSuffix);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AbstractMethodAnnotationPostProcessor.java
@@ -241,7 +241,9 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 		Poller poller = MessagingAnnotationUtils.resolveAttribute(annotations, "poller", Poller.class);
 		Reactive reactive = MessagingAnnotationUtils.resolveAttribute(annotations, "reactive", Reactive.class);
-		Assert.state(reactive == null || poller == null, "The 'poller' and 'reactive' are mutually exclusive.");
+		Assert.state(reactive == null || poller == null,
+				() -> "The 'poller' and 'reactive' attributes are mutually exclusive." +
+						"The bean definition with the problem is: " + beanName);
 		if (poller != null) {
 			applyPollerForEndpoint(endpointBeanDefinition, poller);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AggregatorAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/AggregatorAnnotationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.integration.aggregator.AggregatingMessageHandler;
 import org.springframework.integration.aggregator.MethodInvokingCorrelationStrategy;
 import org.springframework.integration.aggregator.MethodInvokingMessageGroupProcessor;
@@ -42,11 +41,6 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  */
 public class AggregatorAnnotationPostProcessor extends AbstractMethodAnnotationPostProcessor<Aggregator> {
-
-	public AggregatorAnnotationPostProcessor(ConfigurableListableBeanFactory beanFactory) {
-		super(beanFactory);
-	}
-
 
 	@Override
 	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
@@ -86,7 +80,8 @@ public class AggregatorAnnotationPostProcessor extends AbstractMethodAnnotationP
 		return handler;
 	}
 
-	protected boolean beanAnnotationAware() {
+	@Override
+	public boolean beanAnnotationAware() {
 		return false;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/BridgeToAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/annotation/BridgeToAnnotationPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,15 +20,20 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.List;
 
-import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.RuntimeBeanReference;
+import org.springframework.beans.factory.parsing.ComponentDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionBuilder;
+import org.springframework.beans.factory.support.GenericBeanDefinition;
+import org.springframework.core.ResolvableType;
+import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.integration.annotation.BridgeFrom;
 import org.springframework.integration.annotation.BridgeTo;
+import org.springframework.integration.config.ConsumerEndpointFactoryBean;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.handler.BridgeHandler;
 import org.springframework.integration.util.MessagingAnnotationUtils;
-import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -37,45 +42,55 @@ import org.springframework.util.StringUtils;
  * Post-processor for the {@link BridgeTo @BridgeTo} annotation.
  *
  * @author Artem Bilan
+ *
  * @since 4.0
  */
 public class BridgeToAnnotationPostProcessor extends AbstractMethodAnnotationPostProcessor<BridgeTo> {
 
-	public BridgeToAnnotationPostProcessor(ConfigurableListableBeanFactory beanFactory) {
-		super(beanFactory);
+	@Override
+	public boolean supportsPojoMethod() {
+		return false;
 	}
 
 	@Override
-	public boolean shouldCreateEndpoint(Method method, List<Annotation> annotations) {
-		boolean isBean = AnnotatedElementUtils.isAnnotated(method, Bean.class.getName());
-		Assert.isTrue(isBean, "'@BridgeTo' is eligible only for '@Bean' methods");
-
-		boolean isMessageChannelBean = MessageChannel.class.isAssignableFrom(method.getReturnType());
-		Assert.isTrue(isMessageChannelBean, "'@BridgeTo' is eligible only for 'MessageChannel' '@Bean' methods");
-
-		boolean hasBridgeFrom = AnnotatedElementUtils.isAnnotated(method, BridgeFrom.class.getName());
-
-		Assert.isTrue(!hasBridgeFrom, "'@BridgeFrom' and '@BridgeTo' are mutually exclusive 'MessageChannel' " +
-				"'@Bean' method annotations");
-
+	public boolean shouldCreateEndpoint(MergedAnnotations mergedAnnotations, List<Annotation> annotations) {
+		Assert.isTrue(!mergedAnnotations.isPresent(BridgeFrom.class),
+				"'@BridgeFrom' and '@BridgeTo' are mutually exclusive 'MessageChannel' '@Bean' method annotations");
 		return true;
 	}
 
 	@Override
-	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
-		BridgeHandler handler = new BridgeHandler();
-		String outputChannelName = MessagingAnnotationUtils.resolveAttribute(annotations, "value", String.class);
+	protected BeanDefinition resolveHandlerBeanDefinition(String beanName, AnnotatedBeanDefinition beanDefinition,
+			ResolvableType handlerBeanType, List<Annotation> annotationChain) {
+
+		GenericBeanDefinition bridgeHandlerBeanDefinition = new GenericBeanDefinition();
+		bridgeHandlerBeanDefinition.setBeanClass(BridgeHandler.class);
+		String outputChannelName = MessagingAnnotationUtils.resolveAttribute(annotationChain, "value", String.class);
 		if (StringUtils.hasText(outputChannelName)) {
-			handler.setOutputChannelName(outputChannelName);
+			bridgeHandlerBeanDefinition.getPropertyValues()
+					.addPropertyValue("outputChannel", new RuntimeBeanReference(outputChannelName));
 		}
-		return handler;
+		return bridgeHandlerBeanDefinition;
+	}
+
+	@Override
+	protected BeanDefinition createEndpointBeanDefinition(ComponentDefinition handlerBeanDefinition,
+			ComponentDefinition beanDefinition, List<Annotation> annotations) {
+
+		return BeanDefinitionBuilder.genericBeanDefinition(ConsumerEndpointFactoryBean.class)
+				.addPropertyReference("handler", handlerBeanDefinition.getName())
+				.addPropertyReference("inputChannel", beanDefinition.getName())
+				.getBeanDefinition();
 	}
 
 	@Override
 	protected AbstractEndpoint createEndpoint(MessageHandler handler, Method method, List<Annotation> annotations) {
-		Object inputChannel = this.resolveTargetBeanFromMethodWithBeanAnnotation(method);
-		Assert.isInstanceOf(MessageChannel.class, inputChannel);
-		return doCreateEndpoint(handler, (MessageChannel) inputChannel, annotations);
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	protected MessageHandler createHandler(Object bean, Method method, List<Annotation> annotations) {
+		throw new UnsupportedOperationException();
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,10 +22,11 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.integration.annotation.Filter;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.channel.DirectChannel;
@@ -54,16 +55,16 @@ public class FilterAnnotationPostProcessorTests {
 
 	private final QueueChannel outputChannel = new QueueChannel();
 
-	@Before
+	@BeforeEach
 	public void init() {
 		this.context.registerChannel("input", this.inputChannel);
 		this.context.registerChannel("output", this.outputChannel);
-		this.postProcessor.setBeanFactory(this.context.getBeanFactory());
-		this.postProcessor.afterPropertiesSet();
+		this.postProcessor.postProcessBeanDefinitionRegistry((BeanDefinitionRegistry) this.context.getBeanFactory());
+		this.postProcessor.postProcessBeanFactory(this.context.getBeanFactory());
 		this.postProcessor.afterSingletonsInstantiated();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		this.context.close();
 	}
@@ -111,7 +112,7 @@ public class FilterAnnotationPostProcessorTests {
 	@Test
 	public void filterAnnotationWithAdviceArray() {
 		TestAdvice advice = new TestAdvice();
-		context.registerBean("adviceChain", new TestAdvice[] { advice });
+		context.registerBean("adviceChain", new TestAdvice[]{ advice });
 		testValidFilter(new TestFilterWithAdviceDiscardWithin());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
 		assertThat(TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class).get(0)).isSameAs(advice);
@@ -122,10 +123,10 @@ public class FilterAnnotationPostProcessorTests {
 	public void filterAnnotationWithAdviceArrayTwice() {
 		TestAdvice advice1 = new TestAdvice();
 		TestAdvice advice2 = new TestAdvice();
-		context.registerBean("adviceChain1", new TestAdvice[] { advice1, advice2 });
+		context.registerBean("adviceChain1", new TestAdvice[]{ advice1, advice2 });
 		TestAdvice advice3 = new TestAdvice();
 		TestAdvice advice4 = new TestAdvice();
-		context.registerBean("adviceChain2", new TestAdvice[] { advice3, advice4 });
+		context.registerBean("adviceChain2", new TestAdvice[]{ advice3, advice4 });
 		testValidFilter(new TestFilterWithAdviceDiscardWithinTwice());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
 		List<?> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class);
@@ -151,10 +152,10 @@ public class FilterAnnotationPostProcessorTests {
 	public void filterAnnotationWithAdviceCollectionTwice() {
 		TestAdvice advice1 = new TestAdvice();
 		TestAdvice advice2 = new TestAdvice();
-		context.registerBean("adviceChain1", new TestAdvice[] { advice1, advice2 });
+		context.registerBean("adviceChain1", new TestAdvice[]{ advice1, advice2 });
 		TestAdvice advice3 = new TestAdvice();
 		TestAdvice advice4 = new TestAdvice();
-		context.registerBean("adviceChain2", new TestAdvice[] { advice3, advice4 });
+		context.registerBean("adviceChain2", new TestAdvice[]{ advice3, advice4 });
 		testValidFilter(new TestFilterWithAdviceDiscardWithinTwice());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
 		List<?> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorTests.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.config.annotation;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -27,9 +26,10 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -147,14 +147,6 @@ public class MessagingAnnotationPostProcessorTests {
 		assertThat(latch.getCount()).isEqualTo(0);
 		assertThat(testBean.getMessageText()).isEqualTo("foo");
 		context.close();
-	}
-
-	@Test
-	public void testPostProcessorWithoutBeanFactory() {
-		MessagingAnnotationPostProcessor postProcessor =
-				new MessagingAnnotationPostProcessor();
-		assertThatIllegalArgumentException()
-				.isThrownBy(postProcessor::afterPropertiesSet);
 	}
 
 	@Test
@@ -307,12 +299,12 @@ public class MessagingAnnotationPostProcessorTests {
 		context.close();
 	}
 
-	private MessagingAnnotationPostProcessor prepareMessagingAnnotationPostProcessor(
+	private static MessagingAnnotationPostProcessor prepareMessagingAnnotationPostProcessor(
 			ConfigurableApplicationContext context) {
 
 		MessagingAnnotationPostProcessor postProcessor = new MessagingAnnotationPostProcessor();
-		postProcessor.setBeanFactory(context.getBeanFactory());
-		postProcessor.afterPropertiesSet();
+		postProcessor.postProcessBeanDefinitionRegistry((BeanDefinitionRegistry) context.getBeanFactory());
+		postProcessor.postProcessBeanFactory(context.getBeanFactory());
 		postProcessor.afterSingletonsInstantiated();
 		return postProcessor;
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -166,8 +166,7 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 			assertThat(receive.getPayload()).isInstanceOf(MessageRejectedException.class);
 			MessageRejectedException exception = (MessageRejectedException) receive.getPayload();
 			assertThat(exception.getMessage())
-					.contains("message has been rejected in filter: bean " +
-							"'messagingAnnotationsWithBeanAnnotationTests.ContextConfiguration.filter.filter.handler'");
+					.contains("message has been rejected in filter: bean 'filter.filter.handler'");
 
 		}
 
@@ -330,7 +329,7 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 
 		@Bean
 		@ServiceActivator(inputChannel = "aggregatorChannel")
-		public MessageHandler aggregator() {
+		public AggregatingMessageHandler aggregator() {
 			AggregatingMessageHandler handler = new AggregatingMessageHandler(MessageGroup::getMessages);
 			handler.setCorrelationStrategy(new ExpressionEvaluatingCorrelationStrategy("1"));
 			handler.setReleaseStrategy(new ExpressionEvaluatingReleaseStrategy("size() == 10"));
@@ -355,7 +354,7 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 
 		@Bean
 		@Splitter(inputChannel = "splitterChannel", reactive = @Reactive("reactiveCustomizer"))
-		public MessageHandler splitter() {
+		public DefaultMessageSplitter splitter() {
 			DefaultMessageSplitter defaultMessageSplitter = new DefaultMessageSplitter();
 			defaultMessageSplitter.setOutputChannelName("serviceChannel");
 			return defaultMessageSplitter;
@@ -470,7 +469,7 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 
 		@Bean
 		@Splitter(inputChannel = "splitterChannel", applySequence = "false")
-		public MessageHandler splitter() {
+		public DefaultMessageSplitter splitter() {
 			return new DefaultMessageSplitter();
 		}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.Router;
 import org.springframework.integration.channel.DirectChannel;
@@ -42,6 +43,8 @@ public class RouterAnnotationPostProcessorTests {
 
 	private final TestApplicationContext context = TestUtils.createTestApplicationContext();
 
+	private final MessagingAnnotationPostProcessor postProcessor = new MessagingAnnotationPostProcessor();
+
 	private final DirectChannel inputChannel = new DirectChannel();
 
 	private final QueueChannel outputChannel = new QueueChannel();
@@ -53,26 +56,26 @@ public class RouterAnnotationPostProcessorTests {
 	private final QueueChannel stringChannel = new QueueChannel();
 
 
-	@Before
+
+	@BeforeEach
 	public void init() {
 		context.registerChannel("input", inputChannel);
 		context.registerChannel("output", outputChannel);
 		context.registerChannel("routingChannel", routingChannel);
 		context.registerChannel("integerChannel", integerChannel);
 		context.registerChannel("stringChannel", stringChannel);
+		this.postProcessor.postProcessBeanDefinitionRegistry((BeanDefinitionRegistry) this.context.getBeanFactory());
+		this.postProcessor.postProcessBeanFactory(this.context.getBeanFactory());
+		this.postProcessor.afterSingletonsInstantiated();
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		this.context.close();
 	}
 
 	@Test
 	public void testRouter() {
-		MessagingAnnotationPostProcessor postProcessor = new MessagingAnnotationPostProcessor();
-		postProcessor.setBeanFactory(context.getBeanFactory());
-		postProcessor.afterPropertiesSet();
-		postProcessor.afterSingletonsInstantiated();
 		TestRouter testRouter = new TestRouter();
 		postProcessor.postProcessAfterInitialization(testRouter, "test");
 		context.refresh();
@@ -84,10 +87,6 @@ public class RouterAnnotationPostProcessorTests {
 
 	@Test
 	public void testRouterWithListParam() {
-		MessagingAnnotationPostProcessor postProcessor = new MessagingAnnotationPostProcessor();
-		postProcessor.setBeanFactory(context.getBeanFactory());
-		postProcessor.afterPropertiesSet();
-		postProcessor.afterSingletonsInstantiated();
 		TestRouter testRouter = new TestRouter();
 		postProcessor.postProcessAfterInitialization(testRouter, "test");
 		context.refresh();

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,11 @@ package org.springframework.integration.config.annotation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.Splitter;
@@ -39,20 +40,20 @@ import org.springframework.messaging.support.GenericMessage;
  */
 public class SplitterAnnotationPostProcessorTests {
 
-	private TestApplicationContext context = TestUtils.createTestApplicationContext();
+	private final TestApplicationContext context = TestUtils.createTestApplicationContext();
 
-	private DirectChannel inputChannel = new DirectChannel();
+	private final DirectChannel inputChannel = new DirectChannel();
 
-	private QueueChannel outputChannel = new QueueChannel();
+	private final QueueChannel outputChannel = new QueueChannel();
 
 
-	@Before
+	@BeforeEach
 	public void init() {
-		context.registerChannel("input", inputChannel);
-		context.registerChannel("output", outputChannel);
+		this.context.registerChannel("input", this.inputChannel);
+		this.context.registerChannel("output", this.outputChannel);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		this.context.close();
 	}
@@ -60,8 +61,8 @@ public class SplitterAnnotationPostProcessorTests {
 	@Test
 	public void testSplitterAnnotation() {
 		MessagingAnnotationPostProcessor postProcessor = new MessagingAnnotationPostProcessor();
-		postProcessor.setBeanFactory(context.getBeanFactory());
-		postProcessor.afterPropertiesSet();
+		postProcessor.postProcessBeanDefinitionRegistry((BeanDefinitionRegistry) this.context.getBeanFactory());
+		postProcessor.postProcessBeanFactory(this.context.getBeanFactory());
 		postProcessor.afterSingletonsInstantiated();
 		TestSplitter splitter = new TestSplitter();
 		postProcessor.postProcessAfterInitialization(splitter, "testSplitter");

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -298,11 +298,11 @@ public class EnableIntegrationTests {
 	private CountDownLatch inputReceiveLatch;
 
 	@Autowired
-	@Qualifier("enableIntegrationTests.ContextConfiguration2.sendAsyncHandler.serviceActivator")
+	@Qualifier("sendAsyncHandler.serviceActivator")
 	private AbstractEndpoint sendAsyncHandler;
 
 	@Autowired
-	@Qualifier("enableIntegrationTests.ChildConfiguration.autoCreatedChannelMessageSource.inboundChannelAdapter")
+	@Qualifier("autoCreatedChannelMessageSource.inboundChannelAdapter")
 	private Lifecycle autoCreatedChannelMessageSourceAdapter;
 
 	@Autowired
@@ -669,8 +669,7 @@ public class EnableIntegrationTests {
 				.isThrownBy(() -> this.metaBridgeInput.send(testMessage))
 				.withMessageContaining("Dispatcher has no subscribers");
 
-		this.context.getBean("enableIntegrationTests.ContextConfiguration.metaBridgeOutput.bridgeFrom",
-				Lifecycle.class).start();
+		this.context.getBean("metaBridgeOutput.bridgeFrom", Lifecycle.class).start();
 
 		this.metaBridgeInput.send(testMessage);
 		receive = this.metaBridgeOutput.receive(10_000);
@@ -697,8 +696,7 @@ public class EnableIntegrationTests {
 				.isThrownBy(() -> this.myBridgeToInput.send(testMessage))
 				.withMessageContaining("Dispatcher has no subscribers");
 
-		this.context.getBean("enableIntegrationTests.ContextConfiguration.myBridgeToInput.bridgeTo",
-				Lifecycle.class).start();
+		this.context.getBean("myBridgeToInput.bridgeTo", Lifecycle.class).start();
 
 		this.myBridgeToInput.send(bridgeMessage);
 		receive = replyChannel.receive(10_000);
@@ -741,8 +739,7 @@ public class EnableIntegrationTests {
 		assertThat(this.roleController.noEndpointsRunning("bar")).isFalse();
 		Map<String, Boolean> state = this.roleController.getEndpointsRunningStatus("foo");
 		assertThat(state.get("annotationTestService.handle.serviceActivator")).isEqualTo(Boolean.FALSE);
-		assertThat(state.get("enableIntegrationTests.ContextConfiguration2.sendAsyncHandler.serviceActivator"))
-				.isEqualTo(Boolean.TRUE);
+		assertThat(state.get("sendAsyncHandler.serviceActivator")).isEqualTo(Boolean.TRUE);
 		this.roleController.startLifecyclesInRole("foo");
 		assertThat(this.roleController.allEndpointsRunning("foo")).isTrue();
 		this.roleController.stopLifecyclesInRole("foo");
@@ -1690,6 +1687,7 @@ public class EnableIntegrationTests {
 	@InboundChannelAdapter(value = "counterChannel", autoStartup = "false", phase = "23")
 	public @interface MyInboundChannelAdapter {
 
+		@AliasFor(annotation = InboundChannelAdapter.class, attribute = "value")
 		String value() default "";
 
 		String autoStartup() default "";

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/BeanNameTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/BeanNameTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class BeanNameTests {
 
 	@SuppressWarnings("unused")
 	@Autowired
-	@Qualifier("eipBean.handler")
+	@Qualifier("eipBeanHandler")
 	private MessageHandler eipBeanHandler;
 
 	@SuppressWarnings("unused")
@@ -76,11 +76,11 @@ public class BeanNameTests {
 
 	@SuppressWarnings("unused")
 	@Autowired
-	@Qualifier("eipBean2.handler")
+	@Qualifier("eipBean2Handler")
 	private MessageHandler eipBean2Handler;
 
 	@Autowired
-	@Qualifier("eipBean2.handler.wrapper")
+	@Qualifier("eipBean2.handler")
 	private ReplyProducingMessageHandlerWrapper eipBean2HandlerWrapper;
 
 	@SuppressWarnings("unused")
@@ -98,7 +98,7 @@ public class BeanNameTests {
 
 	@SuppressWarnings("unused")
 	@Autowired
-	@Qualifier("eipSource.source")
+	@Qualifier("eipSourceSource")
 	private MessageSource<?> eipSourceSource;
 
 	@Test
@@ -124,10 +124,10 @@ public class BeanNameTests {
 			}
 		}
 
-		@Bean("eipBean.handler")
+		@Bean("eipBeanHandler")
 		@EndpointId("eipBean")
 		@ServiceActivator(inputChannel = "channel2")
-		public MessageHandler replyingHandler() {
+		public AbstractReplyProducingMessageHandler replyingHandler() {
 			return new AbstractReplyProducingMessageHandler() {
 
 				@Override
@@ -138,7 +138,7 @@ public class BeanNameTests {
 			};
 		}
 
-		@Bean("eipBean2.handler")
+		@Bean("eipBean2Handler")
 		@EndpointId("eipBean2")
 		@ServiceActivator(inputChannel = "channel3")
 		public MessageHandler handler() {
@@ -151,7 +151,7 @@ public class BeanNameTests {
 			return null;
 		}
 
-		@Bean("eipSource.source")
+		@Bean("eipSourceSource")
 		@EndpointId("eipSource")
 		@InboundChannelAdapter(channel = "channel3", poller = @Poller(fixedDelay = "5000"))
 		public MessageSource<?> source() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/graph/IntegrationGraphServerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/graph/IntegrationGraphServerTests.java
@@ -139,7 +139,7 @@ public class IntegrationGraphServerTests {
 		assertThat(links.size()).isEqualTo(34);
 
 		jsonArray =
-				JsonPathUtils.evaluate(baos.toByteArray(), "$..nodes[?(@.name == 'expressionRouter')]");
+				JsonPathUtils.evaluate(baos.toByteArray(), "$..nodes[?(@.name == 'expressionRouter.router')]");
 
 		Map<String, Object> expressionRouter = (Map<String, Object>) jsonArray.get(0);
 		assertThat(((List<?>) expressionRouter.get("routes")).size()).isEqualTo(0);
@@ -151,7 +151,7 @@ public class IntegrationGraphServerTests {
 		this.testSource.receive();
 		this.expressionRouterInput.send(MessageBuilder.withPayload("foo").setHeader("foo", "fizChannel").build());
 
-		jsonArray = JsonPathUtils.evaluate(baos.toByteArray(), "$..nodes[?(@.name == 'router')]");
+		jsonArray = JsonPathUtils.evaluate(baos.toByteArray(), "$..nodes[?(@.name == 'router.router')]");
 		String routerJson = jsonArray.toJSONString();
 
 		this.server.rebuild();
@@ -172,7 +172,7 @@ public class IntegrationGraphServerTests {
 		assertThat(links).isNotNull();
 		assertThat(links.size()).isEqualTo(37);
 
-		jsonArray = JsonPathUtils.evaluate(baos.toByteArray(), "$..nodes[?(@.name == 'router')]");
+		jsonArray = JsonPathUtils.evaluate(baos.toByteArray(), "$..nodes[?(@.name == 'router.router')]");
 		routerJson = jsonArray.toJSONString();
 		assertThat(routerJson).contains("\"sendTimers\":{\"successes\":{\"count\":4");
 		jsonArray = JsonPathUtils.evaluate(baos.toByteArray(), "$..nodes[?(@.name == 'toRouter')]");
@@ -200,7 +200,7 @@ public class IntegrationGraphServerTests {
 		assertThat(sourceJson).contains("\"receiveCounters\":{\"successes\":2,\"failures\":1");
 
 		jsonArray =
-				JsonPathUtils.evaluate(baos.toByteArray(), "$..nodes[?(@.name == 'expressionRouter')]");
+				JsonPathUtils.evaluate(baos.toByteArray(), "$..nodes[?(@.name == 'expressionRouter.router')]");
 
 		expressionRouter = (Map<String, Object>) jsonArray.get(0);
 		JSONArray routes = (JSONArray) expressionRouter.get("routes");

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
@@ -48,7 +48,6 @@ import org.springframework.integration.gateway.MessagingGatewaySupport;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
@@ -71,7 +70,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
  */
 @SpringJUnitConfig
 @DirtiesContext
-@TestExecutionListeners(DependencyInjectionTestExecutionListener.class)
+@TestExecutionListeners(DependencyInjectionTestExecutionListener.class) // To ignore other default listeners
 public class MicrometerMetricsTests {
 
 	@Autowired
@@ -149,7 +148,7 @@ public class MicrometerMetricsTests {
 				.counter().count()).isEqualTo(1);
 
 		assertThat(registry.get("spring.integration.send")
-				.tag("name", "eipBean.handler")
+				.tag("name", "eipBean")
 				.tag("result", "success")
 				.timer().count()).isEqualTo(1);
 
@@ -277,7 +276,7 @@ public class MicrometerMetricsTests {
 			SimpleMeterRegistry registry = new SimpleMeterRegistry();
 			registry.config().meterFilter(MeterFilter.deny(id ->
 					"channel".equals(id.getTag("type")) &&
-					"noMeters".equals(id.getTag("name"))));
+							"noMeters".equals(id.getTag("name"))));
 			return registry;
 		}
 
@@ -292,7 +291,7 @@ public class MicrometerMetricsTests {
 		@Bean("eipBean.handler")
 		@EndpointId("eipBean")
 		@ServiceActivator(inputChannel = "channel2")
-		public MessageHandler replyingHandler() {
+		public AbstractReplyProducingMessageHandler replyingHandler() {
 			return new AbstractReplyProducingMessageHandler() {
 
 				@Override

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/config/HazelcastOutboundChannelAdapterConfigTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/config/HazelcastOutboundChannelAdapterConfigTests.java
@@ -20,9 +20,8 @@ import java.util.List;
 import java.util.Queue;
 import java.util.Set;
 
-import org.junit.AfterClass;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -31,9 +30,7 @@ import org.springframework.integration.hazelcast.HazelcastTestRequestHandlerAdvi
 import org.springframework.integration.hazelcast.outbound.util.HazelcastOutboundChannelAdapterTestUtils;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.context.support.AnnotationConfigContextLoader;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import com.hazelcast.instance.impl.HazelcastInstanceFactory;
 import com.hazelcast.map.IMap;
@@ -45,11 +42,11 @@ import com.hazelcast.topic.ITopic;
  * Hazelcast Outbound Channel Adapter JavaConfig driven Unit Test Class
  *
  * @author Eren Avsarogullari
+ * @author Atem Bilan
+ *
  * @since 6.0
  */
-@RunWith(SpringRunner.class)
-@ContextConfiguration(classes = HazelcastIntegrationOutboundTestConfiguration.class,
-		loader = AnnotationConfigContextLoader.class)
+@SpringJUnitConfig(classes = HazelcastIntegrationOutboundTestConfiguration.class)
 @DirtiesContext
 public class HazelcastOutboundChannelAdapterConfigTests {
 
@@ -141,7 +138,7 @@ public class HazelcastOutboundChannelAdapterConfigTests {
 	@Qualifier("replicatedMapRequestHandlerAdvice")
 	private HazelcastTestRequestHandlerAdvice replicatedMapRequestHandlerAdvice;
 
-	@AfterClass
+	@AfterAll
 	public static void shutdown() {
 		HazelcastInstanceFactory.terminateAll();
 	}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcJavaConfigTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/StoredProcJavaConfigTests.java
@@ -80,9 +80,9 @@ public class StoredProcJavaConfigTests {
 		// verify maxMessagesPerPoll == 1
 		assertThat(received).isNull();
 		MessagingTemplate template = new MessagingTemplate(this.control);
-		template.convertAndSend("@'storedProcJavaConfigTests.Config.storedProc.inboundChannelAdapter'.stop()");
+		template.convertAndSend("@'storedProc.inboundChannelAdapter'.stop()");
 		assertThat(template.convertSendAndReceive(
-				"@'storedProcJavaConfigTests.Config.storedProc.inboundChannelAdapter'.isRunning()", Boolean.class))
+				"@'storedProc.inboundChannelAdapter'.isRunning()", Boolean.class))
 				.isFalse();
 	}
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
@@ -139,14 +139,14 @@ public class JmsTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void testPollingFlow() {
-		this.controlBus.send("@'jmsTests.ContextConfiguration.integerMessageSource.inboundChannelAdapter'.start()");
+		this.controlBus.send("@'integerMessageSource.inboundChannelAdapter'.start()");
 		assertThat(this.beanFactory.getBean("integerChannel")).isInstanceOf(FixedSubscriberChannel.class);
 		for (int i = 0; i < 5; i++) {
 			Message<?> message = this.outputChannel.receive(20000);
 			assertThat(message).isNotNull();
 			assertThat(message.getPayload()).isEqualTo("" + i);
 		}
-		this.controlBus.send("@'jmsTests.ContextConfiguration.integerMessageSource.inboundChannelAdapter'.stop()");
+		this.controlBus.send("@'integerMessageSource.inboundChannelAdapter'.stop()");
 
 		assertThat(((InterceptableChannel) this.outputChannel).getInterceptors())
 				.contains(this.testChannelInterceptor);
@@ -353,7 +353,7 @@ public class JmsTests extends ActiveMQMultiContextTests {
 		public IntegrationFlow jmsMessageDrivenFlow() {
 			return IntegrationFlow
 					.from(Jms.messageDrivenChannelAdapter(amqFactory,
-							DefaultMessageListenerContainer.class)
+									DefaultMessageListenerContainer.class)
 							.outputChannel(jmsMessageDrivenInputChannel())
 							.destination("jmsMessageDriven")
 							.configureListenerContainer(c -> c.clientId("foo")))
@@ -406,23 +406,23 @@ public class JmsTests extends ActiveMQMultiContextTests {
 		@Bean
 		public IntegrationFlow jmsInboundGatewayFlow() {
 			return IntegrationFlow.from(
-					Jms.inboundGateway(amqFactory)
-							.requestChannel(jmsInboundGatewayInputChannel())
-							.replyTimeout(1)
-							.errorOnTimeout(true)
-							.errorChannel(new FixedSubscriberChannel(new AbstractReplyProducingMessageHandler() {
+							Jms.inboundGateway(amqFactory)
+									.requestChannel(jmsInboundGatewayInputChannel())
+									.replyTimeout(1)
+									.errorOnTimeout(true)
+									.errorChannel(new FixedSubscriberChannel(new AbstractReplyProducingMessageHandler() {
 
-								@Override
-								protected Object handleRequestMessage(Message<?> requestMessage) {
-									return "error: " +
-											((MessageTimeoutException) requestMessage.getPayload())
-													.getFailedMessage().getPayload() + " is not convertible";
-								}
+										@Override
+										protected Object handleRequestMessage(Message<?> requestMessage) {
+											return "error: " +
+													((MessageTimeoutException) requestMessage.getPayload())
+															.getFailedMessage().getPayload() + " is not convertible";
+										}
 
-							}))
-							.requestDestination("jmsPipelineTest")
-							.configureListenerContainer(c ->
-									c.transactionManager(mock(PlatformTransactionManager.class))))
+									}))
+									.requestDestination("jmsPipelineTest")
+									.configureListenerContainer(c ->
+											c.transactionManager(mock(PlatformTransactionManager.class))))
 					.filter(payload -> !"junk".equals(payload))
 					.<String, String>transform(String::toUpperCase)
 					.get();

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/mock/MockMessageSourceTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/mock/MockMessageSourceTests.java
@@ -100,9 +100,7 @@ public class MockMessageSourceTests {
 	@Test
 	public void testMockMessageSourceInConfig() {
 		Lifecycle channelAdapter =
-				this.applicationContext
-						.getBean("mockMessageSourceTests.Config.testingMessageSource.inboundChannelAdapter",
-								Lifecycle.class);
+				this.applicationContext.getBean("testingMessageSource.inboundChannelAdapter", Lifecycle.class);
 		channelAdapter.start();
 
 		Message<?> receive = this.results.receive(10_000);

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -678,7 +678,7 @@ NOTE: The bean names are generated with the following algorithm:
 This works as though there were no messaging annotation on the `@Bean` method.
 * The `AbstractEndpoint` bean name is generated with the following pattern: `[@Bean name].[decapitalizedAnnotationClassShortName]`.
 For example, the `SourcePollingChannelAdapter` endpoint for the `consoleSource()` definition <<annotations_on_beans,shown earlier>> gets a bean name of `consoleSource.inboundChannelAdapter`.
-Unlike with POJO methods the bean method name is not included into an endpoint bean name.
+Unlike with POJO methods, the bean method name is not included in the endpoint bean name.
 See also <<./overview.adoc#endpoint-bean-names,Endpoint Bean Names>>.
 * If `@Bean` cannot be used directly in the target endpoint (not an instance of a `MessageSource`, `AbstractReplyProducingMessageHandler` or `AbstractMessageRouter`), a respective `AbstractStandardMessageHandlerFactoryBean` is registered to delegate to this `@Bean`.
 The bean name for this wrapper is generated with the following pattern: `[@Bean name].[decapitalizedAnnotationClassShortName].[handler (or source)]`.

--- a/src/reference/asciidoc/configuration.adoc
+++ b/src/reference/asciidoc/configuration.adoc
@@ -624,7 +624,7 @@ public class MyFlowConfiguration {
 
     @Bean
     @ServiceActivator(inputChannel = "httpChannel")
-    public MessageHandler httpHandler() {
+    public HttpRequestExecutingMessageHandler httpHandler() {
     HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler("https://foo/service");
         handler.setExpectedResponseType(String.class);
         handler.setOutputChannelName("outputChannel");
@@ -676,12 +676,15 @@ NOTE: The bean names are generated with the following algorithm:
 
 * The `MessageHandler` (`MessageSource`) `@Bean` gets its own standard name from the method name or `name` attribute on the `@Bean`.
 This works as though there were no messaging annotation on the `@Bean` method.
-* The `AbstractEndpoint` bean name is generated with the following pattern: `[configurationComponentName].[methodName].[decapitalizedAnnotationClassShortName]`.
-For example, the `SourcePollingChannelAdapter` endpoint for the `consoleSource()` definition <<annotations_on_beans,shown earlier>> gets a bean name of `myFlowConfiguration.consoleSource.inboundChannelAdapter`.
+* The `AbstractEndpoint` bean name is generated with the following pattern: `[@Bean name].[decapitalizedAnnotationClassShortName]`.
+For example, the `SourcePollingChannelAdapter` endpoint for the `consoleSource()` definition <<annotations_on_beans,shown earlier>> gets a bean name of `consoleSource.inboundChannelAdapter`.
+Unlike with POJO methods the bean method name is not included into an endpoint bean name.
 See also <<./overview.adoc#endpoint-bean-names,Endpoint Bean Names>>.
+* If `@Bean` cannot be used directly in the target endpoint (not an instance of a `MessageSource`, `AbstractReplyProducingMessageHandler` or `AbstractMessageRouter`), a respective `AbstractStandardMessageHandlerFactoryBean` is registered to delegate to this `@Bean`.
+The bean name for this wrapper is generated with the following pattern: `[@Bean name].[decapitalizedAnnotationClassShortName].[handler (or source)]`.
 
 IMPORTANT: When using these annotations on `@Bean` definitions, the `inputChannel` must reference a declared bean.
-Channels are not automatically declared in this case.
+Channels are automatically declared iif not present in the application context yet.
 
 [NOTE]
 =====


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3844

* Make `MessagingAnnotationPostProcessor` as a `BeanDefinitionRegistryPostProcessor`
to process bean definitions as early as possible and register respective messaging
components at that early phase
* Make bean definitions parsing logic optional for AOT and native mode since beans
have bean parsed during AOT building phase
* Introduce a `BeanDefinitionPropertiesMapper` for easier mapping
of the annotation attributes to the target `BeanDefinition`
* Remove `@Bean`-related logic from method parsing process
* Change the logic for `@Bean`-based endpoint bean names:
since we don't deal with methods on the bean definition phase, then method name
does not make sense.
It even may mislead if we `@Bean` name is based on a method by default, so we end up
with duplicated word in the target endpoint bean name.
Now we don't
* Fix `configuration.adoc` respectively for a new endpoint bean name logic
* In the end the new logic in the `AbstractMethodAnnotationPostProcessor`
is similar to XML parsers: we feed annotation attributes to the
`AbstractStandardMessageHandlerFactoryBean` impls

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
