### PR TITLE
Optimise reading node maybeIndex in Json Property Accessor

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JsonPropertyAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.expression.PropertyAccessor;
 import org.springframework.expression.TypedValue;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * A SpEL {@link PropertyAccessor} that knows how to read properties from JSON objects.
@@ -41,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Paul Martin
  * @author Gary Russell
  * @author Pierre Lakreb
+ * @author Vladislav Fefelov
  *
  * @since 3.0
  */
@@ -109,12 +111,31 @@ public class JsonPropertyAccessor implements PropertyAccessor {
 	 * Return an integer if the String property name can be parsed as an int, or null otherwise.
 	 */
 	private static Integer maybeIndex(String name) {
+		if (!isNumeric(name)) {
+			return null;
+		}
 		try {
 			return Integer.valueOf(name);
 		}
 		catch (NumberFormatException e) {
 			return null;
 		}
+	}
+
+	/**
+	 * Check if the string is a numeric representation (all digits) or not.
+	 */
+	private static boolean isNumeric(String str) {
+		if (!StringUtils.hasLength(str)) {
+			return false;
+		}
+		final int length = str.length();
+		for (int i = 0; i < length; i++) {
+			if (!Character.isDigit(str.charAt(i))) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
I have a service which is actively evaluating SpEL expressions on top of JsonNode. 10s k messages/second are processed upon SpEL expressions filtering.
When analysing its performance I found that a large amount of CPU is dedicated to handling NumberFormatException inside SpEL.
It seems that for every read/canRead operation JsonPropertyAccessor is trying to check whether the property is a number by parsing it with Integer.valueOf inside maybeIndex method. This approach generates a lot of hidden exceptions, which degrade performance significantly.
The following fix allowed me to improve CPU consumption about X3 times on my service. In the screenshot you can see CPU consumption of the service for the last 24h period with a fix deployed at about 11:00.
![image](https://github.com/spring-projects/spring-integration/assets/1238661/70375413-dd15-483c-b18b-2bb3e9db9928)

