### PR TITLE
Improve AOT for some infrastructure

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aot/CoreRuntimeHints.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aot/CoreRuntimeHints.java
@@ -38,8 +38,10 @@ import org.springframework.aot.hint.TypeReference;
 import org.springframework.beans.factory.config.BeanExpressionContext;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.core.DecoratingProxy;
+import org.springframework.integration.aggregator.MessageGroupProcessor;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.GenericSelector;
+import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.gateway.MethodArgsHolder;
 import org.springframework.integration.gateway.RequestReplyExchanger;
@@ -56,7 +58,9 @@ import org.springframework.integration.store.MessageMetadata;
 import org.springframework.integration.support.MutableMessage;
 import org.springframework.integration.support.MutableMessageHeaders;
 import org.springframework.integration.transformer.GenericTransformer;
+import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 
@@ -134,6 +138,10 @@ class CoreRuntimeHints implements RuntimeHintsRegistrar {
 
 		ProxyHints proxyHints = hints.proxies();
 
+		registerSpringJdkProxy(proxyHints, PollableChannel.class);
+		registerSpringJdkProxy(proxyHints, MessageSource.class);
+		registerSpringJdkProxy(proxyHints, MessageHandler.class);
+		registerSpringJdkProxy(proxyHints, MessageGroupProcessor.class);
 		registerSpringJdkProxy(proxyHints, RequestReplyExchanger.class);
 		registerSpringJdkProxy(proxyHints, AbstractReplyProducingMessageHandler.RequestHandler.class);
 		registerSpringJdkProxy(proxyHints, IntegrationFlow.class, SmartLifecycle.class);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aot/IntegrationBeanRegistrationExcludeFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aot/IntegrationBeanRegistrationExcludeFilter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.aot;
+
+import java.util.Arrays;
+
+import org.springframework.beans.factory.aot.BeanRegistrationExcludeFilter;
+import org.springframework.beans.factory.support.RegisteredBean;
+import org.springframework.integration.config.DefaultConfiguringBeanFactoryPostProcessor;
+import org.springframework.integration.config.IntegrationConfigurationBeanFactoryPostProcessor;
+
+/**
+ * The {@link BeanRegistrationExcludeFilter} to exclude beans not need at runtime anymore.
+ * Usually {@link org.springframework.beans.factory.config.BeanFactoryPostProcessor} beans
+ * are excluded since they have contributed their bean definitions code generated during AOT
+ * build phase.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+class IntegrationBeanRegistrationExcludeFilter implements BeanRegistrationExcludeFilter {
+
+	@Override
+	public boolean isExcludedFromAotProcessing(RegisteredBean registeredBean) {
+		Class<?> beanClass = registeredBean.getBeanClass();
+		return Arrays.asList(DefaultConfiguringBeanFactoryPostProcessor.class,
+						IntegrationConfigurationBeanFactoryPostProcessor.class)
+				.contains(beanClass);
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
@@ -23,7 +23,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ThreadPoolExecutor.CallerRunsPolicy;
 
-import org.springframework.aot.AotDetector;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.HierarchicalBeanFactory;
@@ -107,28 +106,26 @@ public class DefaultConfiguringBeanFactoryPostProcessor
 
 	@Override
 	public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
-		if (!AotDetector.useGeneratedArtifacts()) {
-			this.registry = registry;
-			this.beanFactory = (ConfigurableListableBeanFactory) registry;
+		this.registry = registry;
+		this.beanFactory = (ConfigurableListableBeanFactory) registry;
 
-			registerBeanFactoryChannelResolver();
-			registerMessagePublishingErrorHandler();
-			registerNullChannel();
-			registerErrorChannel();
-			registerIntegrationEvaluationContext();
-			registerTaskScheduler();
-			registerIdGeneratorConfigurer();
-			registerIntegrationProperties();
-			registerBuiltInBeans();
-			registerRoleController();
-			registerMessageBuilderFactory();
-			registerHeaderChannelRegistry();
-			registerGlobalChannelInterceptorProcessor();
-			registerDefaultDatatypeChannelMessageConverter();
-			registerArgumentResolverMessageConverter();
-			registerMessageHandlerMethodFactory();
-			registerListMessageHandlerMethodFactory();
-		}
+		registerBeanFactoryChannelResolver();
+		registerMessagePublishingErrorHandler();
+		registerNullChannel();
+		registerErrorChannel();
+		registerIntegrationEvaluationContext();
+		registerTaskScheduler();
+		registerIdGeneratorConfigurer();
+		registerIntegrationProperties();
+		registerBuiltInBeans();
+		registerRoleController();
+		registerMessageBuilderFactory();
+		registerHeaderChannelRegistry();
+		registerGlobalChannelInterceptorProcessor();
+		registerDefaultDatatypeChannelMessageConverter();
+		registerArgumentResolverMessageConverter();
+		registerMessageHandlerMethodFactory();
+		registerListMessageHandlerMethodFactory();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConfigurationBeanFactoryPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConfigurationBeanFactoryPostProcessor.java
@@ -18,7 +18,6 @@ package org.springframework.integration.config;
 
 import java.util.List;
 
-import org.springframework.aot.AotDetector;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -39,16 +38,14 @@ public class IntegrationConfigurationBeanFactoryPostProcessor implements BeanDef
 
 	@Override
 	public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
-		if (!AotDetector.useGeneratedArtifacts()) {
-			ConfigurableListableBeanFactory beanFactory = (ConfigurableListableBeanFactory) registry;
+		ConfigurableListableBeanFactory beanFactory = (ConfigurableListableBeanFactory) registry;
 
-			List<IntegrationConfigurationInitializer> initializers =
-					SpringFactoriesLoader.loadFactories(IntegrationConfigurationInitializer.class,
-							beanFactory.getBeanClassLoader());
+		List<IntegrationConfigurationInitializer> initializers =
+				SpringFactoriesLoader.loadFactories(IntegrationConfigurationInitializer.class,
+						beanFactory.getBeanClassLoader());
 
-			for (IntegrationConfigurationInitializer initializer : initializers) {
-				initializer.initialize(beanFactory);
-			}
+		for (IntegrationConfigurationInitializer initializer : initializers) {
+			initializer.initialize(beanFactory);
 		}
 	}
 

--- a/spring-integration-core/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-integration-core/src/main/resources/META-INF/spring/aot.factories
@@ -1,2 +1,3 @@
 org.springframework.aot.hint.RuntimeHintsRegistrar=org.springframework.integration.aot.CoreRuntimeHints
 org.springframework.beans.factory.aot.BeanRegistrationAotProcessor=org.springframework.integration.aot.GatewayProxyBeanRegistrationAotProcessor
+org.springframework.beans.factory.aot.BeanRegistrationExcludeFilter=org.springframework.integration.aot.IntegrationBeanRegistrationExcludeFilter


### PR DESCRIPTION
* Add more proxy hints for interfaces we use in the framework code
* Implement `BeanRegistrationExcludeFilter` to exlude `BeanFactoryPostProcessor` beans
* Remove `AotDetector.useGeneratedArtifacts()` from those `BFPP`s

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
