### PR TITLE
GH-8581: Do not overwrite configuration of external provided SshClient

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -61,6 +61,7 @@ import org.springframework.util.Assert;
  * @author Pat Turner
  * @author Artem Bilan
  * @author Krzysztof Debski
+ * @author Auke Zaaiman
  *
  * @since 2.0
  */
@@ -335,36 +336,44 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 		if (this.port <= 0) {
 			this.port = SshConstants.DEFAULT_PORT;
 		}
-		ServerKeyVerifier serverKeyVerifier =
-				this.allowUnknownKeys ? AcceptAllServerKeyVerifier.INSTANCE : RejectAllServerKeyVerifier.INSTANCE;
-		if (this.knownHosts != null) {
-			serverKeyVerifier = new ResourceKnownHostsServerKeyVerifier(this.knownHosts);
-		}
-		this.sshClient.setServerKeyVerifier(serverKeyVerifier);
 
-		this.sshClient.setPasswordIdentityProvider(PasswordIdentityProvider.wrapPasswords(this.password));
-		if (this.privateKey != null) {
-			IoResource<Resource> privateKeyResource =
-					new AbstractIoResource<>(Resource.class, this.privateKey) {
+		doInitInnerClient();
 
-						@Override
-						public InputStream openInputStream() throws IOException {
-							return getResourceValue().getInputStream();
-						}
-					};
-			try {
-				Collection<KeyPair> keys =
-						SecurityUtils.getKeyPairResourceParser()
-									.loadKeyPairs(null, privateKeyResource,
-										FilePasswordProvider.of(this.privateKeyPassphrase));
-				this.sshClient.setKeyIdentityProvider(KeyIdentityProvider.wrapKeyPairs(keys));
-			}
-			catch (GeneralSecurityException ex) {
-				throw new IOException("Cannot load private key: " + this.privateKey.getFilename(), ex);
-			}
-		}
-		this.sshClient.setUserInteraction(this.userInteraction);
 		this.sshClient.start();
+	}
+
+	private void doInitInnerClient() throws IOException {
+		if (this.isInnerClient) {
+			ServerKeyVerifier serverKeyVerifier =
+					this.allowUnknownKeys ? AcceptAllServerKeyVerifier.INSTANCE : RejectAllServerKeyVerifier.INSTANCE;
+			if (this.knownHosts != null) {
+				serverKeyVerifier = new ResourceKnownHostsServerKeyVerifier(this.knownHosts);
+			}
+			this.sshClient.setServerKeyVerifier(serverKeyVerifier);
+
+			this.sshClient.setPasswordIdentityProvider(PasswordIdentityProvider.wrapPasswords(this.password));
+			if (this.privateKey != null) {
+				IoResource<Resource> privateKeyResource =
+						new AbstractIoResource<>(Resource.class, this.privateKey) {
+
+							@Override
+							public InputStream openInputStream() throws IOException {
+								return getResourceValue().getInputStream();
+							}
+						};
+				try {
+					Collection<KeyPair> keys =
+							SecurityUtils.getKeyPairResourceParser()
+									.loadKeyPairs(null, privateKeyResource,
+											FilePasswordProvider.of(this.privateKeyPassphrase));
+					this.sshClient.setKeyIdentityProvider(KeyIdentityProvider.wrapKeyPairs(keys));
+				}
+				catch (GeneralSecurityException ex) {
+					throw new IOException("Cannot load private key: " + this.privateKey.getFilename(), ex);
+				}
+			}
+			this.sshClient.setUserInteraction(this.userInteraction);
+		}
 	}
 
 	@Override

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpSessionFactoryTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpSessionFactoryTests.java
@@ -36,9 +36,9 @@ import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * @author Gary Russell
@@ -149,7 +149,7 @@ public class SftpSessionFactoryTests {
 			sftpSessionFactory.setPort(server.getPort());
 			sftpSessionFactory.setUser("user");
 
-			assertDoesNotThrow(() -> sftpSessionFactory.getSession().connect());
+			assertThatNoException().isThrownBy(() -> sftpSessionFactory.getSession());
 		}
 	}
 }


### PR DESCRIPTION
Fixes spring-projects/spring-integration#8581

Moved configuring an internal provided `SshClient` to a separate method, which only will execute if `isInnerClient` is `true`.
Added a test proving an external configured `SshClient` can connect to a `SshServer`.