### PR TITLE
GH-3923: Add @MessagingGateway @Import support

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/GatewayProxyInstantiationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/GatewayProxyInstantiationPostProcessor.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.config;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.annotation.AnnotatedGenericBeanDefinition;
+import org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessor;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.integration.annotation.MessagingGateway;
+import org.springframework.integration.gateway.AnnotationGatewayProxyFactoryBean;
+
+/**
+ * The {@link InstantiationAwareBeanPostProcessor} to wrap beans for {@link MessagingGateway}
+ * into {@link AnnotationGatewayProxyFactoryBean}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.0
+ *
+ * @see AnnotationGatewayProxyFactoryBean
+ */
+class GatewayProxyInstantiationPostProcessor implements
+		InstantiationAwareBeanPostProcessor, ApplicationContextAware {
+
+	private final BeanDefinitionRegistry registry;
+
+	private ApplicationContext applicationContext;
+
+	GatewayProxyInstantiationPostProcessor(BeanDefinitionRegistry registry) {
+		this.registry = registry;
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public Object postProcessBeforeInstantiation(Class<?> beanClass, String beanName) throws BeansException {
+		if (beanClass.isInterface()
+				&& AnnotatedElementUtils.hasAnnotation(beanClass, MessagingGateway.class)
+				&& this.registry.getBeanDefinition(beanName) instanceof AnnotatedGenericBeanDefinition) {
+
+			AnnotationGatewayProxyFactoryBean<?> gatewayProxyFactoryBean =
+					new AnnotationGatewayProxyFactoryBean<>(beanClass);
+			gatewayProxyFactoryBean.setApplicationContext(this.applicationContext);
+			gatewayProxyFactoryBean.setBeanFactory(this.applicationContext.getAutowireCapableBeanFactory());
+			ClassLoader classLoader = this.applicationContext.getClassLoader();
+			if (classLoader != null) {
+				gatewayProxyFactoryBean.setBeanClassLoader(classLoader);
+			}
+			gatewayProxyFactoryBean.setBeanName(beanName);
+			return gatewayProxyFactoryBean;
+		}
+		return null;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -121,7 +121,6 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar {
 		if (!registry.containsBeanDefinition("gatewayProxyBeanDefinitionPostProcessor")) {
 			BeanDefinitionBuilder builder =
 					BeanDefinitionBuilder.genericBeanDefinition(GatewayProxyInstantiationPostProcessor.class,
-							() -> new GatewayProxyInstantiationPostProcessor(registry))
 							.addConstructorArgValue(registry)
 							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -63,6 +63,7 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar {
 		if (importingClassMetadata != null) {
 			registerMessagingAnnotationPostProcessors(registry);
 		}
+		registerGatewayProxyInstantiationPostProcessor(registry);
 	}
 
 	/**
@@ -113,6 +114,18 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar {
 
 			registry.registerBeanDefinition(IntegrationContextUtils.MESSAGING_ANNOTATION_POSTPROCESSOR_NAME,
 					builder.getBeanDefinition());
+		}
+	}
+
+	private void registerGatewayProxyInstantiationPostProcessor(BeanDefinitionRegistry registry) {
+		if (!registry.containsBeanDefinition("gatewayProxyBeanDefinitionPostProcessor")) {
+			BeanDefinitionBuilder builder =
+					BeanDefinitionBuilder.genericBeanDefinition(GatewayProxyInstantiationPostProcessor.class,
+							() -> new GatewayProxyInstantiationPostProcessor(registry))
+							.addConstructorArgValue(registry)
+							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
+
+			registry.registerBeanDefinition("gatewayProxyBeanDefinitionPostProcessor", builder.getBeanDefinition());
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -120,7 +120,7 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar {
 	private void registerGatewayProxyInstantiationPostProcessor(BeanDefinitionRegistry registry) {
 		if (!registry.containsBeanDefinition("gatewayProxyBeanDefinitionPostProcessor")) {
 			BeanDefinitionBuilder builder =
-					BeanDefinitionBuilder.genericBeanDefinition(GatewayProxyInstantiationPostProcessor.class,
+					BeanDefinitionBuilder.genericBeanDefinition(GatewayProxyInstantiationPostProcessor.class)
 							.addConstructorArgValue(registry)
 							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 

--- a/src/reference/asciidoc/gateway.adoc
+++ b/src/reference/asciidoc/gateway.adoc
@@ -319,6 +319,9 @@ Along with the `@MessagingGateway` annotation you can mark a service interface w
 
 Starting with version 6.0, an interface with the `@MessagingGateway` can also be marked with a `@Primary` annotation for respective configuration logic as its possible with any Spring `@Component` definition.
 
+Starting with version 6.0, `@MessagingGateway` interfaces can be used in the standard Spring `@Import` configuration.
+This may be used as an alternative to the  `@IntegrationComponentScan` or manual `AnnotationGatewayProxyFactoryBean` bean definitions.
+
 NOTE: If you have no XML configuration, the `@EnableIntegration` annotation is required on at least one `@Configuration` class.
 See <<./overview.adoc#configuration-enable-integration,Configuration and `@EnableIntegration`>> for more information.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -114,6 +114,8 @@ The Messaging Gateway interface method can now return `Future<Void>` and `Mono<V
 
 Alongside with a `@MessagingGateway` annotation the interface can also be marked with a `@Primary`.
 
+`@MessagingGateway` interfaces can now be `@Import`ed into a configuration.
+
 See <<./gateway.adoc#gateway, Messaging Gateway>> for more information.
 
 The `integrationGlobalProperties` bean is now declared by the framework as an instance of `org.springframework.integration.context.IntegrationProperties` instead of the previously deprecated `java.util.Properties`.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3923

Currently, the `@MessagingGateway` interfaces can be scanned or created explicitly as `@Bean` definition for `AnnotationGatewayProxyFactoryBean`

* Implement a `GatewayProxyBeanDefinitionPostProcessor` which is invoked before instantiation attempt on the `BeanDefinition`
* Verify `@Import` for `@MessagingGateway` interface in the `GatewayInterfaceTests`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
