### PR TITLE
GH-3661: Fix Javadocs for RetryingMLA

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
@@ -72,9 +72,7 @@ public class KafkaInboundGatewaySpec<K, V, R, S extends KafkaInboundGatewaySpec<
 	}
 
 	/**
-	 * Specify a {@link RetryTemplate} instance to wrap
-	 * {@code KafkaInboundGateway.IntegrationRecordMessageListener} into
-	 * {@link org.springframework.kafka.listener.adapter.RetryingMessageListenerAdapter}.
+	 * Specify a {@link RetryTemplate} instance to use for retrying deliveries.
 	 * @param retryTemplate the {@link RetryTemplate} to use.
 	 * @return the spec
 	 */

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
@@ -118,9 +118,7 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 	}
 
 	/**
-	 * Specify a {@link RetryTemplate} instance to wrap
-	 * {@code KafkaMessageDrivenChannelAdapter.IntegrationRecordMessageListener} into
-	 * {@link org.springframework.kafka.listener.adapter.RetryingMessageListenerAdapter}.
+	 * Specify a {@link RetryTemplate} instance to use for retrying deliveries.
 	 * @param retryTemplate the {@link RetryTemplate} to use.
 	 * @return the spec
 	 */
@@ -153,17 +151,13 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 	}
 
 	/**
-	 * The {@code boolean} flag to specify the order how
-	 * {@link org.springframework.kafka.listener.adapter.RetryingMessageListenerAdapter}
-	 * and
-	 * {@link org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapter}
-	 * are wrapped to each other, if both of them are present. Does not make sense if only
-	 * one of {@link RetryTemplate} or {@link RecordFilterStrategy} is present, or any.
-	 * @param filterInRetry the order for
-	 * {@link org.springframework.kafka.listener.adapter.RetryingMessageListenerAdapter}
-	 * and
-	 * {@link org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapter}
-	 * wrapping. Defaults to {@code false}.
+	 * The {@code boolean} flag to specify the order in which the filter and retry
+	 * operations are performed.
+	 * Does not make sense if only one of {@link RetryTemplate} or
+	 * {@link RecordFilterStrategy} is present, or none.
+	 * When true, the filter is called for each retry; when false, the filter is only
+	 * called once for each delivery from the container.
+	 * @param filterInRetry true to filter for each retry. Defaults to {@code false}.
 	 * @return the spec
 	 */
 	public S filterInRetry(boolean filterInRetry) {

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -140,9 +140,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 	}
 
 	/**
-	 * Specify a {@link RetryTemplate} instance to wrap
-	 * {@link KafkaInboundGateway.IntegrationRecordMessageListener} into
-	 * {@code RetryingMessageListenerAdapter}.
+	 * Specify a {@link RetryTemplate} instance to use for retrying deliveries.
 	 * <p>
 	 * IMPORTANT: This form of retry is blocking and could cause a rebalance if the
 	 * aggregate retry delays across all polled records might exceed the

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -199,9 +199,7 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 	}
 
 	/**
-	 * Specify a {@link RetryTemplate} instance to wrap
-	 * {@link KafkaMessageDrivenChannelAdapter.IntegrationRecordMessageListener} into
-	 * {@code RetryingMessageListenerAdapter}.
+	 * Specify a {@link RetryTemplate} instance to use for retrying deliveries.
 	 * <p>
 	 * IMPORTANT: This form of retry is blocking and could cause a rebalance if the
 	 * aggregate retry delays across all polled records might exceed the
@@ -231,16 +229,13 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 	}
 
 	/**
-	 * The {@code boolean} flag to specify the order how
-	 * {@code RetryingMessageListenerAdapter} and
-	 * {@link FilteringMessageListenerAdapter} are wrapped to each other,
-	 * if both of them are present.
+	 * The {@code boolean} flag to specify the order in which the filter and retry
+	 * operations are performed.
 	 * Does not make sense if only one of {@link RetryTemplate} or
-	 * {@link RecordFilterStrategy} is present, or any.
+	 * {@link RecordFilterStrategy} is present, or none.
 	 * When true, the filter is called for each retry; when false, the filter is only
 	 * called once for each delivery from the container.
-	 * @param filterInRetry the order for {@code RetryingMessageListenerAdapter} and
-	 * {@link FilteringMessageListenerAdapter} wrapping. Defaults to {@code false}.
+	 * @param filterInRetry true to filter for each retry. Defaults to {@code false}.
 	 */
 	public void setFilterInRetry(boolean filterInRetry) {
 		this.filterInRetry = filterInRetry;


### PR DESCRIPTION
Use of the `RetryingMessageListenerAdapter` was removed in https://github.com/spring-projects/spring-integration/commit/0550380704afd50e8ac0b03893e3c53107e1b874 but the javadocs were not corrected.
