### PR TITLE
GH-3557: Add maxDepth, dirPredicate to FileReadMS

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,12 @@
 package org.springframework.integration.file.dsl;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.integration.dsl.ComponentsRegistration;
@@ -273,6 +275,32 @@ public class FileInboundChannelAdapterSpec
 	 */
 	public FileInboundChannelAdapterSpec watchEvents(FileReadingMessageSource.WatchEventType... watchEvents) {
 		this.target.setWatchEvents(watchEvents);
+		return this;
+	}
+
+	/**
+	 * Set a depth for files walk API.
+	 * @param watchMaxDepth the depth for files walk.
+	 * @return the spec.
+	 * @since 6.1
+	 * @see #useWatchService
+	 * @see FileReadingMessageSource#setWatchMaxDepth(int)
+	 */
+	public FileInboundChannelAdapterSpec watchMaxDepth(int watchMaxDepth) {
+		target.setWatchMaxDepth(watchMaxDepth);
+		return this;
+	}
+
+	/**
+	 * Set a {@link Predicate} to check if it is eligible for {@link java.nio.file.WatchService}.
+	 * @param watchDirPredicate the {@link Predicate} to check dirs for walking.
+	 * @return the spec.
+	 * @since 6.1
+	 * @see #useWatchService
+	 * @see FileReadingMessageSource#setWatchDirPredicate(Predicate)
+	 */
+	public FileInboundChannelAdapterSpec watchDirPredicate(Predicate<Path> watchDirPredicate) {
+		target.setWatchDirPredicate(watchDirPredicate);
 		return this;
 	}
 

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -386,6 +386,11 @@ The following example shows how to configure different logic for create and modi
 ----
 ====
 
+Starting with version 6.1, the `FileReadingMessageSource` exposes two new `WatchService`-related options:
+
+* `watchMaxDepth` - an argument for the `Files.walkFileTree(Path root, Set attributes, int maxDepth, FileVisitor visitor)` API;
+* `watchDirPredicate` - a `Predicate<Path>` to test if directory in the scanned tree should be walked and registered for `WatchService` with its modification events.
+
 ==== Limiting Memory Consumption
 
 You can use a `HeadDirectoryScanner` to limit the number of files retained in memory.

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -389,7 +389,7 @@ The following example shows how to configure different logic for create and modi
 Starting with version 6.1, the `FileReadingMessageSource` exposes two new `WatchService`-related options:
 
 * `watchMaxDepth` - an argument for the `Files.walkFileTree(Path root, Set attributes, int maxDepth, FileVisitor visitor)` API;
-* `watchDirPredicate` - a `Predicate<Path>` to test if directory in the scanned tree should be walked and registered for `WatchService` with its modification events.
+* `watchDirPredicate` - a `Predicate<Path>` to test if a directory in the scanned tree should be walked and registered with the `WatchService` and the configured watch event kinds.
 
 ==== Limiting Memory Consumption
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -67,5 +67,5 @@ See <<./mail.adoc#mail-inbound, Mail-receiving Channel Adapter>> for more inform
 [[x6.1-file]]
 === Files Changes
 
-The `FileReadingMessageSource` exposes now `watchMaxDepth` and `watchDirPredicate` options for the `WatchService`.
+The `FileReadingMessageSource` now exposes `watchMaxDepth` and `watchDirPredicate` options for the `WatchService`.
 See <<./file.adoc#watch-service-directory-scanner, `WatchServiceDirectoryScanner`>> for more information.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -63,3 +63,9 @@ See <<./jms.adoc#jms-inbound-gateway, JMS Inbound Gateway>> for more information
 
 The (previously deprecated) `ImapIdleChannelAdapter.sendingTaskExecutor` property has been removed in favor of an asynchronous message process downstream in the flow.
 See <<./mail.adoc#mail-inbound, Mail-receiving Channel Adapter>> for more information.
+
+[[x6.1-file]]
+=== Files Changes
+
+The `FileReadingMessageSource` exposes now `watchMaxDepth` and `watchDirPredicate` options for the `WatchService`.
+See <<./file.adoc#watch-service-directory-scanner, `WatchServiceDirectoryScanner`>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3557

* Expose a `watchMaxDepth` on the `FileReadingMessageSource` for its `Files.walkFileTree()` API usage
* Add `watchDirPredicate` option ot the `FileReadingMessageSource` to skip sub-tree for `Files.walkFileTree()` scanning according to some condition against directory `Path`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
