### PR TITLE
GH-3942: Fix Race in Kafka OB Gateway

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaOutboundGatewaySpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaOutboundGatewaySpec.java
@@ -61,6 +61,18 @@ public class KafkaOutboundGatewaySpec<K, V, R, S extends KafkaOutboundGatewaySpe
 	}
 
 	/**
+	 * Set the time to wait for partition assignment, when used as a gateway, to determine
+	 * the default reply-to topic/partition.
+	 * @param duration the duration.
+	 * @return the spec.
+	 * @since 6.0
+	 */
+	public S assigmentDuration(Duration duration) {
+		this.target.setAssignmentDuration(duration);
+		return _this();
+	}
+
+	/**
 	 * A {@link org.springframework.kafka.core.KafkaTemplate}-based {@link KafkaProducerMessageHandlerSpec} extension.
 	 *
 	 * @param <K> the key type.

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
@@ -400,6 +400,7 @@ public class KafkaDslTests {
 		public IntegrationFlow outboundGateFlow() {
 			return IntegrationFlow.from(Gate.class)
 					.handle(Kafka.outboundGateway(producerFactory(), replyContainer())
+							.assigmentDuration(Duration.ofSeconds(30))
 							.flushExpression("true")
 							.sync(true)
 							.configureKafkaTemplate(t -> t.defaultReplyTimeout(Duration.ofSeconds(30))))


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-integration/issues/3942

When determining the default reply-to topic/partition, we need to wait for assignment.

Already covered by `KafkaDslTests` (a recent build failure exposed this problem).

**No back-port - 5.5.x uses 2.7.x by default, which does not support this.**

5.5.x users can call `waitForAssignment` on the `ReplyingKafkaTemplate` that is supplied to the gateways before sending messages.
