### PR TITLE
Fix DSL for inner bean names generation

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
@@ -356,7 +356,7 @@ public class IntegrationFlowBeanPostProcessor
 						.filter(component -> noBeanPresentForComponent(component.getKey(), beanName))
 						.forEach(component ->
 								registerComponent(component.getKey(),
-										generateBeanName(component.getKey(), component.getValue())));
+										generateBeanName(component.getKey(), beanName, component.getValue(), false)));
 
 			}
 		}


### PR DESCRIPTION
The `IntegrationFlowBeanPostProcessor.processIntegrationComponentSpec()` uses a wrong `generateBeanName()` for component to register making the provided `id` as a prefix

* Use `generateBeanName(Object instance, String prefix, @Nullable String fallbackId, boolean useFlowIdAsPrefix)` instead to properly "fallback" to the provided name

**Cherry-pick to `6.1.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
