### PR TITLE
* Use burrunan/gradle-cache-action got GH actions

### DIFF
--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -33,6 +33,9 @@ jobs:
           SI_FATAL_WHEN_NO_BEANFACTORY: true
           NO_REFERENCE_TASK: true
         with:
+          debug: false
+          concurrent: true
+          gradle-build-scan-report: false
           arguments: checkAsciidocLinks check
 
       - name: Capture Test Results

--- a/.github/workflows/pr-build-workflow.yml
+++ b/.github/workflows/pr-build-workflow.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: 17
 
       - name: Run Gradle
-        uses: gradle/gradle-build-action@v2
+        uses: burrunan/gradle-cache-action@v1
         env:
           SI_FATAL_WHEN_NO_BEANFACTORY: true
           NO_REFERENCE_TASK: true


### PR DESCRIPTION
According to the `gradle/gradle-build-action` docs it caches only a `main` branch. This is not appropriate for us since we really never build `main` on GH actions.

With this change we will experiment if `burrunan/gradle-cache-action` does what we would like to get from the Gradle cache feature

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
