### PR TITLE
Propagate Reactor context over headers

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/IntegrationMessageHeaderAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2019 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+
+import reactor.util.context.ContextView;
 
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.lang.Nullable;
@@ -76,6 +78,12 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 	 * Raw source message.
 	 */
 	public static final String SOURCE_DATA = "sourceData";
+
+	/**
+	 * Raw source message.
+	 */
+	public static final String REACTOR_CONTEXT = "reactorContext";
+
 
 	private static final BiFunction<String, String, String> TYPE_VERIFY_MESSAGE_FUNCTION =
 			(name, trailer) -> "The '" + name + trailer;
@@ -173,6 +181,16 @@ public class IntegrationMessageHeaderAccessor extends MessageHeaderAccessor {
 	@Nullable
 	public <T> T getSourceData() {
 		return (T) getHeader(SOURCE_DATA);
+	}
+
+	/**
+	 * Get a {@link ContextView} header if present.
+	 * @return the {@link ContextView} header if present.
+	 * @since 6.0.5
+	 */
+	@Nullable
+	public ContextView getReactorContext() {
+		return getHeader(REACTOR_CONTEXT, ContextView.class);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-core/src/main/java/org/springframework/integration/StaticMessageHeaderAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/StaticMessageHeaderAccessor.java
@@ -124,7 +124,6 @@ public final class StaticMessageHeaderAccessor {
 	}
 
 	/**
-	 /**
 	 * Get a {@link ContextView} header if present.
 	 * @param message the message to get a header from.
 	 * @return the {@link ContextView} header if present.

--- a/spring-integration-core/src/main/java/org/springframework/integration/StaticMessageHeaderAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/StaticMessageHeaderAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,9 @@ package org.springframework.integration;
 import java.io.Closeable;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import reactor.util.context.Context;
+import reactor.util.context.ContextView;
 
 import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.acks.SimpleAcknowledgment;
@@ -118,6 +121,22 @@ public final class StaticMessageHeaderAccessor {
 	@Nullable
 	public static <T> T getSourceData(Message<?> message) {
 		return (T) message.getHeaders().get(IntegrationMessageHeaderAccessor.SOURCE_DATA);
+	}
+
+	/**
+	 /**
+	 * Get a {@link ContextView} header if present.
+	 * @param message the message to get a header from.
+	 * @return the {@link ContextView} header if present.
+	 * @since 6.0.5
+	 */
+	public static ContextView getReactorContext(Message<?> message) {
+		ContextView reactorContext = message.getHeaders()
+				.get(IntegrationMessageHeaderAccessor.REACTOR_CONTEXT, ContextView.class);
+		if (reactorContext == null) {
+			reactorContext = Context.empty();
+		}
+		return reactorContext;
 	}
 
 }

--- a/src/reference/asciidoc/reactive-streams.adoc
+++ b/src/reference/asciidoc/reactive-streams.adoc
@@ -336,14 +336,14 @@ For many other non-reactive channel adapters thread pools are recommended to avo
 [[context-propagation]]
 === Reactive to Imperative Context Propagation
 
-When the https://github.com/micrometer-metrics/context-propagation[Context Propagation] library is on the classpath, the Project Reactor can take `ThreadLocal` values (e.g. https://micrometer.io/docs/observation[Micrometer Observation] or `SecurityContextHolder`) and stores it into a `Subscriber` context.
+When the https://github.com/micrometer-metrics/context-propagation[Context Propagation] library is on the classpath, the Project Reactor can take `ThreadLocal` values (e.g. https://micrometer.io/docs/observation[Micrometer Observation] or `SecurityContextHolder`) and store them into a `Subscriber` context.
 The opposite operation is also possible, when we need to populate a logging MDC for tracing or let services we call from the reactive stream to restore an observation from the scope.
-See more information in the Project Reactor https://projectreactor.io/docs/core/release/reference/#context.propagation[documentation] about its special operators for context propagation.
+See more information in Project Reactor https://projectreactor.io/docs/core/release/reference/#context.propagation[documentation] about its special operators for context propagation.
 The storing and restoring context works smoothly if our whole solution is a single reactive stream composition since a `Subscriber` context is visible from downstream up to the beginning of the composition(`Flux` or `Mono`).
-But if the application switches between different `Flux` instances or into an imperative processing and back, then context tied to the `Subscriber` might not be available.
-For such a use-case Spring Integration provides an additional functionality (starting with version `6.0.5`) to store a Reactor `ContextView` into an `IntegrationMessageHeaderAccessor.REACTOR_CONTEXT` message header produced from the reactive stream, e.g. when we perform direct `send()` operation.
-This header is used then in the `FluxMessageChannel.subscribeTo()` to restore a Reactor context for the `Message` this channel is going to emit.
-Currently, this header is populated from the `WebFluxInboundEndpoint` and `RSocketInboundGateway` components, but can be used in any solution where reactive to imperative integration is done.
+But, if the application switches between different `Flux` instances or into imperative processing and back, then the context tied to the `Subscriber` might not be available.
+For such a use case, Spring Integration provides an additional capability (starting with version `6.0.5`) to store a Reactor `ContextView` into the `IntegrationMessageHeaderAccessor.REACTOR_CONTEXT` message header produced from the reactive stream, e.g. when we perform direct `send()` operation.
+This header is used then in the `FluxMessageChannel.subscribeTo()` to restore a Reactor context for the `Message` that this channel is going to emit.
+Currently, this header is populated from the `WebFluxInboundEndpoint` and `RSocketInboundGateway` components, but can be used in any solution where reactive to imperative integration is performed.
 The logic to populate this header is like this:
 
 ====
@@ -369,7 +369,7 @@ private Message<?> messageWithReactorContextIfAny(Message<?> message, ContextVie
 ----
 ====
 
-Note, that we still need to use a `handle()` operator to make Reactor to restore `ThreadLocal` values from context.
+Note, that we still need to use a `handle()` operator to make Reactor restore `ThreadLocal` values from the context.
 Even if it is sent as a header, the framework cannot make an assumption if it is going to be to restore onto `ThreadLocal` values downstream.
 
 To restore the context from a `Message` on the other `Flux` or `Mono` composition, this logic can be performed:

--- a/src/reference/asciidoc/reactive-streams.adoc
+++ b/src/reference/asciidoc/reactive-streams.adoc
@@ -105,7 +105,7 @@ The subscription for this `Mono` is done using `Schedulers.boundedElastic()` to 
 When the message source returns `null` (no data to pull), the `Mono` is turned into a `repeatWhenEmpty()` state with a `delay` for a subsequent re-subscription based on a `IntegrationReactiveUtils.DELAY_WHEN_EMPTY_KEY` `Duration` entry from the subscriber context.
 By default, it is 1 second.
 If the `MessageSource` produces messages with a `IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK` information in the headers, it is acknowledged (if necessary) in the `doOnSuccess()` of the original `Mono` and rejected in the `doOnError()` if the downstream flow throws a `MessagingException` with the failed message to reject.
-This `ReactiveMessageSourceProducer` could be used for any use-case when a a polling channel adapter's features should be turned into a reactive, on demand solution for any existing `MessageSource<?>` implementation.
+This `ReactiveMessageSourceProducer` could be used for any use-case when a polling channel adapter's features should be turned into a reactive, on demand solution for any existing `MessageSource<?>` implementation.
 
 === Splitter and Aggregator
 
@@ -332,3 +332,53 @@ Currently, Spring Integration provides channel adapter (or gateway) implementati
 The <<./redis.adoc#redis-stream-outbound,Redis Stream Channel Adapters>> are also reactive and uses `ReactiveStreamOperations` from Spring Data.
 More reactive channel adapters are coming, for example for Apache Kafka in <<./kafka.adoc#kafka,Kafka>> based on the `ReactiveKafkaProducerTemplate` and `ReactiveKafkaConsumerTemplate` from https://spring.io/projects/spring-kafka[Spring for Apache Kafka] etc.
 For many other non-reactive channel adapters thread pools are recommended to avoid blocking during reactive stream processing.
+
+[[context-propagation]]
+=== Reactive to Imperative Context Propagation
+
+When the https://github.com/micrometer-metrics/context-propagation[Context Propagation] library is on the classpath, the Project Reactor can take `ThreadLocal` values (e.g. https://micrometer.io/docs/observation[Micrometer Observation] or `SecurityContextHolder`) and stores it into a `Subscriber` context.
+The opposite operation is also possible, when we need to populate a logging MDC for tracing or let services we call from the reactive stream to restore an observation from the scope.
+See more information in the Project Reactor https://projectreactor.io/docs/core/release/reference/#context.propagation[documentation] about its special operators for context propagation.
+The storing and restoring context works smoothly if our whole solution is a single reactive stream composition since a `Subscriber` context is visible from downstream up to the beginning of the composition(`Flux` or `Mono`).
+But if the application switches between different `Flux` instances or into an imperative processing and back, then context tied to the `Subscriber` might not be available.
+For such a use-case Spring Integration provides an additional functionality (starting with version `6.0.5`) to store a Reactor `ContextView` into an `IntegrationMessageHeaderAccessor.REACTOR_CONTEXT` message header produced from the reactive stream, e.g. when we perform direct `send()` operation.
+This header is used then in the `FluxMessageChannel.subscribeTo()` to restore a Reactor context for the `Message` this channel is going to emit.
+Currently, this header is populated from the `WebFluxInboundEndpoint` and `RSocketInboundGateway` components, but can be used in any solution where reactive to imperative integration is done.
+The logic to populate this header is like this:
+
+====
+[source, java]
+----
+return requestMono
+        .flatMap((message) ->
+                Mono.deferContextual((context) ->
+                        Mono.just(message)
+                                .handle((messageToSend, sink) ->
+                                        send(messageWithReactorContextIfAny(messageToSend, context)))));
+...
+
+private Message<?> messageWithReactorContextIfAny(Message<?> message, ContextView context) {
+    if (!context.isEmpty()) {
+        return getMessageBuilderFactory()
+                .fromMessage(message)
+                .setHeader(IntegrationMessageHeaderAccessor.REACTOR_CONTEXT, context)
+                .build();
+    }
+    return message;
+}
+----
+====
+
+Note, that we still need to use a `handle()` operator to make Reactor to restore `ThreadLocal` values from context.
+Even if it is sent as a header, the framework cannot make an assumption if it is going to be to restore onto `ThreadLocal` values downstream.
+
+To restore the context from a `Message` on the other `Flux` or `Mono` composition, this logic can be performed:
+
+====
+[source, java]
+----
+Mono.just(message)
+        .handle((messageToHandle, sink) -> ...)
+        .contextWrite(StaticMessageHeaderAccessor.getReactorContext(message)));
+----
+====


### PR DESCRIPTION
When we do something like `Flux.from(Publisher)`
and don't compose it with the one involved in the `Subscriber` context, we lose this context.

* Provide a mechanism to propagate a Reactor context over message header produce within that context.
* Restore this context in the `FluxMessageChannel` for a new publisher we use in this channel

**Cherry-pick to `6.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
