### PR TITLE
GH-8562: Fix streaming source for remote calls

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractFileInfo.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractFileInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@
 
 package org.springframework.integration.file.remote;
 
-import java.util.Date;
-
 import org.springframework.integration.json.SimpleJsonSerializer;
 
 /**
@@ -27,6 +25,7 @@ import org.springframework.integration.json.SimpleJsonSerializer;
  * @param <F> The target protocol file type.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 2.1
  */
@@ -57,10 +56,9 @@ public abstract class AbstractFileInfo<F> implements FileInfo<F>, Comparable<Fil
 
 	@Override
 	public String toString() {
-		return "FileInfo [isDirectory=" + isDirectory() + ", isLink=" + isLink()
-				+ ", Size=" + getSize() + ", ModifiedTime="
-				+ new Date(getModified()) + ", Filename=" + getFilename()
-				+ ", RemoteDirectory=" + getRemoteDirectory() + ", Permissions=" + getPermissions() + "]";
+		return "FileInfo [isLink=" + isLink()
+				+ ", Filename=" + getFilename()
+				+ ", RemoteDirectory=" + getRemoteDirectory() + "]";
 	}
 
 }

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractFileInfo.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractFileInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.file.remote;
 
+import java.util.Date;
+
 import org.springframework.integration.json.SimpleJsonSerializer;
 
 /**
@@ -25,7 +27,6 @@ import org.springframework.integration.json.SimpleJsonSerializer;
  * @param <F> The target protocol file type.
  *
  * @author Gary Russell
- * @author Artem Bilan
  *
  * @since 2.1
  */
@@ -56,9 +57,10 @@ public abstract class AbstractFileInfo<F> implements FileInfo<F>, Comparable<Fil
 
 	@Override
 	public String toString() {
-		return "FileInfo [isLink=" + isLink()
-				+ ", Filename=" + getFilename()
-				+ ", RemoteDirectory=" + getRemoteDirectory() + "]";
+		return "FileInfo [isDirectory=" + isDirectory() + ", isLink=" + isLink()
+				+ ", Size=" + getSize() + ", ModifiedTime="
+				+ new Date(getModified()) + ", Filename=" + getFilename()
+				+ ", RemoteDirectory=" + getRemoteDirectory() + ", Permissions=" + getPermissions() + "]";
 	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -243,6 +243,10 @@ public class StreamingInboundTests {
 				.isThrownBy(streamer::receive);
 		assertThat(TestUtils.getPropertyValue(streamer, "toBeReceived", BlockingQueue.class)).hasSize(1);
 		assertThat(streamer.metadataMap).hasSize(0);
+		streamer.setStrictOrder(true);
+		assertThatExceptionOfType(UncheckedIOException.class)
+				.isThrownBy(streamer::receive);
+		assertThat(TestUtils.getPropertyValue(streamer, "toBeReceived", BlockingQueue.class)).hasSize(0);
 	}
 
 	public static class Streamer extends AbstractRemoteFileStreamingMessageSource<String> {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbFileInfo.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbFileInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,7 @@ import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.util.Assert;
 
 /**
- * A {@link org.springframework.integration.file.remote.FileInfo} implementation for
- * SMB.
+ * An {@link AbstractFileInfo} implementation for SMB protocol.
  *
  * @author Gregory Bragg
  * @author Artem Bilan
@@ -156,13 +155,18 @@ public class SmbFileInfo extends AbstractFileInfo<SmbFile> {
 		return sb.toString();
 	}
 
-	private static String aceToAllowFlag(ACE ace) {
-		return ace.isAllow() ? "Allow " : "Deny ";
-	}
-
 	@Override
 	public SmbFile getFileInfo() {
 		return this.smbFile;
+	}
+
+	@Override
+	public String toString() {
+		return "SmbFileInfo{smbFile=" + this.smbFile + '}';
+	}
+
+	private static String aceToAllowFlag(ACE ace) {
+		return ace.isAllow() ? "Allow " : "Deny ";
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8562

The `AbstractRemoteFileStreamingMessageSource.doReceive()` takes files first from a `toBeReceived` queue. When `AbstractRemoteFileStreamingMessageSource.remoteFileToMessage()` fails to fetch the file content because of interim connection issue, we reset this file from a filter and rethrow an exception. The next `receive()` call will just go ahead to the next entry in the `toBeReceived` queue, but the file we have just failed for will be retried only on the next list call to the remove directory. This essentially breaks a possible in-order target application logic.

* Introduce `AbstractRemoteFileStreamingMessageSource.strictOrder` option to clear the `toBeReceived` queue when we fail in the `remoteFileToMessage()`, so the next `receive()` call would re-fetch files from remote dir, because the filter has been reset for those files.
* Fix `AbstractFileInfo.toString()` to not perform remote calls when we just log this file. For example, we reset the file for connection failure and log the message about it, but it fails again because we request `size` of the file which may require a remote connection.

**Cherry-pick to `6.0.x` & `5.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
