### PR TITLE
GH-8586: Deprecate IntegrationComponentSpec.get()

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,13 +43,13 @@ public abstract class AmqpInboundChannelAdapterSpec
 	protected final MessageListenerContainerSpec<?, C> listenerContainerSpec; // NOSONAR final
 
 	protected AmqpInboundChannelAdapterSpec(MessageListenerContainerSpec<?, C> listenerContainerSpec) {
-		super(new AmqpInboundChannelAdapter(listenerContainerSpec.get()));
+		super(new AmqpInboundChannelAdapter(listenerContainerSpec.getObject()));
 		this.listenerContainerSpec = listenerContainerSpec;
 	}
 
 	@Override
 	public Map<Object, String> getComponentsToRegister() {
-		return Collections.singletonMap(this.listenerContainerSpec.get(), this.listenerContainerSpec.getId());
+		return Collections.singletonMap(this.listenerContainerSpec.getObject(), this.listenerContainerSpec.getId());
 	}
 
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewaySpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpInboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ public abstract class AmqpInboundGatewaySpec
 	protected final AbstractMessageListenerContainerSpec<?, C> listenerContainerSpec; // NOSONAR final
 
 	protected AmqpInboundGatewaySpec(AbstractMessageListenerContainerSpec<?, C> listenerContainerSpec) {
-		super(new AmqpInboundGateway(listenerContainerSpec.get()));
+		super(new AmqpInboundGateway(listenerContainerSpec.getObject()));
 		this.listenerContainerSpec = listenerContainerSpec;
 	}
 
@@ -53,16 +53,16 @@ public abstract class AmqpInboundGatewaySpec
 	 * @param listenerContainerSpec the {@link AbstractMessageListenerContainerSpec} to use.
 	 * @param amqpTemplate the {@link AmqpTemplate} to use.
 	 */
-	AmqpInboundGatewaySpec(
-			AbstractMessageListenerContainerSpec<?, C> listenerContainerSpec,
+	AmqpInboundGatewaySpec(AbstractMessageListenerContainerSpec<?, C> listenerContainerSpec,
 			AmqpTemplate amqpTemplate) {
-		super(new AmqpInboundGateway(listenerContainerSpec.get(), amqpTemplate));
+
+		super(new AmqpInboundGateway(listenerContainerSpec.getObject(), amqpTemplate));
 		this.listenerContainerSpec = listenerContainerSpec;
 	}
 
 	@Override
 	public Map<Object, String> getComponentsToRegister() {
-		return Collections.singletonMap(this.listenerContainerSpec.get(), this.listenerContainerSpec.getId());
+		return Collections.singletonMap(this.listenerContainerSpec.getObject(), this.listenerContainerSpec.getId());
 	}
 
 }

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/RabbitStreamMessageHandlerSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/RabbitStreamMessageHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ public class RabbitStreamMessageHandlerSpec
 	 * Set to true to wait for a confirmation.
 	 * @param sync true to wait.
 	 * @return this spec.
-	 * @see #setConfirmTimeout(long)
+	 * @see #confirmTimeout(long)
 	 */
 	public RabbitStreamMessageHandlerSpec sync(boolean sync) {
 		this.target.setSync(sync);

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import org.springframework.context.Lifecycle;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.amqp.channel.AbstractAmqpChannel;
+import org.springframework.integration.amqp.channel.PollableAmqpChannel;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter.BatchMode;
 import org.springframework.integration.amqp.inbound.AmqpInboundGateway;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
@@ -472,15 +473,16 @@ public class AmqpTests {
 		}
 
 		@Bean
-		public AbstractAmqpChannel unitChannel(ConnectionFactory rabbitConnectionFactory) {
+		public AmqpPollableMessageChannelSpec<?, PollableAmqpChannel> unitChannel(
+				ConnectionFactory rabbitConnectionFactory) {
+
 			return Amqp.pollableChannel(rabbitConnectionFactory)
 					.queueName("si.dsl.test")
 					.channelTransacted(true)
 					.extractPayload(true)
 					.inboundHeaderMapper(mapperIn())
 					.outboundHeaderMapper(mapperOut())
-					.defaultDeliveryMode(MessageDeliveryMode.NON_PERSISTENT)
-					.get();
+					.defaultDeliveryMode(MessageDeliveryMode.NON_PERSISTENT);
 		}
 
 		@Bean

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandlerTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Chris Bono
+ * @author Artem Bilan
+ *
  * @since 6.0
  */
 public class RabbitStreamMessageHandlerTests implements RabbitTestContainer {
@@ -56,7 +58,7 @@ public class RabbitStreamMessageHandlerTests implements RabbitTestContainer {
 
 		RabbitStreamMessageHandler handler = RabbitStream.outboundStreamAdapter(streamTemplate)
 				.sync(true)
-				.get();
+				.getObject();
 
 		handler.handleMessage(MessageBuilder.withPayload("foo")
 				.setHeader("bar", "baz")

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ package org.springframework.integration.dsl;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
@@ -233,7 +232,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * at the current {@link IntegrationFlow} chain position.
 	 * The provided {@code messageChannelName} is used for the bean registration
 	 * ({@link org.springframework.integration.channel.DirectChannel}), if there is no such a bean
-	 * in the application context. Otherwise the existing {@link MessageChannel} bean is used
+	 * in the application context. Otherwise, the existing {@link MessageChannel} bean is used
 	 * to wire integration endpoints.
 	 * @param messageChannelName the bean name to use.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
@@ -252,7 +251,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 */
 	public B channel(MessageChannelSpec<?, ?> messageChannelSpec) {
 		Assert.notNull(messageChannelSpec, "'messageChannelSpec' must not be null");
-		return channel(messageChannelSpec.get());
+		return channel(messageChannelSpec.getObject());
 	}
 
 	/**
@@ -367,7 +366,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * }
 	 * </pre>
 	 * This method can be used after any {@link #channel} for explicit {@link MessageChannel},
-	 * but with the caution do not impact existing {@link org.springframework.messaging.support.ChannelInterceptor}s.
+	 * but with the caution do not impact existing {@link ChannelInterceptor}s.
 	 * @param wireTapChannel the {@link MessageChannel} bean name to wire-tap.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 */
@@ -377,8 +376,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 	/**
 	 * Populate the {@code Wire Tap} EI Pattern specific
-	 * {@link org.springframework.messaging.support.ChannelInterceptor} implementation
-	 * to the current {@link #currentMessageChannel}.
+	 * {@link ChannelInterceptor} implementation to the current {@link #currentMessageChannel}.
 	 * It is useful when an implicit {@link MessageChannel} is used between endpoints:
 	 * <pre class="code">
 	 * {@code
@@ -388,7 +386,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * }
 	 * </pre>
 	 * This method can be used after any {@link #channel} for explicit {@link MessageChannel},
-	 * but with the caution do not impact existing {@link org.springframework.messaging.support.ChannelInterceptor}s.
+	 * but with the caution do not impact existing {@link ChannelInterceptor}s.
 	 * @param wireTapChannel the {@link MessageChannel} to wire-tap.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 */
@@ -398,8 +396,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 	/**
 	 * Populate the {@code Wire Tap} EI Pattern specific
-	 * {@link org.springframework.messaging.support.ChannelInterceptor} implementation
-	 * to the current {@link #currentMessageChannel}.
+	 * {@link ChannelInterceptor} implementation to the current {@link #currentMessageChannel}.
 	 * It is useful when an implicit {@link MessageChannel} is used between endpoints:
 	 * <pre class="code">
 	 * {@code
@@ -409,7 +406,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * }
 	 * </pre>
 	 * This method can be used after any {@link #channel} for explicit {@link MessageChannel},
-	 * but with the caution do not impact existing {@link org.springframework.messaging.support.ChannelInterceptor}s.
+	 * but with the caution do not impact existing {@link ChannelInterceptor}s.
 	 * @param flow the {@link IntegrationFlow} for wire-tap subflow as an alternative to the {@code wireTapChannel}.
 	 * @param wireTapConfigurer the {@link Consumer} to accept options for the {@link WireTap}.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
@@ -438,8 +435,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 	/**
 	 * Populate the {@code Wire Tap} EI Pattern specific
-	 * {@link org.springframework.messaging.support.ChannelInterceptor} implementation
-	 * to the current {@link #currentMessageChannel}.
+	 * {@link ChannelInterceptor} implementation to the current {@link #currentMessageChannel}.
 	 * It is useful when an implicit {@link MessageChannel} is used between endpoints:
 	 * <pre class="code">
 	 * {@code
@@ -449,7 +445,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * }
 	 * </pre>
 	 * This method can be used after any {@link #channel} for explicit {@link MessageChannel},
-	 * but with the caution do not impact existing {@link org.springframework.messaging.support.ChannelInterceptor}s.
+	 * but with the caution do not impact existing {@link ChannelInterceptor}s.
 	 * @param wireTapChannel the {@link MessageChannel} bean name to wire-tap.
 	 * @param wireTapConfigurer the {@link Consumer} to accept options for the {@link WireTap}.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
@@ -462,8 +458,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 	/**
 	 * Populate the {@code Wire Tap} EI Pattern specific
-	 * {@link org.springframework.messaging.support.ChannelInterceptor} implementation
-	 * to the current {@link #currentMessageChannel}.
+	 * {@link ChannelInterceptor} implementation to the current {@link #currentMessageChannel}.
 	 * It is useful when an implicit {@link MessageChannel} is used between endpoints:
 	 * <pre class="code">
 	 * {@code
@@ -473,7 +468,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * }
 	 * </pre>
 	 * This method can be used after any {@link #channel} for explicit {@link MessageChannel},
-	 * but with the caution do not impact existing {@link org.springframework.messaging.support.ChannelInterceptor}s.
+	 * but with the caution do not impact existing {@link ChannelInterceptor}s.
 	 * @param wireTapChannel the {@link MessageChannel} to wire-tap.
 	 * @param wireTapConfigurer the {@link Consumer} to accept options for the {@link WireTap}.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
@@ -489,8 +484,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 	/**
 	 * Populate the {@code Wire Tap} EI Pattern specific
-	 * {@link org.springframework.messaging.support.ChannelInterceptor} implementation
-	 * to the current {@link #currentMessageChannel}.
+	 * {@link ChannelInterceptor} implementation to the current {@link #currentMessageChannel}.
 	 * <p> It is useful when an implicit {@link MessageChannel} is used between endpoints:
 	 * <pre class="code">
 	 * {@code
@@ -500,14 +494,16 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * }
 	 * </pre>
 	 * This method can be used after any {@link #channel} for explicit {@link MessageChannel},
-	 * but with the caution do not impact existing {@link org.springframework.messaging.support.ChannelInterceptor}s.
+	 * but with the caution do not impact existing {@link ChannelInterceptor}s.
 	 * @param wireTapSpec the {@link WireTapSpec} to use.
-	 * <p> When this EIP-method is used in the end of flow, it appends {@code nullChannel} to terminate flow properly,
-	 * Otherwise {@code Dispatcher has no subscribers} exception is thrown for implicit {@link DirectChannel}.
+	 * <p> When this EIP-method is used in the end of flow,
+	 * it appends a {@code nullChannel} to terminate flow properly,
+	 * Otherwise a {@code Dispatcher has no subscribers} exception
+	 * is thrown for implicit {@link DirectChannel}.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 */
 	public B wireTap(WireTapSpec wireTapSpec) {
-		WireTap interceptor = wireTapSpec.get();
+		WireTap interceptor = wireTapSpec.getObject();
 		InterceptableChannel currentChannel = currentInterceptableChannel();
 		addComponent(wireTapSpec);
 		currentChannel.addInterceptor(interceptor);
@@ -613,7 +609,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 	/**
 	 * Populate the {@link MessageTransformingHandler} instance for the
-	 * {@link org.springframework.integration.handler.MessageProcessor} from provided {@link MessageProcessorSpec}.
+	 * {@link MessageProcessor} from provided {@link MessageProcessorSpec}.
 	 * <pre class="code">
 	 * {@code
 	 *  .transform(Scripts.script("classpath:myScript.py").variable("foo", bar()))
@@ -629,7 +625,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 	/**
 	 * Populate the {@link MessageTransformingHandler} instance for the
-	 * {@link org.springframework.integration.handler.MessageProcessor} from provided {@link MessageProcessorSpec}.
+	 * {@link MessageProcessor} from provided {@link MessageProcessorSpec}.
 	 * In addition, accept options for the integration endpoint using {@link GenericEndpointSpec}.
 	 * <pre class="code">
 	 * {@code
@@ -646,7 +642,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 			Consumer<GenericEndpointSpec<MessageTransformingHandler>> endpointConfigurer) {
 
 		Assert.notNull(messageProcessorSpec, MESSAGE_PROCESSOR_SPEC_MUST_NOT_BE_NULL);
-		MessageProcessor<?> processor = messageProcessorSpec.get();
+		MessageProcessor<?> processor = messageProcessorSpec.getObject();
 		return addComponent(processor)
 				.transform(null, new MethodInvokingTransformer(processor), endpointConfigurer);
 	}
@@ -832,7 +828,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 */
 	public B filter(MessageProcessorSpec<?> messageProcessorSpec, Consumer<FilterEndpointSpec> endpointConfigurer) {
 		Assert.notNull(messageProcessorSpec, MESSAGE_PROCESSOR_SPEC_MUST_NOT_BE_NULL);
-		MessageProcessor<?> processor = messageProcessorSpec.get();
+		MessageProcessor<?> processor = messageProcessorSpec.getObject();
 		return addComponent(processor)
 				.filter(null, new MethodInvokingSelector(processor), endpointConfigurer);
 	}
@@ -1089,7 +1085,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 			Consumer<GenericEndpointSpec<ServiceActivatingHandler>> endpointConfigurer) {
 
 		Assert.notNull(messageProcessorSpec, MESSAGE_PROCESSOR_SPEC_MUST_NOT_BE_NULL);
-		MessageProcessor<?> processor = messageProcessorSpec.get();
+		MessageProcessor<?> processor = messageProcessorSpec.getObject();
 		return addComponent(processor)
 				.handle(new ServiceActivatingHandler(processor), endpointConfigurer);
 	}
@@ -1118,7 +1114,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 		if (messageHandlerSpec instanceof ComponentsRegistration) {
 			addComponents(((ComponentsRegistration) messageHandlerSpec).getComponentsToRegister());
 		}
-		return handle(messageHandlerSpec.get(), endpointConfigurer);
+		return handle(messageHandlerSpec.getObject(), endpointConfigurer);
 	}
 
 	/**
@@ -1287,7 +1283,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 		HeaderEnricherSpec headerEnricherSpec = new HeaderEnricherSpec();
 		headerEnricherSpec.headers(headers);
-		Tuple2<ConsumerEndpointFactoryBean, MessageTransformingHandler> tuple2 = headerEnricherSpec.get();
+		Tuple2<ConsumerEndpointFactoryBean, MessageTransformingHandler> tuple2 = headerEnricherSpec.getObject();
 		return addComponents(headerEnricherSpec.getComponentsToRegister())
 				.handle(tuple2.getT2(), endpointConfigurer);
 	}
@@ -1478,7 +1474,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 			Consumer<SplitterEndpointSpec<MethodInvokingSplitter>> endpointConfigurer) {
 
 		Assert.notNull(messageProcessorSpec, MESSAGE_PROCESSOR_SPEC_MUST_NOT_BE_NULL);
-		MessageProcessor<?> processor = messageProcessorSpec.get();
+		MessageProcessor<?> processor = messageProcessorSpec.getObject();
 		return addComponent(processor)
 				.split(new MethodInvokingSplitter(processor), endpointConfigurer);
 	}
@@ -1569,7 +1565,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	public <S extends AbstractMessageSplitter> B split(MessageHandlerSpec<?, S> splitterMessageHandlerSpec,
 			Consumer<SplitterEndpointSpec<S>> endpointConfigurer) {
 		Assert.notNull(splitterMessageHandlerSpec, "'splitterMessageHandlerSpec' must not be null");
-		return split(splitterMessageHandlerSpec.get(), endpointConfigurer);
+		return split(splitterMessageHandlerSpec.getObject(), endpointConfigurer);
 	}
 
 	/**
@@ -1960,7 +1956,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 			Consumer<RouterSpec<Object, MethodInvokingRouter>> routerConfigurer) {
 
 		Assert.notNull(messageProcessorSpec, MESSAGE_PROCESSOR_SPEC_MUST_NOT_BE_NULL);
-		MessageProcessor<?> processor = messageProcessorSpec.get();
+		MessageProcessor<?> processor = messageProcessorSpec.getObject();
 		addComponent(processor);
 
 		return route(new RouterSpec<>(new MethodInvokingRouter(processor)), routerConfigurer);
@@ -2713,7 +2709,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 		if (gatherer != null) {
 			gatherer.accept(aggregatorSpec);
 		}
-		AggregatingMessageHandler aggregatingMessageHandler = aggregatorSpec.get().getT2();
+		AggregatingMessageHandler aggregatingMessageHandler = aggregatorSpec.getObject().getT2();
 		addComponent(aggregatingMessageHandler);
 		ScatterGatherHandler messageHandler = new ScatterGatherHandler(scatterChannel, aggregatingMessageHandler);
 		return register(new ScatterGatherSpec(messageHandler), scatterGather);
@@ -2766,10 +2762,10 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 		if (gatherer != null) {
 			gatherer.accept(aggregatorSpec);
 		}
-		RecipientListRouter recipientListRouter = recipientListRouterSpec.get().getT2();
+		RecipientListRouter recipientListRouter = recipientListRouterSpec.getObject().getT2();
 		addComponent(recipientListRouter)
 				.addComponents(recipientListRouterSpec.getComponentsToRegister());
-		AggregatingMessageHandler aggregatingMessageHandler = aggregatorSpec.get().getT2();
+		AggregatingMessageHandler aggregatingMessageHandler = aggregatorSpec.getObject().getT2();
 		addComponent(aggregatingMessageHandler);
 		ScatterGatherHandler messageHandler = new ScatterGatherHandler(recipientListRouter, aggregatingMessageHandler);
 		return register(new ScatterGatherSpec(messageHandler), scatterGather);
@@ -2974,16 +2970,16 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 			this.registerOutputChannelIfCan(inputChannel);
 		}
 
-		Tuple2<ConsumerEndpointFactoryBean, ? extends MessageHandler> factoryBeanTuple2 = endpointSpec.get();
+		Tuple2<ConsumerEndpointFactoryBean, ? extends MessageHandler> factoryBeanTuple2 = endpointSpec.getObject();
 
 		addComponents(endpointSpec.getComponentsToRegister());
 
-		if (inputChannel instanceof MessageChannelReference) {
-			factoryBeanTuple2.getT1().setInputChannelName(((MessageChannelReference) inputChannel).getName());
+		if (inputChannel instanceof MessageChannelReference messageChannelReference) {
+			factoryBeanTuple2.getT1().setInputChannelName(messageChannelReference.getName());
 		}
 		else {
-			if (inputChannel instanceof FixedSubscriberChannelPrototype) {
-				String beanName = ((FixedSubscriberChannelPrototype) inputChannel).getName();
+			if (inputChannel instanceof FixedSubscriberChannelPrototype fixedSubscriberChannel) {
+				String beanName = fixedSubscriberChannel.getName();
 				inputChannel = new FixedSubscriberChannel(factoryBeanTuple2.getT2());
 				if (beanName != null) {
 					((FixedSubscriberChannel) inputChannel).setBeanName(beanName);
@@ -3002,8 +2998,8 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 			Object currComponent = getCurrentComponent();
 			if (currComponent != null) {
 				String channelName = null;
-				if (outputChannel instanceof MessageChannelReference) {
-					channelName = ((MessageChannelReference) outputChannel).getName();
+				if (outputChannel instanceof MessageChannelReference channelReference) {
+					channelName = channelReference.getName();
 				}
 
 				if (currComponent instanceof MessageProducer messageProducer) {
@@ -3015,9 +3011,9 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 						messageProducer.setOutputChannel(outputChannel);
 					}
 				}
-				else if (currComponent instanceof SourcePollingChannelAdapterSpec) {
+				else if (currComponent instanceof SourcePollingChannelAdapterSpec sourcePollingChannelAdapterSpec) {
 					SourcePollingChannelAdapterFactoryBean pollingChannelAdapterFactoryBean =
-							((SourcePollingChannelAdapterSpec) currComponent).get().getT1();
+							sourcePollingChannelAdapterSpec.getObject().getT1();
 					if (channelName != null) {
 						pollingChannelAdapterFactoryBean.setOutputChannelName(channelName);
 					}
@@ -3081,13 +3077,11 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 			}
 
 			if (isImplicitChannel()) {
-				Optional<Object> lastComponent =
-						components.keySet()
-								.stream()
-								.reduce((first, second) -> second);
-				if (lastComponent.get() instanceof WireTapSpec) {
-					bridge();
-				}
+				components.keySet()
+						.stream()
+						.reduce((first, second) -> second)
+						.filter(WireTapSpec.class::isInstance)
+						.ifPresent((wireTap) -> bridge());
 			}
 
 			this.integrationFlow = new StandardIntegrationFlow(components);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/EndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/EndpointSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public abstract class EndpointSpec<S extends EndpointSpec<S, F, H>, F extends Be
 		if (components != null) {
 			this.componentsToRegister.putAll(components);
 		}
-		return poller(pollerMetadataSpec.get());
+		return poller(pollerMetadataSpec.getObject());
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -151,7 +151,7 @@ public interface IntegrationFlow {
 	 */
 	static IntegrationFlowBuilder from(MessageChannelSpec<?, ?> messageChannelSpec) {
 		Assert.notNull(messageChannelSpec, "'messageChannelSpec' must not be null");
-		return from(messageChannelSpec.get());
+		return from(messageChannelSpec.getObject());
 	}
 
 	/**
@@ -217,7 +217,7 @@ public interface IntegrationFlow {
 			Consumer<SourcePollingChannelAdapterSpec> endpointConfigurer) {
 
 		Assert.notNull(messageSourceSpec, "'messageSourceSpec' must not be null");
-		return from(messageSourceSpec.get(), endpointConfigurer, registerComponents(messageSourceSpec));
+		return from(messageSourceSpec.getObject(), endpointConfigurer, registerComponents(messageSourceSpec));
 	}
 
 	/**
@@ -321,7 +321,7 @@ public interface IntegrationFlow {
 	 * @see MessageProducerSpec
 	 */
 	static IntegrationFlowBuilder from(MessageProducerSpec<?, ?> messageProducerSpec) {
-		return from(messageProducerSpec.get(), registerComponents(messageProducerSpec));
+		return from(messageProducerSpec.getObject(), registerComponents(messageProducerSpec));
 	}
 
 	/**
@@ -362,7 +362,7 @@ public interface IntegrationFlow {
 	 * @since 6.0
 	 */
 	static IntegrationFlowBuilder from(MessagingGatewaySpec<?, ?> inboundGatewaySpec) {
-		return from(inboundGatewaySpec.get(), registerComponents(inboundGatewaySpec));
+		return from(inboundGatewaySpec.getObject(), registerComponents(inboundGatewaySpec));
 	}
 
 	/**
@@ -445,14 +445,14 @@ public interface IntegrationFlow {
 						"' must be declared as a bean in the application context");
 		Object lastIntegrationComponentFromOther =
 				integrationComponents.keySet().stream().reduce((prev, next) -> next).orElse(null);
-		if (lastIntegrationComponentFromOther instanceof MessageChannel) {
-			return from((MessageChannel) lastIntegrationComponentFromOther);
+		if (lastIntegrationComponentFromOther instanceof MessageChannel messageChannel) {
+			return from(messageChannel);
 		}
-		else if (lastIntegrationComponentFromOther instanceof ConsumerEndpointFactoryBean) {
-			MessageHandler handler = ((ConsumerEndpointFactoryBean) lastIntegrationComponentFromOther).getHandler();
+		else if (lastIntegrationComponentFromOther instanceof ConsumerEndpointFactoryBean factoryBean) {
+			MessageHandler handler = factoryBean.getHandler();
 			handler = extractProxyTarget(handler);
-			if (handler instanceof AbstractMessageProducingHandler) {
-				return buildFlowFromOutputChannel((AbstractMessageProducingHandler) handler);
+			if (handler instanceof AbstractMessageProducingHandler producingHandler) {
+				return buildFlowFromOutputChannel(producingHandler);
 			}
 			lastIntegrationComponentFromOther = handler; // for the exception message below
 		}
@@ -489,9 +489,9 @@ public interface IntegrationFlow {
 	}
 
 	private static IntegrationFlowBuilder registerComponents(Object spec) {
-		if (spec instanceof ComponentsRegistration) {
+		if (spec instanceof ComponentsRegistration componentsRegistration) {
 			return new IntegrationFlowBuilder()
-					.addComponents(((ComponentsRegistration) spec).getComponentsToRegister());
+					.addComponents(componentsRegistration.getComponentsToRegister());
 		}
 		return null;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/MessageChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/MessageChannelSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +100,7 @@ public abstract class MessageChannelSpec<S extends MessageChannelSpec<S, C>, C e
 	 * @see WireTap
 	 */
 	public S wireTap(WireTapSpec wireTapSpec) {
-		WireTap interceptor = wireTapSpec.get();
+		WireTap interceptor = wireTapSpec.getObject();
 		this.componentsToRegister.put(interceptor, null);
 		return interceptor(interceptor);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/DslIntegrationConfigurationInitializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/DslIntegrationConfigurationInitializer.java
@@ -31,11 +31,12 @@ import org.springframework.util.Assert;
  * Registers {@link IntegrationFlowBeanPostProcessor} and checks if all
  * {@link org.springframework.integration.dsl.IntegrationComponentSpec} are extracted to
  * the target object using
- * {@link org.springframework.integration.dsl.IntegrationComponentSpec#get()}.
+ * {@link org.springframework.integration.dsl.IntegrationComponentSpec#getObject()}.
  *
  * @author Artem Bilan
  * @author Gary Russell
  * @author Chris Bono
+ *
  * @since 5.0
  *
  * @see org.springframework.integration.config.IntegrationConfigurationBeanFactoryPostProcessor

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/FluxMessageChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/FluxMessageChannelTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,7 +119,7 @@ public class FluxMessageChannelTests {
 
 	@Test
 	void testFluxMessageChannelCleanUp() throws InterruptedException {
-		FluxMessageChannel flux = MessageChannels.flux().get();
+		FluxMessageChannel flux = MessageChannels.flux().getObject();
 
 		CountDownLatch finishLatch = new CountDownLatch(1);
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/PollersTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/PollersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,19 +35,19 @@ public class PollersTests {
 
 	@Test
 	public void testDurations() {
-		PeriodicTrigger trigger = (PeriodicTrigger) Pollers.fixedDelay(Duration.ofMinutes(1L)).get().getTrigger();
+		PeriodicTrigger trigger = (PeriodicTrigger) Pollers.fixedDelay(Duration.ofMinutes(1L)).getObject().getTrigger();
 		assertThat(trigger.getPeriodDuration()).isEqualTo(Duration.ofSeconds(60));
 		assertThat(trigger.isFixedRate()).isFalse();
 		trigger = (PeriodicTrigger) Pollers.fixedDelay(Duration.ofMinutes(1L), Duration.ofSeconds(10L))
-				.get().getTrigger();
+				.getObject().getTrigger();
 		assertThat(trigger.getPeriodDuration()).isEqualTo(Duration.ofSeconds(60));
 		assertThat(trigger.getInitialDelayDuration()).isEqualTo(Duration.ofSeconds(10));
 		assertThat(trigger.isFixedRate()).isFalse();
-		trigger = (PeriodicTrigger) Pollers.fixedRate(Duration.ofMinutes(1L)).get().getTrigger();
+		trigger = (PeriodicTrigger) Pollers.fixedRate(Duration.ofMinutes(1L)).getObject().getTrigger();
 		assertThat(trigger.getPeriodDuration()).isEqualTo(Duration.ofSeconds(60));
 		assertThat(trigger.isFixedRate()).isTrue();
 		trigger = (PeriodicTrigger) Pollers.fixedRate(Duration.ofMinutes(1L), Duration.ofSeconds(10L))
-				.get().getTrigger();
+				.getObject().getTrigger();
 		assertThat(trigger.getPeriodDuration()).isEqualTo(Duration.ofSeconds(60));
 		assertThat(trigger.getInitialDelayDuration()).isEqualTo(Duration.ofSeconds(10));
 		assertThat(trigger.isFixedRate()).isTrue();

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/composition/IntegrationFlowCompositionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/composition/IntegrationFlowCompositionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.PollerSpec;
 import org.springframework.integration.dsl.Pollers;
 import org.springframework.integration.dsl.context.IntegrationFlowContext;
 import org.springframework.integration.scheduling.PollerMetadata;
@@ -142,8 +143,8 @@ public class IntegrationFlowCompositionTests {
 	public static class ContextConfiguration {
 
 		@Bean(PollerMetadata.DEFAULT_POLLER)
-		PollerMetadata defaultPoller() {
-			return Pollers.fixedDelay(100).get();
+		PollerSpec defaultPoller() {
+			return Pollers.fixedDelay(100);
 		}
 
 		@Bean

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,13 +54,16 @@ import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.FixedSubscriberChannel;
 import org.springframework.integration.channel.NullChannel;
+import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.GenericTransformer;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.MessageChannels;
+import org.springframework.integration.dsl.PollerSpec;
 import org.springframework.integration.dsl.Pollers;
+import org.springframework.integration.dsl.QueueChannelSpec;
 import org.springframework.integration.dsl.Transformers;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
@@ -575,8 +578,8 @@ public class IntegrationFlowTests {
 		}
 
 		@Bean(name = PollerMetadata.DEFAULT_POLLER)
-		public PollerMetadata poller() {
-			return Pollers.fixedRate(100).get();
+		public PollerSpec poller() {
+			return Pollers.fixedRate(100);
 		}
 
 		@Bean(name = IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)
@@ -588,8 +591,8 @@ public class IntegrationFlowTests {
 
 
 		@Bean
-		public MessageChannel suppliedChannel() {
-			return MessageChannels.queue(10).get();
+		public QueueChannelSpec suppliedChannel() {
+			return MessageChannels.queue(10);
 		}
 
 	}
@@ -608,8 +611,8 @@ public class IntegrationFlowTests {
 		}
 
 		@Bean
-		public MessageChannel suppliedChannel2() {
-			return MessageChannels.queue(10).get();
+		public QueueChannelSpec suppliedChannel2() {
+			return MessageChannels.queue(10);
 		}
 
 	}
@@ -627,12 +630,12 @@ public class IntegrationFlowTests {
 
 		@Bean
 		public MessageChannel inputChannel() {
-			return MessageChannels.direct().get();
+			return new DirectChannel();
 		}
 
 		@Bean
 		public MessageChannel foo() {
-			return MessageChannels.publishSubscribe().get();
+			return new PublishSubscribeChannel();
 		}
 
 	}
@@ -682,7 +685,7 @@ public class IntegrationFlowTests {
 
 		@Bean
 		public MessageChannel publishSubscribeChannel() {
-			return MessageChannels.publishSubscribe().get();
+			return new PublishSubscribeChannel();
 		}
 
 		@Bean
@@ -784,8 +787,8 @@ public class IntegrationFlowTests {
 		private MethodInterceptor delayedAdvice;
 
 		@Bean
-		public QueueChannel successChannel() {
-			return MessageChannels.queue().get();
+		public QueueChannelSpec successChannel() {
+			return MessageChannels.queue();
 		}
 
 		@Bean

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,6 @@ import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.gateway.GatewayProxyFactoryBean;
 import org.springframework.integration.gateway.MessagingGatewaySupport;
 import org.springframework.integration.gateway.MethodArgsHolder;
@@ -189,7 +188,7 @@ public class GatewayDslTests {
 
 		@Bean
 		public MessageChannel gatewayError() {
-			return MessageChannels.queue().get();
+			return new QueueChannel();
 		}
 
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/transformers/TransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/transformers/TransformerTests.java
@@ -30,12 +30,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.MessageRejectedException;
 import org.springframework.integration.annotation.Transformer;
+import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.FixedSubscriberChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.codec.Codec;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
-import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.integration.dsl.Transformers;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
 import org.springframework.integration.handler.advice.ExpressionEvaluatingRequestHandlerAdvice;
@@ -423,7 +423,7 @@ public class TransformerTests {
 
 		@Bean
 		public MessageChannel enricherReplyChannel() {
-			return MessageChannels.direct().get();
+			return new DirectChannel();
 		}
 
 		@Bean

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ContentTypeConversionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ContentTypeConversionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -32,6 +31,7 @@ import org.springframework.integration.annotation.GatewayHeader;
 import org.springframework.integration.annotation.MessagingGateway;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.DirectChannelSpec;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.MessageChannels;
 import org.springframework.messaging.Message;
@@ -39,7 +39,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.support.ChannelInterceptor;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -48,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 5.0
  */
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 public class ContentTypeConversionTests {
 
 	@Autowired
@@ -91,7 +91,7 @@ public class ContentTypeConversionTests {
 		}
 
 		@Bean
-		public MessageChannel serviceChannel(final AtomicReference<Object> sendData) {
+		public DirectChannelSpec serviceChannel(AtomicReference<Object> sendData) {
 			return MessageChannels.direct()
 					.interceptor(new ChannelInterceptor() {
 
@@ -101,8 +101,7 @@ public class ContentTypeConversionTests {
 							return message;
 						}
 
-					})
-					.get();
+					});
 		}
 
 		@Bean

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -231,7 +231,7 @@ class KotlinDslTests {
 
 		@Bean(PollerMetadata.DEFAULT_POLLER)
 		fun defaultPoller() =
-			Pollers.fixedDelay(100).maxMessagesPerPoll(1).get()
+			Pollers.fixedDelay(100).maxMessagesPerPoll(1)
 
 		@Bean
 		fun convertFlow() =

--- a/spring-integration-groovy/src/test/groovy/org/springframework/integration/groovy/dsl/test/GroovyDslTests.groovy
+++ b/spring-integration-groovy/src/test/groovy/org/springframework/integration/groovy/dsl/test/GroovyDslTests.groovy
@@ -216,7 +216,7 @@ class GroovyDslTests {
 
 		@Bean(PollerMetadata.DEFAULT_POLLER)
 		poller() {
-			Pollers.fixedDelay(1000).get()
+			Pollers.fixedDelay(1000)
 		}
 
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundChannelAdapterSpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public class TcpInboundChannelAdapterSpec
 	 */
 	protected TcpInboundChannelAdapterSpec(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec) {
 		super(new TcpReceivingChannelAdapter());
-		this.connectionFactory = connectionFactorySpec.get();
+		this.connectionFactory = connectionFactorySpec.getObject();
 		this.target.setConnectionFactory(this.connectionFactory);
 	}
 
@@ -94,7 +94,7 @@ public class TcpInboundChannelAdapterSpec
 	public Map<Object, String> getComponentsToRegister() {
 		return this.connectionFactory != null
 				? Collections.singletonMap(this.connectionFactory, this.connectionFactory.getComponentName())
-				: null;
+				: Collections.emptyMap();
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundGatewaySpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpInboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ public class TcpInboundGatewaySpec extends MessagingGatewaySpec<TcpInboundGatewa
 	 */
 	protected TcpInboundGatewaySpec(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec) {
 		super(new TcpInboundGateway());
-		this.connectionFactory = connectionFactorySpec.get();
+		this.connectionFactory = connectionFactorySpec.getObject();
 		this.target.setConnectionFactory(this.connectionFactory);
 	}
 
@@ -93,7 +93,7 @@ public class TcpInboundGatewaySpec extends MessagingGatewaySpec<TcpInboundGatewa
 	public Map<Object, String> getComponentsToRegister() {
 		return this.connectionFactory != null
 				? Collections.singletonMap(this.connectionFactory, this.connectionFactory.getComponentName())
-				: null;
+				: Collections.emptyMap();
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpOutboundChannelAdapterSpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpOutboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public class TcpOutboundChannelAdapterSpec
 	 */
 	protected TcpOutboundChannelAdapterSpec(AbstractConnectionFactorySpec<?, ?> connectionFactorySpec) {
 		this.target = new TcpSendingMessageHandler();
-		this.connectionFactory = connectionFactorySpec.get();
+		this.connectionFactory = connectionFactorySpec.getObject();
 		this.target.setConnectionFactory(this.connectionFactory);
 	}
 
@@ -94,7 +94,7 @@ public class TcpOutboundChannelAdapterSpec
 	public Map<Object, String> getComponentsToRegister() {
 		return this.connectionFactory != null
 				? Collections.singletonMap(this.connectionFactory, this.connectionFactory.getComponentName())
-				: null;
+				: Collections.emptyMap();
 	}
 
 }

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpOutboundGatewaySpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/TcpOutboundGatewaySpec.java
@@ -58,7 +58,7 @@ public class TcpOutboundGatewaySpec extends MessageHandlerSpec<TcpOutboundGatewa
 	 */
 	public TcpOutboundGatewaySpec(TcpClientConnectionFactorySpec<?, ?> connectionFactorySpec) {
 		this.target = new TcpOutboundGateway();
-		this.connectionFactory = connectionFactorySpec.get();
+		this.connectionFactory = connectionFactorySpec.getObject();
 		this.target.setConnectionFactory(this.connectionFactory);
 	}
 
@@ -120,8 +120,21 @@ public class TcpOutboundGatewaySpec extends MessageHandlerSpec<TcpOutboundGatewa
 	 * @param channelName the name.
 	 * @return the spec.
 	 * @since 5.4
+	 * @deprecated in favor of {@link #unsolicitedMessageChannelName(String)}
+	 * due to the typo in method name.
 	 */
+	@Deprecated(since = "6.1", forRemoval = true)
 	public TcpOutboundGatewaySpec unsolictedMessageChannelName(String channelName) {
+		return unsolicitedMessageChannelName(channelName);
+	}
+
+	/**
+	 * Set the unsolicited message channel name.
+	 * @param channelName the name.
+	 * @return the spec.
+	 * @since 6.1
+	 */
+	public TcpOutboundGatewaySpec unsolicitedMessageChannelName(String channelName) {
 		this.target.setUnsolicitedMessageChannelName(channelName);
 		return this;
 	}
@@ -131,8 +144,21 @@ public class TcpOutboundGatewaySpec extends MessageHandlerSpec<TcpOutboundGatewa
 	 * @param channel the channel.
 	 * @return the spec.
 	 * @since 5.4
+	 * @deprecated in favor of {@link #unsolicitedMessageChannel(MessageChannel)}
+	 * due to the typo in method name.
 	 */
+	@Deprecated(since = "6.1", forRemoval = true)
 	public TcpOutboundGatewaySpec unsolictedMessageChannelName(MessageChannel channel) {
+		return unsolicitedMessageChannel(channel);
+	}
+
+	/**
+	 * Set the unsolicited message channel.
+	 * @param channel the channel.
+	 * @return the spec.
+	 * @since 6.1
+	 */
+	public TcpOutboundGatewaySpec unsolicitedMessageChannel(MessageChannel channel) {
 		this.target.setUnsolicitedMessageChannel(channel);
 		return this;
 	}
@@ -141,7 +167,7 @@ public class TcpOutboundGatewaySpec extends MessageHandlerSpec<TcpOutboundGatewa
 	public Map<Object, String> getComponentsToRegister() {
 		return this.connectionFactory != null
 				? Collections.singletonMap(this.connectionFactory, this.connectionFactory.getComponentName())
-				: null;
+				: Collections.emptyMap();
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFactoryTests.java
@@ -45,16 +45,18 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Gary Russell
  * @author Tim Ysewyn
+ * @author Artem Bilan
+ *
  * @since 5.0
  *
  */
-public class ConnectionFacforyTests {
+public class ConnectionFactoryTests {
 
 	@Test
 	public void test() throws Exception {
 		ApplicationEventPublisher publisher = e -> {
 		};
-		AbstractServerConnectionFactory server = Tcp.netServer(0).backlog(2).soTimeout(5000).get();
+		AbstractServerConnectionFactory server = Tcp.netServer(0).backlog(2).soTimeout(5000).getObject();
 		final AtomicReference<Message<?>> received = new AtomicReference<>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		server.registerListener(m -> {
@@ -66,7 +68,7 @@ public class ConnectionFacforyTests {
 		server.afterPropertiesSet();
 		server.start();
 		TestingUtilities.waitListening(server, null);
-		AbstractClientConnectionFactory client = Tcp.netClient("localhost", server.getPort()).get();
+		AbstractClientConnectionFactory client = Tcp.netClient("localhost", server.getPort()).getObject();
 		client.setApplicationEventPublisher(publisher);
 		client.afterPropertiesSet();
 		client.start();
@@ -78,20 +80,20 @@ public class ConnectionFacforyTests {
 	}
 
 	@Test
-	public void shouldReturnNioFlavor() throws Exception {
-		AbstractServerConnectionFactory server = Tcp.nioServer(0).get();
+	public void shouldReturnNioFlavor() {
+		AbstractServerConnectionFactory server = Tcp.nioServer(0).getObject();
 		assertThat(server instanceof TcpNioServerConnectionFactory).isTrue();
 
-		AbstractClientConnectionFactory client = Tcp.nioClient("localhost", server.getPort()).get();
+		AbstractClientConnectionFactory client = Tcp.nioClient("localhost", server.getPort()).getObject();
 		assertThat(client instanceof TcpNioClientConnectionFactory).isTrue();
 	}
 
 	@Test
-	public void shouldReturnNetFlavor() throws Exception {
-		AbstractServerConnectionFactory server = Tcp.netServer(0).get();
+	public void shouldReturnNetFlavor() {
+		AbstractServerConnectionFactory server = Tcp.netServer(0).getObject();
 		assertThat(server instanceof TcpNetServerConnectionFactory).isTrue();
 
-		AbstractClientConnectionFactory client = Tcp.netClient("localhost", server.getPort()).get();
+		AbstractClientConnectionFactory client = Tcp.netClient("localhost", server.getPort()).getObject();
 		assertThat(client instanceof TcpNetClientConnectionFactory).isTrue();
 	}
 
@@ -104,7 +106,7 @@ public class ConnectionFacforyTests {
 				.socketSupport(sockSupp)
 				.connectionSupport(conSupp)
 				.socketFactorySupport(factSupp)
-				.get();
+				.getObject();
 		assertThat(TestUtils.getPropertyValue(server, "tcpSocketSupport")).isSameAs(sockSupp);
 		assertThat(TestUtils.getPropertyValue(server, "tcpNetConnectionSupport")).isSameAs(conSupp);
 		assertThat(TestUtils.getPropertyValue(server, "tcpSocketFactorySupport")).isSameAs(factSupp);
@@ -118,7 +120,7 @@ public class ConnectionFacforyTests {
 				.socketSupport(sockSupp)
 				.directBuffers(true)
 				.connectionSupport(conSupp)
-				.get();
+				.getObject();
 		assertThat(TestUtils.getPropertyValue(server, "tcpSocketSupport")).isSameAs(sockSupp);
 		assertThat(TestUtils.getPropertyValue(server, "usingDirectBuffers", Boolean.class)).isTrue();
 		assertThat(TestUtils.getPropertyValue(server, "tcpNioConnectionSupport")).isSameAs(conSupp);
@@ -133,7 +135,7 @@ public class ConnectionFacforyTests {
 				.socketSupport(sockSupp)
 				.connectionSupport(conSupp)
 				.socketFactorySupport(factSupp)
-				.get();
+				.getObject();
 		assertThat(TestUtils.getPropertyValue(client, "tcpSocketSupport")).isSameAs(sockSupp);
 		assertThat(TestUtils.getPropertyValue(client, "tcpNetConnectionSupport")).isSameAs(conSupp);
 		assertThat(TestUtils.getPropertyValue(client, "tcpSocketFactorySupport")).isSameAs(factSupp);
@@ -147,7 +149,7 @@ public class ConnectionFacforyTests {
 				.socketSupport(sockSupp)
 				.directBuffers(true)
 				.connectionSupport(conSupp)
-				.get();
+				.getObject();
 		assertThat(TestUtils.getPropertyValue(client, "tcpSocketSupport")).isSameAs(sockSupp);
 		assertThat(TestUtils.getPropertyValue(client, "usingDirectBuffers", Boolean.class)).isTrue();
 		assertThat(TestUtils.getPropertyValue(client, "tcpNioConnectionSupport")).isSameAs(conSupp);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -208,7 +208,7 @@ public final class Jms {
 	public static JmsMessageDrivenChannelAdapterSpec<?> messageDrivenChannelAdapter(
 			JmsListenerContainerSpec<?, ? extends AbstractMessageListenerContainer> jmsListenerContainerSpec) {
 
-		return new JmsMessageDrivenChannelAdapterSpec<>(jmsListenerContainerSpec.get());
+		return new JmsMessageDrivenChannelAdapterSpec<>(jmsListenerContainerSpec.getObject());
 	}
 
 	/**
@@ -216,7 +216,9 @@ public final class Jms {
 	 * @param listenerContainer the {@link AbstractMessageListenerContainer} to build on
 	 * @return the {@link JmsMessageDrivenChannelAdapterSpec} instance
 	 */
-	public static JmsMessageDrivenChannelAdapterSpec<?> messageDrivenChannelAdapter(AbstractMessageListenerContainer listenerContainer) {
+	public static JmsMessageDrivenChannelAdapterSpec<?> messageDrivenChannelAdapter(
+			AbstractMessageListenerContainer listenerContainer) {
+
 		return new JmsMessageDrivenChannelAdapterSpec<>(listenerContainer);
 	}
 
@@ -227,14 +229,10 @@ public final class Jms {
 	 */
 	public static JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<JmsDefaultListenerContainerSpec, DefaultMessageListenerContainer>
 	messageDrivenChannelAdapter(ConnectionFactory connectionFactory) {
-		try {
-			return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<>(
-					new JmsDefaultListenerContainerSpec()
-							.connectionFactory(connectionFactory));
-		}
-		catch (Exception e) {
-			throw new IllegalStateException(e);
-		}
+
+		return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<>(
+				new JmsDefaultListenerContainerSpec()
+						.connectionFactory(connectionFactory));
 	}
 
 	/**
@@ -249,15 +247,11 @@ public final class Jms {
 	public static <C extends AbstractMessageListenerContainer>
 	JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec<?, C>
 	messageDrivenChannelAdapter(ConnectionFactory connectionFactory, Class<C> containerClass) {
-		try {
-			JmsListenerContainerSpec<?, C> spec =
-					new JmsListenerContainerSpec<>(containerClass)
-							.connectionFactory(connectionFactory);
-			return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec(spec);
-		}
-		catch (Exception e) {
-			throw new IllegalStateException(e);
-		}
+
+		JmsListenerContainerSpec<?, C> spec =
+				new JmsListenerContainerSpec<>(containerClass)
+						.connectionFactory(connectionFactory);
+		return new JmsMessageDrivenChannelAdapterSpec.JmsMessageDrivenChannelAdapterListenerContainerSpec(spec);
 	}
 
 	/**
@@ -268,14 +262,10 @@ public final class Jms {
 	 */
 	public static JmsDefaultListenerContainerSpec container(ConnectionFactory connectionFactory,
 			Destination destination) {
-		try {
-			return new JmsDefaultListenerContainerSpec()
-					.connectionFactory(connectionFactory)
-					.destination(destination);
-		}
-		catch (Exception e) {
-			throw new IllegalStateException(e);
-		}
+
+		return new JmsDefaultListenerContainerSpec()
+				.connectionFactory(connectionFactory)
+				.destination(destination);
 	}
 
 	/**
@@ -286,14 +276,10 @@ public final class Jms {
 	 */
 	public static JmsDefaultListenerContainerSpec container(ConnectionFactory connectionFactory,
 			String destinationName) {
-		try {
-			return new JmsDefaultListenerContainerSpec()
-					.connectionFactory(connectionFactory)
-					.destination(destinationName);
-		}
-		catch (Exception e) {
-			throw new IllegalStateException(e);
-		}
+
+		return new JmsDefaultListenerContainerSpec()
+				.connectionFactory(connectionFactory)
+				.destination(destinationName);
 	}
 
 	private Jms() {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundChannelAdapterSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,8 @@ public class JmsInboundChannelAdapterSpec<S extends JmsInboundChannelAdapterSpec
 	}
 
 	private JmsInboundChannelAdapterSpec(ConnectionFactory connectionFactory) {
-		this.target = new JmsDestinationPollingSource(this.jmsTemplateSpec.connectionFactory(connectionFactory).get());
+		this.target =
+				new JmsDestinationPollingSource(this.jmsTemplateSpec.connectionFactory(connectionFactory).getObject());
 	}
 
 	/**
@@ -118,7 +119,7 @@ public class JmsInboundChannelAdapterSpec<S extends JmsInboundChannelAdapterSpec
 
 		@Override
 		public Map<Object, String> getComponentsToRegister() {
-			return Collections.singletonMap(this.jmsTemplateSpec.get(), this.jmsTemplateSpec.getId());
+			return Collections.singletonMap(this.jmsTemplateSpec.getObject(), this.jmsTemplateSpec.getId());
 		}
 
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundGatewaySpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundGatewaySpec.java
@@ -246,9 +246,9 @@ public class JmsInboundGatewaySpec<S extends JmsInboundGatewaySpec<S>>
 		private final S spec;
 
 		protected JmsInboundGatewayListenerContainerSpec(S spec) {
-			super(spec.get());
+			super(spec.getObject());
 			this.spec = spec;
-			this.spec.get().setAutoStartup(false);
+			this.spec.getObject().setAutoStartup(false);
 		}
 
 		/**

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageDrivenChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,9 +80,9 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 	}
 
 	/**
-	 * Set to false to prevent listener container shutdown when the endpoint is stopped.
+	 * Set to 'false' to prevent listener container shutdown when the endpoint is stopped.
 	 * Then, if so configured, any cached consumer(s) in the container will remain.
-	 * Otherwise the shared connection and will be closed and the listener invokers shut
+	 * Otherwise, the shared connection and will be closed and the listener invokers shut
 	 * down; this behavior is new starting with version 5.1. Default: true.
 	 * @param shutdown false to not shutdown.
 	 * @return the spec.
@@ -106,9 +106,9 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 		private final S spec;
 
 		protected JmsMessageDrivenChannelAdapterListenerContainerSpec(S spec) {
-			super(spec.get());
+			super(spec.getObject());
 			this.spec = spec;
-			this.spec.get().setAutoStartup(false);
+			this.spec.getObject().setAutoStartup(false);
 
 		}
 
@@ -141,6 +141,7 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 		 */
 		public JmsMessageDrivenChannelAdapterListenerContainerSpec<S, C> configureListenerContainer(
 				Consumer<S> configurer) {
+
 			Assert.notNull(configurer, "'configurer' must not be null");
 			configurer.accept(this.spec);
 			return _this();
@@ -148,7 +149,7 @@ public class JmsMessageDrivenChannelAdapterSpec<S extends JmsMessageDrivenChanne
 
 		@Override
 		public Map<Object, String> getComponentsToRegister() {
-			return Collections.singletonMap(this.spec.get(), this.spec.getId());
+			return Collections.singletonMap(this.spec.getObject(), this.spec.getId());
 		}
 
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsOutboundChannelAdapterSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsOutboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,8 @@ public class JmsOutboundChannelAdapterSpec<S extends JmsOutboundChannelAdapterSp
 	}
 
 	private JmsOutboundChannelAdapterSpec(ConnectionFactory connectionFactory) {
-		this.target = new JmsSendingMessageHandler(this.jmsTemplateSpec.connectionFactory(connectionFactory).get());
+		this.target =
+				new JmsSendingMessageHandler(this.jmsTemplateSpec.connectionFactory(connectionFactory).getObject());
 	}
 
 	/**
@@ -101,7 +102,7 @@ public class JmsOutboundChannelAdapterSpec<S extends JmsOutboundChannelAdapterSp
 	 * which a message will be sent.
 	 * @param destination the destination name.
 	 * @return the current {@link JmsOutboundChannelAdapterSpec}.
-	 * @see JmsSendingMessageHandler#setDestinationExpression(Expression)
+	 * @see JmsSendingMessageHandler#setDestinationExpression
 	 */
 	public S destinationExpression(String destination) {
 		this.target.setDestinationExpression(PARSER.parseExpression(destination));
@@ -119,7 +120,7 @@ public class JmsOutboundChannelAdapterSpec<S extends JmsOutboundChannelAdapterSp
 	 * @param destinationFunction the destination function.
 	 * @param <P> the expected payload type.
 	 * @return the current {@link JmsOutboundChannelAdapterSpec}.
-	 * @see JmsSendingMessageHandler#setDestinationExpression(Expression)
+	 * @see JmsSendingMessageHandler#setDestinationExpression
 	 * @see FunctionExpression
 	 */
 	public <P> S destination(Function<Message<P>, ?> destinationFunction) {
@@ -194,7 +195,7 @@ public class JmsOutboundChannelAdapterSpec<S extends JmsOutboundChannelAdapterSp
 
 		@Override
 		public Map<Object, String> getComponentsToRegister() {
-			return Collections.singletonMap(this.jmsTemplateSpec.get(), this.jmsTemplateSpec.getId());
+			return Collections.singletonMap(this.jmsTemplateSpec.getObject(), this.jmsTemplateSpec.getId());
 		}
 
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsOutboundGatewaySpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -296,7 +296,7 @@ public class JmsOutboundGatewaySpec extends MessageHandlerSpec<JmsOutboundGatewa
 		Assert.notNull(configurer, "'configurer' must not be null");
 		ReplyContainerSpec spec = new ReplyContainerSpec();
 		configurer.accept(spec);
-		this.target.setReplyContainerProperties(spec.get());
+		this.target.setReplyContainerProperties(spec.getObject());
 		return _this();
 	}
 

--- a/spring-integration-jms/src/test/kotlin/org/springframework/integration/jms/dsl/JmsDslKotlinTests.kt
+++ b/spring-integration-jms/src/test/kotlin/org/springframework/integration/jms/dsl/JmsDslKotlinTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.integration.IntegrationMessageHeaderAccessor
+import org.springframework.integration.channel.QueueChannel
 import org.springframework.integration.config.EnableIntegration
 import org.springframework.integration.dsl.MessageChannels
 import org.springframework.integration.dsl.integrationFlow
@@ -112,10 +113,10 @@ class JmsDslKotlinTests : ActiveMQMultiContextTests() {
 		}
 
 		@Bean
-		fun jmsOutboundInboundReplyChannel() = MessageChannels.queue().get()
+		fun jmsOutboundInboundReplyChannel() = MessageChannels.queue()
 
 		@Bean
-		fun jmsMessageDrivenFlowWithContainer() =
+		fun jmsMessageDrivenFlowWithContainer(jmsOutboundInboundReplyChannel: QueueChannel) =
 			integrationFlow(
 				Jms.messageDrivenChannelAdapter(
 					Jms.container(amqFactory, "containerSpecDestination")
@@ -125,7 +126,7 @@ class JmsDslKotlinTests : ActiveMQMultiContextTests() {
 					.headerMapper(jmsHeaderMapper())
 			) {
 				transform { it: String -> it.trim { it <= ' ' } }
-				channel(jmsOutboundInboundReplyChannel())
+				channel(jmsOutboundInboundReplyChannel)
 			}
 
 	}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.TopicPartition;
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessagingGatewaySpec;
 import org.springframework.integration.kafka.inbound.KafkaInboundGateway;
+import org.springframework.integration.support.ObjectStringMapBuilder;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.ConsumerSeekAware;
@@ -163,9 +164,10 @@ public class KafkaInboundGatewaySpec<K, V, R, S extends KafkaInboundGatewaySpec<
 
 		@Override
 		public Map<Object, String> getComponentsToRegister() {
-			return Map.of(
-					this.containerSpec.getObject(), this.containerSpec.getId(),
-					this.templateSpec.getObject(), this.templateSpec.getId());
+			return new ObjectStringMapBuilder()
+					.put(this.containerSpec.getObject(), this.containerSpec.getId())
+					.put(this.templateSpec.getObject(), this.templateSpec.getId())
+					.get();
 		}
 
 	}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessagingGatewaySpec;
 import org.springframework.integration.kafka.inbound.KafkaInboundGateway;
-import org.springframework.integration.support.ObjectStringMapBuilder;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.ConsumerSeekAware;
@@ -102,6 +101,7 @@ public class KafkaInboundGatewaySpec<K, V, R, S extends KafkaInboundGatewaySpec<
 	 */
 	public S onPartitionsAssignedSeekCallback(
 			BiConsumer<Map<TopicPartition, Long>, ConsumerSeekAware.ConsumerSeekCallback> onPartitionsAssignedCallback) {
+
 		this.target.setOnPartitionsAssignedSeekCallback(onPartitionsAssignedCallback);
 		return _this();
 	}
@@ -128,7 +128,7 @@ public class KafkaInboundGatewaySpec<K, V, R, S extends KafkaInboundGatewaySpec<
 		KafkaInboundGatewayListenerContainerSpec(KafkaMessageListenerContainerSpec<K, V> containerSpec,
 				KafkaTemplateSpec<K, R> templateSpec) {
 
-			super(containerSpec.get(), templateSpec.getTemplate());
+			super(containerSpec.getObject(), templateSpec.getTemplate());
 			this.containerSpec = containerSpec;
 			this.templateSpec = templateSpec;
 		}
@@ -163,10 +163,9 @@ public class KafkaInboundGatewaySpec<K, V, R, S extends KafkaInboundGatewaySpec<
 
 		@Override
 		public Map<Object, String> getComponentsToRegister() {
-			return new ObjectStringMapBuilder()
-					.put(this.containerSpec.get(), this.containerSpec.getId())
-					.put(this.templateSpec.get(), this.templateSpec.getId())
-					.get();
+			return Map.of(
+					this.containerSpec.getObject(), this.containerSpec.getId(),
+					this.templateSpec.getObject(), this.templateSpec.getId());
 		}
 
 	}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 
 	KafkaMessageDrivenChannelAdapterSpec(AbstractMessageListenerContainer<K, V> messageListenerContainer,
 			KafkaMessageDrivenChannelAdapter.ListenerMode listenerMode) {
+
 		super(new KafkaMessageDrivenChannelAdapter<>(messageListenerContainer, listenerMode));
 		this.container = messageListenerContainer;
 	}
@@ -174,6 +175,7 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 	 */
 	public S onPartitionsAssignedSeekCallback(
 			BiConsumer<Map<TopicPartition, Long>, ConsumerSeekAware.ConsumerSeekCallback> onPartitionsAssignedCallback) {
+
 		this.target.setOnPartitionsAssignedSeekCallback(onPartitionsAssignedCallback);
 		return _this();
 	}
@@ -196,7 +198,7 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 
 		KafkaMessageDrivenChannelAdapterListenerContainerSpec(KafkaMessageListenerContainerSpec<K, V> spec,
 				KafkaMessageDrivenChannelAdapter.ListenerMode listenerMode) {
-			super(spec.get(), listenerMode);
+			super(spec.getObject(), listenerMode);
 			this.spec = spec;
 		}
 
@@ -208,6 +210,7 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 		 */
 		public KafkaMessageDrivenChannelAdapterListenerContainerSpec<K, V> configureListenerContainer(
 				Consumer<KafkaMessageListenerContainerSpec<K, V>> configurer) {
+
 			Assert.notNull(configurer, "The 'configurer' cannot be null");
 			configurer.accept(this.spec);
 			return _this();
@@ -215,7 +218,7 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 
 		@Override
 		public Map<Object, String> getComponentsToRegister() {
-			return Collections.singletonMap(this.spec.get(), this.spec.getId());
+			return Collections.singletonMap(this.spec.getObject(), this.spec.getId());
 		}
 
 	}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaOutboundGatewaySpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -110,7 +110,7 @@ public class KafkaOutboundGatewaySpec<K, V, R, S extends KafkaOutboundGatewaySpe
 
 		@Override
 		public Map<Object, String> getComponentsToRegister() {
-			return Collections.singletonMap(this.kafkaTemplateSpec.get(), this.kafkaTemplateSpec.getId());
+			return Collections.singletonMap(this.kafkaTemplateSpec.getTemplate(), this.kafkaTemplateSpec.getId());
 		}
 
 	}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaProducerMessageHandlerSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaProducerMessageHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -429,10 +429,9 @@ public class KafkaProducerMessageHandlerSpec<K, V, S extends KafkaProducerMessag
 
 		@Override
 		public Map<Object, String> getComponentsToRegister() {
-			return Collections.singletonMap(this.kafkaTemplateSpec.get(), this.kafkaTemplateSpec.getId());
+			return Collections.singletonMap(this.kafkaTemplateSpec.getTemplate(), this.kafkaTemplateSpec.getId());
 		}
 
 	}
 
 }
-

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,12 +38,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.MessageRejectedException;
-import org.springframework.integration.channel.BroadcastCapableChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.Pollers;
 import org.springframework.integration.kafka.channel.PollableKafkaChannel;
+import org.springframework.integration.kafka.channel.PublishSubscribeKafkaChannel;
 import org.springframework.integration.kafka.inbound.KafkaErrorSendingMessageRecoverer;
 import org.springframework.integration.kafka.inbound.KafkaInboundGateway;
 import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter;
@@ -427,10 +427,11 @@ public class KafkaDslTests {
 		@Bean
 		public IntegrationFlow channels(KafkaTemplate<Integer, String> template,
 				ConcurrentKafkaListenerContainerFactory<Integer, String> containerFactory,
-				KafkaMessageSource<?, ?> channelSource) {
+				KafkaMessageSource<?, ?> channelSource,
+				PublishSubscribeKafkaChannel publishSubscribeKafkaChannel) {
 
 			return IntegrationFlow.from(topic6Channel(template, containerFactory))
-					.publishSubscribeChannel(pubSub(template, containerFactory), channel -> channel
+					.publishSubscribeChannel(publishSubscribeKafkaChannel, channel -> channel
 							.subscribe(f -> f.channel(
 									Kafka.pollableChannel(template, channelSource).id("topic8Channel")))
 							.subscribe(f -> f.channel(
@@ -439,11 +440,10 @@ public class KafkaDslTests {
 		}
 
 		@Bean
-		public BroadcastCapableChannel pubSub(KafkaTemplate<Integer, String> template,
+		public KafkaPublishSubscribeChannelSpec pubSub(KafkaTemplate<Integer, String> template,
 				ConcurrentKafkaListenerContainerFactory<Integer, String> containerFactory) {
 
-			return Kafka.publishSubscribeChannel(template, containerFactory, TEST_TOPIC7)
-					.get();
+			return Kafka.publishSubscribeChannel(template, containerFactory, TEST_TOPIC7);
 		}
 
 		@Bean

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
@@ -539,7 +539,7 @@ class MessageDrivenAdapterTests {
 				.messageDrivenChannelAdapter(container, ListenerMode.record)
 				.recordMessageConverter(new StringJsonMessageConverter())
 				.payloadType(Foo.class)
-				.get();
+				.getObject();
 		QueueChannel out = new QueueChannel();
 		adapter.setOutputChannel(out);
 		adapter.afterPropertiesSet();

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/dsl/MongoDbTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/dsl/MongoDbTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,9 +40,11 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.data.mongodb.core.query.BasicQuery;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.MessageChannels;
+import org.springframework.integration.dsl.QueueChannelSpec;
 import org.springframework.integration.handler.ReplyRequiredException;
 import org.springframework.integration.mongodb.MongoDbContainerTest;
 import org.springframework.integration.mongodb.outbound.MessageCollectionCallback;
@@ -333,16 +335,16 @@ class MongoDbTests implements MongoDbContainerTest {
 		}
 
 		@Bean
-		public IntegrationFlow gatewayCollectionCallbackFlow() {
+		public IntegrationFlow gatewayCollectionCallbackFlow(QueueChannel getResultChannel) {
 			return f -> f
 					.handle(collectionCallbackOutboundGateway(
 							(collection, requestMessage) -> collection.countDocuments()))
-					.channel(getResultChannel());
+					.channel(getResultChannel);
 		}
 
 		@Bean
-		public MessageChannel getResultChannel() {
-			return MessageChannels.queue().get();
+		public QueueChannelSpec getResultChannel() {
+			return MessageChannels.queue();
 		}
 
 		@Bean

--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/dsl/ScriptMessageSourceSpec.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/dsl/ScriptMessageSourceSpec.java
@@ -67,7 +67,7 @@ public class ScriptMessageSourceSpec extends MessageSourceSpec<ScriptMessageSour
 	 * The {@link ScriptVariableGenerator} to use.
 	 * @param variableGenerator the {@link ScriptVariableGenerator}
 	 * @return the current spec
-	 * @see ScriptSpec#variableGenerator(ScriptVariableGenerator) 
+	 * @see ScriptSpec#variableGenerator(ScriptVariableGenerator)
 	 */
 	public ScriptMessageSourceSpec variableGenerator(ScriptVariableGenerator variableGenerator) {
 		this.delegate.variableGenerator(variableGenerator);

--- a/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/dsl/ScriptMessageSourceSpec.java
+++ b/spring-integration-scripting/src/main/java/org/springframework/integration/scripting/dsl/ScriptMessageSourceSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class ScriptMessageSourceSpec extends MessageSourceSpec<ScriptMessageSour
 	 * The {@link ScriptVariableGenerator} to use.
 	 * @param variableGenerator the {@link ScriptVariableGenerator}
 	 * @return the current spec
-	 * @see ScriptSpec#variableGenerator
+	 * @see ScriptSpec#variableGenerator(ScriptVariableGenerator) 
 	 */
 	public ScriptMessageSourceSpec variableGenerator(ScriptVariableGenerator variableGenerator) {
 		this.delegate.variableGenerator(variableGenerator);
@@ -121,12 +121,12 @@ public class ScriptMessageSourceSpec extends MessageSourceSpec<ScriptMessageSour
 
 	@Override
 	protected MessageSource<?> doGet() {
-		return new MessageProcessorMessageSource(this.delegate.get());
+		return new MessageProcessorMessageSource(this.delegate.getObject());
 	}
 
 	@Override
 	public Map<Object, String> getComponentsToRegister() {
-		return Collections.singletonMap(this.delegate.get(), this.delegate.getId());
+		return Collections.singletonMap(this.delegate.getObject(), this.delegate.getId());
 	}
 
 }

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,12 +59,12 @@ public class WsDslTests {
 		Unmarshaller unmarshaller = mock(Unmarshaller.class);
 		MarshallingWebServiceInboundGateway gateway = Ws.marshallingInboundGateway(marshaller)
 				.unmarshaller(unmarshaller)
-				.get();
+				.getObject();
 		assertThat(TestUtils.getPropertyValue(gateway, "marshaller")).isSameAs(marshaller);
 		assertThat(TestUtils.getPropertyValue(gateway, "unmarshaller")).isSameAs(unmarshaller);
 
 		marshaller = mock(Both.class);
-		gateway = Ws.marshallingInboundGateway(marshaller).get();
+		gateway = Ws.marshallingInboundGateway(marshaller).getObject();
 		assertThat(TestUtils.getPropertyValue(gateway, "marshaller")).isSameAs(marshaller);
 		assertThat(TestUtils.getPropertyValue(gateway, "unmarshaller")).isSameAs(marshaller);
 	}
@@ -73,7 +73,7 @@ public class WsDslTests {
 	void simpleInbound() {
 		SimpleWebServiceInboundGateway gateway = Ws.simpleInboundGateway()
 				.extractPayload(false)
-				.get();
+				.getObject();
 		assertThat(TestUtils.getPropertyValue(gateway, "extractPayload", Boolean.class)).isFalse();
 	}
 
@@ -104,7 +104,7 @@ public class WsDslTests {
 						.messageSenders(messageSender)
 						.requestCallback(requestCallback)
 						.uriVariableExpressions(uriVariableExpressions)
-						.get();
+						.getObject();
 		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller")).isSameAs(marshaller);
 		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller")).isSameAs(unmarshaller);
 		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory")).isSameAs(messageFactory);
@@ -147,7 +147,7 @@ public class WsDslTests {
 						.requestCallback(requestCallback)
 						.uriVariableExpressions(uriVariableExpressions)
 						.extractPayload(false)
-						.get();
+						.getObject();
 		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory")).isSameAs(messageFactory);
 		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.faultMessageResolver"))
 				.isSameAs(faultMessageResolver);
@@ -178,7 +178,7 @@ public class WsDslTests {
 						.ignoreEmptyResponses(true)
 						.requestCallback(requestCallback)
 						.uriVariableExpressions(uriVariableExpressions)
-						.get();
+						.getObject();
 		assertThat(TestUtils.getPropertyValue(gateway, "uri")).isSameAs(uri);
 		assertThat(TestUtils.getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
 		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
@@ -209,7 +209,7 @@ public class WsDslTests {
 						.requestCallback(requestCallback)
 						.uriVariableExpressions(uriVariableExpressions)
 						.extractPayload(false)
-						.get();
+						.getObject();
 		assertThat(TestUtils.getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
 		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
 		assertThat(TestUtils.getPropertyValue(gateway, "uriVariableExpressions")).isEqualTo(uriVariableExpressions);
@@ -225,4 +225,3 @@ public class WsDslTests {
 	}
 
 }
-

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -39,8 +39,8 @@ public class MyConfiguration {
     }
 
     @Bean
-    public IntegrationFlow myFlow() {
-        return IntegrationFlow.fromSupplier(integerSource()::getAndIncrement,
+    public IntegrationFlow myFlow(AtomicInteger integerSource) {
+        return IntegrationFlow.fromSupplier(integerSource::getAndIncrement,
                                          c -> c.poller(Pollers.fixedRate(100)))
                     .channel("inputChannel")
                     .filter((Integer p) -> p > 0)
@@ -62,6 +62,10 @@ You need not replace all of your existing XML configuration to use Java configur
 
 The `org.springframework.integration.dsl` package contains the `IntegrationFlowBuilder` API mentioned earlier and a number of `IntegrationComponentSpec` implementations, which are also builders and provide the fluent API to configure concrete endpoints.
 The `IntegrationFlowBuilder` infrastructure provides common https://www.enterpriseintegrationpatterns.com/[enterprise integration patterns] (EIP) for message-based applications, such as channels, endpoints, pollers, and channel interceptors.
+
+IMPORTANT:: The `IntegrationComponentSpec` is a `FactoryBean` implementation, therefore its `getObject()` method must not be called from the target configuration.
+The `IntegrationComponentSpec` implementation must be left as is for bean definition and the framework will take about its lifecycle.
+A bean method parameter injection for the target `IntegrationComponentSpec` type (a `FactoryBean` value) must be used for `IntegrationFlow` bean definitions instead of bean method references.
 
 Endpoints are expressed as verbs in the DSL to improve readability.
 The following list includes the common DSL method names and the associated EIP endpoint:
@@ -163,10 +167,9 @@ The following example shows how to use it:
 [source,java]
 ----
 @Bean
-public MessageChannel priorityChannel() {
+public PriorityChannelSpec priorityChannel() {
     return MessageChannels.priority(this.mongoDbChannelMessageStore, "priorityGroup")
-                        .interceptor(wireTap())
-                        .get();
+                        .interceptor(wireTap());
 }
 ----
 ====
@@ -181,13 +184,13 @@ The following example shows the possible ways to use the `channel()` EIP method:
 [source,java]
 ----
 @Bean
-public MessageChannel queueChannel() {
-    return MessageChannels.queue().get();
+public QueueChannelSpec queueChannel() {
+    return MessageChannels.queue();
 }
 
 @Bean
-public MessageChannel publishSubscribe() {
-    return MessageChannels.publishSubscribe().get();
+public PublishSubscribeChannelSpec<?> publishSubscribe() {
+    return MessageChannels.publishSubscribe();
 }
 
 @Bean
@@ -261,7 +264,7 @@ public PollerSpec poller() {
 
 See https://docs.spring.io/spring-integration/api/org/springframework/integration/dsl/Pollers.html[`Pollers`] and https://docs.spring.io/spring-integration/api/org/springframework/integration/dsl/PollerSpec.html[`PollerSpec`] in the Javadoc for more information.
 
-IMPORTANT: If you use the DSL to construct a `PollerSpec` as a `@Bean`, do not call the `get()` method in the bean definition.
+IMPORTANT: If you use the DSL to construct a `PollerSpec` as a `@Bean`, do not call the `getObject()` method in the bean definition.
 The `PollerSpec` is a `FactoryBean` that generates the `PollerMetadata` object from the specification and initializes all of its properties.
 
 [[java-dsl-reactive]]
@@ -833,30 +836,21 @@ For example, we now can configure several subscribers as sub-flows on the `Jms.p
 [source,java]
 ----
 @Bean
-public BroadcastCapableChannel jmsPublishSubscribeChannel() {
+public JmsPublishSubscribeMessageChannelSpec jmsPublishSubscribeChannel() {
     return Jms.publishSubscribeChannel(jmsConnectionFactory())
-                .destination("pubsub")
-                .get();
+                .destination("pubsub");
 }
 
 @Bean
-public IntegrationFlow pubSubFlow() {
+public IntegrationFlow pubSubFlow(BroadcastCapableChannel jmsPublishSubscribeChannel) {
     return f -> f
-            .publishSubscribeChannel(jmsPublishSubscribeChannel(),
+            .publishSubscribeChannel(jmsPublishSubscribeChannel,
                     pubsub -> pubsub
                             .subscribe(subFlow -> subFlow
                                 .channel(c -> c.queue("jmsPubSubBridgeChannel1")))
                             .subscribe(subFlow -> subFlow
                                 .channel(c -> c.queue("jmsPubSubBridgeChannel2"))));
 }
-
-@Bean
-public BroadcastCapableChannel jmsPublishSubscribeChannel(ConnectionFactory jmsConnectionFactory) {
-    return (BroadcastCapableChannel) Jms.publishSubscribeChannel(jmsConnectionFactory)
-            .destination("pubsub")
-            .get();
-}
-
 ----
 ====
 

--- a/src/reference/asciidoc/dsl.adoc
+++ b/src/reference/asciidoc/dsl.adoc
@@ -63,9 +63,9 @@ You need not replace all of your existing XML configuration to use Java configur
 The `org.springframework.integration.dsl` package contains the `IntegrationFlowBuilder` API mentioned earlier and a number of `IntegrationComponentSpec` implementations, which are also builders and provide the fluent API to configure concrete endpoints.
 The `IntegrationFlowBuilder` infrastructure provides common https://www.enterpriseintegrationpatterns.com/[enterprise integration patterns] (EIP) for message-based applications, such as channels, endpoints, pollers, and channel interceptors.
 
-IMPORTANT:: The `IntegrationComponentSpec` is a `FactoryBean` implementation, therefore its `getObject()` method must not be called from the target configuration.
-The `IntegrationComponentSpec` implementation must be left as is for bean definition and the framework will take about its lifecycle.
-A bean method parameter injection for the target `IntegrationComponentSpec` type (a `FactoryBean` value) must be used for `IntegrationFlow` bean definitions instead of bean method references.
+IMPORTANT:: The `IntegrationComponentSpec` is a `FactoryBean` implementation, therefore its `getObject()` method must not be called from bean definitions.
+The `IntegrationComponentSpec` implementation must be left as is for bean definitions and the framework will manage its lifecycle.
+Bean method parameter injection for the target `IntegrationComponentSpec` type (a `FactoryBean` value) must be used for `IntegrationFlow` bean definitions instead of bean method references.
 
 Endpoints are expressed as verbs in the DSL to improve readability.
 The following list includes the common DSL method names and the associated EIP endpoint:

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -41,9 +41,9 @@ See <<./filter.adoc#filter, Filter>> for more information.
  - The default timeout for send and receive operations in gateways and replying channel adapters has been changed from infinity to `30` seconds.
 Only one left as a `1` second is a `receiveTimeout` for `PollingConsumer` to not block a scheduler thread too long and let other queued tasks to be performed with the `TaskScheduler`.
 
- - An `IntegrationComponentSpec.get()` method has been deprecated with removal plans in the next version.
+ - The `IntegrationComponentSpec.get()` method has been deprecated with removal planned for the next version.
 Since `IntegrationComponentSpec` is a `FactoryBean`, its bean definition must stay as is without any target object resolutions.
-The Java DSL and the framework by itself will take care about the proper `IntegrationComponentSpec` lifecycle.
+The Java DSL and the framework by itself will manage the `IntegrationComponentSpec` lifecycle.
 See <<./dsl.adoc#java-dsl, Java DSL>> for more information.
 
 [[x6.1-web-sockets]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -41,6 +41,11 @@ See <<./filter.adoc#filter, Filter>> for more information.
  - The default timeout for send and receive operations in gateways and replying channel adapters has been changed from infinity to `30` seconds.
 Only one left as a `1` second is a `receiveTimeout` for `PollingConsumer` to not block a scheduler thread too long and let other queued tasks to be performed with the `TaskScheduler`.
 
+ - An `IntegrationComponentSpec.get()` method has been deprecated with removal plans in the next version.
+Since `IntegrationComponentSpec` is a `FactoryBean`, its bean definition must stay as is without any target object resolutions.
+The Java DSL and the framework by itself will take care about the proper `IntegrationComponentSpec` lifecycle.
+See <<./dsl.adoc#java-dsl, Java DSL>> for more information.
+
 [[x6.1-web-sockets]]
 === Web Sockets Changes
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8586

The `IntegrationComponentSpec` is not a plain wrapper around single component. Sometimes it comes with several components where all of them must be registered as beans.
If `IntegrationComponentSpec.get()` is called from end-user code, we may lose other related components, for example filters in the `FileInboundChannelAdapterSpec`.

* Deprecate `IntegrationComponentSpec.get()` with no-op for end-user, rather encourage to leave it as is and let the framework take care about its lifecycle and related components registration
* Fix `IntegrationComponentSpec` logic to deal as a simple `FactoryBean` instead of extra overhead via `AbstractFactoryBean`
* Use `IntegrationComponentSpec.getObject()` in the framework code where `get()` was called
* Fix tests to expose `IntegrationComponentSpec` as beans instead of previously called `get()`
* Some other clean up and typos fixes in the affected classes
* Document the change

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
