### PR TITLE
GH-4014: MQTT ClientManager: completion timeouts

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,10 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 
 	private int phase = DEFAULT_MANAGER_PHASE;
 
+	private long completionTimeout = ClientManager.DEFAULT_COMPLETION_TIMEOUT;
+
+	private long disconnectCompletionTimeout = ClientManager.DISCONNECT_COMPLETION_TIMEOUT;
+
 	private boolean manualAcks;
 
 	private ApplicationEventPublisher applicationEventPublisher;
@@ -96,6 +100,34 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 		return this.connectCallbacks;
 	}
 
+	/**
+	 * Set the completion timeout for operations.
+	 * Default {@value #DEFAULT_COMPLETION_TIMEOUT} milliseconds.
+	 * @param completionTimeout The timeout.
+	 * @since 6.0.3
+	 */
+	public void setCompletionTimeout(long completionTimeout) {
+		this.completionTimeout = completionTimeout;
+	}
+
+	protected long getCompletionTimeout() {
+		return this.completionTimeout;
+	}
+
+	/**
+	 * Set the completion timeout when disconnecting.
+	 * Default {@value #DISCONNECT_COMPLETION_TIMEOUT} milliseconds.
+	 * @param completionTimeout The timeout.
+	 * @since 6.0.3
+	 */
+	public synchronized void setDisconnectCompletionTimeout(long completionTimeout) {
+		this.disconnectCompletionTimeout = completionTimeout;
+	}
+
+	protected long getDisconnectCompletionTimeout() {
+		return this.disconnectCompletionTimeout;
+	}
+
 	@Override
 	public boolean isManualAcks() {
 		return this.manualAcks;
@@ -123,7 +155,7 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 	}
 
 	/**
-	 * The phase of component autostart in {@link SmartLifecycle}.
+	 * The phase of component auto-start in {@link SmartLifecycle}.
 	 * If the custom one is required, note that for the correct behavior it should be less than phase of
 	 * {@link AbstractMqttMessageDrivenChannelAdapter} implementations.
 	 * The default phase is {@link #DEFAULT_MANAGER_PHASE}.

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,16 @@ import org.springframework.context.SmartLifecycle;
  * @since 6.0
  */
 public interface ClientManager<T, C> extends SmartLifecycle, MqttComponent<C> {
+
+	/**
+	 * The default completion timeout in milliseconds.
+	 */
+	long DEFAULT_COMPLETION_TIMEOUT = 30_000L;
+
+	/**
+	 * The default disconnect completion timeout in milliseconds.
+	 */
+	long DISCONNECT_COMPLETION_TIMEOUT = 5_000L;
 
 	/**
 	 * Return the managed client.

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,8 +101,7 @@ public class Mqttv5ClientManager
 		}
 		setClient(client);
 		try {
-			client.connect(this.connectionOptions)
-					.waitForCompletion(this.connectionOptions.getConnectionTimeout());
+			client.connect(this.connectionOptions).waitForCompletion(getCompletionTimeout());
 		}
 		catch (MqttException ex) {
 			if (this.connectionOptions.isAutomaticReconnect()) {
@@ -142,7 +141,7 @@ public class Mqttv5ClientManager
 		}
 
 		try {
-			client.disconnectForcibly(this.connectionOptions.getConnectionTimeout());
+			client.disconnectForcibly(getDisconnectCompletionTimeout());
 		}
 		catch (MqttException e) {
 			logger.error("Could not disconnect from the client", e);

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,14 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 	/**
 	 * The default completion timeout in milliseconds.
 	 */
-	public static final long DEFAULT_COMPLETION_TIMEOUT = 30_000L;
+	@Deprecated(since = "6.0.3", forRemoval = true)
+	public static final long DEFAULT_COMPLETION_TIMEOUT = ClientManager.DEFAULT_COMPLETION_TIMEOUT;
+
+	/**
+	 * The default disconnect completion timeout in milliseconds.
+	 */
+	@Deprecated(since = "6.0.3", forRemoval = true)
+	public static final long DISCONNECT_COMPLETION_TIMEOUT = ClientManager.DISCONNECT_COMPLETION_TIMEOUT;
 
 	protected final Lock topicLock = new ReentrantLock(); // NOSONAR
 
@@ -73,7 +80,9 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 
 	private final ClientManager<T, C> clientManager;
 
-	private long completionTimeout = DEFAULT_COMPLETION_TIMEOUT;
+	private long completionTimeout = ClientManager.DEFAULT_COMPLETION_TIMEOUT;
+
+	private long disconnectCompletionTimeout = ClientManager.DISCONNECT_COMPLETION_TIMEOUT;
 
 	private boolean manualAcks;
 
@@ -179,6 +188,20 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 		}
 	}
 
+	/**
+	 * Set the completion timeout when disconnecting.
+	 * Default {@value #DISCONNECT_COMPLETION_TIMEOUT} milliseconds.
+	 * @param completionTimeout The timeout.
+	 * @since 5.1.10
+	 */
+	public synchronized void setDisconnectCompletionTimeout(long completionTimeout) {
+		this.disconnectCompletionTimeout = completionTimeout;
+	}
+
+	protected long getDisconnectCompletionTimeout() {
+		return this.disconnectCompletionTimeout;
+	}
+
 	@Override
 	protected void onInit() {
 		super.onInit();
@@ -223,8 +246,8 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 	}
 
 	/**
-	 * Set the completion timeout for operations. Not settable using the namespace.
-	 * Default {@value #DEFAULT_COMPLETION_TIMEOUT} milliseconds.
+	 * Set the completion timeout for operations.
+	 * Default {@value ClientManager#DEFAULT_COMPLETION_TIMEOUT} milliseconds.
 	 * @param completionTimeout The timeout.
 	 * @since 4.1
 	 */

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ResubscribeAfterAutomaticReconnectTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ResubscribeAfterAutomaticReconnectTests.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mqtt;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
+import org.eclipse.paho.mqttv5.client.MqttConnectionOptionsBuilder;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.mqtt.event.MqttSubscribedEvent;
+import org.springframework.integration.mqtt.inbound.Mqttv5PahoMessageDrivenChannelAdapter;
+import org.springframework.integration.mqtt.outbound.Mqttv5PahoMessageHandler;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 6.0.3
+ */
+@SpringJUnitConfig
+@DirtiesContext
+public class ResubscribeAfterAutomaticReconnectTests implements MosquittoContainerTest {
+
+	@Autowired
+	@Qualifier("mqttOutFlow.input")
+	private MessageChannel mqttOutFlowInput;
+
+	@Autowired
+	private PollableChannel fromMqttChannel;
+
+	@Autowired
+	private MqttConnectionOptions connectionOptions;
+
+	@Autowired
+	Config config;
+
+	@Test
+	void messageReceivedAfterResubscriptionOnLostConnection() throws InterruptedException {
+		GenericMessage<String> testMessage = new GenericMessage<>("test");
+		this.mqttOutFlowInput.send(testMessage);
+		assertThat(this.fromMqttChannel.receive(10_000)).isNotNull();
+
+		MOSQUITTO_CONTAINER.stop();
+		MOSQUITTO_CONTAINER.start();
+		connectionOptions.setServerURIs(new String[] {MosquittoContainerTest.mqttUrl()});
+
+		assertThat(this.config.subscribeLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		this.mqttOutFlowInput.send(testMessage);
+		assertThat(this.fromMqttChannel.receive(10_000)).isNotNull();
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class Config {
+
+		CountDownLatch subscribeLatch = new CountDownLatch(2);
+
+		@Bean
+		public MqttConnectionOptions mqttConnectOptions() {
+			return new MqttConnectionOptionsBuilder()
+					.serverURI(MosquittoContainerTest.mqttUrl())
+					.automaticReconnect(true)
+					.build();
+		}
+
+		@Bean
+		public IntegrationFlow mqttOutFlow(MqttConnectionOptions mqttConnectOptions) {
+			Mqttv5PahoMessageHandler messageHandler =
+					new Mqttv5PahoMessageHandler(mqttConnectOptions, "mqttv5SIout");
+			messageHandler.setDefaultTopic("siTest");
+			return f -> f.handle(messageHandler);
+		}
+
+		@Bean
+		public IntegrationFlow mqttInFlow(MqttConnectionOptions mqttConnectOptions) {
+			Mqttv5PahoMessageDrivenChannelAdapter messageProducer =
+					new Mqttv5PahoMessageDrivenChannelAdapter(mqttConnectOptions, "mqttInClient", "siTest");
+
+			return IntegrationFlow.from(messageProducer)
+					.channel(c -> c.queue("fromMqttChannel"))
+					.get();
+		}
+
+		@EventListener(MqttSubscribedEvent.class)
+		public void mqttEvents() {
+			this.subscribeLatch.countDown();
+		}
+
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/4014

The `ClientManager` implementations uses by mistake a `connectionTimeout` for operations with completion wait

* Introduce `completionTimeout` and `disconnectCompletionTimeout` for `ClientManager` abstraction to realign the logic with existing channel adapters and Paho Client by itself.
* Deprecate `DEFAULT_COMPLETION_TIMEOUT` and `DISCONNECT_COMPLETION_TIMEOUT` constants in the `AbstractMqttMessageDrivenChannelAdapter` in favor of respective replacement in the `ClientManager`
* Pull `disconnectCompletionTimeout` property from the `MqttPahoMessageDrivenChannelAdapter` to its superclass
* Use new `disconnectCompletionTimeout` in the `Mqttv5PahoMessageDrivenChannelAdapter` for similar `disconnectForcibly()` call
* Fix Lifecycle race condition when `ClientManager` is started by the outbound channel adapter (`Integer.MIN_VALUE` phase and auto-startup - see `DefaultLifecycleProcessor.doStart()` and logic around `dependencies`) which is much earlier than `MessageProducerSupport` (`Integer.MAX_VALUE / 2` phase) and there a `connectComplete()` callback might be called before the `MessageProducerSupport.start()`. For that purpose check for an `isRunning()` in the `connectComplete()` before subscribing and set `readyToSubscribeOnStart` flag to `subscribe()` in a `doStart()` of this `MqttMessageDrivenChannelAdapter`
* Remove redundant `MqttPahoMessageDrivenChannelAdapter.cleanSession` property in favor of `this.clientFactory.getConnectionOptions().isCleanSession()` call

GH-8550: MQTT: Always re-subscribe on re-connect

Fixes https://github.com/spring-projects/spring-integration/issues/8550

Turns out the Paho MQTT client does not re-subscribe when connection re-established on automatic reconnection

* Fix `AbstractMqttMessageDrivenChannelAdapter` to always subscribe to their topics in the `connectComplete()` independently of the `reconnect` status
* Verify behavior with `MOSQUITTO_CONTAINER` image restart in Docker

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
