### PR TITLE
GH-3957: Add JmsInboundGateway.replyToExpression

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedFunction.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedFunction.java
@@ -21,6 +21,9 @@ import java.util.function.Function;
 /**
  * A Function-like interface which allows throwing Error.
  *
+* @param <T> the input type.
+* @param <R> the output type.
+ *
  * @author Artem Bilan
  *
  * @since 6.1

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedFunction.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedFunction.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.util;
+
+import java.util.function.Function;
+
+/**
+ * A Function-like interface which allows throwing Error.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.1
+ */
+@FunctionalInterface
+public interface CheckedFunction<T, R> {
+
+	R apply(T t) throws Throwable;
+
+	default Function<T, R> unchecked() {
+		return t1 -> {
+			try {
+				return apply(t1);
+			}
+			catch (Throwable t) {
+				return sneakyThrow(t);
+			}
+		};
+	}
+
+	@SuppressWarnings("unchecked")
+	private static <T extends Throwable, R> R sneakyThrow(Throwable t) throws T {
+		throw (T) t;
+	}
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedFunction.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedFunction.java
@@ -21,8 +21,8 @@ import java.util.function.Function;
 /**
  * A Function-like interface which allows throwing Error.
  *
-* @param <T> the input type.
-* @param <R> the output type.
+ * @param <T> the input type.
+ * @param <R> the output type.
  *
  * @author Artem Bilan
  *
@@ -31,22 +31,25 @@ import java.util.function.Function;
 @FunctionalInterface
 public interface CheckedFunction<T, R> {
 
-	R apply(T t) throws Throwable;
+	R apply(T t) throws Throwable; // NOSONAR
 
 	default Function<T, R> unchecked() {
 		return t1 -> {
 			try {
 				return apply(t1);
 			}
-			catch (Throwable t) {
-				return sneakyThrow(t);
+			catch (Throwable t) { // NOSONAR
+				if (t instanceof RuntimeException runtimeException) {
+					throw runtimeException;
+				}
+				else if (t instanceof Error error) {
+					throw error;
+				}
+				else {
+					throw new IllegalStateException(t);
+				}
 			}
 		};
-	}
-
-	@SuppressWarnings("unchecked")
-	private static <T extends Throwable, R> R sneakyThrow(Throwable t) throws T {
-		throw (T) t;
 	}
 
 }

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/ChannelPublishingJmsMessageListener.java
@@ -270,8 +270,9 @@ public class ChannelPublishingJmsMessageListener
 	}
 
 	/**
-	 * Set a SpEL expression to resolve a 'replyTo' destination from a request {@link jakarta.jms.Message}
-	 * as a root evaluation object if {@link jakarta.jms.Message#getJMSReplyTo()} is null.
+	 * Set a SpEL expression to resolve a 'replyTo' destination from a request
+	 * {@link jakarta.jms.Message} as a root evaluation object
+	 * if {@link jakarta.jms.Message#getJMSReplyTo()} is null.
 	 * @param replyToExpression the SpEL expression for 'replyTo' destination.
 	 * @since 6.1
 	 */
@@ -436,9 +437,11 @@ public class ChannelPublishingJmsMessageListener
 
 	/**
 	 * Determine a reply destination for the given message.
-	 * It will first check the JMS Reply-To {@link Destination} of the supplied request message;
-	 * if that is null, then the configured {@link #replyToExpression} is evaluated (if any), then a
-	 * {@link #resolveDefaultReplyDestination default reply destination} is returned; if this too is null,
+	 * It will first check the JMS Reply-To {@link Destination}
+	 * of the supplied request message;
+	 * if that is null, then the configured {@link #replyToExpression} is evaluated
+	 * (if any), then a{@link #resolveDefaultReplyDestination default reply destination}
+	 * is returned; if this too is null,
 	 * then an {@link InvalidDestinationException} is thrown.
 	 * @param request the original incoming JMS message
 	 * @param session the JMS Session to operate on

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsInboundGateway.java
@@ -103,9 +103,9 @@ public class JmsInboundGateway extends MessagingGatewaySupport implements Orderl
 	}
 
 	/**
-	 * Set to false to prevent listener container shutdown when the endpoint is stopped.
+	 * Set to {@code false} to prevent listener container shutdown when the endpoint is stopped.
 	 * Then, if so configured, any cached consumer(s) in the container will remain.
-	 * Otherwise the shared connection and will be closed and the listener invokers shut
+	 * Otherwise, the shared connection and will be closed and the listener invokers shut
 	 * down; this behavior is new starting with version 5.1. Default: true.
 	 * @param shutdownContainerOnStop false to not shutdown.
 	 * @since 5.1

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundGatewaySpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,15 @@ package org.springframework.integration.jms.dsl;
 import java.util.function.Consumer;
 
 import jakarta.jms.Destination;
+import jakarta.jms.Message;
 
+import org.springframework.expression.Expression;
 import org.springframework.integration.dsl.MessagingGatewaySpec;
+import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.jms.ChannelPublishingJmsMessageListener;
 import org.springframework.integration.jms.JmsHeaderMapper;
 import org.springframework.integration.jms.JmsInboundGateway;
+import org.springframework.integration.util.CheckedFunction;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.destination.DestinationResolver;
@@ -134,6 +138,44 @@ public class JmsInboundGatewaySpec<S extends JmsInboundGatewaySpec<S>>
 	 */
 	public S destinationResolver(DestinationResolver destinationResolver) {
 		this.target.getListener().setDestinationResolver(destinationResolver);
+		return _this();
+	}
+
+
+	/**
+	 * Set a SpEL expression to resolve a 'replyTo' destination from a request {@link jakarta.jms.Message}
+	 * as a root evaluation object if {@link jakarta.jms.Message#getJMSReplyTo()} is null.
+	 * @param replyToExpression the SpEL expression for 'replyTo' destination.
+	 * @return the spec.
+	 * @since 6.1
+	 * @see ChannelPublishingJmsMessageListener#setReplyToExpression(Expression)
+	 */
+	public S replyToExpression(String replyToExpression) {
+		return replyToExpression(PARSER.parseExpression(replyToExpression));
+	}
+
+	/**
+	 * Set a function to resolve a 'replyTo' destination from a request {@link jakarta.jms.Message}
+	 * as a root evaluation object if {@link jakarta.jms.Message#getJMSReplyTo()} is null.
+	 * @param replyToFunction the function for 'replyTo' destination.
+	 * @return the spec.
+	 * @since 6.1
+	 * @see ChannelPublishingJmsMessageListener#setReplyToExpression(Expression)
+	 */
+	public S replyToFunction(CheckedFunction<Message, ?> replyToFunction) {
+		return replyToExpression(new FunctionExpression<>(replyToFunction.unchecked()));
+	}
+
+	/**
+	 * Set a SpEL expression to resolve a 'replyTo' destination from a request {@link jakarta.jms.Message}
+	 * as a root evaluation object if {@link jakarta.jms.Message#getJMSReplyTo()} is null.
+	 * @param replyToExpression the SpEL expression for 'replyTo' destination.
+	 * @return the spec.
+	 * @since 6.1
+	 * @see ChannelPublishingJmsMessageListener#setReplyToExpression(Expression)
+	 */
+	public S replyToExpression(Expression replyToExpression) {
+		this.target.getListener().setReplyToExpression(replyToExpression);
 		return _this();
 	}
 

--- a/src/reference/asciidoc/jms.adoc
+++ b/src/reference/asciidoc/jms.adoc
@@ -411,11 +411,11 @@ Starting with version 5.1, when the endpoint is stopped while the application re
 Previously, the connection and consumers remained open.
 To revert to the previous behavior, set the `shutdownContainerOnStop` on the `JmsInboundGateway` to `false`.
 
-By default, a `JmsInboundGateway` looks for a `jakarta.jms.Message.getJMSReplyTo()` property in the received message for sending a reply.
+By default, the `JmsInboundGateway` looks for a `jakarta.jms.Message.getJMSReplyTo()` property in the received message to determine where to send a reply.
 Otherwise, it can be configured with a static `defaultReplyDestination`, or `defaultReplyQueueName` or `defaultReplyTopicName`.
-In addition, starting with version 6.1, a `replyToExpression` can be configured on a provided `ChannelPublishingJmsMessageListener` to determine a reply destination dynamically if standard `JMSReplyTo` property cannot be on request.
-A received `jakarta.jms.Message` is used a root evaluation context object.
-The following example demonstrates how to use Java DSL API to configure an inbound JMS gateway for custom reply destination resolved from request message:
+In addition, starting with version 6.1, a `replyToExpression` can be configured on a provided `ChannelPublishingJmsMessageListener` to determine the reply destination dynamically, if the standard `JMSReplyTo` property is `null` on the request.
+The received `jakarta.jms.Message` is used the root evaluation context object.
+The following example demonstrates how to use Java DSL API to configure an inbound JMS gateway with a custom reply destination resolved from the request message:
 
 ====
 [source,java]

--- a/src/reference/asciidoc/jms.adoc
+++ b/src/reference/asciidoc/jms.adoc
@@ -411,11 +411,32 @@ Starting with version 5.1, when the endpoint is stopped while the application re
 Previously, the connection and consumers remained open.
 To revert to the previous behavior, set the `shutdownContainerOnStop` on the `JmsInboundGateway` to `false`.
 
+By default, a `JmsInboundGateway` looks for a `jakarta.jms.Message.getJMSReplyTo()` property in the received message for sending a reply.
+Otherwise, it can be configured with a static `defaultReplyDestination`, or `defaultReplyQueueName` or `defaultReplyTopicName`.
+In addition, starting with version 6.1, a `replyToExpression` can be configured on a provided `ChannelPublishingJmsMessageListener` to determine a reply destination dynamically if standard `JMSReplyTo` property cannot be on request.
+A received `jakarta.jms.Message` is used a root evaluation context object.
+The following example demonstrates how to use Java DSL API to configure an inbound JMS gateway for custom reply destination resolved from request message:
+
+====
+[source,java]
+----
+@Bean
+public IntegrationFlow jmsInboundGatewayFlow(ConnectionFactory connectionFactory) {
+    return IntegrationFlow.from(
+                    Jms.inboundGateway(connectionFactory)
+                            .requestDestination("requestDestination")
+                            .replyToFunction(message -> message.getStringProperty("myReplyTo")))
+            .<String, String>transform(String::toUpperCase)
+            .get();
+}
+----
+====
+
 [[jms-outbound-gateway]]
 === Outbound Gateway
 
-The outbound gateway creates JMS messages from Spring Integration messages and sends them to a 'request-destination'.
-It then handles the JMS reply message either by using a selector to receive from the 'reply-destination' that you configure or, if no 'reply-destination' is provided, by creating JMS `TemporaryQueue` (or `TemporaryTopic` if `replyPubSubDomain= true`) instances.
+The outbound gateway creates JMS messages from Spring Integration messages and sends them to a `request-destination`.
+It then handles the JMS reply message either by using a selector to receive from the `reply-destination` that you configure or, if no `reply-destination` is provided, by creating JMS `TemporaryQueue` (or `TemporaryTopic` if `replyPubSubDomain= true`) instances.
 
 [[jms-outbound-gateway-memory-caution]]
 [CAUTION]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -36,5 +36,5 @@ See <<./web-sockets.adoc#web-socket-overview, WebSocket Overview>> for more info
 [[x6.1-jms]]
 === JMS Changes
 
-A `JmsInboundGateway`, via its `ChannelPublishingJmsMessageListener`, can now be configured with a `replyToExpression` to resolve a reply destination against request message at runtime.
+The `JmsInboundGateway`, via its `ChannelPublishingJmsMessageListener`, can now be configured with a `replyToExpression` to resolve a reply destination against the request message at runtime.
 See <<./jms.adoc#jms-inbound-gateway, JMS Inbound Gateway>> for more information.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -27,9 +27,14 @@ See <<./zip.adoc#zip,Zip Support>>  for more information.
 [[x6.1-general]]
 === General Changes
 
-
 [[x6.1-web-sockets]]
 === Web Sockets Changes
 
 A `ClientWebSocketContainer` can now be configured with a predefined `URI` instead of a combination of `uriTemplate` and `uriVariables`.
 See <<./web-sockets.adoc#web-socket-overview, WebSocket Overview>> for more information.
+
+[[x6.1-jms]]
+=== JMS Changes
+
+A `JmsInboundGateway`, via its `ChannelPublishingJmsMessageListener`, can now be configured with a `replyToExpression` to resolve a reply destination against request message at runtime.
+See <<./jms.adoc#jms-inbound-gateway, JMS Inbound Gateway>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3957

Sometimes we cannot use a standard `JmsReplyTo` property for sending replies from the server. A `DestinationResolver` API does not have access to the request message.

* Introduce a `ChannelPublishingJmsMessageListener.replyToExpression` property to evaluate a reply destination against request JMS `Message`
* Use this expression only of no `JmsReplyTo` property
* Expose this property on Java DSL level
* To simplify end-user experience with lambda configuration for this property, introduce a `CheckedFunction` which essentially re-throws exception "sneaky" way

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
