### PR TITLE
Fix double start for `AbstractEndpoint`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.endpoint;
 
-import java.lang.reflect.UndeclaredThrowableException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.endpoint;
 
+import java.lang.reflect.UndeclaredThrowableException;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -154,9 +155,9 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 				try {
 					doStart();
 				}
-				catch (Exception ex) {
+				catch (RuntimeException ex) {
 					this.active = false;
-					throw new IllegalStateException("Cannot start endpoint", ex);
+					throw ex;
 				}
 				this.running = true;
 				logger.info(() -> "started " + this);

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractEndpoint.java
@@ -149,9 +149,15 @@ public abstract class AbstractEndpoint extends IntegrationObjectSupport
 	public final void start() {
 		this.lifecycleLock.lock();
 		try {
-			if (!this.running) {
+			if (!this.running && !this.active) {
 				this.active = true;
-				doStart();
+				try {
+					doStart();
+				}
+				catch (Exception ex) {
+					this.active = false;
+					throw new IllegalStateException("Cannot start endpoint", ex);
+				}
 				this.running = true;
 				logger.info(() -> "started " + this);
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flowservices/FlowServiceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flowservices/FlowServiceTests.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.aop.framework.Advised;
@@ -144,7 +145,7 @@ public class FlowServiceTests {
 				.isEqualTo("B");
 
 		assertThat(receive2.getHeaders().getTimestamp() - receive1.getHeaders().getTimestamp())
-				.isGreaterThanOrEqualTo(500);
+				.isCloseTo(500, Percentage.withPercentage(10));
 	}
 
 	@Configuration

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flowservices/FlowServiceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flowservices/FlowServiceTests.java
@@ -55,6 +55,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.TriggerContext;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
@@ -116,6 +117,34 @@ public class FlowServiceTests {
 		Message<?> message = replyChannel.receive(10000);
 		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isEqualTo("FOO");
+	}
+
+	@Autowired
+	@Qualifier("delaysBetweenPollsInput")
+	private MessageChannel delaysBetweenPollsInput;
+
+	@Autowired
+	@Qualifier("delaysBetweenPollsOutput")
+	private PollableChannel delaysBetweenPollsOutput;
+
+	@Test
+	public void noDoubleStartForEndpoints() {
+		this.delaysBetweenPollsInput.send(new GenericMessage<>("A,B"));
+
+		Message<?> receive1 = this.delaysBetweenPollsOutput.receive(10_000);
+
+		assertThat(receive1).isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("A");
+
+		Message<?> receive2 = this.delaysBetweenPollsOutput.receive(10_000);
+
+		assertThat(receive2).isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("B");
+
+		assertThat(receive2.getHeaders().getTimestamp() - receive1.getHeaders().getTimestamp())
+				.isGreaterThanOrEqualTo(500);
 	}
 
 	@Configuration
@@ -222,6 +251,25 @@ public class FlowServiceTests {
 		@ServiceActivator
 		public String handle(String payload, @Header String foo) {
 			return payload + ":" + foo;
+		}
+
+	}
+
+	@Component
+	public static class DelaysBetweenPollsAdapter extends IntegrationFlowAdapter {
+
+		@ServiceActivator
+		public String handle(String payload) {
+			return payload;
+		}
+
+		@Override
+		protected IntegrationFlowDefinition<?> buildFlow() {
+			return from("delaysBetweenPollsInput")
+					.split(splitter -> splitter.delimiters(","))
+					.channel(MessageChannels.queue())
+					.handle(this, "handle", e -> e.poller(poller -> poller.fixedDelay(500).maxMessagesPerPoll(1)))
+					.channel(MessageChannels.queue("delaysBetweenPollsOutput"));
 		}
 
 	}


### PR DESCRIPTION
When we use POJO methods in the `IntegrationFlowAdapter`, the `IntegrationFlowAdapter` is set as a `target` for the `MessagingMethodInvokerHelper`. When endpoint is started by the application context, such a `start()` is propagated down to the `MessagingMethodInvokerHelper`.
And in our case back into an `IntegrationFlowAdapter` instance. This one, in turn, starts its `IntegrationFlow` internally which leads to the start of the mentioned endpoint in the beginning.
Therefore, we cause a recursive `start()` call on this endpoint from itself. The `running` flag is set when we are already done with the `doStart()` logic. Therefore a recursive `start()` call leads to two concurrent polling tasks in the `AbstractPollingEndpoint`.

* Check also for the `active` flag in the `AbstractEndpoint.start()` and reset it in case of exception in the `doStart()`

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
