### PR TITLE
Rework infra logic onto IntegrationProperties

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractSubscribableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/AbstractSubscribableAmqpChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
-import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.dispatcher.AbstractDispatcher;
 import org.springframework.integration.dispatcher.MessageDispatcher;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
@@ -166,10 +165,10 @@ abstract class AbstractSubscribableAmqpChannel extends AbstractAmqpChannel
 		super.onInit();
 		this.dispatcher = this.createDispatcher();
 		if (this.maxSubscribers == null) {
-			this.maxSubscribers = this.getIntegrationProperty(this.isPubSub ?
-							IntegrationProperties.CHANNELS_MAX_BROADCAST_SUBSCRIBERS :
-							IntegrationProperties.CHANNELS_MAX_UNICAST_SUBSCRIBERS,
-					Integer.class);
+			this.maxSubscribers =
+					this.isPubSub
+							? getIntegrationProperties().getChannelsMaxBroadcastSubscribers()
+							: getIntegrationProperties().getChannelsMaxUnicastSubscribers();
 		}
 		setMaxSubscribers(this.maxSubscribers);
 		String queue = obtainQueueName(this.channelName);

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.channel;
 
-import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.dispatcher.LoadBalancingStrategy;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
 import org.springframework.integration.dispatcher.UnicastingDispatcher;
@@ -86,10 +85,7 @@ public class DirectChannel extends AbstractSubscribableChannel {
 	protected void onInit() {
 		super.onInit();
 		if (this.maxSubscribers == null) {
-			Integer max = getIntegrationProperty(IntegrationProperties.CHANNELS_MAX_UNICAST_SUBSCRIBERS, Integer.class);
-			if (max != null) {
-				setMaxSubscribers(max);
-			}
+			setMaxSubscribers(getIntegrationProperties().getChannelsMaxUnicastSubscribers());
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.concurrent.Executor;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.IntegrationPatternType;
-import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
 import org.springframework.integration.util.ErrorHandlingTaskExecutor;
 import org.springframework.lang.Nullable;
@@ -38,9 +37,9 @@ import org.springframework.util.ErrorHandler;
  */
 public class PublishSubscribeChannel extends AbstractExecutorChannel implements BroadcastCapableChannel {
 
-	private ErrorHandler errorHandler;
-
 	private final boolean requireSubscribers;
+
+	private ErrorHandler errorHandler;
 
 	private boolean ignoreFailures;
 
@@ -122,7 +121,7 @@ public class PublishSubscribeChannel extends AbstractExecutorChannel implements 
 
 	/**
 	 * Specify whether failures for one or more of the handlers should be
-	 * ignored. By default this is false meaning that an Exception
+	 * ignored. By default, this is false meaning that an Exception
 	 * will be thrown whenever a handler fails. To override this and suppress
 	 * Exceptions, set the value to true.
 	 * @param ignoreFailures true if failures should be ignored.
@@ -188,9 +187,7 @@ public class PublishSubscribeChannel extends AbstractExecutorChannel implements 
 		}
 
 		if (this.maxSubscribers == null) {
-			Integer maxSubscribers =
-					getIntegrationProperty(IntegrationProperties.CHANNELS_MAX_BROADCAST_SUBSCRIBERS, Integer.class);
-			setMaxSubscribers(maxSubscribers);
+			setMaxSubscribers(getIntegrationProperties().getChannelsMaxBroadcastSubscribers());
 		}
 		dispatcherToUse.setBeanFactory(beanFactory);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -64,8 +64,6 @@ public abstract class IntegrationContextUtils {
 
 	public static final String INTEGRATION_GLOBAL_PROPERTIES_BEAN_NAME = "integrationGlobalProperties";
 
-	public static final String MERGED_INTEGRATION_GLOBAL_PROPERTIES_BEAN_NAME = "mergedIntegrationGlobalProperties";
-
 	public static final String CHANNEL_INITIALIZER_BEAN_NAME = "channelInitializer";
 
 	public static final String AUTO_CREATE_CHANNEL_CANDIDATES_BEAN_NAME = "$autoCreateChannelCandidates";

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.context;
 
-import java.util.Properties;
 import java.util.UUID;
 
 import org.springframework.aop.framework.AopProxyUtils;
@@ -86,7 +85,7 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	private TaskScheduler taskScheduler;
 
-	private Properties integrationProperties = IntegrationProperties.defaults();
+	private IntegrationProperties integrationProperties = new IntegrationProperties();
 
 	private ConversionService conversionService;
 
@@ -290,12 +289,9 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 
 	/**
 	 * @return The global integration properties.
-	 * @deprecated since version 5.5 in favor of {@link #getIntegrationProperty(String, Class)};
-	 * will be replaced with {@link IntegrationProperties} variant in the next major version.
 	 * @see IntegrationContextUtils#getIntegrationProperties(BeanFactory)
 	 */
-	@Deprecated
-	protected Properties getIntegrationProperties() {
+	protected IntegrationProperties getIntegrationProperties() {
 		return this.integrationProperties;
 	}
 
@@ -315,9 +311,11 @@ public abstract class IntegrationObjectSupport implements BeanNameAware, NamedCo
 	 * @param  tClass the class to convert a value of Integration property.
 	 * @param <T> The expected type of the property.
 	 * @return the value of the Integration property converted to the provide type.
+	 * @deprecated in favor of {@link #getIntegrationProperties()}
 	 */
+	@Deprecated(since = "6.0")
 	protected <T> T getIntegrationProperty(String key, Class<T> tClass) {
-		return this.defaultConversionService.convert(this.integrationProperties.getProperty(key), tClass);
+		return this.defaultConversionService.convert(this.integrationProperties.toProperties().getProperty(key), tClass);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,11 @@ import org.springframework.util.StringUtils;
  * @since 3.0
  */
 public final class IntegrationProperties {
+
+	/**
+	 * A singleton with default values.
+	 */
+	public static final IntegrationProperties DEFAULT_INSTANCE = new IntegrationProperties();
 
 	public static final String INTEGRATION_PROPERTIES_PREFIX = "spring.integration.";
 
@@ -127,6 +132,8 @@ public final class IntegrationProperties {
 
 	private String[] noAutoStartupEndpoints = { };
 
+	private volatile Properties properties;
+
 	static {
 		DEFAULTS = new IntegrationProperties().toProperties();
 	}
@@ -137,6 +144,7 @@ public final class IntegrationProperties {
 	 */
 	public void setChannelsAutoCreate(boolean channelsAutoCreate) {
 		this.channelsAutoCreate = channelsAutoCreate;
+		this.properties = null;
 	}
 
 	/**
@@ -153,6 +161,7 @@ public final class IntegrationProperties {
 	 */
 	public void setChannelsMaxUnicastSubscribers(int channelsMaxUnicastSubscribers) {
 		this.channelsMaxUnicastSubscribers = channelsMaxUnicastSubscribers;
+		this.properties = null;
 	}
 
 	/**
@@ -169,6 +178,7 @@ public final class IntegrationProperties {
 	 */
 	public void setChannelsMaxBroadcastSubscribers(int channelsMaxBroadcastSubscribers) {
 		this.channelsMaxBroadcastSubscribers = channelsMaxBroadcastSubscribers;
+		this.properties = null;
 	}
 
 	/**
@@ -185,6 +195,7 @@ public final class IntegrationProperties {
 	 */
 	public void setErrorChannelRequireSubscribers(boolean errorChannelRequireSubscribers) {
 		this.errorChannelRequireSubscribers = errorChannelRequireSubscribers;
+		this.properties = null;
 	}
 
 	/**
@@ -201,6 +212,7 @@ public final class IntegrationProperties {
 	 */
 	public void setErrorChannelIgnoreFailures(boolean errorChannelIgnoreFailures) {
 		this.errorChannelIgnoreFailures = errorChannelIgnoreFailures;
+		this.properties = null;
 	}
 
 	/**
@@ -217,6 +229,7 @@ public final class IntegrationProperties {
 	 */
 	public void setTaskSchedulerPoolSize(int taskSchedulerPoolSize) {
 		this.taskSchedulerPoolSize = taskSchedulerPoolSize;
+		this.properties = null;
 	}
 
 	/**
@@ -233,6 +246,7 @@ public final class IntegrationProperties {
 	 */
 	public void setMessagingTemplateThrowExceptionOnLateReply(boolean messagingTemplateThrowExceptionOnLateReply) {
 		this.messagingTemplateThrowExceptionOnLateReply = messagingTemplateThrowExceptionOnLateReply;
+		this.properties = null;
 	}
 
 	/**
@@ -250,6 +264,7 @@ public final class IntegrationProperties {
 	public void setReadOnlyHeaders(String... readOnlyHeaders) {
 		Assert.notNull(readOnlyHeaders, "'readOnlyHeaders' must not be null.");
 		this.readOnlyHeaders = Arrays.copyOf(readOnlyHeaders, readOnlyHeaders.length);
+		this.properties = null;
 	}
 
 	/**
@@ -267,6 +282,7 @@ public final class IntegrationProperties {
 	public void setNoAutoStartupEndpoints(String... noAutoStartupEndpoints) {
 		Assert.notNull(noAutoStartupEndpoints, "'noAutoStartupEndpoints' must not be null.");
 		this.noAutoStartupEndpoints = Arrays.copyOf(noAutoStartupEndpoints, noAutoStartupEndpoints.length);
+		this.properties = null;
 	}
 
 	/**
@@ -283,20 +299,24 @@ public final class IntegrationProperties {
 	 * @since 5.5
 	 */
 	public Properties toProperties() {
-		Properties properties = new Properties();
+		if (this.properties == null) {
+			Properties props = new Properties();
 
-		properties.setProperty(CHANNELS_AUTOCREATE, "" + this.channelsAutoCreate);
-		properties.setProperty(CHANNELS_MAX_UNICAST_SUBSCRIBERS, "" + this.channelsMaxUnicastSubscribers);
-		properties.setProperty(CHANNELS_MAX_BROADCAST_SUBSCRIBERS, "" + this.channelsMaxBroadcastSubscribers);
-		properties.setProperty(ERROR_CHANNEL_REQUIRE_SUBSCRIBERS, "" + this.errorChannelRequireSubscribers);
-		properties.setProperty(ERROR_CHANNEL_IGNORE_FAILURES, "" + this.errorChannelIgnoreFailures);
-		properties.setProperty(TASK_SCHEDULER_POOL_SIZE, "" + this.taskSchedulerPoolSize);
-		properties.setProperty(THROW_EXCEPTION_ON_LATE_REPLY, "" + this.messagingTemplateThrowExceptionOnLateReply);
-		properties.setProperty(READ_ONLY_HEADERS, StringUtils.arrayToCommaDelimitedString(this.readOnlyHeaders));
-		properties.setProperty(ENDPOINTS_NO_AUTO_STARTUP,
-				StringUtils.arrayToCommaDelimitedString(this.noAutoStartupEndpoints));
+			props.setProperty(CHANNELS_AUTOCREATE, "" + this.channelsAutoCreate);
+			props.setProperty(CHANNELS_MAX_UNICAST_SUBSCRIBERS, "" + this.channelsMaxUnicastSubscribers);
+			props.setProperty(CHANNELS_MAX_BROADCAST_SUBSCRIBERS, "" + this.channelsMaxBroadcastSubscribers);
+			props.setProperty(ERROR_CHANNEL_REQUIRE_SUBSCRIBERS, "" + this.errorChannelRequireSubscribers);
+			props.setProperty(ERROR_CHANNEL_IGNORE_FAILURES, "" + this.errorChannelIgnoreFailures);
+			props.setProperty(TASK_SCHEDULER_POOL_SIZE, "" + this.taskSchedulerPoolSize);
+			props.setProperty(THROW_EXCEPTION_ON_LATE_REPLY, "" + this.messagingTemplateThrowExceptionOnLateReply);
+			props.setProperty(READ_ONLY_HEADERS, StringUtils.arrayToCommaDelimitedString(this.readOnlyHeaders));
+			props.setProperty(ENDPOINTS_NO_AUTO_STARTUP,
+					StringUtils.arrayToCommaDelimitedString(this.noAutoStartupEndpoints));
 
-		return properties;
+			this.properties = props;
+		}
+
+		return this.properties;
 	}
 
 	/**
@@ -349,7 +369,7 @@ public final class IntegrationProperties {
 	public static String getExpressionFor(String key) {
 		if (DEFAULTS.containsKey(key)) {
 			return "#{T(org.springframework.integration.context.IntegrationContextUtils)" +
-					".getIntegrationProperties(beanFactory).getProperty('" + key + "')}";
+					".getIntegrationProperties(beanFactory).toProperties().getProperty('" + key + "')}";
 		}
 		else {
 			throw new IllegalArgumentException("The provided key [" + key +

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.springframework.integration.core;
 
-import java.util.Properties;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.context.IntegrationContextUtils;
@@ -32,6 +30,7 @@ import org.springframework.messaging.core.GenericMessagingTemplate;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ *
  * @since 1.0
  *
  */
@@ -85,11 +84,10 @@ public class MessagingTemplate extends GenericMessagingTemplate {
 		if (!this.throwExceptionOnLateReplySet) {
 			synchronized (this) {
 				if (!this.throwExceptionOnLateReplySet) {
-					Properties integrationProperties =
+					IntegrationProperties integrationProperties =
 							IntegrationContextUtils.getIntegrationProperties(this.beanFactory);
-					Boolean throwExceptionOnLateReply = Boolean.valueOf(integrationProperties
-							.getProperty(IntegrationProperties.THROW_EXCEPTION_ON_LATE_REPLY));
-					super.setThrowExceptionOnLateReply(throwExceptionOnLateReply);
+					super.setThrowExceptionOnLateReply(
+							integrationProperties.isMessagingTemplateThrowExceptionOnLateReply());
 					this.throwExceptionOnLateReplySet = true;
 				}
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -23,7 +23,6 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationObjectSupport;
-import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.support.SmartLifecycleRoleController;
 import org.springframework.integration.support.management.IntegrationManagedResource;
 import org.springframework.integration.support.management.ManageableSmartLifecycle;
@@ -98,9 +97,7 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 		super.onInit();
 
 		if (!this.autoStartupSetExplicitly) {
-			String[] endpointNamePatterns =
-					getIntegrationProperty(IntegrationProperties.ENDPOINTS_NO_AUTO_STARTUP, String[].class);
-
+			String[] endpointNamePatterns = getIntegrationProperties().getNoAutoStartupEndpoints();
 			for (String pattern : endpointNamePatterns) {
 				if (PatternMatchUtils.simpleMatch(pattern, getComponentName())) {
 					this.autoStartup = false;

--- a/spring-integration-core/src/test/java/org/springframework/integration/context/IntegrationContextTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/context/IntegrationContextTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2021 the original author or authors.
+ * Copyright 2013-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,6 @@
 package org.springframework.integration.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Properties;
 
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +37,7 @@ public class IntegrationContextTests {
 
 	@Autowired
 	@Qualifier(IntegrationContextUtils.INTEGRATION_GLOBAL_PROPERTIES_BEAN_NAME)
-	private Properties integrationProperties;
+	private IntegrationProperties integrationProperties;
 
 	@Autowired
 	@Qualifier("fooService")
@@ -53,12 +51,10 @@ public class IntegrationContextTests {
 	private ThreadPoolTaskScheduler taskScheduler;
 
 	@Test
-	@SuppressWarnings("deprecation")
 	public void testIntegrationContextComponents() {
-		assertThat(this.integrationProperties.get(IntegrationProperties.THROW_EXCEPTION_ON_LATE_REPLY))
-				.isEqualTo("true");
-		assertThat(this.integrationProperties.get(IntegrationProperties.TASK_SCHEDULER_POOL_SIZE)).isEqualTo("20");
-		assertThat(this.serviceActivator.getIntegrationProperties()).isEqualTo(this.integrationProperties);
+		assertThat(this.integrationProperties.isMessagingTemplateThrowExceptionOnLateReply()).isTrue();
+		assertThat(this.integrationProperties.getTaskSchedulerPoolSize()).isEqualTo(20);
+		assertThat(this.serviceActivator.getIntegrationProperties()).isSameAs(this.integrationProperties);
 		assertThat(TestUtils.getPropertyValue(this.taskScheduler, "poolSize")).isEqualTo(20);
 		assertThat(this.serviceActivator.isAutoStartup()).isFalse();
 		assertThat(this.serviceActivator.isRunning()).isFalse();

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/SubscribableJmsChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.channel.BroadcastCapableChannel;
-import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.dispatcher.AbstractDispatcher;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
 import org.springframework.integration.dispatcher.MessageDispatcher;
@@ -126,10 +125,10 @@ public class SubscribableJmsChannel extends AbstractJmsChannel
 			this.dispatcher = unicastingDispatcher;
 		}
 		if (this.maxSubscribers == null) {
-			this.maxSubscribers = this.getIntegrationProperty(isPubSub ?
-							IntegrationProperties.CHANNELS_MAX_BROADCAST_SUBSCRIBERS :
-							IntegrationProperties.CHANNELS_MAX_UNICAST_SUBSCRIBERS,
-					Integer.class);
+			this.maxSubscribers =
+					isPubSub
+							? getIntegrationProperties().getChannelsMaxBroadcastSubscribers()
+							: getIntegrationProperties().getChannelsMaxUnicastSubscribers();
 		}
 		this.dispatcher.setMaxSubscribers(this.maxSubscribers);
 	}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.channel.BroadcastCapableChannel;
 import org.springframework.integration.channel.ChannelUtils;
-import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
 import org.springframework.integration.support.converter.SimpleMessageConverter;
 import org.springframework.integration.support.management.ManageableSmartLifecycle;
@@ -139,8 +138,7 @@ public class SubscribableRedisChannel extends AbstractMessageChannel
 		}
 		super.onInit();
 		if (this.maxSubscribers == null) {
-			setMaxSubscribers(
-					getIntegrationProperty(IntegrationProperties.CHANNELS_MAX_BROADCAST_SUBSCRIBERS, Integer.class));
+			setMaxSubscribers(getIntegrationProperties().getChannelsMaxBroadcastSubscribers());
 		}
 		if (this.messageConverter == null) {
 			this.messageConverter = new SimpleMessageConverter();

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -60,7 +60,7 @@ All Spring Integration async API has been migrated to the `CompletableFuture`.
 
 See <<./gateway.adoc#gw-completable-future, CompletableFuture support>> for more information.
 
-The `integrationGlobalProperties` bean is now declared by the framework as an instance of `org.springframework.integration.context.IntegrationProperties` instead of deprecated before `java.util.Properties`.
+The `integrationGlobalProperties` bean is now declared by the framework as an instance of `org.springframework.integration.context.IntegrationProperties` instead of the previously deprecated `java.util.Properties`.
 
 [[x6.0-http]]
 === HTTP Changes

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -60,6 +60,8 @@ All Spring Integration async API has been migrated to the `CompletableFuture`.
 
 See <<./gateway.adoc#gw-completable-future, CompletableFuture support>> for more information.
 
+The `integrationGlobalProperties` bean is now declared by the framework as an instance of `org.springframework.integration.context.IntegrationProperties` instead of deprecated before `java.util.Properties`.
+
 [[x6.0-http]]
 === HTTP Changes
 


### PR DESCRIPTION
The `Properties` bean has been deprecated since `5.5`

* Register a default `integrationGlobalProperties` as a `IntegrationProperties`
* Fix respective usages from the `Properties`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
