### PR TITLE
Reduce instance supplier use to appease AOT

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IdempotentReceiverAutoProxyCreatorInitializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IdempotentReceiverAutoProxyCreatorInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,7 @@ import org.springframework.util.StringUtils;
  * to Consumer Endpoints are present.
  *
  * @author Artem Bilan
+ * @author Chris Bono
  *
  * @since 4.1
  */
@@ -83,8 +84,7 @@ public class IdempotentReceiverAutoProxyCreatorInitializer implements Integratio
 
 		if (!idempotentEndpointsMapping.isEmpty()) {
 			BeanDefinition bd =
-					BeanDefinitionBuilder.rootBeanDefinition(IdempotentReceiverAutoProxyCreator.class,
-									IdempotentReceiverAutoProxyCreator::new)
+					BeanDefinitionBuilder.rootBeanDefinition(IdempotentReceiverAutoProxyCreator.class)
 							.addPropertyValue("idempotentEndpointsMapping", idempotentEndpointsMapping)
 							.getBeanDefinition();
 			registry.registerBeanDefinition(IDEMPOTENT_RECEIVER_AUTO_PROXY_CREATOR_BEAN_NAME, bd);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationComponentScanRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationComponentScanRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Chris Bono
  *
  * @since 4.0
  */
@@ -109,7 +110,7 @@ public class IntegrationComponentScanRegistrar implements ImportBeanDefinitionRe
 		}
 
 		registry.registerBeanDefinition(BEAN_NAME,
-				BeanDefinitionBuilder.genericBeanDefinition(IntegrationComponentScanRegistrar.class, () -> this)
+				BeanDefinitionBuilder.genericBeanDefinition(IntegrationComponentScanRegistrar.class)
 						.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
 						.getBeanDefinition());
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConfigUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.integration.channel.DirectChannel;
  * Shared utility methods for Integration configuration.
  *
  * @author Artem Bilan
+ * @author Chris Bono
  *
  * @since 4.0
  */
@@ -57,15 +58,14 @@ public final class IntegrationConfigUtils {
 			String methodSignature) {
 
 		BeanDefinitionBuilder builder =
-				BeanDefinitionBuilder.genericBeanDefinition(SpelFunctionFactoryBean.class,
-								() -> new SpelFunctionFactoryBean(aClass, methodSignature))
+				BeanDefinitionBuilder.genericBeanDefinition(SpelFunctionFactoryBean.class)
 						.addConstructorArgValue(aClass)
 						.addConstructorArgValue(methodSignature);
 		registry.registerBeanDefinition(functionId, builder.getBeanDefinition());
 	}
 
 	public static void autoCreateDirectChannel(String channelName, BeanDefinitionRegistry registry) {
-		registry.registerBeanDefinition(channelName, new RootBeanDefinition(DirectChannel.class, DirectChannel::new));
+		registry.registerBeanDefinition(channelName, new RootBeanDefinition(DirectChannel.class));
 	}
 
 	public static BeanNameGenerator annotationBeanNameGenerator(BeanDefinitionRegistry registry) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConverterInitializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationConverterInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.integration.support.utils.IntegrationUtils;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Chris Bono
  *
  * @since 4.0
  */
@@ -60,13 +61,12 @@ public class IntegrationConverterInitializer implements IntegrationConfiguration
 
 		if (!registry.containsBeanDefinition(IntegrationContextUtils.CONVERTER_REGISTRAR_BEAN_NAME)) {
 			registry.registerBeanDefinition(IntegrationContextUtils.CONVERTER_REGISTRAR_BEAN_NAME,
-					new RootBeanDefinition(ConverterRegistrar.class, ConverterRegistrar::new));
+					new RootBeanDefinition(ConverterRegistrar.class));
 		}
 
 		if (!registry.containsBeanDefinition(IntegrationUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME)) {
 			registry.registerBeanDefinition(IntegrationUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME,
-					new RootBeanDefinition(CustomConversionServiceFactoryBean.class,
-							CustomConversionServiceFactoryBean::new));
+					new RootBeanDefinition(CustomConversionServiceFactoryBean.class));
 		}
 
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/IntegrationRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Chris Bono
  *
  * @since 4.0
  */
@@ -73,8 +74,7 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar {
 	private void registerDefaultConfiguringBeanFactoryPostProcessor(BeanDefinitionRegistry registry) {
 		if (!registry.containsBeanDefinition(IntegrationContextUtils.DEFAULT_CONFIGURING_POSTPROCESSOR_BEAN_NAME)) {
 			BeanDefinitionBuilder postProcessorBuilder =
-					BeanDefinitionBuilder.genericBeanDefinition(DefaultConfiguringBeanFactoryPostProcessor.class,
-									DefaultConfiguringBeanFactoryPostProcessor::new)
+					BeanDefinitionBuilder.genericBeanDefinition(DefaultConfiguringBeanFactoryPostProcessor.class)
 							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 			registry.registerBeanDefinition(IntegrationContextUtils.DEFAULT_CONFIGURING_POSTPROCESSOR_BEAN_NAME,
 					postProcessorBuilder.getBeanDefinition());
@@ -90,8 +90,7 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar {
 				IntegrationContextUtils.INTEGRATION_CONFIGURATION_POST_PROCESSOR_BEAN_NAME)) {
 
 			BeanDefinitionBuilder postProcessorBuilder =
-					BeanDefinitionBuilder.genericBeanDefinition(IntegrationConfigurationBeanFactoryPostProcessor.class,
-									IntegrationConfigurationBeanFactoryPostProcessor::new)
+					BeanDefinitionBuilder.genericBeanDefinition(IntegrationConfigurationBeanFactoryPostProcessor.class)
 							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 			registry.registerBeanDefinition(IntegrationContextUtils.INTEGRATION_CONFIGURATION_POST_PROCESSOR_BEAN_NAME,
 					postProcessorBuilder.getBeanDefinition());
@@ -108,8 +107,7 @@ public class IntegrationRegistrar implements ImportBeanDefinitionRegistrar {
 	private void registerMessagingAnnotationPostProcessors(BeanDefinitionRegistry registry) {
 		if (!registry.containsBeanDefinition(IntegrationContextUtils.MESSAGING_ANNOTATION_POSTPROCESSOR_NAME)) {
 			BeanDefinitionBuilder builder =
-					BeanDefinitionBuilder.genericBeanDefinition(MessagingAnnotationPostProcessor.class,
-									MessagingAnnotationPostProcessor::new)
+					BeanDefinitionBuilder.genericBeanDefinition(MessagingAnnotationPostProcessor.class)
 							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 
 			registry.registerBeanDefinition(IntegrationContextUtils.MESSAGING_ANNOTATION_POSTPROCESSOR_NAME,

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessageHistoryRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessageHistoryRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.integration.history.MessageHistoryConfigurer;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Chris Bono
  *
  * @since 4.0
  */
@@ -61,8 +62,7 @@ public class MessageHistoryRegistrar implements ImportBeanDefinitionRegistrar {
 		}
 
 		BeanDefinition messageHistoryConfigurer =
-				BeanDefinitionBuilder.genericBeanDefinition(MessageHistoryConfigurer.class,
-								MessageHistoryConfigurer::new)
+				BeanDefinitionBuilder.genericBeanDefinition(MessageHistoryConfigurer.class)
 						.addPropertyValue("componentNamePatterns", patterns)
 						.getBeanDefinition();
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/PublisherRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/PublisherRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.util.StringUtils;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Chris Bono
  *
  * @since 4.0
  */
@@ -52,8 +53,7 @@ public class PublisherRegistrar implements ImportBeanDefinitionRegistrar {
 						: (String) annotationAttributes.get("defaultChannel");
 
 		BeanDefinitionBuilder builder =
-				BeanDefinitionBuilder.genericBeanDefinition(PublisherAnnotationBeanPostProcessor.class,
-								PublisherAnnotationBeanPostProcessor::new)
+				BeanDefinitionBuilder.genericBeanDefinition(PublisherAnnotationBeanPostProcessor.class)
 						.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 
 		if (StringUtils.hasText(defaultChannel)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/GatewayParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -269,7 +269,7 @@ public class GatewayParser implements BeanDefinitionParser {
 			Map<String, Object>[] defaultHeaders) {
 
 		BeanDefinitionBuilder methodMetadataBuilder =
-				BeanDefinitionBuilder.genericBeanDefinition(GatewayMethodMetadata.class, GatewayMethodMetadata::new);
+				BeanDefinitionBuilder.genericBeanDefinition(GatewayMethodMetadata.class);
 
 		if (StringUtils.hasText(defaultPayloadExpression)) {
 			methodMetadataBuilder.addPropertyValue("payloadExpression",

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/DslIntegrationConfigurationInitializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/DslIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.util.Assert;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Chris Bono
  * @since 5.0
  *
  * @see org.springframework.integration.config.IntegrationConfigurationBeanFactoryPostProcessor
@@ -60,13 +61,11 @@ public class DslIntegrationConfigurationInitializer implements IntegrationConfig
 		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) configurableListableBeanFactory;
 		if (!registry.containsBeanDefinition(INTEGRATION_FLOW_BPP_BEAN_NAME)) {
 			registry.registerBeanDefinition(INTEGRATION_FLOW_BPP_BEAN_NAME,
-					new RootBeanDefinition(IntegrationFlowBeanPostProcessor.class,
-							IntegrationFlowBeanPostProcessor::new));
+					new RootBeanDefinition(IntegrationFlowBeanPostProcessor.class));
 			registry.registerBeanDefinition(INTEGRATION_FLOW_CONTEXT_BEAN_NAME,
-					new RootBeanDefinition(StandardIntegrationFlowContext.class, StandardIntegrationFlowContext::new));
+					new RootBeanDefinition(StandardIntegrationFlowContext.class));
 			registry.registerBeanDefinition(INTEGRATION_FLOW_REPLY_PRODUCER_CLEANER_BEAN_NAME,
-					new RootBeanDefinition(IntegrationFlowDefinition.ReplyProducerCleaner.class,
-							IntegrationFlowDefinition.ReplyProducerCleaner::new));
+					new RootBeanDefinition(IntegrationFlowDefinition.ReplyProducerCleaner.class));
 		}
 	}
 

--- a/spring-integration-groovy/src/main/java/org/springframework/integration/groovy/config/GroovyIntegrationConfigurationInitializer.java
+++ b/spring-integration-groovy/src/main/java/org/springframework/integration/groovy/config/GroovyIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.integration.scripting.config.ScriptExecutingProcessor
  * The Groovy Module Integration infrastructure {@code beanFactory} initializer.
  *
  * @author Artem Bilan
+ * @author Chris Bono
  *
  * @since 5.0
  */
@@ -52,8 +53,7 @@ public class GroovyIntegrationConfigurationInitializer implements IntegrationCon
 	protected void registerScriptExecutorProviderIfNecessary(BeanDefinitionRegistry registry) {
 		if (!registry.containsBeanDefinition(ScriptExecutingProcessorFactory.BEAN_NAME)) {
 			registry.registerBeanDefinition(ScriptExecutingProcessorFactory.BEAN_NAME,
-					new RootBeanDefinition(GroovyAwareScriptExecutingProcessorFactory.class,
-							GroovyAwareScriptExecutingProcessorFactory::new));
+					new RootBeanDefinition(GroovyAwareScriptExecutingProcessorFactory.class));
 		}
 	}
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpIntegrationConfigurationInitializer.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.integration.http.inbound.IntegrationRequestMappingHan
  * The HTTP Integration infrastructure {@code beanFactory} initializer.
  *
  * @author Artem Bilan
+ * @author Chris Bono
  *
  * @since 4.0
  */
@@ -62,8 +63,7 @@ public class HttpIntegrationConfigurationInitializer implements IntegrationConfi
 		if (HttpContextUtils.WEB_MVC_PRESENT &&
 				!registry.containsBeanDefinition(HttpContextUtils.HANDLER_MAPPING_BEAN_NAME)) {
 			BeanDefinitionBuilder requestMappingBuilder =
-					BeanDefinitionBuilder.genericBeanDefinition(IntegrationRequestMappingHandlerMapping.class,
-									IntegrationRequestMappingHandlerMapping::new)
+					BeanDefinitionBuilder.genericBeanDefinition(IntegrationRequestMappingHandlerMapping.class)
 							.addPropertyValue("order", 0)
 							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 			registry.registerBeanDefinition(HttpContextUtils.HANDLER_MAPPING_BEAN_NAME,

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/IntegrationGraphControllerRegistrar.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/IntegrationGraphControllerRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,7 +24,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
@@ -49,6 +48,7 @@ import org.springframework.integration.http.management.IntegrationGraphControlle
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Chris Bono
  *
  * @since 4.3
  */
@@ -73,7 +73,7 @@ public class IntegrationGraphControllerRegistrar implements ImportBeanDefinition
 
 		if (!registry.containsBeanDefinition(IntegrationContextUtils.INTEGRATION_GRAPH_SERVER_BEAN_NAME)) {
 			registry.registerBeanDefinition(IntegrationContextUtils.INTEGRATION_GRAPH_SERVER_BEAN_NAME,
-					new RootBeanDefinition(IntegrationGraphServer.class, IntegrationGraphServer::new));
+					new RootBeanDefinition(IntegrationGraphServer.class));
 		}
 
 		String path = (String) annotationAttributes.get("value");
@@ -91,20 +91,14 @@ public class IntegrationGraphControllerRegistrar implements ImportBeanDefinition
 			String graphControllerPath) {
 
 		AbstractBeanDefinition controllerPropertiesPopulator =
-				BeanDefinitionBuilder.genericBeanDefinition(GraphControllerPropertiesPopulator.class,
-								() -> new GraphControllerPropertiesPopulator(graphControllerPath))
+				BeanDefinitionBuilder.genericBeanDefinition(GraphControllerPropertiesPopulator.class)
 						.addConstructorArgValue(graphControllerPath)
 						.setRole(BeanDefinition.ROLE_INFRASTRUCTURE)
 						.getBeanDefinition();
 		BeanDefinitionReaderUtils.registerWithGeneratedName(controllerPropertiesPopulator, registry);
 
 		BeanDefinition graphController =
-				BeanDefinitionBuilder.rootBeanDefinition(IntegrationGraphController.class,
-								() ->
-										new IntegrationGraphController(
-												((BeanFactory) registry)
-														.getBean(IntegrationContextUtils.INTEGRATION_GRAPH_SERVER_BEAN_NAME,
-																IntegrationGraphServer.class)))
+				BeanDefinitionBuilder.rootBeanDefinition(IntegrationGraphController.class)
 						.addConstructorArgReference(IntegrationContextUtils.INTEGRATION_GRAPH_SERVER_BEAN_NAME)
 						.getBeanDefinition();
 
@@ -132,16 +126,14 @@ public class IntegrationGraphControllerRegistrar implements ImportBeanDefinition
 	}
 
 	private static AbstractBeanDefinition webMvcControllerCorsConfigurerBean(String path, String[] allowedOrigins) {
-		return BeanDefinitionBuilder.genericBeanDefinition(WebMvcIntegrationGraphCorsConfigurer.class,
-						() -> new WebMvcIntegrationGraphCorsConfigurer(path, allowedOrigins))
+		return BeanDefinitionBuilder.genericBeanDefinition(WebMvcIntegrationGraphCorsConfigurer.class)
 				.addConstructorArgValue(path)
 				.addConstructorArgValue(allowedOrigins)
 				.getBeanDefinition();
 	}
 
 	private static AbstractBeanDefinition webFluxControllerCorsConfigurerBean(String path, String[] allowedOrigins) {
-		return BeanDefinitionBuilder.genericBeanDefinition(WebFluxIntegrationGraphCorsConfigurer.class,
-						() -> new WebFluxIntegrationGraphCorsConfigurer(path, allowedOrigins))
+		return BeanDefinitionBuilder.genericBeanDefinition(WebFluxIntegrationGraphCorsConfigurer.class)
 				.addConstructorArgValue(path)
 				.addConstructorArgValue(allowedOrigins)
 				.getBeanDefinition();

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/JmxIntegrationConfigurationInitializer.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/JmxIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.springframework.integration.monitor.IntegrationMBeanExporter;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Chris Bono
  *
  * @since 4.0
  */
@@ -45,7 +46,7 @@ public class JmxIntegrationConfigurationInitializer implements IntegrationConfig
 				&& beanFactory.getBeanNamesForType(IntegrationMBeanExporter.class, false, false).length > 0) {
 
 			((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(MBEAN_EXPORTER_HELPER_BEAN_NAME,
-					new RootBeanDefinition(MBeanExporterHelper.class, MBeanExporterHelper::new));
+					new RootBeanDefinition(MBeanExporterHelper.class));
 		}
 	}
 

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxIntegrationConfigurationInitializer.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/config/WebFluxIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,7 @@ import org.springframework.integration.webflux.support.WebFluxContextUtils;
  * The WebFlux Integration infrastructure {@code beanFactory} initializer.
  *
  * @author Artem Bilan
+ * @author Chris Bono
  *
  * @since 5.0
  */
@@ -70,15 +71,14 @@ public class WebFluxIntegrationConfigurationInitializer implements IntegrationCo
 				!registry.containsBeanDefinition(WebFluxContextUtils.HANDLER_MAPPING_BEAN_NAME)) {
 
 			BeanDefinitionBuilder requestMappingBuilder =
-					BeanDefinitionBuilder.genericBeanDefinition(WebFluxIntegrationRequestMappingHandlerMapping.class,
-									WebFluxIntegrationRequestMappingHandlerMapping::new)
+					BeanDefinitionBuilder.genericBeanDefinition(WebFluxIntegrationRequestMappingHandlerMapping.class)
 							.addPropertyValue("order", 0)
 							.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 			registry.registerBeanDefinition(WebFluxContextUtils.HANDLER_MAPPING_BEAN_NAME,
 					requestMappingBuilder.getBeanDefinition());
 
 			BeanDefinitionReaderUtils.registerWithGeneratedName(
-					new RootBeanDefinition(IntegrationHandlerResultHandler.class, IntegrationHandlerResultHandler::new),
+					new RootBeanDefinition(IntegrationHandlerResultHandler.class),
 					registry);
 		}
 	}

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/config/WebSocketIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Chris Bono
  *
  * @since 4.1
  */
@@ -85,8 +86,7 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 			if (!registry.containsBeanDefinition("defaultSockJsTaskScheduler")) {
 
 				BeanDefinitionBuilder beanDefinitionBuilder =
-						BeanDefinitionBuilder.genericBeanDefinition(ThreadPoolTaskScheduler.class,
-										ThreadPoolTaskScheduler::new)
+						BeanDefinitionBuilder.genericBeanDefinition(ThreadPoolTaskScheduler.class)
 								.addPropertyValue("threadNamePrefix", "SockJS-")
 								.addPropertyValue("poolSize", Runtime.getRuntime().availableProcessors())
 								.addPropertyValue("removeOnCancelPolicy", true);
@@ -97,19 +97,16 @@ public class WebSocketIntegrationConfigurationInitializer implements Integration
 					!registry.containsBeanDefinition(WEB_SOCKET_HANDLER_MAPPING_BEAN_NAME)) {
 
 				registry.registerBeanDefinition("integrationServletWebSocketHandlerRegistry",
-						new RootBeanDefinition(IntegrationServletWebSocketHandlerRegistry.class,
-								IntegrationServletWebSocketHandlerRegistry::new));
+						new RootBeanDefinition(IntegrationServletWebSocketHandlerRegistry.class));
 
 				BeanDefinitionBuilder beanDefinitionBuilder =
-						BeanDefinitionBuilder.genericBeanDefinition(IntegrationDynamicWebSocketHandlerMapping.class,
-										IntegrationDynamicWebSocketHandlerMapping::new)
+						BeanDefinitionBuilder.genericBeanDefinition(IntegrationDynamicWebSocketHandlerMapping.class)
 								.addPropertyValue("patternParser", new PathPatternParser())
 								.addPropertyValue("order", 0);
 				BeanDefinitionReaderUtils.registerWithGeneratedName(beanDefinitionBuilder.getBeanDefinition(), registry);
 
 				BeanDefinitionBuilder enableWebSocketBuilder =
-						BeanDefinitionBuilder.genericBeanDefinition(WebSocketHandlerMappingFactoryBean.class,
-										WebSocketHandlerMappingFactoryBean::new)
+						BeanDefinitionBuilder.genericBeanDefinition(WebSocketHandlerMappingFactoryBean.class)
 								.addPropertyReference("registry", "integrationServletWebSocketHandlerRegistry")
 								.addPropertyReference("sockJsTaskScheduler", "defaultSockJsTaskScheduler")
 								.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WsIntegrationConfigurationInitializer.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WsIntegrationConfigurationInitializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,8 +37,8 @@ import org.springframework.ws.server.endpoint.adapter.MessageEndpointAdapter;
  * registers only the {@link org.springframework.ws.server.endpoint.adapter.DefaultMethodEndpointAdapter},
  * which isn't appropriate for the {@link org.springframework.ws.server.endpoint.MessageEndpoint} implementations.
  *
- *
  * @author Artem Bilan
+ * @author Chris Bono
  *
  * @since 4.3
  *
@@ -56,8 +56,7 @@ public class WsIntegrationConfigurationInitializer implements IntegrationConfigu
 		if (beanFactory instanceof BeanDefinitionRegistry) {
 			if (beanFactory.getBeanNamesForType(EndpointAdapter.class, false, false).length > 0) {
 				BeanDefinitionBuilder requestMappingBuilder =
-						BeanDefinitionBuilder.genericBeanDefinition(MessageEndpointAdapter.class,
-										MessageEndpointAdapter::new)
+						BeanDefinitionBuilder.genericBeanDefinition(MessageEndpointAdapter.class)
 								.setRole(BeanDefinition.ROLE_INFRASTRUCTURE);
 				((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(MESSAGE_ENDPOINT_ADAPTER_BEAN_NAME,
 						requestMappingBuilder.getBeanDefinition());


### PR DESCRIPTION
* Remove the use of instance suppliers on bean definitions that are processed during the AOT phase.

* The remaining areas that use instance suppliers do so at runtime and do not use reflection, but instead
are passed the configured bean to register.

See https://github.com/spring-cloud/spring-cloud-stream/issues/2655