### PR TITLE
GH-3421: Resolve `throws Exception;` in the API

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/AbstractMailMessageTransformer.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/AbstractMailMessageTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,15 +39,13 @@ import org.springframework.messaging.Message;
  * @author Gary Russell
  * @author Artem Bilan
  */
-public abstract class AbstractMailMessageTransformer<T> implements Transformer,
-		BeanFactoryAware {
+public abstract class AbstractMailMessageTransformer<T> implements Transformer, BeanFactoryAware {
 
 	private BeanFactory beanFactory;
 
 	private MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
 	private boolean messageBuilderFactorySet;
-
 
 	@Override
 	public final void setBeanFactory(BeanFactory beanFactory) {
@@ -67,28 +65,19 @@ public abstract class AbstractMailMessageTransformer<T> implements Transformer,
 	@Override
 	public Message<?> transform(Message<?> message) {
 		Object payload = message.getPayload();
-		if (!(payload instanceof jakarta.mail.Message)) {
+		if (!(payload instanceof jakarta.mail.Message mailMessage)) {
 			throw new MessageTransformationException(message, getClass().getSimpleName()
 					+ " requires a jakarta.mail.Message payload");
 		}
-		jakarta.mail.Message mailMessage = (jakarta.mail.Message) payload;
 		AbstractIntegrationMessageBuilder<T> builder;
-		try {
-			builder = this.doTransform(mailMessage);
-		}
-		catch (Exception e) {
-			throw new MessageTransformationException(message, "failed to transform mail message", e);
-		}
+		builder = doTransform(mailMessage);
 		if (builder == null) {
 			throw new MessageTransformationException(message, "failed to transform mail message");
 		}
-		builder.copyHeaders(extractHeaderMapFromMailMessage(mailMessage));
-		return builder.build();
+		return builder.copyHeaders(extractHeaderMapFromMailMessage(mailMessage)).build();
 	}
 
-	protected abstract AbstractIntegrationMessageBuilder<T> doTransform(jakarta.mail.Message mailMessage)
-			throws Exception; // NOSONAR
-
+	protected abstract AbstractIntegrationMessageBuilder<T> doTransform(jakarta.mail.Message mailMessage);
 
 	private static Map<String, Object> extractHeaderMapFromMailMessage(jakarta.mail.Message mailMessage) {
 		return MailUtils.extractStandardHeaders(mailMessage);

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/WebSocketListener.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/WebSocketListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,25 +42,20 @@ public interface WebSocketListener extends SubProtocolCapable {
 	 * Handle the received {@link WebSocketMessage}.
 	 * @param session the WebSocket session
 	 * @param message the WebSocket message
-	 * @throws Exception the 'onMessage' Exception
 	 */
-	void onMessage(WebSocketSession session, WebSocketMessage<?> message)
-			throws Exception; // NOSONAR Remove in 5.2
+	void onMessage(WebSocketSession session, WebSocketMessage<?> message);
 
 	/**
 	 * Invoked after a {@link WebSocketSession} has started.
 	 * @param session the WebSocket session
-	 * @throws Exception the 'afterSessionStarted' Exception
 	 */
-	void afterSessionStarted(WebSocketSession session) throws Exception; // NOSONAR Remove in 5.2
+	void afterSessionStarted(WebSocketSession session);
 
 	/**
 	 * Invoked after a {@link WebSocketSession} has ended.
 	 * @param session the WebSocket session
 	 * @param closeStatus the reason why the session was closed
-	 * @throws Exception the 'afterSessionEnded' Exception
 	 */
-	void afterSessionEnded(WebSocketSession session, CloseStatus closeStatus)
-			throws Exception; // NOSONAR Remove in 5.2
+	void afterSessionEnded(WebSocketSession session, CloseStatus closeStatus);
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3421

Remove `throws Exception;` from production code to honor the rule `Generic exceptions should never be thrown` which is enabled on SonarQube

* Rework affected usages to `try..catch` with throwing respective runtime exception or just logging
* Some other refactoring for the affected classes

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
