### PR TITLE
GH-3813: ClientWebSocketContainer URI setting

### DIFF
--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/ClientWebSocketContainerTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/ClientWebSocketContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ public class ClientWebSocketContainerTests {
 		webSocketClient.setUserProperties(userProperties);
 
 		ClientWebSocketContainer container =
-				new ClientWebSocketContainer(webSocketClient, server.getWsBaseUrl() + "/ws/websocket");
+				new ClientWebSocketContainer(webSocketClient, new URI(server.getWsBaseUrl() + "/ws/websocket"));
 
 		TestWebSocketListener messageListener = new TestWebSocketListener();
 		container.setMessageListener(messageListener);

--- a/src/reference/asciidoc/web-sockets.adoc
+++ b/src/reference/asciidoc/web-sockets.adoc
@@ -87,6 +87,10 @@ It does so under the provided `paths` and other server WebSocket options (such a
 This registration is achieved with an infrastructural `WebSocketIntegrationConfigurationInitializer` component, which does the same as the `@EnableWebSocket` annotation.
 This means that, by using `@EnableIntegration` (or any Spring Integration namespace in the application context), you can omit the `@EnableWebSocket` declaration, because the Spring Integration infrastructure detects all WebSocket endpoints.
 
+Starting with version 6.1, the `ClientWebSocketContainer` can be configured with provided `URI` instead of `uriTemplate` and `uriVariables` combination.
+This is useful in cases when custom encoding is required for some parts of the uri.
+See an `UriComponentsBuilder` API for convenience.
+
 [[web-socket-inbound-adapter]]
 === WebSocket Inbound Channel Adapter
 

--- a/src/reference/asciidoc/web-sockets.adoc
+++ b/src/reference/asciidoc/web-sockets.adoc
@@ -87,7 +87,7 @@ It does so under the provided `paths` and other server WebSocket options (such a
 This registration is achieved with an infrastructural `WebSocketIntegrationConfigurationInitializer` component, which does the same as the `@EnableWebSocket` annotation.
 This means that, by using `@EnableIntegration` (or any Spring Integration namespace in the application context), you can omit the `@EnableWebSocket` declaration, because the Spring Integration infrastructure detects all WebSocket endpoints.
 
-Starting with version 6.1, the `ClientWebSocketContainer` can be configured with provided `URI` instead of `uriTemplate` and `uriVariables` combination.
+Starting with version 6.1, the `ClientWebSocketContainer` can be configured with a provided `URI` instead of `uriTemplate` and `uriVariables` combination.
 This is useful in cases when custom encoding is required for some parts of the uri.
 See an `UriComponentsBuilder` API for convenience.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -31,5 +31,5 @@ See <<./zip.adoc#zip,Zip Support>>  for more information.
 [[x6.1-web-sockets]]
 === Web Sockets Changes
 
-A `ClientWebSocketContainer` can now be configured with predefined `URI` instead of `uriTemplate` and `uriVariables` combination.
+A `ClientWebSocketContainer` can now be configured with a predefined `URI` instead of a combination of `uriTemplate` and `uriVariables`.
 See <<./web-sockets.adoc#web-socket-overview, WebSocket Overview>> for more information.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -26,3 +26,10 @@ See <<./zip.adoc#zip,Zip Support>>  for more information.
 
 [[x6.1-general]]
 === General Changes
+
+
+[[x6.1-web-sockets]]
+=== Web Sockets Changes
+
+A `ClientWebSocketContainer` can now be configured with predefined `URI` instead of `uriTemplate` and `uriVariables` combination.
+See <<./web-sockets.adoc#web-socket-overview, WebSocket Overview>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3813

Introduce a `ClientWebSocketContainer(WebSocketClient client, URI uri)` ctor to let end-user to decide what and how should be encoded the URI for WebSocket connection

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
