### PR TITLE
Replace javadoc mentions of JSch with MINA SSHD

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -115,7 +115,7 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 	}
 
 	/**
-	 * Intended for use in tests so the jsch can be mocked.
+	 * Intended for use in tests so the MINA SSHD can be mocked.
 	 * @param sshClient The SshClient instance.
 	 * @param isSharedSession true if the session is to be shared.
 	 */

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -38,7 +38,7 @@ import org.springframework.util.PatternMatchUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * Default SFTP {@link Session} implementation. Wraps a JSCH session instance.
+ * Default SFTP {@link Session} implementation. Wraps a MINA SSHD session instance.
  *
  * @author Josh Long
  * @author Mario Gray


### PR DESCRIPTION
JSch was replaced with MINA SSHD in v6 upgrade.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
