### PR TITLE
Executor instead of ThreadFactory for DebeziumMP

### DIFF
--- a/spring-integration-debezium/src/main/java/org/springframework/integration/debezium/dsl/DebeziumMessageProducerSpec.java
+++ b/spring-integration-debezium/src/main/java/org/springframework/integration/debezium/dsl/DebeziumMessageProducerSpec.java
@@ -18,7 +18,6 @@ package org.springframework.integration.debezium.dsl;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.ThreadFactory;
 
 import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
@@ -30,7 +29,6 @@ import org.springframework.integration.debezium.inbound.DebeziumMessageProducer;
 import org.springframework.integration.debezium.support.DefaultDebeziumHeaderMapper;
 import org.springframework.integration.dsl.MessageProducerSpec;
 import org.springframework.messaging.support.HeaderMapper;
-import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
 /**
  * A {@link org.springframework.integration.dsl.MessageProducerSpec} for {@link DebeziumMessageProducer}.

--- a/spring-integration-debezium/src/main/java/org/springframework/integration/debezium/dsl/DebeziumMessageProducerSpec.java
+++ b/spring-integration-debezium/src/main/java/org/springframework/integration/debezium/dsl/DebeziumMessageProducerSpec.java
@@ -25,6 +25,7 @@ import io.debezium.engine.DebeziumEngine;
 import io.debezium.engine.Header;
 import io.debezium.engine.format.SerializationFormat;
 
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.integration.debezium.inbound.DebeziumMessageProducer;
 import org.springframework.integration.debezium.support.DefaultDebeziumHeaderMapper;
 import org.springframework.integration.dsl.MessageProducerSpec;
@@ -35,6 +36,7 @@ import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
  * A {@link org.springframework.integration.dsl.MessageProducerSpec} for {@link DebeziumMessageProducer}.
  *
  * @author Christian Tzolov
+ * @author Artem Bilan
  *
  * @since 6.2
  */
@@ -74,19 +76,18 @@ public class DebeziumMessageProducerSpec
 	}
 
 	/**
-	 * Set a {@link ThreadFactory} for the Debezium executor. Defaults to the {@link CustomizableThreadFactory} with a
-	 * {@code debezium:inbound-channel-adapter-thread-} prefix.
-	 * @param threadFactory the {@link ThreadFactory} instance to use.
+	 * Set a {@link TaskExecutor} for the Debezium engine.
+	 * @param taskExecutor the {@link TaskExecutor} to use.
 	 * @return the spec.
 	 */
-	public DebeziumMessageProducerSpec threadFactory(ThreadFactory threadFactory) {
-		this.target.setThreadFactory(threadFactory);
+	public DebeziumMessageProducerSpec taskExecutor(TaskExecutor taskExecutor) {
+		this.target.setTaskExecutor(taskExecutor);
 		return this;
 	}
 
 	/**
-	 * Set the outbound message content type. Must be aligned with the {@link SerializationFormat} configuration used by
-	 * the provided {@link DebeziumEngine}.
+	 * Set the outbound message content type.
+	 * Must be aligned with the {@link SerializationFormat} configuration used by the provided {@link DebeziumEngine}.
 	 * @param contentType payload content type.
 	 * @return the spec.
 	 */

--- a/src/reference/asciidoc/debezium.adoc
+++ b/src/reference/asciidoc/debezium.adoc
@@ -78,8 +78,7 @@ Defaults to `false`.
 - `headerMapper` - custom `HeaderMapper` implementation that allows for selecting and converting the `ChangeEvent` headers into `Message` headers.
 The default `DefaultDebeziumHeaderMapper` implementation provides a setter for `setHeaderNamesToMap`.
 By default, all headers are mapped.
-- `threadFactory` - Set custom `ThreadFactory` for the Debezium executor service.
-Debezium Engine is designed to be submitted to an `Executor` or `ExecutorService` for execution by single thread.
+- `taskExecutor` - Set a custom `TaskExecutor` for the Debezium engine.
 
 The following code snippets demonstrate various configuration for this channel adapter:
 


### PR DESCRIPTION
Related to https://github.com/spring-projects/spring-integration/issues/8642

For consistency with other Spring requirements and realignment with virtual threads, it is better to require a `TaskExecutor` injection instead of `ThreadFactory`

* Fix `DebeziumMessageProducer` to rely on a `TaskExecutor` API instead of `ThreadFactory` and `ExecutorService`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
