### PR TITLE
Improve Delayer DSL

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -1178,12 +1178,18 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	/**
 	 * Populate a {@link DelayHandler} to the current integration flow position
 	 * with default options.
+	 * Shortcut for:
+	 * <pre class="code">
+	 * {@code
+	 *  .delay(delayer -> delayer.messageGroupId(groupId))
+	 * }
+	 * </pre>
 	 * @param groupId the {@code groupId} for delayed messages in the
 	 * {@link org.springframework.integration.store.MessageGroupStore}.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 */
 	public B delay(String groupId) {
-		return delay(groupId, null);
+		return delay(delayer -> delayer.messageGroupId(groupId));
 	}
 
 	/**
@@ -1192,10 +1198,23 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * {@link org.springframework.integration.store.MessageGroupStore}.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
+	 * @deprecated since 6.2 in favor of {@link #delay(Consumer)}
 	 * @see DelayerEndpointSpec
 	 */
+	@Deprecated(since = "6.2", forRemoval = true)
 	public B delay(String groupId, @Nullable Consumer<DelayerEndpointSpec> endpointConfigurer) {
 		return register(new DelayerEndpointSpec(new DelayHandler(groupId)), endpointConfigurer);
+	}
+
+	/**
+	 * Populate a {@link DelayHandler} to the current integration flow position.
+	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
+	 * @return the current {@link BaseIntegrationFlowDefinition}.
+	 * @since 6.2
+	 * @see DelayerEndpointSpec
+	 */
+	public B delay(Consumer<DelayerEndpointSpec> endpointConfigurer) {
+		return register(new DelayerEndpointSpec(), endpointConfigurer);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/DelayerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/DelayerEndpointSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,10 @@ import org.springframework.util.Assert;
 public class DelayerEndpointSpec extends ConsumerEndpointSpec<DelayerEndpointSpec, DelayHandler> {
 
 	private final List<Advice> delayedAdvice = new LinkedList<>();
+
+	protected DelayerEndpointSpec() {
+		this(new DelayHandler());
+	}
 
 	protected DelayerEndpointSpec(DelayHandler delayHandler) {
 		super(delayHandler);
@@ -222,6 +226,18 @@ public class DelayerEndpointSpec extends ConsumerEndpointSpec<DelayerEndpointSpe
 	 */
 	public <P> DelayerEndpointSpec delayFunction(Function<Message<P>, Object> delayFunction) {
 		this.handler.setDelayExpression(new FunctionExpression<>(delayFunction));
+		return this;
+	}
+
+	/**
+	 * Set a group id to manage delayed messages by this handler.
+	 * @param messageGroupId the group id for delayed messages.
+	 * @return the endpoint spec.
+	 * @since 6.2
+	 * @see DelayHandler#setMessageGroupId(String)
+	 */
+	public DelayerEndpointSpec messageGroupId(String messageGroupId) {
+		this.handler.setMessageGroupId(messageGroupId);
 		return this;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -132,7 +132,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 
 	/**
 	 * Construct an instance with default options.
-	 * The {@link #messageGroupId} must be provided then via setter.
+	 * The {@link #messageGroupId}must then be provided via the setter.
 	 * @since 6.2
 	 */
 	public DelayHandler() {
@@ -318,7 +318,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 
 	@Override
 	protected void doInit() {
-		Assert.notNull(this.messageGroupId, "The 'messageGroupId' must be provided");
+		Assert.notNull(this.messageGroupId, "A 'messageGroupId' must be provided");
 
 		if (this.messageStore == null) {
 			this.messageStore = new SimpleMessageStore();

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
@@ -561,8 +561,21 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	/**
 	 * Populate a [DelayHandler] to the current integration flow position.
 	 */
+	@Deprecated("since 6.2",
+			ReplaceWith("""delay { 
+								messageGroupId(groupId) 
+							}"""))
+	@Suppress("DEPRECATION")
 	fun delay(groupId: String, endpointConfigurer: DelayerEndpointSpec.() -> Unit = {}) {
 		this.delegate.delay(groupId, endpointConfigurer)
+	}
+
+	/**
+	 * Populate a [DelayHandler] to the current integration flow position.
+	 * @since 6.2
+	 */
+	fun delay(endpointConfigurer: DelayerEndpointSpec.() -> Unit) {
+		this.delegate.delay(endpointConfigurer)
 	}
 
 	/**

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
@@ -562,9 +562,10 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Populate a [DelayHandler] to the current integration flow position.
 	 */
 	@Deprecated("since 6.2",
-			ReplaceWith("""delay { 
-								messageGroupId(groupId) 
-							}"""))
+			ReplaceWith("""
+				delay { 
+					messageGroupId(groupId) 
+				}"""))
 	@Suppress("DEPRECATION")
 	fun delay(groupId: String, endpointConfigurer: DelayerEndpointSpec.() -> Unit = {}) {
 		this.delegate.delay(groupId, endpointConfigurer)
@@ -726,10 +727,11 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Provide the [HeaderFilter] to the current [IntegrationFlow].
 	 */
 	@Deprecated("since 6.2",
-			ReplaceWith("""headerFilter { 
-										patternMatch() 
-										headersToRemove() 
-									}"""))
+			ReplaceWith("""
+				headerFilter { 
+					patternMatch() 
+					headersToRemove() 
+				}"""))
 	fun headerFilter(headersToRemove: String, patternMatch: Boolean = true) {
 		headerFilter {
 			patternMatch(patternMatch)

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
@@ -801,7 +801,8 @@ public class IntegrationFlowTests {
 			return IntegrationFlow.from("bridgeFlow2Input")
 					.bridge(c -> c.autoStartup(false).id("bridge"))
 					.fixedSubscriberChannel()
-					.delay("delayer", d -> d
+					.delay(d -> d
+							.messageGroupId("delayer")
 							.delayExpression("200")
 							.advice(this.delayedAdvice)
 							.messageStore(this.messageStore()))

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
@@ -320,7 +320,10 @@ class KotlinDslTests {
 				wireTap {
 					channel { queue("wireTapChannel") }
 				}
-				delay("delayGroup") { defaultDelay(100) }
+				delay {
+					messageGroupId("delayGroup")
+					defaultDelay(100)
+				}
 				transform<String> { it.uppercase() }
 			}
 

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/dsl/IntegrationFlowEventsTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/dsl/IntegrationFlowEventsTests.java
@@ -184,7 +184,8 @@ public class IntegrationFlowEventsTests {
 		@Bean
 		public IntegrationFlow delayFlow() {
 			return flow -> flow
-					.delay(GROUP_ID, e -> e
+					.delay(e -> e
+							.messageGroupId(GROUP_ID)
 							.messageStore(messageGroupStore)
 							.id("delayer"))
 					.channel(MessageChannels.queue("delayedResults"));

--- a/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
+++ b/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
@@ -618,7 +618,9 @@ class GroovyIntegrationFlowDefinition {
 	 * {@link org.springframework.integration.store.MessageGroupStore}.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
 	 * @see org.springframework.integration.dsl.DelayerEndpointSpec
+	 * @deprecated since 6.2 in favor of {@link #delay(groovy.lang.Closure)}
 	 */
+	@Deprecated(since = "6.2", forRemoval = true)
 	GroovyIntegrationFlowDefinition delay(
 			String groupId,
 			@DelegatesTo(value = DelayerEndpointSpec, strategy = Closure.DELEGATE_FIRST)
@@ -626,6 +628,21 @@ class GroovyIntegrationFlowDefinition {
 					Closure<?> endpointConfigurer = null) {
 
 		this.delegate.delay groupId, createConfigurerIfAny(endpointConfigurer)
+		this
+	}
+
+	/**
+	 * Populate a {@link org.springframework.integration.handler.DelayHandler} to the current integration flow position.
+	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
+	 * @see org.springframework.integration.dsl.DelayerEndpointSpec
+	 * @since 6.2
+	 */
+	GroovyIntegrationFlowDefinition delay(
+			@DelegatesTo(value = DelayerEndpointSpec, strategy = Closure.DELEGATE_FIRST)
+			@ClosureParams(value = SimpleType.class, options = 'org.springframework.integration.dsl.DelayerEndpointSpec')
+					Closure<?> endpointConfigurer) {
+
+		this.delegate.delay createConfigurerIfAny(endpointConfigurer)
 		this
 	}
 
@@ -657,7 +674,7 @@ class GroovyIntegrationFlowDefinition {
 	GroovyIntegrationFlowDefinition enrichHeaders(
 			@DelegatesTo(value = HeaderEnricherSpec, strategy = Closure.DELEGATE_FIRST)
 			@ClosureParams(value = SimpleType.class, options = 'org.springframework.integration.dsl.HeaderEnricherSpec')
-					Closure<?> enricherConfigurer = null) {
+					Closure<?> enricherConfigurer) {
 
 		this.delegate.enrichHeaders createConfigurerIfAny(enricherConfigurer)
 		this

--- a/spring-integration-groovy/src/test/groovy/org/springframework/integration/groovy/dsl/test/GroovyDslTests.groovy
+++ b/spring-integration-groovy/src/test/groovy/org/springframework/integration/groovy/dsl/test/GroovyDslTests.groovy
@@ -314,7 +314,10 @@ class GroovyDslTests {
 				wireTap integrationFlow {
 					channel { queue 'wireTapChannel' }
 				}
-				delay 'delayGroup', { defaultDelay 100 }
+				delay  {
+					messageGroupId 'delayGroup'
+					defaultDelay 100
+				}
 				transform String, { it.toUpperCase() }
 			}
 		}

--- a/src/reference/asciidoc/delayer.adoc
+++ b/src/reference/asciidoc/delayer.adoc
@@ -33,7 +33,8 @@ If you need to determine the delay for each message, you can also provide the Sp
 @Bean
 public IntegrationFlow flow() {
     return IntegrationFlow.from("input")
-            .delay("delayer.messageGroupId", d -> d
+            .delay(d -> d
+                    .messageGroupId("delayer.messageGroupId")
                     .defaultDelay(3_000L)
                     .delayExpression("headers['delay']"))
             .channel("output")
@@ -46,7 +47,8 @@ public IntegrationFlow flow() {
 @Bean
 fun flow() =
     integrationFlow("input") {
-        delay("delayer.messageGroupId") {
+        delay {
+            messageGroupId("delayer.messageGroupId")
             defaultDelay(3000L)
             delayExpression("headers['delay']")
         }

--- a/src/reference/asciidoc/groovy-dsl.adoc
+++ b/src/reference/asciidoc/groovy-dsl.adoc
@@ -35,10 +35,10 @@ flowLambda() {
         wireTap integrationFlow {
             channel { queue 'wireTapChannel' }
         }
-        delay  {
-		        messageGroupId 'delayGroup'
-		        defaultDelay 100
-		    }
+        delay {
+		    messageGroupId 'delayGroup'
+		    defaultDelay 100
+        }
         transform String, { it.toUpperCase() }
     }
 }

--- a/src/reference/asciidoc/groovy-dsl.adoc
+++ b/src/reference/asciidoc/groovy-dsl.adoc
@@ -35,7 +35,10 @@ flowLambda() {
         wireTap integrationFlow {
             channel { queue 'wireTapChannel' }
         }
-        delay 'delayGroup', { defaultDelay 100 }
+        delay  {
+		        messageGroupId 'delayGroup'
+		        defaultDelay 100
+		    }
         transform String, { it.toUpperCase() }
     }
 }


### PR DESCRIPTION
Move `groupId` option from a `delay()` method arg to the `DelayerEndpointSpec` to make it cleaner from code reading perspective
* Expose new DSL method based on just a `DelayerEndpointSpec` for Kotlin &v Groovy
* Deprecate multi-arg `delay()` methods in favor of `Consumer<DelayerEndpointSpec>`-based

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
