### PR TITLE
Warn about dropped message in filter

### DIFF
--- a/src/reference/asciidoc/filter.adoc
+++ b/src/reference/asciidoc/filter.adoc
@@ -88,9 +88,9 @@ If you want rejected messages to be routed to a specific channel, provide that r
 ----
 ====
 
-If the `throwExceptionOnRejection == false` and no `discardChannel` provided, the message is silently dropped and an `o.s.i.filter.MessageFilter` instance just emits a warning into logs (starting with version 6.1) about this discarded message.
-To fully drop the message off and even lose the mentioned warning in logs, a `nullChannel` can be configured as a `discardChannel` on the filter.
-This way, the goal of the framework is to never be silent by default until an explicit option is set.
+If the `throwExceptionOnRejection == false` and no `discardChannel` is provided, the message is silently dropped and an `o.s.i.filter.MessageFilter` instance just emits a warning log message (starting with version 6.1) about this discarded message.
+To drop the message with no warning in the logs, a `NullChannel` can be configured as the `discardChannel` on the filter.
+The goal of the framework is to not be completely silent, by default, requiring an explicit option to be set, if that is the desired behavior.
 
 See also <<./handler-advice.adoc#advising-filters,Advising Filters>>.
 

--- a/src/reference/asciidoc/filter.adoc
+++ b/src/reference/asciidoc/filter.adoc
@@ -88,6 +88,8 @@ If you want rejected messages to be routed to a specific channel, provide that r
 ----
 ====
 
+If the `throwExceptionOnRejection == false` and no `discardChannel` provided, the message is silently dropped and an `o.s.i.filter.MessageFilter` instance just emits a warning into logs (starting with version 6.1) about this discarded message.
+
 See also <<./handler-advice.adoc#advising-filters,Advising Filters>>.
 
 NOTE: Message filters are commonly used in conjunction with a publish-subscribe channel.

--- a/src/reference/asciidoc/filter.adoc
+++ b/src/reference/asciidoc/filter.adoc
@@ -89,6 +89,8 @@ If you want rejected messages to be routed to a specific channel, provide that r
 ====
 
 If the `throwExceptionOnRejection == false` and no `discardChannel` provided, the message is silently dropped and an `o.s.i.filter.MessageFilter` instance just emits a warning into logs (starting with version 6.1) about this discarded message.
+To fully drop the message off and even lose the mentioned warning in logs, a `nullChannel` can be configured as a `discardChannel` on the filter.
+This way, the goal of the framework is to never be silent by default until an explicit option is set.
 
 See also <<./handler-advice.adoc#advising-filters,Advising Filters>>.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -30,6 +30,8 @@ See <<./zip.adoc#zip,Zip Support>>  for more information.
  - Added support for transforming to/from Protocol Buffers.
  See <<./transformer.adoc#Protobuf-transformers, Protocol Buffers Transformers>> for more information.
 
+ - The `MessageFilter` now emits a warning into logs when message is silently discarded and dropped.
+See <<./filter.adoc#filter, Filter>> for more information.
 
 [[x6.1-web-sockets]]
 === Web Sockets Changes


### PR DESCRIPTION
Buy default the `MessageFilter` just drops a discarded message silently. If a request-reply gateway is used upstream, then it becomes unclear why the flow sometimes doesn't work.

* Add a waring log ot emit for default behavior. This still doesn't fix the request-reply problem, but at least it can give a clue what is going on

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
