### PR TITLE
Obtain observed timers in the Integration Graph

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -245,6 +245,11 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 	}
 
 	@Override
+	public boolean isObserved() {
+		return !ObservationRegistry.NOOP.equals(this.observationRegistry);
+	}
+
+	@Override
 	protected void onInit() {
 		super.onInit();
 		if (this.messageConverter == null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -200,6 +200,11 @@ public abstract class MessageProducerSupport extends AbstractEndpoint
 	}
 
 	@Override
+	public boolean isObserved() {
+		return !ObservationRegistry.NOOP.equals(this.observationRegistry);
+	}
+
+	@Override
 	public IntegrationPatternType getIntegrationPatternType() {
 		return IntegrationPatternType.inbound_channel_adapter;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -370,6 +370,11 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 		this.observationRegistry = observationRegistry;
 	}
 
+	@Override
+	public boolean isObserved() {
+		return !ObservationRegistry.NOOP.equals(this.observationRegistry);
+	}
+
 	public void setObservationConvention(
 			@Nullable MessageRequestReplyReceiverObservationConvention observationConvention) {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MicrometerNodeEnhancer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MicrometerNodeEnhancer.java
@@ -179,7 +179,7 @@ public class MicrometerNodeEnhancer {
 				(long) (failures == null ? 0 : failures.count()));
 	}
 
-	private static TimerStats buildTimerStats(Timer timer) {
+	private static TimerStats buildTimerStats(@Nullable Timer timer) {
 		return timer == null
 				? ZERO_TIMER_STATS
 				: new TimerStats(timer.count(), timer.mean(TimeUnit.MILLISECONDS), timer.max(TimeUnit.MILLISECONDS));

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MicrometerNodeEnhancer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MicrometerNodeEnhancer.java
@@ -22,14 +22,21 @@ import java.util.concurrent.TimeUnit;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.search.Search;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.integration.support.management.IntegrationManagement;
+import org.springframework.integration.support.management.observation.DefaultMessageReceiverObservationConvention;
+import org.springframework.integration.support.management.observation.DefaultMessageSenderObservationConvention;
+import org.springframework.integration.support.management.observation.IntegrationObservation;
+import org.springframework.lang.Nullable;
 
 /**
  * Add micrometer metrics to the node.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 5.2
  *
  */
@@ -86,35 +93,55 @@ public class MicrometerNodeEnhancer {
 	}
 
 	private <T extends IntegrationNode> SendTimers retrieveTimers(T node, String type) {
-		Timer successTimer = null;
+		Timer successTimer = obtainTimer(node, type, true);
+		Timer failureTimer = obtainTimer(node, type, false);
+
+		return new SendTimers(buildTimerStats(successTimer), buildTimerStats(failureTimer));
+	}
+
+	@Nullable
+	private <T extends IntegrationNode> Timer obtainTimer(T node, String type, boolean success) {
 		try {
-			successTimer = this.registry.get(IntegrationManagement.SEND_TIMER_NAME)
-					.tag(TAG_TYPE, type)
-					.tag(TAG_NAME, node.getName())
-					.tag(TAG_RESULT, "success")
-					.timer();
+			if (node.isObserved()) {
+				return observationTimer(node, type, success);
+			}
+			else {
+				return this.registry.get(IntegrationManagement.SEND_TIMER_NAME)
+						.tag(TAG_TYPE, type)
+						.tag(TAG_NAME, node.getName())
+						.tag(TAG_RESULT, success ? "success" : "failure")
+						.timer();
+			}
 		}
-		catch (@SuppressWarnings(UNUSED) Exception e) { // NOSONAR ignored
-			// NOSONAR empty
+		catch (Exception ex) {
+			return null;
 		}
-		Timer failureTimer = null;
-		try {
-			failureTimer = this.registry.get(IntegrationManagement.SEND_TIMER_NAME)
-					.tag(TAG_TYPE, type)
-					.tag(TAG_NAME, node.getName())
-					.tag(TAG_RESULT, "failure")
-					.timer();
+	}
+
+	@Nullable
+	private <T extends IntegrationNode> Timer observationTimer(T node, String type, boolean success) {
+		Search timerSearch =
+				switch (type) {
+					case "channel" -> this.registry.find(DefaultMessageSenderObservationConvention.INSTANCE.getName())
+							.tag(IntegrationObservation.ProducerTags.COMPONENT_TYPE.asString(), "producer");
+					case "handler" -> this.registry.find(DefaultMessageReceiverObservationConvention.INSTANCE.getName())
+							.tag(IntegrationObservation.HandlerTags.COMPONENT_TYPE.asString(), "handler");
+					default -> null;
+				};
+
+		if (timerSearch != null) {
+			try {
+				return timerSearch
+						.tag(IntegrationObservation.HandlerTags.COMPONENT_NAME.asString(), node.getName())
+						.tag("error", value -> success == "none".equals(value))
+						.timer();
+			}
+			catch (Exception ex) {
+				return null;
+			}
 		}
-		catch (@SuppressWarnings(UNUSED) Exception e) { // NOSONAR ignored
-			// NOSONAR empty;
-		}
-		TimerStats successes = successTimer == null ? ZERO_TIMER_STATS
-				: new TimerStats(successTimer.count(), successTimer.mean(TimeUnit.MILLISECONDS),
-				successTimer.max(TimeUnit.MILLISECONDS));
-		TimerStats failures = failureTimer == null ? ZERO_TIMER_STATS
-				: new TimerStats(failureTimer.count(), failureTimer.mean(TimeUnit.MILLISECONDS),
-				failureTimer.max(TimeUnit.MILLISECONDS));
-		return new SendTimers(successes, failures);
+
+		return null;
 	}
 
 	private <T extends IntegrationNode> void enhanceWithCounts(T node, String type) {
@@ -148,6 +175,12 @@ public class MicrometerNodeEnhancer {
 		return new ReceiveCounters(
 				(long) (successes == null ? 0 : successes.count()),
 				(long) (failures == null ? 0 : failures.count()));
+	}
+
+	private static TimerStats buildTimerStats(Timer timer) {
+		return timer == null
+				? ZERO_TIMER_STATS
+				: new TimerStats(timer.count(), timer.mean(TimeUnit.MILLISECONDS), timer.max(TimeUnit.MILLISECONDS));
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
@@ -61,9 +61,8 @@ public abstract class AbstractMessageHandler extends MessageHandlerSupport
 		if (isLoggingEnabled()) {
 			this.logger.debug(() -> this + " received message: " + message);
 		}
-		ObservationRegistry observationRegistry = getObservationRegistry();
-		if (observationRegistry != null) {
-			handleWithObservation(message, observationRegistry);
+		if (isObserved()) {
+			handleWithObservation(message, getObservationRegistry());
 		}
 		else {
 			MetricsCaptor metricsCaptor = getMetricsCaptor();

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerSupport.java
@@ -32,6 +32,7 @@ import org.springframework.integration.support.management.TrackableComponent;
 import org.springframework.integration.support.management.metrics.MeterFacade;
 import org.springframework.integration.support.management.metrics.MetricsCaptor;
 import org.springframework.integration.support.management.metrics.TimerFacade;
+import org.springframework.util.Assert;
 
 /**
  * Base class for Message handling components that provides basic validation and error
@@ -63,7 +64,7 @@ public abstract class MessageHandlerSupport extends IntegrationObjectSupport
 
 	private MetricsCaptor metricsCaptor;
 
-	private ObservationRegistry observationRegistry;
+	private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
 	private int order = Ordered.LOWEST_PRECEDENCE;
 
@@ -95,7 +96,13 @@ public abstract class MessageHandlerSupport extends IntegrationObjectSupport
 
 	@Override
 	public void registerObservationRegistry(ObservationRegistry observationRegistry) {
+		Assert.notNull(observationRegistry, "'observationRegistry' must not be null");
 		this.observationRegistry = observationRegistry;
+	}
+
+	@Override
+	public boolean isObserved() {
+		return !ObservationRegistry.NOOP.equals(this.observationRegistry);
 	}
 
 	protected ObservationRegistry getObservationRegistry() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagement.java
@@ -107,8 +107,8 @@ public interface IntegrationManagement extends NamedComponent, DisposableBean {
 	}
 
 	/**
-	 * True if this implementation is going to dela with not {@link  ObservationRegistry#NOOP} instance.
-	 * @return true if this implementation is going to dela with not {@link  ObservationRegistry#NOOP} instance.
+	 * True if this implementation is going to deal with a registry other than the {@link  ObservationRegistry#NOOP} instance.
+	 * @return true if this implementation is going to deal with a registry other than the {@link  ObservationRegistry#NOOP} instance.
 	 * @since 6.0.1
 	 */
 	default boolean isObserved() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagement.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/IntegrationManagement.java
@@ -106,6 +106,15 @@ public interface IntegrationManagement extends NamedComponent, DisposableBean {
 		// no op
 	}
 
+	/**
+	 * True if this implementation is going to dela with not {@link  ObservationRegistry#NOOP} instance.
+	 * @return true if this implementation is going to dela with not {@link  ObservationRegistry#NOOP} instance.
+	 * @since 6.0.1
+	 */
+	default boolean isObserved() {
+		return false;
+	}
+
 	@Override
 	default void destroy() {
 		// no op

--- a/spring-integration-core/src/test/java/org/springframework/integration/graph/integration-graph-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/graph/integration-graph-context.xml
@@ -15,7 +15,7 @@
 		<int:service-activator expression="payload" />
 	</int:chain>
 
-	<int:filter id="myFilter" input-channel="filterChannel" discard-channel="three" expression="true" />
+	<int:filter id="myFilter" input-channel="filterInputChannel" discard-channel="three" expression="true" />
 
 	<int:aggregator id="myAggregator" input-channel="polledChannel" discard-channel="three" />
 


### PR DESCRIPTION
The `Observation` populates slightly different Micrometer timer names and their tags

* Fix `MicrometerNodeEnhancer` to search timers in the registry according to the `Observation` convention if the provided component is observed
* For that purpose expose an `IntegrationManagement.isObserved()` option to check of component is instrumented with an `Observation`
* Improve the logic in the `IntegrationGraphServer` to delegate into a `Function` to call `micrometerEnhancer.enhance()` instead of `static` property which might not be OK in the environment where several integration applications are ran in the same JVM

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
