### PR TITLE
GH-3954: Fix WebFlux XML config for ambiguity

### DIFF
--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParser.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParser.java
@@ -53,7 +53,7 @@ public class WebFluxOutboundChannelAdapterParser extends HttpOutboundChannelAdap
 		if (StringUtils.hasText(webClientRef)) {
 			if (element.hasAttribute("encoding-mode")) {
 				parserContext.getReaderContext()
-						.error("The 'web-client' and 'encoding-mode' are mutually exclusive.", element);
+						.error("The 'web-client' and 'encoding-mode' attributes are mutually exclusive.", element);
 			}
 
 			builder.getBeanDefinition()
@@ -72,8 +72,8 @@ public class WebFluxOutboundChannelAdapterParser extends HttpOutboundChannelAdap
 
 		if (hasType && hasTypeExpression) {
 			parserContext.getReaderContext()
-					.error("The 'publisher-element-type' and 'publisher-element-type-expression' " +
-							"are mutually exclusive. You can only have one or the other", element);
+					.error("The 'publisher-element-type' and 'publisher-element-type-expression' attributes " +
+							"are mutually exclusive.", element);
 		}
 
 		if (hasType) {

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParser.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParser.java
@@ -51,6 +51,11 @@ public class WebFluxOutboundChannelAdapterParser extends HttpOutboundChannelAdap
 
 		String webClientRef = element.getAttribute("web-client");
 		if (StringUtils.hasText(webClientRef)) {
+			if (element.hasAttribute("encoding-mode")) {
+				parserContext.getReaderContext()
+						.error("The 'web-client' and 'encoding-mode' are mutually exclusive.", element);
+			}
+
 			builder.getBeanDefinition()
 					.getConstructorArgumentValues()
 					.addIndexedArgumentValue(1, new RuntimeBeanReference(webClientRef));

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParser-encoding-mode-fail.xml
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParser-encoding-mode-fail.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:int-webflux="http://www.springframework.org/schema/integration/webflux"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/integration/webflux https://www.springframework.org/schema/integration/webflux/spring-integration-webflux.xsd">
+
+	<bean id="webClient" class="org.springframework.web.reactive.function.client.WebClient"
+				factory-method="create"/>
+
+	<int-webflux:outbound-gateway url="/fake"
+							   web-client="webClient"
+							   encoding-mode="VALUES_ONLY"/>
+
+</beans>

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests-context.xml
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests-context.xml
@@ -25,6 +25,7 @@
 	<outbound-gateway id="reactiveFullConfig"
 					  url="http://localhost/test2"
 					  http-method="PUT"
+					  encoding-mode="NONE"
 					  request-channel="requests"
 					  reply-timeout="1234"
 					  extract-request-payload="false"

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
@@ -146,7 +146,7 @@ public class WebFluxOutboundGatewayParserTests {
 				.isThrownBy(() ->
 						new ClassPathXmlApplicationContext("WebFluxOutboundGatewayParser-encoding-mode-fail.xml",
 						getClass()))
-				.withMessageContaining("The 'web-client' and 'encoding-mode' are mutually exclusive");
+				.withMessageContaining("The 'web-client' and 'encoding-mode' attributes are mutually exclusive");
 	}
 
 }

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
@@ -24,7 +24,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.expression.Expression;
 import org.springframework.http.HttpMethod;
 import org.springframework.integration.endpoint.AbstractEndpoint;
@@ -35,8 +37,10 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.reactive.function.BodyExtractor;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Artem Bilan
@@ -132,6 +136,17 @@ public class WebFluxOutboundGatewayParserTests {
 				.isEqualTo(false);
 		assertThat(handlerAccessor.getPropertyValue("attributeVariablesExpression.expression"))
 				.isEqualTo("{name:{first:'Nikola',last:'Tesla'},dob:{day:10,month:'July',year:1856}}");
+		assertThat(handlerAccessor.getPropertyValue("webClient.uriBuilderFactory.encodingMode"))
+				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.NONE);
+	}
+
+	@Test
+	void webClientAndEncodingModeExclusiveness() {
+		assertThatExceptionOfType(BeanDefinitionParsingException.class)
+				.isThrownBy(() ->
+						new ClassPathXmlApplicationContext("WebFluxOutboundGatewayParser-encoding-mode-fail.xml",
+						getClass()))
+				.withMessageContaining("The 'web-client' and 'encoding-mode' are mutually exclusive");
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3954

When `web-client` attribute is provided for the WebFlux outbound components configuration via XML, the `encoding-mode` is silently ignored

* Check for `encoding-mode` attribute presence in the `WebFluxOutboundChannelAdapterParser` when `web-client` is provided and throw respective exception to reject such a config

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
