### PR TITLE
GH-3953: Use lazy-load for output channels

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
@@ -211,8 +211,8 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 
 					new BeanDefinitionPropertiesMapper(handlerBeanDefinition, annotations)
 							.setPropertyValue(SEND_TIMEOUT_ATTRIBUTE)
-							.setPropertyReference("outputChannel")
-							.setPropertyReference("defaultOutputChannel");
+							.setPropertyValue("outputChannel", "outputChannelName")
+							.setPropertyValue("defaultOutputChannel", "defaultOutputChannelName");
 				}
 
 				if (isClassIn(handlerBeanClass, AbstractMessageProducingHandler.class,


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3953

The replying `MessageHandler` can resolve the target output channel in on-demand manner. A new messaging annotations on `@Bean` parsing algorithm is missing the lazy-load opportunity and uses a `RuntimeBeanReference` for output channel options loading its bean eagerly.

* Fix `AbstractMethodAnnotationPostProcessor` to use a `outputChannelName` and `defaultOutputChannelName` target properties for channel names to set.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
