### PR TITLE
Gh 4014

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -43,6 +43,13 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T, C>, ApplicationEventPublisherAware {
 
+	/**
+	 * The default completion timeout in milliseconds.
+	 * @since 6.0.3
+	 * @author Jiří Patera
+	 */
+	public static final long DEFAULT_COMPLETION_TIMEOUT = 30_000L;
+
 	protected final Log logger = LogFactory.getLog(this.getClass()); // NOSONAR
 
 	private static final int DEFAULT_MANAGER_PHASE = 0;
@@ -62,6 +69,8 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 	private String beanName;
 
 	private T client;
+
+	private long completionTimeout = DEFAULT_COMPLETION_TIMEOUT;
 
 	protected AbstractMqttClientManager(String clientId) {
 		Assert.notNull(clientId, "'clientId' is required");
@@ -120,6 +129,21 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 	@Override
 	public String getBeanName() {
 		return this.beanName;
+	}
+
+	/**
+	 * Set the completion timeout for operations. Not settable using the namespace.
+	 * Default {@value #DEFAULT_COMPLETION_TIMEOUT} milliseconds.
+	 * @param completionTimeout The timeout.
+	 * @since 6.0.3
+	 * @author Jiří Patera
+	 */
+	public void setCompletionTimeout(long completionTimeout) {
+		this.completionTimeout = completionTimeout;
+	}
+
+	protected long getCompletionTimeout() {
+		return this.completionTimeout;
 	}
 
 	/**

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
@@ -98,7 +98,7 @@ public class Mqttv3ClientManager
 		setClient(client);
 		try {
 			client.connect(this.connectionOptions)
-					.waitForCompletion(this.connectionOptions.getConnectionTimeout());
+					.waitForCompletion(getCompletionTimeout());
 		}
 		catch (MqttException e) {
 			// See GH-3822
@@ -138,7 +138,7 @@ public class Mqttv3ClientManager
 			return;
 		}
 		try {
-			client.disconnectForcibly(this.connectionOptions.getConnectionTimeout());
+			client.disconnectForcibly(getCompletionTimeout());
 		}
 		catch (MqttException e) {
 			logger.error("Could not disconnect from the client", e);

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -102,7 +102,7 @@ public class Mqttv5ClientManager
 		setClient(client);
 		try {
 			client.connect(this.connectionOptions)
-					.waitForCompletion(this.connectionOptions.getConnectionTimeout());
+					.waitForCompletion(getCompletionTimeout());
 		}
 		catch (MqttException ex) {
 			if (this.connectionOptions.isAutomaticReconnect()) {
@@ -142,7 +142,7 @@ public class Mqttv5ClientManager
 		}
 
 		try {
-			client.disconnectForcibly(this.connectionOptions.getConnectionTimeout());
+			client.disconnectForcibly(getCompletionTimeout());
 		}
 		catch (MqttException e) {
 			logger.error("Could not disconnect from the client", e);

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -66,12 +66,12 @@ public class MqttPahoMessageDrivenChannelAdapter
 
 	/**
 	 * The default disconnect completion timeout in milliseconds.
+	 * @deprecated As of release 6.0.3, replaced by {@link AbstractMqttMessageDrivenChannelAdapter#DEFAULT_COMPLETION_TIMEOUT}
 	 */
-	public static final long DISCONNECT_COMPLETION_TIMEOUT = 5_000L;
+	@Deprecated(since = "6.0.3")
+	public static final long DISCONNECT_COMPLETION_TIMEOUT = DEFAULT_COMPLETION_TIMEOUT;
 
 	private final MqttPahoClientFactory clientFactory;
-
-	private long disconnectCompletionTimeout = DISCONNECT_COMPLETION_TIMEOUT;
 
 	private volatile IMqttAsyncClient client;
 
@@ -143,9 +143,11 @@ public class MqttPahoMessageDrivenChannelAdapter
 	 * Default {@value #DISCONNECT_COMPLETION_TIMEOUT} milliseconds.
 	 * @param completionTimeout The timeout.
 	 * @since 5.1.10
+	 * @deprecated As of release 6.0.3, replaced by {@link #setCompletionTimeout(long)}
 	 */
+	@Deprecated(since = "6.0.3")
 	public synchronized void setDisconnectCompletionTimeout(long completionTimeout) {
-		this.disconnectCompletionTimeout = completionTimeout;
+		setCompletionTimeout(completionTimeout);
 	}
 
 	@Override
@@ -217,7 +219,7 @@ public class MqttPahoMessageDrivenChannelAdapter
 		}
 
 		try {
-			this.client.disconnectForcibly(this.disconnectCompletionTimeout);
+			this.client.disconnectForcibly(getCompletionTimeout());
 		}
 		catch (MqttException ex) {
 			logger.error(ex, "Exception while disconnecting");

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
@@ -512,7 +512,7 @@ public class MqttAdapterTests {
 
 		new DirectFieldAccessor(adapter).setPropertyValue("running", Boolean.TRUE);
 		adapter.stop();
-		verify(client).disconnectForcibly(5_000L);
+		verify(client).disconnectForcibly(30_000L);
 	}
 
 	private MqttPahoMessageDrivenChannelAdapter buildAdapterIn(final IMqttAsyncClient client, Boolean cleanSession)


### PR DESCRIPTION
GH-4014: Fix inconsistent usage of MQTT timeouts

Fixes https://github.com/spring-projects/spring-integration/issues/4014

Also fixes error log with text "... Never happens."

* Introduce `completionTimeout` into a `ClientManager` abstraction
and fix inappropriate usages of the `connectionTimeout` over there.

* Deprecate the `disconnectCompletionTimeout` in favor of
`completionTimeout` for consistency with other similar places.

* Update MqttAdapterTests.testDifferentQos JUnit test.

* TODO: There is still a problematic JUnit test ClientManagerBackToBackTests.testV3ClientManagerReconnect. It passes when executed alone, but fails when executed together with other tests. It seems to me that there is some race condition or improper Spring context initialization. I am not able to sort this out. The test used to pass before this fix, but that was "a pass by an accident" as it logged the problematic exception  "... Never happens" and then passed.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
