### PR TITLE
GH-8674: Fix ServerKeyVerifier impl for key type

### DIFF
--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpSessionFactoryTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpSessionFactoryTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.sftp.session;
 import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -121,7 +122,7 @@ public class SftpSessionFactoryTests {
 				asyncTaskExecutor.execute(() -> concurrentSessions.add(sftpSessionFactory.getSession()));
 			}
 
-			await().until(() -> concurrentSessions.size() == 3);
+			await().atMost(Duration.ofSeconds(30)).until(() -> concurrentSessions.size() == 3);
 
 			assertThat(concurrentSessions.get(0))
 					.isNotEqualTo(concurrentSessions.get(1))


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8674

The `ResourceKnownHostsServerKeyVerifier` does not take into account that several different keys can be present in the known hosts resource for the same host/port

* Fix `ResourceKnownHostsServerKeyVerifier` to find a list of knows host for the requested session. Then iterate of this result to match the key type first and then compare keys and their `revoked` marker

**Cherry-pick to `6.1.x` & `6.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
