### PR TITLE
GH-3902: Add Kotlin Coroutines Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ ext {
     junit4Version = '4.13.2'
     junitJupiterVersion = '5.9.0'
     jythonVersion = '2.7.3'
+    kotlinCoroutinesVersion = '1.6.4'
     kryoVersion = '5.3.0'
     lettuceVersion = '6.2.0.RELEASE'
     log4jVersion = '2.19.0'
@@ -168,6 +169,7 @@ allprojects {
             mavenBom "org.apache.camel:camel-bom:$camelVersion"
             mavenBom "org.testcontainers:testcontainers-bom:$testcontainersVersion"
             mavenBom "org.apache.groovy:groovy-bom:$groovyVersion"
+            mavenBom "org.jetbrains.kotlinx:kotlinx-coroutines-bom:$kotlinCoroutinesVersion"
         }
 
     }
@@ -541,7 +543,7 @@ project('spring-integration-core') {
         }
         optionalApi "io.github.resilience4j:resilience4j-ratelimiter:$resilience4jVersion"
         optionalApi "org.apache.avro:avro:$avroVersion"
-        optionalApi 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+        optionalApi 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor'
 
         testImplementation "org.aspectj:aspectjweaver:$aspectjVersion"
         testImplementation "org.hamcrest:hamcrest-core:$hamcrestVersion"

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/DefaultConfiguringBeanFactoryPostProcessor.java
@@ -45,6 +45,7 @@ import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.context.IntegrationProperties;
 import org.springframework.integration.handler.LoggingHandler;
+import org.springframework.integration.handler.support.IntegrationMessageHandlerMethodFactory;
 import org.springframework.integration.json.JsonPathUtils;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.SmartLifecycleRoleController;
@@ -462,10 +463,10 @@ public class DefaultConfiguringBeanFactoryPostProcessor
 	}
 
 	private static BeanDefinitionBuilder createMessageHandlerMethodFactoryBeanDefinition(boolean listCapable) {
-		return BeanDefinitionBuilder.genericBeanDefinition(MessageHandlerMethodFactoryCreatingFactoryBean.class,
-						() -> new MessageHandlerMethodFactoryCreatingFactoryBean(listCapable))
+		return BeanDefinitionBuilder.genericBeanDefinition(IntegrationMessageHandlerMethodFactory.class,
+						() -> new IntegrationMessageHandlerMethodFactory(listCapable))
 				.addConstructorArgValue(listCapable)
-				.addPropertyReference("argumentResolverMessageConverter",
+				.addPropertyReference("messageConverter",
 						IntegrationContextUtils.ARGUMENT_RESOLVER_MESSAGE_CONVERTER_BEAN_NAME);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMethodInboundMessageMapper.java
@@ -44,6 +44,7 @@ import org.springframework.integration.mapping.MessageMappingException;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
+import org.springframework.integration.util.CoroutinesUtils;
 import org.springframework.integration.util.MessagingAnnotationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
@@ -289,6 +290,9 @@ class GatewayMethodInboundMessageMapper implements InboundMessageMapper<Object[]
 			for (int i = 0; i < GatewayMethodInboundMessageMapper.this.parameterList.size(); i++) {
 				Object argumentValue = arguments[i];
 				MethodParameter methodParameter = GatewayMethodInboundMessageMapper.this.parameterList.get(i);
+				if (CoroutinesUtils.isContinuationType(methodParameter.getParameterType())) {
+					continue;
+				}
 				Annotation annotation =
 						MessagingAnnotationUtils.findMessagePartAnnotation(methodParameter.getParameterAnnotations(),
 								false);

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -582,7 +582,7 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		Object continuation = null;
 		if (gateway.isSuspendingFunction) {
 			for (Object argument : invocation.getArguments()) {
-				if (CoroutinesUtils.KOTLIN_CONTINUATION_CLASS.isAssignableFrom(argument.getClass())) {
+				if (argument != null && CoroutinesUtils.isContinuation(argument)) {
 					continuation = argument;
 					break;
 				}
@@ -1029,8 +1029,8 @@ public class GatewayProxyFactoryBean extends AbstractEndpoint
 		this.gatewayMap.values().forEach(MethodInvocationGateway::stop);
 	}
 
-	@SuppressWarnings("unchecked")
 	@Nullable
+	@SuppressWarnings("unchecked")
 	private <T> T convert(Object source, Class<T> expectedReturnType, @Nullable Object continuation) {
 		if (continuation != null) {
 			return CoroutinesUtils.monoAwaitSingleOrNull((Mono<T>) source, continuation);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
@@ -102,6 +102,10 @@ public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<
 		return this.delegate.isRunning();
 	}
 
+	public boolean isAsync() {
+		return this.delegate.isAsync();
+	}
+
 	@Override
 	@Nullable
 	@SuppressWarnings("unchecked")

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
@@ -18,9 +18,7 @@ package org.springframework.integration.handler;
 
 import java.lang.reflect.Method;
 
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.context.Lifecycle;
-import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.IntegrationPattern;
 import org.springframework.integration.IntegrationPatternType;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -69,15 +67,7 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 
 	@Override
 	protected void doInit() {
-		if (this.processor instanceof AbstractMessageProcessor) {
-			ConversionService conversionService = getConversionService();
-			if (conversionService != null) {
-				((AbstractMessageProcessor<?>) this.processor).setConversionService(conversionService);
-			}
-		}
-		if (this.processor instanceof BeanFactoryAware && this.getBeanFactory() != null) {
-			((BeanFactoryAware) this.processor).setBeanFactory(this.getBeanFactory());
-		}
+		setupMessageProcessor(this.processor);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/ContinuationHandlerMethodArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/ContinuationHandlerMethodArgumentResolver.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler.support;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.integration.util.CoroutinesUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * No-op resolver for method arguments of type {@link kotlin.coroutines.Continuation}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+public class ContinuationHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return CoroutinesUtils.isContinuationType(parameter.getParameterType());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+		return Mono.empty();
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationInvocableHandlerMethod.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationInvocableHandlerMethod.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler.support;
+
+import java.lang.reflect.Method;
+
+import org.springframework.core.CoroutinesUtils;
+import org.springframework.core.KotlinDetector;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+
+/**
+ * An {@link InvocableHandlerMethod} extension for Spring Integration requirements.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ */
+public class IntegrationInvocableHandlerMethod extends InvocableHandlerMethod {
+
+	public IntegrationInvocableHandlerMethod(Object bean, Method method) {
+		super(bean, method);
+	}
+
+	@Override
+	protected Object doInvoke(Object... args) throws Exception {
+		Method method = getBridgedMethod();
+		if (KotlinDetector.isSuspendingFunction(method)) {
+			return CoroutinesUtils.invokeSuspendingFunction(method, getBean(), args);
+		}
+		else {
+			return super.doInvoke(args);
+		}
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationMessageHandlerMethodFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationMessageHandlerMethodFactory.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.KotlinDetector;
 import org.springframework.integration.support.NullAwarePayloadArgumentResolver;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
@@ -98,7 +99,9 @@ public class IntegrationMessageHandlerMethodFactory extends DefaultMessageHandle
 			resolvers.add(new CollectionArgumentResolver(true));
 		}
 		resolvers.add(new MapArgumentResolver());
-		resolvers.add(new ContinuationHandlerMethodArgumentResolver());
+		if (KotlinDetector.isKotlinPresent()) {
+			resolvers.add(new ContinuationHandlerMethodArgumentResolver());
+		}
 
 		for (HandlerMethodArgumentResolver resolver : resolvers) {
 			if (resolver instanceof BeanFactoryAware) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -33,13 +33,11 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.commons.logging.LogFactory;
-import org.reactivestreams.Publisher;
 
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.AopProxyUtils;
@@ -55,7 +53,6 @@ import org.springframework.core.KotlinDetector;
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ParameterNameDiscoverer;
-import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.convert.ConversionFailedException;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -1025,10 +1025,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 	public boolean isAsync() {
 		if (this.handlerMethodsList.size() == 1) {
 			Method methodToCheck = this.handlerMethodsList.get(0).values().iterator().next().method;
-			return Publisher.class.isAssignableFrom(methodToCheck.getReturnType())
-					|| CompletableFuture.class.isAssignableFrom(methodToCheck.getReturnType())
-					|| KotlinDetector.isSuspendingFunction(methodToCheck)
-					|| ReactiveAdapterRegistry.getSharedInstance().getAdapter(methodToCheck.getReturnType()) != null;
+			return KotlinDetector.isSuspendingFunction(methodToCheck);
 		}
 		return false;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -33,11 +33,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
 import org.apache.commons.logging.LogFactory;
+import org.reactivestreams.Publisher;
 
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.AopProxyUtils;
@@ -49,9 +51,11 @@ import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.Lifecycle;
 import org.springframework.context.expression.StandardBeanExpressionResolver;
+import org.springframework.core.KotlinDetector;
 import org.springframework.core.LocalVariableTableParameterNameDiscoverer;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.ParameterNameDiscoverer;
+import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.convert.ConversionFailedException;
@@ -73,13 +77,13 @@ import org.springframework.integration.annotation.UseSpelInvoker;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.Pausable;
 import org.springframework.integration.support.MutableMessage;
-import org.springframework.integration.support.NullAwarePayloadArgumentResolver;
 import org.springframework.integration.support.converter.ConfigurableCompositeMessageConverter;
 import org.springframework.integration.support.json.JsonObjectMapper;
 import org.springframework.integration.support.json.JsonObjectMapperProvider;
 import org.springframework.integration.support.management.ManageableLifecycle;
 import org.springframework.integration.util.AbstractExpressionEvaluator;
 import org.springframework.integration.util.AnnotatedMethodFilter;
+import org.springframework.integration.util.CoroutinesUtils;
 import org.springframework.integration.util.FixedMethodFilter;
 import org.springframework.integration.util.MessagingAnnotationUtils;
 import org.springframework.integration.util.UniqueMethodFilter;
@@ -91,9 +95,7 @@ import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
-import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.messaging.handler.invocation.MethodArgumentResolutionException;
 import org.springframework.util.Assert;
@@ -119,7 +121,6 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Trung Pham
- *
  * @since 2.0
  */
 public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator implements ManageableLifecycle {
@@ -162,8 +163,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		SPEL_COMPILERS.put(SpelCompilerMode.MIXED, EXPRESSION_PARSER_MIXED);
 	}
 
-	private MessageHandlerMethodFactory messageHandlerMethodFactory =
-			new DefaultMessageHandlerMethodFactory();
+	private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
 	private final Object targetObject;
 
@@ -521,7 +521,6 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 	 * This should not be needed in production but we have many tests
 	 * that don't run in an application context.
 	 */
-
 	private void initializeHandler(HandlerMethod candidate) {
 		ExpressionParser parser;
 		if (candidate.useSpelInvoker == null) {
@@ -547,35 +546,13 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		messageConverter.setBeanFactory(beanFactory);
 		messageConverter.afterPropertiesSet();
 
-		List<HandlerMethodArgumentResolver> customArgumentResolvers = new LinkedList<>();
-		PayloadExpressionArgumentResolver payloadExpressionArgumentResolver = new PayloadExpressionArgumentResolver();
-		PayloadsArgumentResolver payloadsArgumentResolver = new PayloadsArgumentResolver();
-
-		customArgumentResolvers.add(payloadExpressionArgumentResolver);
-		customArgumentResolvers.add(new NullAwarePayloadArgumentResolver(messageConverter));
-		customArgumentResolvers.add(payloadsArgumentResolver);
-
-		CollectionArgumentResolver collectionArgumentResolver = null;
-
-		if (this.canProcessMessageList) {
-			collectionArgumentResolver = new CollectionArgumentResolver(true);
-			customArgumentResolvers.add(collectionArgumentResolver);
-		}
-
-		MapArgumentResolver mapArgumentResolver = new MapArgumentResolver();
-		customArgumentResolvers.add(mapArgumentResolver);
-		payloadExpressionArgumentResolver.setBeanFactory(beanFactory);
-		payloadsArgumentResolver.setBeanFactory(beanFactory);
-		mapArgumentResolver.setBeanFactory(beanFactory);
-		if (collectionArgumentResolver != null) {
-			collectionArgumentResolver.setBeanFactory(beanFactory);
-		}
-
-		DefaultMessageHandlerMethodFactory localHandlerMethodFactory =
-				(DefaultMessageHandlerMethodFactory) this.messageHandlerMethodFactory;
+		IntegrationMessageHandlerMethodFactory localHandlerMethodFactory =
+				new IntegrationMessageHandlerMethodFactory(this.canProcessMessageList);
 		localHandlerMethodFactory.setMessageConverter(messageConverter);
-		localHandlerMethodFactory.setCustomArgumentResolvers(customArgumentResolvers);
+		localHandlerMethodFactory.setBeanFactory(beanFactory);
 		localHandlerMethodFactory.afterPropertiesSet();
+
+		this.messageHandlerMethodFactory = localHandlerMethodFactory;
 	}
 
 	@Nullable
@@ -802,7 +779,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 						AopUtils.selectInvocableMethod(methodToProcess, ClassUtils.getUserClass(this.targetObject)));
 			}
 			catch (Exception ex) {
-					LOGGER.debug(ex, "Method [" + methodToProcess + "] is not eligible for Message handling.");
+				LOGGER.debug(ex, "Method [" + methodToProcess + "] is not eligible for Message handling.");
 				return null;
 			}
 
@@ -828,9 +805,9 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 	private boolean isPausableMethod(Method pausableMethod) {
 		Class<?> declaringClass = pausableMethod.getDeclaringClass();
 		boolean pausable = (Pausable.class.isAssignableFrom(declaringClass)
-					|| Lifecycle.class.isAssignableFrom(declaringClass))
+				|| Lifecycle.class.isAssignableFrom(declaringClass))
 				&& ReflectionUtils.findMethod(Pausable.class, pausableMethod.getName(),
-						pausableMethod.getParameterTypes()) != null;
+				pausableMethod.getParameterTypes()) != null;
 		if (pausable) {
 			this.logger.trace(() -> pausableMethod + " is not considered a candidate method unless explicitly requested");
 		}
@@ -870,7 +847,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			if (handlerMethod1.isMessageMethod()) {
 				if (fallbackMessageMethods.containsKey(targetParameterType)) {
 					// we need to check for duplicate type matches,
-					// but only if we end up falling back
+					// but only if we end up falling back,
 					// and we'll only keep track of the first one
 					ambiguousFallbackMessageGenericType.compareAndSet(null, targetParameterType);
 				}
@@ -910,7 +887,6 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			Map<Class<?>, HandlerMethod> candidateMethods) {
 		if (AopUtils.isAopProxy(this.targetObject)) {
 			final AtomicReference<Method> targetMethod = new AtomicReference<>();
-			final AtomicReference<Class<?>> targetClass = new AtomicReference<>();
 			Class<?>[] interfaces = ((Advised) this.targetObject).getProxiedInterfaces();
 			for (Class<?> clazz : interfaces) {
 				ReflectionUtils.doWithMethods(clazz, method1 -> {
@@ -920,7 +896,6 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 					}
 					else {
 						targetMethod.set(method1);
-						targetClass.set(clazz);
 					}
 				}, method12 -> method12.getName().equals(this.methodName));
 			}
@@ -1047,6 +1022,17 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 						&& method.getParameterTypes().length == 0));
 	}
 
+	public boolean isAsync() {
+		if (this.handlerMethodsList.size() == 1) {
+			Method methodToCheck = this.handlerMethodsList.get(0).values().iterator().next().method;
+			return Publisher.class.isAssignableFrom(methodToCheck.getReturnType())
+					|| CompletableFuture.class.isAssignableFrom(methodToCheck.getReturnType())
+					|| KotlinDetector.isSuspendingFunction(methodToCheck)
+					|| ReactiveAdapterRegistry.getSharedInstance().getAdapter(methodToCheck.getReturnType()) != null;
+		}
+		return false;
+	}
+
 	/**
 	 * Helper class for generating and exposing metadata for a candidate handler method. The metadata includes the SpEL
 	 * expression and the expected payload type.
@@ -1079,7 +1065,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 		// The number of times InvocableHandlerMethod was attempted and failed - enables us to eventually
 		// give up trying to call it when it just doesn't seem to be possible.
-		// Switching to spelOnly afterwards forever.
+		// Switching to 'spelOnly' afterwards forever.
 		private volatile int failedAttempts = 0;
 
 		HandlerMethod(Method method, boolean canProcessMessageList) {
@@ -1190,6 +1176,9 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 								+ "Consider using @Payload or @Headers on at least one of the parameters.");
 				populateMapParameterForExpression(sb, parameterType);
 				return true;
+			}
+			else if (CoroutinesUtils.isContinuationType(parameterType)) {
+				sb.append("null");
 			}
 			else {
 				sb.append("payload");
@@ -1370,7 +1359,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		/**
 		 * SpEL Function to retrieve a required header.
 		 * @param headers the headers.
-		 * @param header the header name
+		 * @param header  the header name
 		 * @return the header
 		 * @throws IllegalArgumentException if the header does not exist
 		 */

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -488,7 +488,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 	private synchronized void initialize() {
 		if (isProvidedMessageHandlerFactoryBean()) {
-			LOGGER.trace("Overriding default instance of MessageHandlerMethodFactory with provided one.");
+			LOGGER.trace("Overriding default instance of MessageHandlerMethodFactory with the one provided.");
 			this.messageHandlerMethodFactory =
 					getBeanFactory()
 							.getBean(

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -488,7 +488,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 	private synchronized void initialize() {
 		if (isProvidedMessageHandlerFactoryBean()) {
-			LOGGER.info("Overriding default instance of MessageHandlerMethodFactory with provided one.");
+			LOGGER.trace("Overriding default instance of MessageHandlerMethodFactory with provided one.");
 			this.messageHandlerMethodFactory =
 					getBeanFactory()
 							.getBean(

--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageProcessingSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageProcessingSplitter.java
@@ -18,67 +18,57 @@ package org.springframework.integration.splitter;
 
 import java.util.Collection;
 
-import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.context.Lifecycle;
-import org.springframework.core.convert.ConversionService;
-import org.springframework.integration.handler.AbstractMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.support.management.ManageableLifecycle;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
 /**
- * Base class for Message Splitter implementations that delegate to a
- * {@link MessageProcessor} instance.
+ * Base class for Message Splitter implementations that delegate to a {@link MessageProcessor} instance.
  *
  * @author Mark Fisher
  * @author Artem Bilan
+ *
  * @since 2.0
  */
-abstract class AbstractMessageProcessingSplitter extends AbstractMessageSplitter
-		implements ManageableLifecycle {
+abstract class AbstractMessageProcessingSplitter extends AbstractMessageSplitter implements ManageableLifecycle {
 
-	private final MessageProcessor<Collection<?>> messageProcessor;
+	private final MessageProcessor<Collection<?>> processor;
 
 
 	protected AbstractMessageProcessingSplitter(MessageProcessor<Collection<?>> expressionEvaluatingMessageProcessor) {
 		Assert.notNull(expressionEvaluatingMessageProcessor, "messageProcessor must not be null");
-		this.messageProcessor = expressionEvaluatingMessageProcessor;
+		this.processor = expressionEvaluatingMessageProcessor;
 	}
 
 	@Override
 	protected void doInit() {
-		ConversionService conversionService = getConversionService();
-		if (conversionService != null && this.messageProcessor instanceof AbstractMessageProcessor) {
-			((AbstractMessageProcessor<?>) this.messageProcessor).setConversionService(conversionService);
-		}
-		if (this.messageProcessor instanceof BeanFactoryAware && this.getBeanFactory() != null) {
-			((BeanFactoryAware) this.messageProcessor).setBeanFactory(this.getBeanFactory());
-		}
+		setupMessageProcessor(this.processor);
 	}
 
 	@Override
 	protected final Object splitMessage(Message<?> message) {
-		return this.messageProcessor.processMessage(message);
+		return this.processor.processMessage(message);
 	}
 
 	@Override
 	public void start() {
-		if (this.messageProcessor instanceof Lifecycle) {
-			((Lifecycle) this.messageProcessor).start();
+		if (this.processor instanceof Lifecycle lifecycle) {
+			lifecycle.start();
 		}
 	}
 
 	@Override
 	public void stop() {
-		if (this.messageProcessor instanceof Lifecycle) {
-			((Lifecycle) this.messageProcessor).stop();
+		if (this.processor instanceof Lifecycle lifecycle) {
+			lifecycle.stop();
 		}
 	}
 
 	@Override
 	public boolean isRunning() {
-		return !(this.messageProcessor instanceof Lifecycle) || ((Lifecycle) this.messageProcessor).isRunning();
+		return !(this.processor instanceof Lifecycle) || ((Lifecycle) this.processor).isRunning();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CoroutinesUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CoroutinesUtils.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.util;
+
+import org.springframework.core.KotlinDetector;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+import reactor.core.publisher.Mono;
+
+/**
+ * Additional utilities for working with Kotlin Coroutines.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ *
+ * @see org.springframework.core.CoroutinesUtils
+ */
+public final class CoroutinesUtils {
+
+	/**
+	 * The {@link kotlin.coroutines.Continuation} class object.
+	 */
+	@Nullable
+	public static final Class<?> KOTLIN_CONTINUATION_CLASS;
+
+	static {
+		if (KotlinDetector.isKotlinPresent()) {
+			Class<?> kotlinClass = null;
+			try {
+				kotlinClass = ClassUtils.forName("kotlin.coroutines.Continuation", ClassUtils.getDefaultClassLoader());
+			}
+			catch (ClassNotFoundException ex) {
+				//Ignore: assume no Kotlin in classpath
+			}
+			finally {
+				KOTLIN_CONTINUATION_CLASS = kotlinClass;
+			}
+		}
+		else {
+			KOTLIN_CONTINUATION_CLASS = null;
+		}
+	}
+
+	public static boolean isContinuation(Object candidate) {
+		return isContinuationType(candidate.getClass());
+	}
+
+	public static boolean isContinuationType(Class<?> candidate) {
+		return KOTLIN_CONTINUATION_CLASS != null && KOTLIN_CONTINUATION_CLASS.isAssignableFrom(candidate);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T monoAwaitSingleOrNull(Mono<? extends T> source, Object continuation) {
+		Assert.notNull(KOTLIN_CONTINUATION_CLASS, "Kotlin Coroutines library is not present in classpath");
+		Assert.isAssignable(KOTLIN_CONTINUATION_CLASS, continuation.getClass());
+		return (T) kotlinx.coroutines.reactor.MonoKt.awaitSingleOrNull(
+				source, (kotlin.coroutines.Continuation<T>) continuation);
+	}
+
+	private CoroutinesUtils() {
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CoroutinesUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CoroutinesUtils.java
@@ -66,6 +66,7 @@ public final class CoroutinesUtils {
 		return KOTLIN_CONTINUATION_CLASS != null && KOTLIN_CONTINUATION_CLASS.isAssignableFrom(candidate);
 	}
 
+	@Nullable
 	@SuppressWarnings("unchecked")
 	public static <T> T monoAwaitSingleOrNull(Mono<? extends T> source, Object continuation) {
 		Assert.notNull(KOTLIN_CONTINUATION_CLASS, "Kotlin Coroutines library is not present in classpath");

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,7 @@ package org.springframework.integration.groovy.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -32,16 +31,14 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Mark Fisher
  * @author Artem Bilan
  * @since 2.0
  */
-@ContextConfiguration
-@RunWith(SpringJUnit4ClassRunner.class)
+@SpringJUnitConfig
 public class GroovySplitterTests {
 
 	@Autowired
@@ -82,10 +79,10 @@ public class GroovySplitterTests {
 	public void testInt2433VerifyRiddingOfMessageProcessorsWrapping() {
 		assertThat(this.groovySplitterMessageHandler instanceof MethodInvokingSplitter).isTrue();
 		@SuppressWarnings("rawtypes")
-		MessageProcessor messageProcessor = TestUtils.getPropertyValue(this.groovySplitterMessageHandler,
-				"messageProcessor", MessageProcessor.class);
+		MessageProcessor messageProcessor =
+				TestUtils.getPropertyValue(this.groovySplitterMessageHandler, "processor", MessageProcessor.class);
 		//before it was MethodInvokingMessageProcessor
-		assertThat(messageProcessor instanceof GroovyScriptExecutingMessageProcessor).isTrue();
+		assertThat(messageProcessor).isInstanceOf(GroovyScriptExecutingMessageProcessor.class);
 	}
 
 }

--- a/src/reference/asciidoc/functions-support.adoc
+++ b/src/reference/asciidoc/functions-support.adoc
@@ -110,32 +110,3 @@ public IntegrationFlow supplierFlow() {
 ====
 
 This function support is useful when used together with the https://cloud.spring.io/spring-cloud-function/[Spring Cloud Function] framework, where we have a function catalog and can refer to its member functions from an integration flow definition.
-
-[[kotlin-functions-support]]
-==== Kotlin Lambdas
-
-The Framework also has been improved to support Kotlin lambdas for functions, so now you can use a combination of the Kotlin language and Spring Integration flow definitions:
-
-====
-[source, java]
-----
-@Bean
-@Transformer(inputChannel = "functionServiceChannel")
-fun kotlinFunction(): (String) -> String {
-    return { it.toUpperCase() }
-}
-
-@Bean
-@ServiceActivator(inputChannel = "messageConsumerServiceChannel")
-fun kotlinConsumer(): (Message<Any>) -> Unit {
-    return { print(it) }
-}
-
-@Bean
-@InboundChannelAdapter(value = "counterChannel",
-        poller = [Poller(fixedRate = "10", maxMessagesPerPoll = "1")])
-fun kotlinSupplier(): () -> String {
-    return { "baz" }
-}
-----
-====

--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -771,6 +771,8 @@ mono.subscribe(invoice -> handleInvoice(invoice));
 
 The calling thread continues, with `handleInvoice()` being called when the flow completes.
 
+Also see <<./kotlin-functions.adoc#kotlin-coroutines,Kotlin Coroutines>> for more information.
+
 ===== Downstream Flows Returning an Asynchronous Type
 
 As mentioned in the <<gateway-asynctaskexecutor>> section above, if you wish some downstream component to return a message with an async payload (`Future`, `Mono`, and others), you must explicitly set the async executor to `null` (or `""` when using XML configuration).

--- a/src/reference/asciidoc/index-single.adoc
+++ b/src/reference/asciidoc/index-single.adoc
@@ -37,6 +37,8 @@ include::./kotlin-dsl.adoc[]
 
 include::./system-management.adoc[]
 
+include::./reactive-streams.adoc[]
+
 include::./endpoint-summary.adoc[]
 
 include::./amqp.adoc[]

--- a/src/reference/asciidoc/kotlin-functions.adoc
+++ b/src/reference/asciidoc/kotlin-functions.adoc
@@ -31,7 +31,7 @@ fun kotlinSupplier(): () -> String {
 ==== Kotlin Coroutines
 
 Starting with version 6.0, Spring Integration provides support for https://kotlinlang.org/docs/coroutines-guide.html[Kotlin Coroutines].
-Now the `suspend` functions and `kotlinx.coroutines.Deferred` & `kotlinx.coroutines.flow.Flow` return types can be used for service methods:
+Now `suspend` functions and `kotlinx.coroutines.Deferred` & `kotlinx.coroutines.flow.Flow` return types can be used for service methods:
 
 ====
 [source, kotlin]
@@ -53,10 +53,10 @@ The framework treats them as Reactive Streams interactions and uses `ReactiveAda
 Such a function reply is processed then in the reply channel, if it is a `ReactiveStreamsSubscribableChannel`, or as a result of `CompletableFuture` in the respective callback.
 
 NOTE: The functions with `Flow` result are not `async` by default on the `@ServiceActivator`, so `Flow` instance is produced as a reply message payload.
-It is already target application to process this object as a coroutine or convert it to `Flux`, respectively.
+It is the target application's responsibility to process this object as a coroutine or convert it to `Flux`, respectively.
 
 The `@MessagingGateway` interface methods also can be marked with a `suspend` modifier when declared in Kotlin.
-The framework utilizes a `Mono` logic internally to perform request-reply for downstream flow.
+The framework utilizes a `Mono` internally to perform request-reply using the downstream flow.
 Such a `Mono` result is processed by the `MonoKt.awaitSingleOrNull()` API internally to fulfil a `kotlin.coroutines.Continuation` argument fo the called `suspend` function of the gateway:
 
 ====

--- a/src/reference/asciidoc/kotlin-functions.adoc
+++ b/src/reference/asciidoc/kotlin-functions.adoc
@@ -1,0 +1,85 @@
+[[kotlin-functions-support]]
+=== Kotlin Support
+
+The Framework also has been improved to support Kotlin lambdas for functions, so now you can use a combination of the Kotlin language and Spring Integration flow definitions:
+
+====
+[source, kotlin]
+----
+@Bean
+@Transformer(inputChannel = "functionServiceChannel")
+fun kotlinFunction(): (String) -> String {
+    return { it.toUpperCase() }
+}
+
+@Bean
+@ServiceActivator(inputChannel = "messageConsumerServiceChannel")
+fun kotlinConsumer(): (Message<Any>) -> Unit {
+    return { print(it) }
+}
+
+@Bean
+@InboundChannelAdapter(value = "counterChannel",
+        poller = Poller(fixedRate = "10", maxMessagesPerPoll = "1"))
+fun kotlinSupplier(): () -> String {
+    return { "baz" }
+}
+----
+====
+
+[[kotlin-coroutines]]
+==== Kotlin Coroutines
+
+Starting with version 6.0, Spring Integration provides support for https://kotlinlang.org/docs/coroutines-guide.html[Kotlin Coroutines].
+Now the `suspend` functions and `kotlinx.coroutines.Deferred` & `kotlinx.coroutines.flow.Flow` return types can be used for service methods:
+
+====
+[source, kotlin]
+----
+@ServiceActivator(inputChannel = "suspendServiceChannel", outputChannel = "resultChannel")
+suspend fun suspendServiceFunction(payload: String) = payload.uppercase()
+
+@ServiceActivator(inputChannel = "flowServiceChannel", outputChannel = "resultChannel")
+fun flowServiceFunction(payload: String) =
+    flow {
+        for (i in 1..3) {
+            emit("$payload #$i")
+        }
+    }
+----
+====
+
+The framework treats them as Reactive Streams interactions and uses `ReactiveAdapterRegistry` to convert to respective `Mono` and `Flux` reactor types.
+Such a function reply is processed then in the reply channel, if it is a `ReactiveStreamsSubscribableChannel`, or as a result of `CompletableFuture` in the respective callback.
+
+The `@MessagingGateway` interface methods also can be marked with a `suspend` modifier when declared in Kotlin.
+The framework utilizes a `Mono` logic internally to perform request-reply for downstream flow.
+Such a `Mono` result is processed by the `MonoKt.awaitSingleOrNull()` API internally to fulfil a `kotlin.coroutines.Continuation` argument fo the called `suspend` function of the gateway:
+
+====
+[source, kotlin]
+----
+@MessagingGateway(defaultRequestChannel = "suspendRequestChannel")
+interface SuspendFunGateway {
+
+    suspend fun suspendGateway(payload: String): String
+
+}
+----
+====
+
+This method has to be called as a coroutine according to Kotlin language requirements:
+
+====
+[source, kotlin]
+----
+@Autowired
+private lateinit var suspendFunGateway: SuspendFunGateway
+
+fun someServiceMethod() {
+    runBlocking {
+        val reply = suspendFunGateway.suspendGateway("test suspend gateway")
+    }
+}
+----
+====

--- a/src/reference/asciidoc/kotlin-functions.adoc
+++ b/src/reference/asciidoc/kotlin-functions.adoc
@@ -39,7 +39,7 @@ Now the `suspend` functions and `kotlinx.coroutines.Deferred` & `kotlinx.corouti
 @ServiceActivator(inputChannel = "suspendServiceChannel", outputChannel = "resultChannel")
 suspend fun suspendServiceFunction(payload: String) = payload.uppercase()
 
-@ServiceActivator(inputChannel = "flowServiceChannel", outputChannel = "resultChannel")
+@ServiceActivator(inputChannel = "flowServiceChannel", outputChannel = "resultChannel", async = "true")
 fun flowServiceFunction(payload: String) =
     flow {
         for (i in 1..3) {
@@ -51,6 +51,9 @@ fun flowServiceFunction(payload: String) =
 
 The framework treats them as Reactive Streams interactions and uses `ReactiveAdapterRegistry` to convert to respective `Mono` and `Flux` reactor types.
 Such a function reply is processed then in the reply channel, if it is a `ReactiveStreamsSubscribableChannel`, or as a result of `CompletableFuture` in the respective callback.
+
+NOTE: The functions with `Flow` result are not `async` by default on the `@ServiceActivator`, so `Flow` instance is produced as a reply message payload.
+It is already target application to process this object as a coroutine or convert it to `Flux`, respectively.
 
 The `@MessagingGateway` interface methods also can be marked with a `suspend` modifier when declared in Kotlin.
 The framework utilizes a `Mono` logic internally to perform request-reply for downstream flow.

--- a/src/reference/asciidoc/messaging-endpoints.adoc
+++ b/src/reference/asciidoc/messaging-endpoints.adoc
@@ -1,22 +1,13 @@
 [[messaging-endpoints-chapter]]
 == Messaging Endpoints
 
-// BE SURE TO PRECEDE ALL include:: with a blank line - see https://asciidoctor.org/docs/user-manual/#include-partitioning
 include::./endpoint.adoc[]
-
 include::./gateway.adoc[]
-
 include::./service-activator.adoc[]
-
 include::./delayer.adoc[]
-
 include::./scripting.adoc[]
-
 include::./groovy.adoc[]
-
 include::./handler-advice.adoc[]
-
 include::./logging-adapter.adoc[]
-
 include::./functions-support.adoc[]
-// BE SURE TO PRECEDE ALL include:: with a blank line - see https://asciidoctor.org/docs/user-manual/#include-partitioning
+include::./kotlin-functions.adoc[]

--- a/src/reference/asciidoc/messaging-endpoints.adoc
+++ b/src/reference/asciidoc/messaging-endpoints.adoc
@@ -1,13 +1,24 @@
 [[messaging-endpoints-chapter]]
 == Messaging Endpoints
 
+// BE SURE TO PRECEDE ALL include:: with a blank line - see https://asciidoctor.org/docs/user-manual/#include-partitioning
 include::./endpoint.adoc[]
+
 include::./gateway.adoc[]
+
 include::./service-activator.adoc[]
+
 include::./delayer.adoc[]
+
 include::./scripting.adoc[]
+
 include::./groovy.adoc[]
+
 include::./handler-advice.adoc[]
+
 include::./logging-adapter.adoc[]
+
 include::./functions-support.adoc[]
+
 include::./kotlin-functions.adoc[]
+// BE SURE TO PRECEDE ALL include:: with a blank line - see https://asciidoctor.org/docs/user-manual/#include-partitioning

--- a/src/reference/asciidoc/reactive-streams.adoc
+++ b/src/reference/asciidoc/reactive-streams.adoc
@@ -49,6 +49,8 @@ With a `ReactiveStreamsSubscribableChannel` for the `outputChannel`, there is no
 
 See <<./service-activator.adoc#async-service-activator,Asynchronous Service Activator>> for more information.
 
+Also see <<./kotlin-functions.adoc#kotlin-coroutines,Kotlin Coroutines>> for more information.
+
 === `FluxMessageChannel` and `ReactiveStreamsConsumer`
 
 The `FluxMessageChannel` is a combined implementation of `MessageChannel` and `Publisher<Message<?>>`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -79,6 +79,12 @@ See <<./scripting.adoc#scripting,Scripting Support>> for more information.
 The Apache Cassandra Spring Integration Extensions project has been migrated as the `spring-integration-cassandra` module.
 See <<./cassandra.adoc#cassandra,Apache Cassandra Support>> for more information.
 
+[[x6.0-kotlin-coroutines]]
+==== Kotlin Coroutines
+
+Kotlin Coroutines support has been introduced to the framework.
+
+See <<./kotlin-functions.adoc#kotlin-coroutines,Kotlin Coroutines>> for more information.
 [[x6.0-general]]
 === General Changes
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3902

* Add `isAsync()` propagation from the `MessagingMethodInvokerHelper` to the `AbstractMessageProducingHandler` to set into its `async` property. The logic is based on a `CompletableFuture`, `Publisher` or Kotlin `suspend` return types of the POJO method
* Introduce `IntegrationMessageHandlerMethodFactory` and `IntegrationInvocableHandlerMethod` to extend the logic to newly introduced `ContinuationHandlerMethodArgumentResolver` and call for Kotlin suspend functions.
* Remove `MessageHandlerMethodFactoryCreatingFactoryBean` since its logic now is covered with the `IntegrationMessageHandlerMethodFactory`
* Kotlin suspend functions are essentially reactive, so use `CoroutinesUtils.invokeSuspendingFunction()` and existing logic in the `AbstractMessageProducingHandler` to deal with `Publisher` reply

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
