### PR TITLE
docs(kotlin-dsl): correct IntegrationFlow import

### DIFF
--- a/src/reference/asciidoc/kotlin-dsl.adoc
+++ b/src/reference/asciidoc/kotlin-dsl.adoc
@@ -3,7 +3,7 @@
 
 The Kotlin DSL is a wrapper and extension to <<./dsl.adoc#java-dsl,Java DSL>> and aimed to make Spring Integration development on Kotlin as smooth and straightforward as possible with interoperability with the existing Java API and Kotlin language-specific structures.
 
-All you need to get started is just an import for `org.springframework.integration.dsl.integrationFlow` - an overloaded global function for Kotlin DSL.
+All you need to get started is just an import for `org.springframework.integration.dsl.IntegrationFlow` - an overloaded global function for Kotlin DSL.
 
 For `IntegrationFlow` definitions as lambdas we typically don't need anything else from Kotlin and just declare a bean like this:
 


### PR DESCRIPTION

I was writing a guide to Spring Integration and Koltin DSL. I noticed a case mistake in the `IntegrationFlow` [import](https://docs.spring.io/spring-integration/reference/html/kotlin-dsl.html#kotlin-dsl), hence this PR.


![integration-flow-err](https://user-images.githubusercontent.com/64139733/235453237-a411e6cb-eaf2-422f-a0d2-ebb8e333edc6.png)
