### PR TITLE
GH-3660: Invoke well-known lambdas explicitly

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/LambdaMessageProcessorTests.java
@@ -23,7 +23,6 @@ import java.util.Date;
 import java.util.Objects;
 import java.util.function.Function;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -107,7 +106,6 @@ public class LambdaMessageProcessorTests {
 
 
 	@Test
-	@Disabled("Until https://github.com/spring-projects/spring-integration/issues/3660")
 	public void testCustomConverter() {
 		LambdaMessageProcessor lmp = new LambdaMessageProcessor(Function.identity(), TestPojo.class);
 		lmp.setBeanFactory(this.beanFactory);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3660

* Change the `LambdaMessageProcessor` to invoke `Function`, `GenericHandler`, `GenericSelector` & `GenericTransformer` explicitly without reflection. This allows to avoid `--add-opens` for Java types to be used from reflections. Plus this removes some overhead with native images. And in general it is faster than reflection invocation.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
