### PR TITLE
GH-3986: Integration mock: fix ReactiveMH support

### DIFF
--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -347,6 +347,8 @@ assertSame(message, messageArgumentCaptor.getValue());
 ----
 ====
 
+NOTE: The regular `MessageHandler` mocking (or `MockMessageHandler`) has to be used even for a `ReactiveStreamsConsumer` with a `ReactiveMessageHandler` configuration.
+
 See the https://docs.spring.io/spring-integration/api/org/springframework/integration/test/mock/MockIntegration.html[`MockIntegration`] and https://docs.spring.io/spring-integration/api/org/springframework/integration/test/mock/MockMessageHandler.html[`MockMessageHandler`] Javadoc for more information.
 
 [[testing-other-resources]]


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3986

The `ReactiveStreamsConsumer` in addition to plain `Subscriber` and `MessageHandler` also supports a `ReactiveMessageHandler`, but `MockIntegrationContext` doesn't handle a scenario when `ReactiveMessageHandler` is provided for consumer

* Rework the logic in the `MockIntegrationContext` to substitute a `ReactiveMessageHandler` in the `ReactiveStreamsConsumer` which has a precedence in its logic over plain `Subscriber`.
* Wrap a plain `MessageHandler` mock into a `ReactiveMessageHandler` before substitution in the `ReactiveStreamsConsumer`
* Reset `ReactiveStreamsConsumer.reactiveMessageHandler` with source `ReactiveMessageHandler` or `null` respectively to an original `ReactiveStreamsConsumer` configuration
* Mention `ReactiveMessageHandler` use-case in the `testing.adoc`

**Cherry-pick to `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
