### PR TITLE
GH-8659: Fix the WatchServiceDirectoryScanner to detect new file afte…

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -533,6 +533,10 @@ public class FileReadingMessageSource extends AbstractMessageSource<File> implem
 			logger.debug(() -> "Watch event [" + event.kind() + "] for file [" + file + "]");
 
 			if (StandardWatchEventKinds.ENTRY_DELETE.equals(event.kind())) {
+				if (this.pathKeys.containsKey(file.toPath())) {
+					WatchKey watchKey = this.pathKeys.remove(file.toPath());
+					watchKey.cancel();
+				}
 				if (getFilter() instanceof ResettableFileListFilter<File> resettableFileListFilter) {
 					resettableFileListFilter.remove(file);
 				}
@@ -554,7 +558,7 @@ public class FileReadingMessageSource extends AbstractMessageSource<File> implem
 				}
 				else {
 					logger.debug(() -> "A file [" + file + "] for the event [" + event.kind() +
-							"] doesn't exist. Ignored.");
+							"] doesn't exist. Ignored. Maybe DELETE event is not watched ?");
 				}
 			}
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -93,6 +93,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Steven Pearce
+ * @author Patryk Ziobron
  */
 public class FileReadingMessageSource extends AbstractMessageSource<File> implements ManageableLifecycle {
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileReadingMessageSource.java
@@ -533,8 +533,9 @@ public class FileReadingMessageSource extends AbstractMessageSource<File> implem
 			logger.debug(() -> "Watch event [" + event.kind() + "] for file [" + file + "]");
 
 			if (StandardWatchEventKinds.ENTRY_DELETE.equals(event.kind())) {
-				if (this.pathKeys.containsKey(file.toPath())) {
-					WatchKey watchKey = this.pathKeys.remove(file.toPath());
+				Path filePath = file.toPath();
+				if (this.pathKeys.containsKey(filePath)) {
+					WatchKey watchKey = this.pathKeys.remove(filePath);
 					watchKey.cancel();
 				}
 				if (getFilter() instanceof ResettableFileListFilter<File> resettableFileListFilter) {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/WatchServiceDirectoryScannerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/WatchServiceDirectoryScannerTests.java
@@ -130,9 +130,9 @@ public class WatchServiceDirectoryScannerTests {
 		File top2 = File.createTempFile("tmp", null, this.rootDir);
 		File foo2 = File.createTempFile("foo", ".txt", this.foo);
 		File bar2 = File.createTempFile("bar", ".txt", this.bar);
-		File bazA = new File(this.foo, "bazA");
-		bazA.mkdir();
-		File baz1 = File.createTempFile("baz", ".txt", bazA);
+		File baz = new File(this.foo, "baz");
+		baz.mkdir();
+		File baz1 = File.createTempFile("baz", ".txt", baz);
 		files = scanner.listFiles(this.rootDir);
 		int n = 0;
 		Set<File> accum = new HashSet<>(files);
@@ -170,7 +170,7 @@ public class WatchServiceDirectoryScannerTests {
 
 		assertThat(accum).containsAll(filesForOverflow);
 
-		File baz2 = File.createTempFile("baz2", ".txt", bazA);
+		File baz2 = File.createTempFile("baz2", ".txt", baz);
 
 		n = 0;
 		while (n++ < 300 && accum.size() < 605) {
@@ -207,19 +207,7 @@ public class WatchServiceDirectoryScannerTests {
 
 		assertThat(removeFileLatch.await(10, TimeUnit.SECONDS)).isTrue();
 
-		File bazB = new File(this.foo, "bazB");
-		bazA.renameTo(bazB);
-		File baz3 = File.createTempFile("baz3", ".txt", bazB);
-
-		while (n++ < 300 && files.size() < 1) {
-			Thread.sleep(100);
-			files = scanner.listFiles(this.rootDir);
-			accum.addAll(files);
-		}
-
-		assertThat(files).hasSize(1).contains(baz3);
-
-		File baz4 = File.createTempFile("baz4", ".txt", bazB);
+		File baz3 = File.createTempFile("baz3", ".txt", baz);
 
 		n = 0;
 		Message<File> fileMessage = null;
@@ -228,7 +216,7 @@ public class WatchServiceDirectoryScannerTests {
 		}
 
 		assertThat(fileMessage).isNotNull();
-		assertThat(fileMessage.getPayload()).isEqualTo(baz4);
+		assertThat(fileMessage.getPayload()).isEqualTo(baz3);
 		assertThat(fileMessage.getHeaders().get(FileHeaders.RELATIVE_PATH, String.class))
 				.startsWith(TestUtils.applySystemFileSeparator("foo/baz/"));
 

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -372,8 +372,7 @@ With such an option, we can use one downstream flow logic for new files and use 
 The following example shows how to configure different logic for create and modify events in the same directory:
 
 It is worth mentioning that the `ENTRY_DELETE` event is involved in the rename operation of sub-directory of the watched directory.
-More specifically, `ENTRY_DELETE` event, which is related to the previous directory name, precedes `ENTRY_CREATE` event
-which notifies about the new (renamed) directory.
+More specifically, `ENTRY_DELETE` event, which is related to the previous directory name, precedes `ENTRY_CREATE` event which notifies about the new (renamed) directory.
 On some operating systems (like Windows), the `ENTRY_DELETE` event has to be registered to deal with that situation.
 Otherwise, renaming watched sub-directory in the File Explorer could result in the new files not being detected in that sub-directory.
 

--- a/src/reference/asciidoc/file.adoc
+++ b/src/reference/asciidoc/file.adoc
@@ -371,6 +371,12 @@ For this purpose, the `watch-events` property (`FileReadingMessageSource.setWatc
 With such an option, we can use one downstream flow logic for new files and use some other logic for modified files.
 The following example shows how to configure different logic for create and modify events in the same directory:
 
+It is worth mentioning that the `ENTRY_DELETE` event is involved in the rename operation of sub-directory of the watched directory.
+More specifically, `ENTRY_DELETE` event, which is related to the previous directory name, precedes `ENTRY_CREATE` event
+which notifies about the new (renamed) directory.
+On some operating systems (like Windows), the `ENTRY_DELETE` event has to be registered to deal with that situation.
+Otherwise, renaming watched sub-directory in the File Explorer could result in the new files not being detected in that sub-directory.
+
 ====
 [source,xml]
 ----


### PR DESCRIPTION
Fix the WatchServiceDirectoryScanner to detect new file after renaming the sub-folder of the watched folder (Java 7 WatchService)

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
