### PR TITLE
Optimize synchronized in PartitionedDispatcher

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
@@ -151,10 +151,16 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 		return partitionDispatcher.dispatch(message);
 	}
 
-	private synchronized void populatedPartitions() {
+	private void populatedPartitions() {
 		if (this.partitions.isEmpty()) {
-			for (int i = 0; i < this.partitionCount; i++) {
-				this.partitions.put(i, newPartition());
+			synchronized (this.partitions) {
+				if (this.partitions.isEmpty()) {
+					Map<Integer, UnicastingDispatcher> partitionsToUse = new HashMap<>();
+					for (int i = 0; i < this.partitionCount; i++) {
+						partitionsToUse.put(i, newPartition());
+					}
+					this.partitions.putAll(partitionsToUse);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Even if the `PartitionedDispatcher.populatedPartitions()` is fast, in-memory, non-blocking operation, its active call from the `dispatch()` on every message sent to the channel may pin the virtual thread.

* Optimize the `populatedPartitions()` for double `if` where we will step into a `synchronized` block only for first several concurrent messages

**Cherry-pick to `6.1.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
