### PR TITLE
Optional io.micrometer:context-propagation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,7 +87,6 @@ ext {
     lettuceVersion = '6.2.2.RELEASE'
     log4jVersion = '2.19.0'
     mailVersion = '1.0.0'
-    micrometerPropagationVersion = '1.0.2'
     micrometerTracingVersion = '1.0.2'
     micrometerVersion = '1.10.4'
     mockitoVersion = '4.10.0'
@@ -533,7 +532,6 @@ project('spring-integration-core') {
         }
         api 'io.projectreactor:reactor-core'
         api 'io.micrometer:micrometer-observation'
-        api "io.micrometer:context-propagation:$micrometerPropagationVersion"
 
         optionalApi 'com.fasterxml.jackson.core:jackson-databind'
         optionalApi 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
-import io.micrometer.context.ContextSnapshot;
 import io.micrometer.observation.ObservationRegistry;
 import org.reactivestreams.Publisher;
 import org.reactivestreams.Subscriber;
@@ -721,7 +720,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 			throw new MessageMappingException("Cannot map to message: " + object, e);
 		}
 
-		return Mono.deferContextual(contextView -> {
+		return Mono.defer(() -> {
 					Object originalReplyChannelHeader = requestMessage.getHeaders().getReplyChannel();
 					Object originalErrorChannelHeader = requestMessage.getHeaders().getErrorChannel();
 
@@ -739,13 +738,13 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 							.setErrorChannel(replyChan)
 							.build();
 
-					var scope = ContextSnapshot.setAllThreadLocalsFrom(contextView);
-					try (scope) {
-						sendMessageForReactiveFlow(requestChannel, messageToSend);
-					}
-
-					return buildReplyMono(requestMessage, replyChan.replyMono.asMono(), error,
-							originalReplyChannelHeader, originalErrorChannelHeader);
+					return Mono.just(messageToSend)
+							.handle((message, synchronousSink) -> {
+								sendMessageForReactiveFlow(requestChannel, message);
+								synchronousSink.complete();
+							})
+							.then(buildReplyMono(requestMessage, replyChan.replyMono.asMono(), error,
+									originalReplyChannelHeader, originalErrorChannelHeader));
 				})
 				.onErrorResume(t -> error ? Mono.error(t) : handleSendError(requestMessage, t));
 	}


### PR DESCRIPTION
For better performance by default it is better to not pull a `io.micrometer:context-propagation` a hard dependency.

* Remove `io.micrometer:context-propagation` dependency management
* It is pulled transitively by the `io.micrometer:micrometer-tracing-integration-test` in test scope
* Rework all the `ContextSnapshot` usage in the reactive code to respective recommended `handle()` API in `Flux` and `Mono`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
