### PR TITLE
GH-8613: Add JsonPropertyAccessor type for native

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aot/CoreRuntimeHints.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aot/CoreRuntimeHints.java
@@ -34,6 +34,7 @@ import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.SerializationHints;
+import org.springframework.aot.hint.TypeReference;
 import org.springframework.beans.factory.config.BeanExpressionContext;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.integration.aggregator.MessageGroupProcessor;
@@ -100,6 +101,14 @@ class CoreRuntimeHints implements RuntimeHintsRegistrar {
 		if (ClassUtils.isPresent("com.jayway.jsonpath.JsonPath", classLoader)) {
 			reflectionHints.registerType(JsonPathUtils.class, MemberCategory.INVOKE_PUBLIC_METHODS);
 		}
+
+		reflectionHints.registerType(
+				TypeReference.of("org.springframework.integration.json.JsonPropertyAccessor$ComparableJsonNode"),
+				MemberCategory.INVOKE_PUBLIC_METHODS);
+
+		reflectionHints.registerType(
+				TypeReference.of("org.springframework.integration.json.JsonPropertyAccessor$ArrayNodeAsList"),
+				MemberCategory.INVOKE_PUBLIC_METHODS);
 
 		// For #xpath() SpEL function
 		reflectionHints.registerTypeIfPresent(classLoader, "org.springframework.integration.xml.xpath.XPathUtils",


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8613

If `JsonPropertyAccessor` is registered for SpEL, it would be great to have it working in native images as well.

Since SpEL is fully based on reflection, expose
`JsonPropertyAccessor$ComparableJsonNode` and `JsonPropertyAccessor$ArrayNodeAsList` reflection hints for their method invocations from SpEL

**Cherry-pick to `6.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
