### PR TITLE
GH-8654: Fix bean deps for messaging annotations

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/AbstractMethodAnnotationPostProcessor.java
@@ -270,6 +270,7 @@ public abstract class AbstractMethodAnnotationPostProcessor<T extends Annotation
 		String endpointBeanName =
 				generateHandlerBeanName(beanName, mergedAnnotations)
 						.replaceFirst("\\.(handler|source)$", "");
+		this.beanFactory.registerDependentBean(beanName, endpointBeanName);
 		this.definitionRegistry.registerBeanDefinition(endpointBeanName, endpointBeanDefinition);
 	}
 

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
+import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.mqtt.core.Mqttv3ClientManager;
@@ -195,8 +196,9 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		}
 
 		@Bean
-		public IntegrationFlow mqttOutFlow(Mqttv5ClientManager mqttv5ClientManager) {
-			return f -> f.handle(new Mqttv5PahoMessageHandler(mqttv5ClientManager));
+		@ServiceActivator(inputChannel = "mqttOutFlow.input")
+		public Mqttv5PahoMessageHandler mqttv5PahoMessageHandler(Mqttv5ClientManager mqttv5ClientManager) {
+			return new Mqttv5PahoMessageHandler(mqttv5ClientManager);
 		}
 
 		@Bean


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8654

Spring Framework has an ability to start dependant beans automatically when we start the current one.

The `AbstractMethodAnnotationPostProcessor` is missing a bean dependency registration causing errors in target applications when Messaging Annotations configuration is used.

* Add `registerDependentBean()` into an `AbstractMethodAnnotationPostProcessor` when we generate and register a `ConsumerEndpointFactoryBean`
* Change one of the `ClientManagerBackToBackTests` configuration to rely on a `@ServiceActivator` for `Mqttv5PahoMessageHandler` bean to ensure that change in the `AbstractMethodAnnotationPostProcessor` has a proper effect

**Cherry-pick to `6.1.x` & `6.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
