### PR TITLE
Revise JS support for regular JVM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -872,6 +872,7 @@ project('spring-integration-scripting') {
         }
         optionalApi 'org.jetbrains.kotlin:kotlin-compiler-embeddable'
         providedImplementation "org.graalvm.sdk:graal-sdk:$graalvmVersion"
+        providedImplementation "org.graalvm.js:js:$graalvmVersion"
 
         testImplementation "org.jruby:jruby-complete:$jrubyVersion"
         testImplementation 'org.apache.groovy:groovy-jsr223'

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223HeaderEnricherTests.java
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223HeaderEnricherTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package org.springframework.integration.scripting.config.jsr223;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.channel.QueueChannel;
@@ -35,7 +34,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 2.1
  */
-@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 @SpringJUnitConfig
 public class Jsr223HeaderEnricherTests {
 

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223InboundChannelAdapterTests.java
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223InboundChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.integration.scripting.config.jsr223;
 import java.util.Date;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -36,7 +35,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 2.0
  */
-@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 @SpringJUnitConfig
 @DirtiesContext
 public class Jsr223InboundChannelAdapterTests {

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223TransformerTests.java
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/config/jsr223/Jsr223TransformerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.integration.channel.QueueChannel;
@@ -39,7 +38,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 2.0
  */
-@EnabledIfSystemProperty(named = "org.graalvm.language.js.home", matches = ".+js$")
 @SpringJUnitConfig
 public class Jsr223TransformerTests {
 

--- a/src/reference/asciidoc/scripting.adoc
+++ b/src/reference/asciidoc/scripting.adoc
@@ -295,4 +295,4 @@ By default, the framework sets `allowAllAccess` to `true` on the shared Polyglot
 
 This can be customized via overloaded `PolyglotScriptExecutor` constructor which accepts a `org.graalvm.polyglot.Context.Builder`.
 
-The usage of JavaScript in the framework components remains the same, on ly the difference that now it is going to work only on GraalVM with installed `js` component.
+To enable this JavaScript support the GraalVM with installed `js` component has to be used or `org.graalvm.sdk:graal-sdk` and `org.graalvm.js:js` dependencies must be included for regular host JVM.

--- a/src/reference/asciidoc/scripting.adoc
+++ b/src/reference/asciidoc/scripting.adoc
@@ -295,4 +295,4 @@ By default, the framework sets `allowAllAccess` to `true` on the shared Polyglot
 
 This can be customized via overloaded `PolyglotScriptExecutor` constructor which accepts a `org.graalvm.polyglot.Context.Builder`.
 
-To enable this JavaScript support the GraalVM with installed `js` component has to be used or `org.graalvm.sdk:graal-sdk` and `org.graalvm.js:js` dependencies must be included for regular host JVM.
+To enable this JavaScript support, GraalVM with the `js` component installed has to be used or, when using a regular JVM, the `org.graalvm.sdk:graal-sdk` and `org.graalvm.js:js` dependencies must be included.


### PR DESCRIPTION
Turns out that we just need to have `org.graalvm.sdk:graal-sdk` and `org.graalvm.js:js` dependencies for regular JVM to enable JavaScript support for Spring Integration Scripting module

* Add respective `providedImplementation` dependencies
* Remove `@EnabledIfSystemProperty` from unit tests
* Mention those dependencies in the doc

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
