### PR TITLE
GH-3969: SFTP: Bring back support for empty path

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -96,6 +96,7 @@ public class SftpSession implements Session<SftpClient.DirEntry> {
 				remoteDir = remotePath;
 			}
 		}
+		remoteDir = remoteDir.length() == 0 ? this.sftpClient.canonicalPath("") : remoteDir;
 		return StreamSupport.stream(this.sftpClient.readDir(remoteDir).spliterator(), false)
 				.filter((entry) -> !isPattern || PatternMatchUtils.simpleMatch(remoteFile, entry.getFilename()));
 	}

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
@@ -32,6 +32,7 @@ import org.springframework.integration.file.DefaultFileNameGenerator;
 import org.springframework.integration.file.remote.ClientCallbackWithoutResult;
 import org.springframework.integration.file.remote.SessionCallbackWithoutResult;
 import org.springframework.integration.file.remote.session.CachingSessionFactory;
+import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.sftp.SftpTestSupport;
@@ -122,6 +123,14 @@ public class SftpRemoteFileTemplateTests extends SftpTestSupport {
 				.withStackTraceContaining("he destination file already exists at 'test.file'.");
 
 		sessionFactory.destroy();
+	}
+
+	@Test
+	public void lsUserHome() throws IOException {
+		try (Session<SftpClient.DirEntry> session = this.sessionFactory.getSession()) {
+			String[] entries = session.listNames("");
+			assertThat(entries).contains(".", "sftpSource", "sftpTarget");
+		}
 	}
 
 	@Configuration


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3969

In previous version for SFTP client (Jsch), the empty path for `LS` command has meant a `user home`.
Turns out the MINA `SftpClient` does not support automatic user home resolution from the empty path.

* Fix `SftpSession` to resolve an empty path into a user home via `canicalPath()` operation

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
