### PR TITLE
GH-8664: Do not use broken `observeWithContext()`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -595,14 +595,16 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 	private Message<?> sendAndReceiveWithObservation(MessageChannel requestChannel, Object object,
 			Message<?> requestMessage) {
 
+		MessageRequestReplyReceiverContext context =
+				new MessageRequestReplyReceiverContext(requestMessage, getComponentName());
+
 		return IntegrationObservation.GATEWAY.observation(this.observationConvention,
 						DefaultMessageRequestReplyReceiverObservationConvention.INSTANCE,
-						() -> new MessageRequestReplyReceiverContext(requestMessage, getComponentName()),
-						this.observationRegistry)
-				.<MessageRequestReplyReceiverContext, Message<?>>observeWithContext((ctx) -> {
+						() -> context, this.observationRegistry)
+				.observe(() -> {
 					Message<?> replyMessage = doSendAndReceive(requestChannel, object, requestMessage);
 					if (replyMessage != null) {
-						ctx.setResponse(replyMessage);
+						context.setResponse(replyMessage);
 					}
 					return replyMessage;
 				});


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8664

When an `Observation` is turned to `NoopObservation`, the `observeWithContext()` fails with `ClassCastException` since `NoopObservation` serves just plain `Context` not the one we supplied

* Fix `MessagingGatewaySupport.sendAndReceiveWithObservation()` same way as it is in version `6.0.x`
* Modify `IntegrationObservabilityZipkinTests` to reject some `Observation` via `observationPredicate()` configuration

**Cherry-pick to `6.1.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
