### PR TITLE
Do not build exception instances in advance

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/FunctionExpression.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/FunctionExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,13 +57,9 @@ public class FunctionExpression<S> implements Expression {
 
 	private final EvaluationContext defaultContext = new StandardEvaluationContext();
 
-	private final EvaluationException readOnlyException;
-
 	public FunctionExpression(Function<S, ?> function) {
 		Assert.notNull(function, "'function' must not be null.");
 		this.function = function;
-		this.readOnlyException = new EvaluationException(getExpressionString(),
-				"FunctionExpression is a 'read only' Expression implementation");
 	}
 
 	@Override
@@ -123,60 +119,65 @@ public class FunctionExpression<S> implements Expression {
 
 	@Override
 	public Class<?> getValueType() throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public Class<?> getValueType(@Nullable Object rootObject) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public Class<?> getValueType(EvaluationContext context) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public Class<?> getValueType(EvaluationContext context, @Nullable Object rootObject) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public TypeDescriptor getValueTypeDescriptor() throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public TypeDescriptor getValueTypeDescriptor(@Nullable Object rootObject) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context, @Nullable Object rootObject)
 			throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public void setValue(EvaluationContext context, @Nullable Object value) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public void setValue(@Nullable Object rootObject, @Nullable Object value) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public void setValue(EvaluationContext context, @Nullable Object rootObject, @Nullable Object value)
 			throws EvaluationException {
 
-		throw this.readOnlyException;
+		throw readOnlyException();
+	}
+
+	private EvaluationException readOnlyException() {
+		return new EvaluationException(getExpressionString(),
+				"FunctionExpression is a 'read only' Expression implementation");
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/SupplierExpression.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/SupplierExpression.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,6 +47,7 @@ import org.springframework.util.Assert;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ *
  * @since 5.0
  */
 public class SupplierExpression<T> implements Expression {
@@ -55,13 +56,9 @@ public class SupplierExpression<T> implements Expression {
 
 	private final EvaluationContext defaultContext = new StandardEvaluationContext();
 
-	private final EvaluationException readOnlyException;
-
 	public SupplierExpression(Supplier<T> supplier) {
 		Assert.notNull(supplier, "'function' must not be null.");
 		this.supplier = supplier;
-		this.readOnlyException = new EvaluationException(getExpressionString(),
-				"SupplierExpression is a 'read only' Expression implementation");
 	}
 
 	@Override
@@ -108,58 +105,63 @@ public class SupplierExpression<T> implements Expression {
 
 	@Override
 	public Class<?> getValueType() throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public Class<?> getValueType(Object rootObject) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public Class<?> getValueType(EvaluationContext context) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public Class<?> getValueType(EvaluationContext context, Object rootObject) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public TypeDescriptor getValueTypeDescriptor() throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public TypeDescriptor getValueTypeDescriptor(Object rootObject) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context, Object rootObject)
 			throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public void setValue(EvaluationContext context, Object value) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public void setValue(Object rootObject, Object value) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
 	}
 
 	@Override
 	public void setValue(EvaluationContext context, Object rootObject, Object value) throws EvaluationException {
-		throw this.readOnlyException;
+		throw readOnlyException();
+	}
+
+	private EvaluationException readOnlyException() {
+		return new EvaluationException(getExpressionString(),
+				"SupplierExpression is a 'read only' Expression implementation");
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -281,9 +281,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 				MessageGroup group = this.groupIdToMessageGroup.get(groupId);
 				if (group == null) {
 					if (this.groupCapacity > 0 && messages.length > this.groupCapacity) {
-						throw new MessagingException(getClass().getSimpleName() +
-								" was out of capacity (" + this.groupCapacity + ") for group '" + groupId +
-								"', try constructing it with a larger number.");
+						throw outOfCapacityException(groupId);
 					}
 					group = getMessageGroupFactory().create(groupId);
 					this.groupIdToMessageGroup.put(groupId, group);
@@ -301,9 +299,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 						lock.unlock();
 						if (!upperBound.tryAcquire(this.upperBoundTimeout)) {
 							unlocked = true;
-							throw new MessagingException(getClass().getSimpleName() +
-									" was out of capacity (" + this.groupCapacity + ") for group '" + groupId +
-									"', try constructing it with a larger number.");
+							throw outOfCapacityException(groupId);
 						}
 						lock.lockInterruptibly();
 						group.add(message);
@@ -322,6 +318,12 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 			Thread.currentThread().interrupt();
 			throw new MessagingException(INTERRUPTED_WHILE_OBTAINING_LOCK, e);
 		}
+	}
+
+	private MessagingException outOfCapacityException(Object groupId) {
+		return new MessagingException(getClass().getSimpleName() +
+				" was out of capacity (" + this.groupCapacity + ") for group '" + groupId +
+				"', try constructing it with a larger number.");
 	}
 
 	@Override


### PR DESCRIPTION
When no `cause` and no clean context of the exception thrown, the code place where an exception has been created is confusing.

* Fix `SimpleMessageStore` to create an `out of capacity` exception in the `addMessagesToGroup()` exactly at the point where it is thrown
* Fix `FunctionExpression` and `SupplierExpression` do not pre-create `readOnlyException`: it is unlikely these kind of expressions are going to be used in the SpEL `write` context, so we save some time and memory not creating extra object and the plain call `throw new` gives us a clean context what method call has ended up with such an exception

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
