### PR TITLE
GH-8638: Kafka: Send All Fails to Failure Channel

### DIFF
--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -80,6 +80,7 @@
 					  value="org.assertj.core.api.Assertions.*,
 					  org.xmlunit.assertj3.XmlAssert.*,
 				org.assertj.core.api.Assumptions.*,
+				org.assertj.core.api.InstanceOfAssertFactories.*,
 				org.awaitility.Awaitility.*,
 				org.mockito.Mockito.*,
 				org.mockito.BDDMockito.*,


### PR DESCRIPTION
Resolveshttps://github.com/spring-projects/spring-integration/issues/8638

Previously, immediate failures (e.g. timeout getting metadata) were only thrown as exceptions, and not sent to the failure channel, if present.

**cherry-pick to all supported branches**
