### PR TITLE
Fix Messaging annotations for MH bean factories

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
@@ -395,11 +395,16 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 		Class<?> classToCheck = handlerBeanType.toClass();
 
+		// Any out-of-the-box MessageHandler factory bean is considered as direct handler usage.
+		if (AbstractSimpleMessageHandlerFactoryBean.class.isAssignableFrom(classToCheck)) {
+			return beanDefinition;
+		}
+
 		if (FactoryBean.class.isAssignableFrom(classToCheck)) {
 			classToCheck = this.beanFactory.getType(beanName);
 		}
 
-		if (isClassIn(classToCheck, AbstractReplyProducingMessageHandler.class, AbstractMessageRouter.class)) {
+		if (isClassIn(classToCheck, AbstractMessageProducingHandler.class, AbstractMessageRouter.class)) {
 			checkMessageHandlerAttributes(beanName, annotations);
 			return beanDefinition;
 		}


### PR DESCRIPTION
The `AbstractMethodAnnotationPostProcessor` makes a decision to use a `MessageHandler` bean definition as is without wrapping by the type of `MessageHandler`. There are some of them can be configured via `AbstractSimpleMessageHandlerFactoryBean`, e.g. an `AggregatorFactoryBean`

* Check for the `AbstractSimpleMessageHandlerFactoryBean` to return as is
* Widen the replying producer by the `AbstractMessageProducingHandler` type
* Add an `AggregatorFactoryBean` with a `@ServiceActivator` configuration to test coverage

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
