### PR TITLE
GH-8559: Document how to enable SOCKS for SFTP

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -115,8 +115,8 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 	}
 
 	/**
-	 * Intended for use in tests so the MINA SSHD can be mocked.
-	 * @param sshClient The SshClient instance.
+	 * Instantiate based on the provided {@link SshClient}, e.g. some extension for HTTP/SOCKS.
+	 * @param sshClient the {@link SshClient} instance.
 	 * @param isSharedSession true if the session is to be shared.
 	 */
 	public DefaultSftpSessionFactory(SshClient sshClient, boolean isSharedSession) {

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -75,6 +75,9 @@ Under the covers, the SFTP Session Factory relies on the https://mina.apache.org
 However, Spring Integration also supports the caching of SFTP sessions.
 See <<sftp-session-caching>> for more information.
 
+NOTE: The `DefaultSftpSessionFactory` can be based on externally configured `SshClient` or its extension.
+For example, an `org.eclipse.jgit.internal.transport.sshd.JGitSshClient` extension from the `org.eclipse.jgit:org.eclipse.jgit.ssh.apache` library may be used to bring (back) support for HTTP/SOCKS proxies.
+
 [IMPORTANT]
 =====
 The `SshClient` supports multiple channels (operations) over a connection to the server.

--- a/src/reference/asciidoc/sftp.adoc
+++ b/src/reference/asciidoc/sftp.adoc
@@ -75,8 +75,8 @@ Under the covers, the SFTP Session Factory relies on the https://mina.apache.org
 However, Spring Integration also supports the caching of SFTP sessions.
 See <<sftp-session-caching>> for more information.
 
-NOTE: The `DefaultSftpSessionFactory` can be based on externally configured `SshClient` or its extension.
-For example, an `org.eclipse.jgit.internal.transport.sshd.JGitSshClient` extension from the `org.eclipse.jgit:org.eclipse.jgit.ssh.apache` library may be used to bring (back) support for HTTP/SOCKS proxies.
+NOTE: The `DefaultSftpSessionFactory` can use an externally configured or extended `SshClient`.
+For example, the `org.eclipse.jgit.internal.transport.sshd.JGitSshClient` extension from the `org.eclipse.jgit:org.eclipse.jgit.ssh.apache` library may be used to provide support for HTTP/SOCKS proxies.
 
 [IMPORTANT]
 =====


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8559

An out-of-the-box `SshClient` does not provide a smooth HTTP/SOCKS proxy configuration.

* Mention in the `sftp.adoc` that `JGitSshClient`, configured with SOCKS, can be injected into a `DefaultSftpSessionFactory`
* Fix Javadocs for `DefaultSftpSessionFactory`, respectively

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
