### PR TITLE
Fix reactive error handling for request-reply

### DIFF
--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/dsl/WebFluxDslTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/dsl/WebFluxDslTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ import org.springframework.integration.webflux.outbound.WebFluxRequestExecutingM
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
@@ -462,6 +463,7 @@ public class WebFluxDslTests {
 		@Bean
 		public IntegrationFlow errorFlow() {
 			return f -> f
+					.filter(Message.class, ErrorMessage.class::isInstance)
 					.enrichHeaders(h -> h.header(HttpHeaders.STATUS_CODE, HttpStatus.BAD_GATEWAY));
 		}
 


### PR DESCRIPTION
Related to https://stackoverflow.com/questions/75109345/spring-integration-webflux-inboundgateway-replychannel-for-error-response

The `MessagingGatewaySupport.doSendAndReceiveMessageReactive()` uses `MutableMessageBuilder` to build a new message for next `send` operation.
Even if this is an error flow, the provided `ErrorMessage` becomes a plain `MutableMessage`. This may break some downstream logics, like `TracingChannelInterceptor` from Spring Cloud Sleuth, which checks for the `Message` class to rebuild or reuse a message content. Therefore, an error handling flow is not able to extract error info because it is just lost.

* Fix `MessagingGatewaySupport.doSendAndReceiveMessageReactive()` to check for message type before choosing an `AbstractIntegrationMessageBuilder` impl for building a new message. The regular `MessageBuilder` just builds a new `ErrorMessage` for an exception payload.
* Add `filter()` into a `WebFluxDslTests` error handling flow to be sure that message for error sub-flow is really an `ErrorMessage`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
