### PR TITLE
Demonstrate `@Publisher` with an `@EventListener`

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
@@ -530,7 +530,7 @@ public class AmqpTests {
 			return new QueueChannel();
 		}
 
-		@RabbitListener(queuesToDeclare = @Queue("publisherQueue"))
+		@RabbitListener(queuesToDeclare = @org.springframework.amqp.rabbit.annotation.Queue("publisherQueue"))
 		@Publisher("fromRabbitViaPublisher")
 		@Payload("#args.payload.toUpperCase()")
 		public void consumeForPublisher(String payload) {

--- a/src/reference/asciidoc/amqp.adoc
+++ b/src/reference/asciidoc/amqp.adoc
@@ -253,6 +253,39 @@ In that regard, it is more similar to the JMS message-driven channel adapter.
 Starting with version 5.5, the `AmqpInboundChannelAdapter` can be configured with an `org.springframework.amqp.rabbit.retry.MessageRecoverer` strategy which is used in the `RecoveryCallback` when the retry operation is called internally.
 See `setMessageRecoverer()` JavaDocs for more information.
 
+The `@Publisher` annotation also can be used in combination with a `@RabbitListener`:
+
+====
+[source, java]
+----
+@Configuration
+@EnableIntegration
+@EnableRabbit
+@EnablePublisher
+public static class ContextConfiguration {
+
+    @Bean
+    QueueChannel fromRabbitViaPublisher() {
+        return new QueueChannel();
+    }
+
+    @RabbitListener(queuesToDeclare = @Queue("publisherQueue"))
+    @Publisher("fromRabbitViaPublisher")
+    @Payload("#args.payload.toUpperCase()")
+    public void consumeForPublisher(String payload) {
+
+    }
+
+}
+----
+====
+
+By default, the `@Publisher` AOP interceptor deals with a return value from a method call.
+However, the return value from a `@RabbitListener` method is treated as an AMQP reply message.
+Therefore, such an approach cannot be used together with a `@Publisher`, so a `@Payload` annotation with respective SpEL expression against method arguments is a recommended way for this combination.
+See more information about the `@Publisher` in the <<./message-publishing.adoc#publisher-annotation, Annotation-driven Configuration>> section.
+
+
 [[amqp-debatching]]
 ==== Batched Messages
 

--- a/src/reference/asciidoc/event.adoc
+++ b/src/reference/asciidoc/event.adoc
@@ -177,3 +177,31 @@ public IntegrationFlow eventsOutFlow(ApplicationEventPublishingMessageHandler ev
 }
 ----
 ====
+
+The `@Publisher` annotation also can be used in combination with an `@EventListener`:
+
+====
+[source, java]
+----
+@Configuration
+@EnableIntegration
+@EnablePublisher
+public static class ContextConfiguration {
+
+     @Bean
+     QueueChannel eventFromPublisher() {
+         return new QueueChannel();
+     }
+
+     @EventListener
+     @Publisher("eventFromPublisher")
+     public String publishEventToChannel(TestApplicationEvent3 testApplicationEvent3) {
+         return testApplicationEvent3.getSource().toString();
+     }
+
+}
+----
+====
+
+In this case a return value of the event listener method is used as a payload for a `Message` to be published to that `eventFromPublisher` channel.
+See more information about the `@Publisher` in the <<./message-publishing.adoc#publisher-annotation, Annotation-driven Configuration>> section.


### PR DESCRIPTION
The `@EventListener` from Spring Framework is a good tool for POJO configuration to subscribe to events from an `ApplicationContext`. The `@Publisher` is an AOP tool to publish a `Message` from POJO method call.

* Add a test and docs to demonstrate how the `@Publisher` can be used together with an `@EventListener`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
