### PR TITLE
GH-3945: Fix `not eligible for getting processed`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.aop;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -64,6 +65,8 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 
 	private final PublisherMetadataSource metadataSource;
 
+	private final AtomicBoolean templateInitialized = new AtomicBoolean();
+
 	private DestinationResolver<MessageChannel> channelResolver;
 
 	private BeanFactory beanFactory;
@@ -94,10 +97,6 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
-		this.messagingTemplate.setBeanFactory(beanFactory);
-		if (this.channelResolver == null) {
-			this.channelResolver = ChannelResolverUtils.getChannelResolver(this.beanFactory);
-		}
 	}
 
 	protected MessageBuilderFactory getMessageBuilderFactory() {
@@ -111,8 +110,9 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 	}
 
 	@Override
-	public final Object invoke(final MethodInvocation invocation) throws Throwable {
-		final StandardEvaluationContext context = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
+	public final Object invoke(MethodInvocation invocation) throws Throwable {
+		initMessagingTemplateIfAny();
+		StandardEvaluationContext context = ExpressionUtils.createStandardEvaluationContext(this.beanFactory);
 		Class<?> targetClass = AopUtils.getTargetClass(invocation.getThis());
 		final Method method = AopUtils.getMostSpecificMethod(invocation.getMethod(), targetClass);
 		String[] argumentNames = resolveArgumentNames(method);
@@ -143,6 +143,15 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 		}
 	}
 
+	private void initMessagingTemplateIfAny() {
+		if (this.templateInitialized.compareAndSet(false, true)) {
+			this.messagingTemplate.setBeanFactory(beanFactory);
+			if (this.channelResolver == null) {
+				this.channelResolver = ChannelResolverUtils.getChannelResolver(this.beanFactory);
+			}
+		}
+	}
+
 	private String[] resolveArgumentNames(Method method) {
 		return this.parameterNameDiscoverer.getParameterNames(method);
 	}
@@ -163,20 +172,14 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 			}
 			Message<?> message = builder.build();
 			String channelName = this.metadataSource.getChannelName(method);
-			MessageChannel channel = null;
 			if (channelName != null) {
-				Assert.state(this.channelResolver != null, "ChannelResolver is required to resolve channel names.");
-				channel = this.channelResolver.resolveDestination(channelName);
-			}
-			if (channel != null) {
-				this.messagingTemplate.send(channel, message);
+				this.messagingTemplate.send(channelName, message);
 			}
 			else {
 				String channelNameToUse = this.defaultChannelName;
 				if (channelNameToUse != null && this.messagingTemplate.getDefaultDestination() == null) {
 					Assert.state(this.channelResolver != null, "ChannelResolver is required to resolve channel names.");
-					this.messagingTemplate.setDefaultChannel(
-							this.channelResolver.resolveDestination(channelNameToUse));
+					this.messagingTemplate.setDefaultChannel(this.channelResolver.resolveDestination(channelNameToUse));
 					this.defaultChannelName = null;
 				}
 				this.messagingTemplate.send(message);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
@@ -144,7 +144,7 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 
 	private void initMessagingTemplateIfAny() {
 		if (!this.templateInitialized) {
-			this.messagingTemplate.setBeanFactory(beanFactory);
+			this.messagingTemplate.setBeanFactory(this.beanFactory);
 			if (this.channelResolver == null) {
 				this.channelResolver = ChannelResolverUtils.getChannelResolver(this.beanFactory);
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
@@ -19,7 +19,6 @@ package org.springframework.integration.aop;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
@@ -65,17 +65,17 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 
 	private final PublisherMetadataSource metadataSource;
 
-	private final AtomicBoolean templateInitialized = new AtomicBoolean();
-
 	private DestinationResolver<MessageChannel> channelResolver;
 
 	private BeanFactory beanFactory;
 
 	private MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
-	private boolean messageBuilderFactorySet;
-
 	private String defaultChannelName;
+
+	private volatile boolean messageBuilderFactorySet;
+
+	private volatile boolean templateInitialized;
 
 	public MessagePublishingInterceptor(PublisherMetadataSource metadataSource) {
 		Assert.notNull(metadataSource, "metadataSource must not be null");
@@ -144,11 +144,12 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 	}
 
 	private void initMessagingTemplateIfAny() {
-		if (this.templateInitialized.compareAndSet(false, true)) {
+		if (!this.templateInitialized) {
 			this.messagingTemplate.setBeanFactory(beanFactory);
 			if (this.channelResolver == null) {
 				this.channelResolver = ChannelResolverUtils.getChannelResolver(this.beanFactory);
 			}
+			this.templateInitialized = true;
 		}
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
@@ -572,7 +572,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		if (StringUtils.hasText(inputChannelName)) {
 			MessageChannel inputChannel;
 			try {
-				inputChannel = this.channelResolver.resolveDestination(inputChannelName);
+				inputChannel = getChannelResolver().resolveDestination(inputChannelName);
 			}
 			catch (DestinationResolutionException e) {
 				if (e.getCause() instanceof NoSuchBeanDefinitionException) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
@@ -174,7 +174,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	protected DestinationResolver<MessageChannel> getChannelResolver() {
 		if (this.channelResolver == null) {
-			this.channelResolver = ChannelResolverUtils.getChannelResolver(beanFactory);
+			this.channelResolver = ChannelResolverUtils.getChannelResolver(this.beanFactory);
 		}
 		return this.channelResolver;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
@@ -141,7 +141,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 	private ConversionService conversionService;
 
-	private DestinationResolver<MessageChannel> channelResolver;
+	private volatile DestinationResolver<MessageChannel> channelResolver;
 
 	@SuppressWarnings(UNCHECKED)
 	public AbstractMethodAnnotationPostProcessor() {
@@ -154,10 +154,10 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = (ConfigurableListableBeanFactory) beanFactory;
 		this.definitionRegistry = (BeanDefinitionRegistry) beanFactory;
-		this.conversionService = this.beanFactory.getConversionService() != null
-				? this.beanFactory.getConversionService()
-				: DefaultConversionService.getSharedInstance();
-		this.channelResolver = ChannelResolverUtils.getChannelResolver(beanFactory);
+		this.conversionService =
+				this.beanFactory.getConversionService() != null
+						? this.beanFactory.getConversionService()
+						: DefaultConversionService.getSharedInstance();
 	}
 
 	protected ConfigurableListableBeanFactory getBeanFactory() {
@@ -173,6 +173,9 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 	}
 
 	protected DestinationResolver<MessageChannel> getChannelResolver() {
+		if (this.channelResolver == null) {
+			this.channelResolver = ChannelResolverUtils.getChannelResolver(beanFactory);
+		}
 		return this.channelResolver;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationManagementConfiguration.java
@@ -44,9 +44,11 @@ import org.springframework.util.StringUtils;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 4.2
  */
 @Configuration(proxyBeanMethods = false)
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class IntegrationManagementConfiguration implements ImportAware, EnvironmentAware {
 
 	private AnnotationAttributes attributes;


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3945

The `IntegrationManagementConfiguration` produces an `IntegrationManagementConfigurer` which is a `BeanPostProcessor`. According to Spring recommendation this kind of infrastructure beans must be declared as `static`. Due to an `implements ImportAware, EnvironmentAware` nature of the `IntegrationManagementConfiguration`, we cannot use `static @Bean` method.
But since the `IntegrationManagementConfiguration` is not involved in any bean post-processing, it is safe to follow recommendation and mark it as a `@Role(BeanDefinition.ROLE_INFRASTRUCTURE)`.

* Fix `MessagePublishingInterceptor` to initialize `MessagingTemplate` and `DestinationResolver` lazily
* Fix `AbstractMethodAnnotationPostProcessor` to initialize `DestinationResolver` lazily

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
