### PR TITLE
GH-8566: Fix `SftpSession.append()` for `Write`

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -132,7 +132,10 @@ public class SftpSession implements Session<SftpClient.DirEntry> {
 	public void append(InputStream inputStream, String destination) throws IOException {
 		synchronized (this.sftpClient) {
 			OutputStream outputStream =
-					this.sftpClient.write(destination, SftpClient.OpenMode.Create, SftpClient.OpenMode.Append);
+					this.sftpClient.write(destination,
+							SftpClient.OpenMode.Create,
+							SftpClient.OpenMode.Write,
+							SftpClient.OpenMode.Append);
 			FileCopyUtils.copy(inputStream, outputStream);
 		}
 	}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8566

Turns out some SFTP servers are strict enough to not let to append into existing file if we don't give in addition a `Write` open mode flag as well

**Cherry-pick to `6.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
