### PR TITLE
GH-3866: DefLockRepository: expose query setters

### DIFF
--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests-context.xml
@@ -24,6 +24,8 @@
 
 	<bean id="lockClient" class="org.springframework.integration.jdbc.lock.DefaultLockRepository">
 		<constructor-arg name="dataSource" ref="dataSource"/>
+		<property name="insertQuery"
+				  value="INSERT INTO INT_LOCK (REGION, LOCK_KEY, CLIENT_ID, CREATED_DATE) VALUES (?, ?, ?, ?)"/>
 	</bean>
 
 	<tx:annotation-driven/>

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -1143,7 +1143,7 @@ The `INT_` can be changed according to the target database design requirements.
 Therefore, you must use `prefix` property on the `DefaultLockRepository` bean definition.
 
 Sometimes, one application has moved to such a state that it cannot release the distributed lock and remove the particular record in the database.
-For this purpose, such dead-locks can be expired by the other application on the next locking invocation.
+For this purpose, such deadlocks can be expired by the other application on the next locking invocation.
 The `timeToLive` (TTL) option on the `DefaultLockRepository` is provided for this purpose.
 You may also want to specify `CLIENT_ID` for the locks stored for a given `DefaultLockRepository` instance.
 If so, you can specify the `id` to be associated with the `DefaultLockRepository` as a constructor parameter.
@@ -1161,6 +1161,17 @@ String with version 5.5.6, the `JdbcLockRegistry` is support automatically clean
 See its JavaDocs for more information.
 
 String with version 6.0, the `DefaultLockRepository` can be supplied with a `PlatformTransactionManager` instead of relying on the primary bean from the application context.
+
+String with version 6.1, the `DefaultLockRepository` can be configured for custom `insert`, `update` and `renew` queries.
+For this purpose the respective setters and getters are exposed.
+For example, an insert query for PostgreSQL hint can be configured like this:
+
+====
+[source,java]
+----
+lockRepository.setInsertQuery(lockRepository.getInsertQuery() + " ON CONFLICT DO NOTHING");
+----
+====
 
 [[jdbc-metadata-store]]
 === JDBC Metadata Store

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -75,3 +75,10 @@ See <<./file.adoc#watch-service-directory-scanner, `WatchServiceDirectoryScanner
 
 The Java DSL API for Rabbit Streams (the `RabbitStream` factory) exposes additional properties for simple configurations.
 See <<./amqp.adoc#rmq-streams, `RabbitMQ Stream Queue Support`>> for more information.
+
+
+[[x6.1-jdbc]]
+=== JDBC Changes
+
+The `DefaultLockRepository` now exposes setters for `insert`, `update` and `renew` queries.
+See <<./jdbc.adoc#jdbc-lock-registry, JDBC Lock Registry>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/3866

Some RDBMS vendors (or their JDBC drivers) may just log the problem without throwing an exception.

* Expose setters for UPDATE and INSERTS queries in the `DefaultLockRepository` to let end-user to modify them respectively, e.g. be able to add a PostgreSQL `ON CONFLICT DO NOTHING` hint.
* Refactor `DefaultLockRepository` to `Instant` instead of `LocalDateTime` with zone offset.
* Refactor `ttl` property to `Duration` type
* Fix `dead-lock` typo to `deadlock`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
