### PR TITLE
GH-3980: Fix DefaultSftpSFactory for concurrency

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -320,7 +320,7 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 		return clientSession;
 	}
 
-	private void initClient() throws IOException {
+	private synchronized void initClient() throws IOException {
 		if (this.initialized.compareAndSet(false, true)) {
 			if (this.port <= 0) {
 				this.port = SshConstants.DEFAULT_PORT;


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3980

When not `isSharedSession`, the `initClient()` is called for every session we request from the factory and in concurrent calls we end up with not initialized SSH client in some threads.

* Add `synchronized` to the `initClient()` to block other threads while the first one initialize the client

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
