### PR TITLE
Improve messaging gateway mapping

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/BarrierMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/BarrierMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -1467,7 +1467,7 @@ public class EnableIntegrationTests {
 	@TestMessagingGateway
 	public interface TestGateway {
 
-		@Gateway(headers = @GatewayHeader(name = "calledMethod", expression = "#gatewayMethod.name"))
+		@Gateway(headers = @GatewayHeader(name = "calledMethod", expression = "method.name"))
 		String echo(String payload);
 
 		@Gateway(requestChannel = "sendAsyncChannel")
@@ -1482,7 +1482,7 @@ public class EnableIntegrationTests {
 	@TestMessagingGateway2
 	public interface TestGateway2 {
 
-		@Gateway(headers = @GatewayHeader(name = "calledMethod", expression = "#gatewayMethod.name"))
+		@Gateway(headers = @GatewayHeader(name = "calledMethod", expression = "method.name"))
 		String echo2(String payload);
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
@@ -393,10 +393,10 @@ public class AsyncGatewayTests {
 
 		CompletableFuture<Message<?>> returnMessageListenable(String s);
 
-		@Gateway(headers = @GatewayHeader(name = "method", expression = "#gatewayMethod.name"))
+		@Gateway(headers = @GatewayHeader(name = "method", expression = "method.name"))
 		CustomFuture returnCustomFuture(String s);
 
-		@Gateway(headers = @GatewayHeader(name = "method", expression = "#gatewayMethod.name"))
+		@Gateway(headers = @GatewayHeader(name = "method", expression = "method.name"))
 		Future<?> returnCustomFutureWithTypeFuture(String s);
 
 		Mono<String> returnStringPromise(String s);

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests-context.xml
@@ -13,9 +13,9 @@
 			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests$Bar"
 			default-request-channel="requestChannelBaz"
 			error-channel="errorChannel">
-		<int:default-header name="name" expression="#gatewayMethod.name"/>
-		<int:default-header name="string" expression="#gatewayMethod.toString()"/>
-		<int:default-header name="object" expression="#gatewayMethod"/>
+		<int:default-header name="name" expression="method.name"/>
+		<int:default-header name="string" expression="method.toString()"/>
+		<int:default-header name="object" expression="method"/>
 		<int:method name="baz">
 			<int:header name="name" value="overrideGlobal"/>
 		</int:method>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -522,8 +522,8 @@ public class GatewayInterfaceTests {
 
 		void baz(String payload);
 
-		@Gateway(payloadExpression = "#args[0]", requestChannel = "lateReplyChannel",
-				requestTimeoutExpression = "#args[1]", replyTimeoutExpression = "#args[2]")
+		@Gateway(payloadExpression = "args[0]", requestChannel = "lateReplyChannel",
+				requestTimeoutExpression = "args[1]", replyTimeoutExpression = "args[2]")
 		String lateReply(String payload, long requestTimeout, long replyTimeout);
 
 	}
@@ -651,7 +651,7 @@ public class GatewayInterfaceTests {
 	@Profile("gatewayTest")
 	public interface Int2634Gateway {
 
-		@Gateway(requestChannel = "gatewayChannel", payloadExpression = "#args[0]")
+		@Gateway(requestChannel = "gatewayChannel", payloadExpression = "args[0]")
 		Object test1(Map<Object, ?> map);
 
 		@Gateway(requestChannel = "gatewayChannel")

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests2-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests2-context.xml
@@ -8,9 +8,9 @@
 	<int:gateway id="sampleGateway"
 			service-interface="org.springframework.integration.gateway.GatewayInterfaceTests.Bar"
 			default-request-channel="requestChannelBaz" default-payload-expression="'foo'">
-		<int:default-header name="name" expression="#gatewayMethod.name"/>
-		<int:default-header name="string" expression="#gatewayMethod.toString()"/>
-		<int:default-header name="object" expression="#gatewayMethod"/>
+		<int:default-header name="name" expression="method.name"/>
+		<int:default-header name="string" expression="method.toString()"/>
+		<int:default-header name="object" expression="method"/>
 		<int:method name="baz">
 			<int:header name="name" value="overrideGlobal"/>
 		</int:method>

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyMessageMappingTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyMessageMappingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -226,10 +226,10 @@ public class GatewayProxyMessageMappingTests {
 
 		void twoMapsAndOneAnnotatedWithPayload(@Payload Map<String, Object> payload, Map<String, Object> headers);
 
-		@Payload("#args[0] + #args[1] + '!'")
+		@Payload("args[0] + args[1] + '!'")
 		void payloadAnnotationAtMethodLevel(String a, String b);
 
-		@Payload("@testBean.exclaim(#args[0])")
+		@Payload("@testBean.exclaim(args[0])")
 		void payloadAnnotationAtMethodLevelUsingBeanResolver(String s);
 
 		void payloadAnnotationWithExpression(@Payload("toUpperCase()") String s);

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests-context.xml
@@ -8,13 +8,13 @@
 			https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<int:gateway id="gateway" service-interface="org.springframework.integration.gateway.GatewayWithPayloadExpressionTests$SampleGateway">
-		<int:method name="send1" request-channel="input" payload-expression="#args[0] + 'bar'"/>
-		<int:method name="send2" request-channel="input" payload-expression="@testBean.sum(#args[0])"/>
-		<int:method name="send3" request-channel="input" payload-expression="#gatewayMethod.name"/>
+		<int:method name="send1" request-channel="input" payload-expression="args[0] + 'bar'"/>
+		<int:method name="send2" request-channel="input" payload-expression="@testBean.sum(args[0])"/>
+		<int:method name="send3" request-channel="input" payload-expression="method.name"/>
 	</int:gateway>
 
 	<int:gateway id="annotatedGateway"
-				 service-interface="org.springframework.integration.gateway.GatewayWithPayloadExpressionTests.SampleAnnotatedGateway"
+				 service-interface="org.springframework.integration.gateway.GatewayWithPayloadExpressionTests$SampleAnnotatedGateway"
 				 default-request-channel="input"/>
 
 	<int:channel id="input">

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayWithPayloadExpressionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,15 +18,13 @@ package org.springframework.integration.gateway;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Mark Fisher
@@ -35,8 +33,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
  *
  * @since 2.0
  */
-@RunWith(SpringJUnit4ClassRunner.class)
-@ContextConfiguration
+@SpringJUnitConfig
 public class GatewayWithPayloadExpressionTests {
 
 	@Autowired
@@ -91,7 +88,7 @@ public class GatewayWithPayloadExpressionTests {
 
 	public interface SampleAnnotatedGateway {
 
-		@Payload("#args[0] + #args[1]")
+		@Payload("args[0] + args[1]")
 		void send(String value1, String value2);
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/TestService.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/TestService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ public interface TestService {
 
 	void oneWay(String input);
 
-	@Payload("#args[0]")
+	@Payload("args[0]")
 	void oneWayWithTimeouts(String input, Long sendTimeout, Long receiveTimeout);
 
 	String solicitResponse();
@@ -51,7 +51,7 @@ public interface TestService {
 
 	Message<?> requestReplyWithMessageReturnValue(String input);
 
-	@Payload("#gatewayMethod.name + #args.length")
+	@Payload("method.name + args.length")
 	String requestReplyWithPayloadAnnotation();
 
 	Future<Message<?>> async(String s);

--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -163,13 +163,7 @@ NOTE: If a no-argument gateway is specified in XML, and the interface method has
 The `<header/>` element supports `expression` as an alternative to `value`.
 The SpEL expression is evaluated to determine the value of the header.
 Starting with version 5.2, the `#root` object of the evaluation context is a `MethodArgsHolder` with `getMethod()` and `getArgs()` accessors.
-
-These two expression evaluation context variables are deprecated since version 5.2:
-
-* #args: An `Object[]` containing the method arguments
-* #gatewayMethod: The object (derived from `java.reflect.Method`) that represents the method in the `service-interface` that was invoked.
-A header containing this variable can be used later in the flow (for example, for routing).
-For example, if you wish to route on the simple method name, you might add a header with the following expression: `#gatewayMethod.name`.
+For example, if you wish to route on the simple method name, you might add a header with the following expression: `method.name`.
 
 NOTE: The `java.reflect.Method` is not serializable.
 A header with an expression of `method` is lost if you later serialize the message.


### PR DESCRIPTION
The `#args` and `#gatewayMethod` SpEL variables have been deprecated for a while

* Remove their population and usage in favor of `MethodArgsHolder` `root` of the evaluation context This change optimize a gateway mapping logic the way that there is no need in evaluation context for every call: we can just reuse a global one
* Some other `GatewayMethodInboundMessageMapper` code style refactoring
* Fix effected test classes and their configs

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
