### PR TITLE
GH-8642: Revise executors in the project

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiator.java
@@ -180,13 +180,13 @@ public class LockRegistryLeaderInitiator implements SmartLifecycle, DisposableBe
 	/**
 	 * Set the {@link ExecutorService}, where is not provided then a default of
 	 * single thread Executor will be used.
-	 * @param taskExecutor the executor service
+	 * @param executorService the executor service
 	 * @since 5.0.2
 	 * @deprecated since 6.2 in favor of {@link #setTaskExecutor(AsyncTaskExecutor)}
 	 */
 	@Deprecated(since = "6.2", forRemoval = true)
-	public void setTaskExecutor(ExecutorService taskExecutor) {
-		setTaskExecutor(new TaskExecutorAdapter(taskExecutor));
+	public void setExecutorService(ExecutorService executorService) {
+		setTaskExecutor(new TaskExecutorAdapter(executorService));
 	}
 
 	/**

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiatorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiatorTests.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.core.task.SyncTaskExecutor;
-import org.springframework.core.task.support.ExecutorServiceAdapter;
+import org.springframework.core.task.support.TaskExecutorAdapter;
 import org.springframework.integration.leader.Context;
 import org.springframework.integration.leader.DefaultCandidate;
 import org.springframework.integration.leader.event.DefaultLeaderEventPublisher;
@@ -252,9 +252,8 @@ public class LockRegistryLeaderInitiatorTests {
 				.given(lock)
 				.tryLock(anyLong(), eq(TimeUnit.MILLISECONDS));
 
-		new DirectFieldAccessor(another).setPropertyValue("executorService",
-				new ExecutorServiceAdapter(
-						new SyncTaskExecutor()));
+		new DirectFieldAccessor(another).setPropertyValue("taskExecutor",
+				new TaskExecutorAdapter(new SyncTaskExecutor()));
 
 		another.start();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiatorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/leader/LockRegistryLeaderInitiatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,14 @@
 package org.springframework.integration.support.leader;
 
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.core.task.SyncTaskExecutor;
@@ -37,7 +35,6 @@ import org.springframework.integration.leader.event.DefaultLeaderEventPublisher;
 import org.springframework.integration.leader.event.LeaderEventPublisher;
 import org.springframework.integration.support.locks.DefaultLockRegistry;
 import org.springframework.integration.support.locks.LockRegistry;
-import org.springframework.integration.test.util.TestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -69,7 +66,7 @@ public class LockRegistryLeaderInitiatorTests {
 	private final LockRegistryLeaderInitiator initiator =
 			new LockRegistryLeaderInitiator(this.registry, new DefaultCandidate());
 
-	@Before
+	@BeforeEach
 	public void init() {
 		this.initiator.setLeaderEventPublisher(new CountingPublisher(this.granted, this.revoked));
 	}
@@ -295,29 +292,6 @@ public class LockRegistryLeaderInitiatorTests {
 		assertThat(exceptionThrown.get()).isTrue();
 
 		another.stop();
-	}
-
-	@Test
-	public void shouldShutdownInternalExecutorService() {
-		this.initiator.start();
-		this.initiator.destroy();
-
-		ExecutorService executorService =
-				TestUtils.getPropertyValue(this.initiator, "executorService", ExecutorService.class);
-
-		assertThat(executorService.isShutdown()).isTrue();
-	}
-
-	@Test
-	public void doNotShutdownProvidedExecutorService() {
-		LockRegistryLeaderInitiator another = new LockRegistryLeaderInitiator(this.registry);
-		ExecutorService executorService = Executors.newSingleThreadExecutor();
-		another.setExecutorService(executorService);
-
-		another.start();
-		another.destroy();
-
-		assertThat(executorService.isShutdown()).isFalse();
 	}
 
 	private static class CountingPublisher implements LeaderEventPublisher {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/channel/PostgresSubscribableChannel.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/channel/PostgresSubscribableChannel.java
@@ -65,7 +65,7 @@ public class PostgresSubscribableChannel extends AbstractSubscribableChannel
 
 	private RetryTemplate retryTemplate = RetryTemplate.builder().maxAttempts(1).build();
 
-	private Executor executor = new SimpleAsyncTaskExecutor();
+	private Executor executor;
 
 	/**
 	 * Create a subscribable channel for a Postgres database.
@@ -113,6 +113,14 @@ public class PostgresSubscribableChannel extends AbstractSubscribableChannel
 	public void setRetryTemplate(RetryTemplate retryTemplate) {
 		Assert.notNull(retryTemplate, "A retry template must be provided.");
 		this.retryTemplate = retryTemplate;
+	}
+
+	@Override
+	protected void onInit() {
+		super.onInit();
+		if (this.executor == null) {
+			this.executor = new SimpleAsyncTaskExecutor(getBeanName() + "-dispatcher-");
+		}
 	}
 
 	@Override

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/channel/PostgresChannelMessageTableSubscriberTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/channel/PostgresChannelMessageTableSubscriberTests.java
@@ -124,6 +124,8 @@ public class PostgresChannelMessageTableSubscriberTests implements PostgresConta
 
 		this.postgresSubscribableChannel =
 				new PostgresSubscribableChannel(messageStore, groupId, postgresChannelMessageTableSubscriber);
+		this.postgresSubscribableChannel.setBeanName("testPostgresChannel");
+		this.postgresSubscribableChannel.afterPropertiesSet();
 	}
 
 	@AfterEach

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/channel/SubscribableRedisChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,10 +67,9 @@ public class SubscribableRedisChannel extends AbstractMessageChannel
 
 	private final String topicName;
 
-	private final BroadcastingDispatcher dispatcher = new BroadcastingDispatcher(true);
+	private Executor taskExecutor;
 
-	// defaults
-	private Executor taskExecutor = new SimpleAsyncTaskExecutor();
+	private final BroadcastingDispatcher dispatcher = new BroadcastingDispatcher(true);
 
 	private RedisSerializer<?> serializer = new StringRedisSerializer();
 
@@ -148,6 +147,11 @@ public class SubscribableRedisChannel extends AbstractMessageChannel
 			((BeanFactoryAware) this.messageConverter).setBeanFactory(beanFactory);
 		}
 		this.container.setConnectionFactory(this.connectionFactory);
+
+		if (this.taskExecutor == null) {
+			this.taskExecutor = new SimpleAsyncTaskExecutor(getBeanName() + "-");
+		}
+
 		if (!(this.taskExecutor instanceof ErrorHandlingTaskExecutor)) {
 			ErrorHandler errorHandler = ChannelUtils.getErrorHandler(beanFactory);
 			this.taskExecutor = new ErrorHandlingTaskExecutor(this.taskExecutor, errorHandler);

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/leader/RedisLockRegistryLeaderInitiatorTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/leader/RedisLockRegistryLeaderInitiatorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,12 @@ package org.springframework.integration.redis.leader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.integration.leader.Context;
 import org.springframework.integration.leader.DefaultCandidate;
@@ -33,7 +33,6 @@ import org.springframework.integration.redis.RedisContainerTest;
 import org.springframework.integration.redis.util.RedisLockRegistry;
 import org.springframework.integration.support.leader.LockRegistryLeaderInitiator;
 import org.springframework.integration.test.condition.LogLevels;
-import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -64,8 +63,7 @@ class RedisLockRegistryLeaderInitiatorTests implements RedisContainerTest {
 		for (int i = 0; i < 2; i++) {
 			LockRegistryLeaderInitiator initiator =
 					new LockRegistryLeaderInitiator(registry, new DefaultCandidate("foo:" + i, "bar"));
-			initiator.setExecutorService(
-					Executors.newSingleThreadExecutor(new CustomizableThreadFactory("lock-leadership-" + i + "-")));
+			initiator.setTaskExecutor(new SimpleAsyncTaskExecutor("lock-leadership-" + i + "-"));
 			initiator.setLeaderEventPublisher(countingPublisher);
 			initiators.add(initiator);
 		}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8642

* Rework some `Executors.newSingleThreadExecutor()` to `ExecutorServiceAdapter(new SimpleAsyncTaskExecutor())`
* Expose `TaskExecutor` setters; deprecate `ExecutorService`-based
* Some other code clean up in the effected classes: `LogAccessor`, no `synchronized` in critical blocks
* Give a meaningful prefix for default threads in the context of components, e.g. `SubscribableRedisChannel` - `getBeanName() + "-"`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
