### PR TITLE
Fix Groovy DSL for new splitter style

### DIFF
--- a/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
+++ b/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
@@ -47,6 +47,7 @@ import org.springframework.integration.dsl.ResequencerSpec
 import org.springframework.integration.dsl.RouterSpec
 import org.springframework.integration.dsl.ScatterGatherSpec
 import org.springframework.integration.dsl.SplitterEndpointSpec
+import org.springframework.integration.dsl.SplitterSpec
 import org.springframework.integration.dsl.TransformerEndpointSpec
 import org.springframework.integration.dsl.WireTapSpec
 import org.springframework.integration.filter.MethodInvokingSelector
@@ -711,17 +712,46 @@ class GroovyIntegrationFlowDefinition {
 	}
 
 	/**
+	 * Populate the {@link DefaultMessageSplitter} with default options to the current integration flow position.
+	 */
+	GroovyIntegrationFlowDefinition split() {
+		this.delegate.split()
+		this
+	}
+
+	/**
 	 * Populate the {@link DefaultMessageSplitter} with provided options
 	 * to the current integration flow position.
 	 * Used with a Closure expression (optional).
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options
 	 * and for {@link DefaultMessageSplitter}.
+	 * @since 6.2
+	 * @see SplitterSpec
+	 */
+	GroovyIntegrationFlowDefinition splitWith(
+			@DelegatesTo(value = SplitterSpec, strategy = Closure.DELEGATE_FIRST)
+			@ClosureParams(value = SimpleType.class, options = 'org.springframework.integration.dsl.SplitterSpec')
+					Closure<?> splitConfigurer) {
+
+		this.delegate.splitWith createConfigurerIfAny(splitConfigurer)
+		this
+	}
+
+	/**
+	 * Populate the {@link DefaultMessageSplitter} with provided options
+	 * to the current integration flow position.
+	 * Used with a Closure expression.
+	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options
+	 * and for {@link DefaultMessageSplitter}.
+	 * @deprecated since 6.2 in favor of {@link #splitWith(groovy.lang.Closure)}
 	 * @see SplitterEndpointSpec
 	 */
+	@Deprecated(since = '6.2', forRemoval = true)
+	@SuppressWarnings(['removal', 'deprecation'])
 	GroovyIntegrationFlowDefinition split(
 			@DelegatesTo(value = SplitterEndpointSpec<DefaultMessageSplitter>, strategy = Closure.DELEGATE_FIRST)
 			@ClosureParams(value = SimpleType.class, options = 'org.springframework.integration.dsl.SplitterEndpointSpec')
-					Closure<?> endpointConfigurer = null) {
+					Closure<?> endpointConfigurer) {
 
 		this.delegate.split createConfigurerIfAny(endpointConfigurer)
 		this
@@ -733,7 +763,10 @@ class GroovyIntegrationFlowDefinition {
 	 * @param expression the splitter SpEL expression.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options
 	 * and for {@link ExpressionEvaluatingSplitter}.
+	 * @deprecated since 6.2 in favor of {@link #splitWith(groovy.lang.Closure)}
 	 */
+	@Deprecated(since = '6.2', forRemoval = true)
+	@SuppressWarnings(['removal', 'deprecation'])
 	GroovyIntegrationFlowDefinition split(
 			String expression,
 			@DelegatesTo(value = SplitterEndpointSpec<ExpressionEvaluatingSplitter>, strategy = Closure.DELEGATE_FIRST)
@@ -752,7 +785,10 @@ class GroovyIntegrationFlowDefinition {
 	 * @param methodName the method to invoke.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options
 	 * and for {@link MethodInvokingSplitter}.
+	 * @deprecated since 6.2 in favor of {@link #splitWith(groovy.lang.Closure)}
 	 */
+	@Deprecated(since = '6.2', forRemoval = true)
+	@SuppressWarnings(['removal', 'deprecation'])
 	GroovyIntegrationFlowDefinition split(
 			Object service, String methodName = null,
 			@DelegatesTo(value = SplitterEndpointSpec<MethodInvokingSplitter>, strategy = Closure.DELEGATE_FIRST)
@@ -772,7 +808,10 @@ class GroovyIntegrationFlowDefinition {
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options
 	 * and for {@link MethodInvokingSplitter}.
 	 * @see org.springframework.integration.dsl.SplitterEndpointSpec
+	 * @deprecated since 6.2 in favor of {@link #splitWith(groovy.lang.Closure)}
 	 */
+	@Deprecated(since = '6.2', forRemoval = true)
+	@SuppressWarnings(['removal', 'deprecation'])
 	GroovyIntegrationFlowDefinition split(
 			String beanName, String methodName,
 			@DelegatesTo(value = SplitterEndpointSpec<MethodInvokingSplitter>, strategy = Closure.DELEGATE_FIRST)
@@ -791,7 +830,10 @@ class GroovyIntegrationFlowDefinition {
 	 * @param messageProcessorSpec the splitter {@link MessageProcessorSpec}.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options
 	 * and for {@link MethodInvokingSplitter}.
+	 * @deprecated since 6.2 in favor of {@link #splitWith(groovy.lang.Closure)}
 	 */
+	@Deprecated(since = '6.2', forRemoval = true)
+	@SuppressWarnings(['removal', 'deprecation'])
 	GroovyIntegrationFlowDefinition split(
 			MessageProcessorSpec<?> messageProcessorSpec,
 			@DelegatesTo(value = SplitterEndpointSpec<MethodInvokingSplitter>, strategy = Closure.DELEGATE_FIRST)
@@ -811,8 +853,11 @@ class GroovyIntegrationFlowDefinition {
 	 * Conversion to this type will be attempted, if necessary.
 	 * @param splitter the splitter {@link Function}.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
-	 * @param < P >                                                  the payload type or {@code Message.class}.
+	 * @param <P> the payload type or {@code Message.class}.
+	 * @deprecated since 6.2 in favor of {@link #splitWith(groovy.lang.Closure)}
 	 */
+	@Deprecated(since = '6.2', forRemoval = true)
+	@SuppressWarnings(['removal', 'deprecation'])
 	<P> GroovyIntegrationFlowDefinition split(
 			Class<P> expectedType, Function<P, ?> splitter,
 			@DelegatesTo(value = SplitterEndpointSpec<MethodInvokingSplitter>, strategy = Closure.DELEGATE_FIRST)
@@ -830,9 +875,12 @@ class GroovyIntegrationFlowDefinition {
 	 * flow position.
 	 * @param splitterMessageHandlerSpec the {@link MessageHandlerSpec} to populate.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
-	 * @param < S >                                                  the {@link AbstractMessageSplitter}
+	 * @param <S> the {@link AbstractMessageSplitter}
+	 * @deprecated since 6.2 in favor of {@link #splitWith(groovy.lang.Closure)}
 	 * @see org.springframework.integration.dsl.SplitterEndpointSpec
 	 */
+	@Deprecated(since = '6.2', forRemoval = true)
+	@SuppressWarnings(['removal', 'deprecation'])
 	<S extends AbstractMessageSplitter> GroovyIntegrationFlowDefinition split(
 			MessageHandlerSpec<?, S> splitterMessageHandlerSpec,
 			@DelegatesTo(value = SplitterEndpointSpec<S>, strategy = Closure.DELEGATE_FIRST)
@@ -848,9 +896,12 @@ class GroovyIntegrationFlowDefinition {
 	 * flow position.
 	 * @param splitter the {@link AbstractMessageSplitter} to populate.
 	 * @param endpointConfigurer the {@link Consumer} to provide integration endpoint options.
-	 * @param < S >                                                  the {@link AbstractMessageSplitter}
+	 * @param <S> the {@link AbstractMessageSplitter}
+	 * @deprecated since 6.2 in favor of {@link #splitWith(groovy.lang.Closure)}
 	 * @see org.springframework.integration.dsl.SplitterEndpointSpec
 	 */
+	@Deprecated(since = '6.2', forRemoval = true)
+	@SuppressWarnings(['removal', 'deprecation'])
 	<S extends AbstractMessageSplitter> GroovyIntegrationFlowDefinition split(
 			S splitter,
 			@DelegatesTo(value = SplitterEndpointSpec<S>, strategy = Closure.DELEGATE_FIRST)

--- a/spring-integration-groovy/src/test/groovy/org/springframework/integration/groovy/dsl/test/GroovyDslTests.groovy
+++ b/spring-integration-groovy/src/test/groovy/org/springframework/integration/groovy/dsl/test/GroovyDslTests.groovy
@@ -269,8 +269,15 @@ class GroovyDslTests {
 						transform {
 							transformer { it.toUpperCase() }
 						}
-						split Message<?>, { it.payload }
-						split Object, { it }, { id 'splitterEndpoint' }
+						splitWith {
+							expectedType Message<?>
+							function { it.payload }
+						}
+						splitWith {
+							expectedType Object
+							id 'splitterEndpoint'
+							function { it }
+						}
 						resequence()
 						aggregate {
 							id 'aggregator'

--- a/src/reference/asciidoc/groovy-dsl.adoc
+++ b/src/reference/asciidoc/groovy-dsl.adoc
@@ -89,8 +89,15 @@ functionFlow() {
 		            transformer { it.toUpperCase() }
                     expectedType String
                 }
-                split Message<?>, { it.payload }
-                split Object, { it }, { id 'splitterEndpoint' }
+                splitWith {
+				    expectedType Message<?>
+				    function { it.payload }
+				}
+				splitWith {
+				    expectedType Object
+				    id 'splitterEndpoint'
+				    function { it }
+				}
                 resequence()
                 aggregate {
                     id 'aggregator'

--- a/src/reference/asciidoc/groovy-dsl.adoc
+++ b/src/reference/asciidoc/groovy-dsl.adoc
@@ -90,14 +90,14 @@ functionFlow() {
                     expectedType String
                 }
                 splitWith {
-				    expectedType Message<?>
-				    function { it.payload }
-				}
-				splitWith {
-				    expectedType Object
-				    id 'splitterEndpoint'
-				    function { it }
-				}
+                    expectedType Message<?>
+                    function { it.payload }
+                }
+                splitWith {
+                    expectedType Object
+                    id 'splitterEndpoint'
+                    function { it }
+                }
                 resequence()
                 aggregate {
                     id 'aggregator'

--- a/src/reference/asciidoc/splitter.adoc
+++ b/src/reference/asciidoc/splitter.adoc
@@ -97,7 +97,10 @@ fun someFlow() =
 @Bean
 someFlow() {
     integrationFlow {
-        split Message<?>, { it.payload }
+        splitWith {
+		    expectedType Message<?>
+		    function { it.payload }
+        }
     }
 }
 ----

--- a/src/reference/asciidoc/zip.adoc
+++ b/src/reference/asciidoc/zip.adoc
@@ -229,8 +229,12 @@ fun unzipFlow(executor: Executor) =
 unzipFlow(Executor executor) {
     integrationFlow 'unzipChannel',
             {
-                transform new UnZipTransformer()
-                split new UnZipResultSplitter()
+                transformWith {
+                    ref new UnZipTransformer()
+                }
+                splitWith {
+                    ref new UnZipResultSplitter()
+                }
                 channel { executor 'entriesChannel', executor }
             }
 }


### PR DESCRIPTION
* Introduce a new `GroovyIntegrationFlowDefinition.splitWith()` to avoid clashing with existing method
* Deprecate all other `split()` variants, but left one without arguments for a default splitting options
* Fix doc for new splitter style

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
