### PR TITLE
GH-8680: Check DB for table on start

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -740,7 +740,9 @@ project('spring-integration-jdbc') {
         testImplementation "org.apache.derby:derbyclient:$derbyVersion"
         testImplementation "org.postgresql:postgresql:$postgresVersion"
         testImplementation "mysql:mysql-connector-java:$mysqlVersion"
-        testImplementation "org.apache.commons:commons-dbcp2:$commonsDbcp2Version"
+        testImplementation ("org.apache.commons:commons-dbcp2:$commonsDbcp2Version") {
+            exclude group: 'commons-logging'
+        }
         testImplementation 'org.testcontainers:mysql'
         testImplementation 'org.testcontainers:postgresql'
 

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
@@ -51,7 +51,7 @@ import org.springframework.util.Assert;
  * This class implements {@link SmartLifecycle} and calls
  * {@code SELECT COUNT(REGION) FROM %sLOCK} query
  * according to the provided prefix on {@link #start()} to check if required table is present in DB.
- * The application context is going to fail starting if table is not present.
+ * The application context will fail to start if the table is not present.
  *
  * @author Dave Syer
  * @author Artem Bilan

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.sql.DataSource;
 
@@ -29,6 +30,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.SmartInitializingSingleton;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -45,6 +47,11 @@ import org.springframework.util.Assert;
  * Otherwise, it opens a possibility to break {@link java.util.concurrent.locks.Lock} contract,
  * where {@link JdbcLockRegistry} uses non-shared {@link java.util.concurrent.locks.ReentrantLock}s
  * for local synchronizations.
+ * <p>
+ * This class implements {@link SmartLifecycle} and calls
+ * {@code SELECT COUNT(REGION) FROM %sLOCK} query
+ * according to the provided prefix on {@link #start()} to check if required table is present in DB.
+ * The application context is going to fail starting if table is not present.
  *
  * @author Dave Syer
  * @author Artem Bilan
@@ -56,7 +63,8 @@ import org.springframework.util.Assert;
  * @since 4.3
  */
 public class DefaultLockRepository
-		implements LockRepository, InitializingBean, ApplicationContextAware, SmartInitializingSingleton {
+		implements LockRepository, InitializingBean, ApplicationContextAware, SmartInitializingSingleton,
+		SmartLifecycle {
 
 	/**
 	 * Default value for the table prefix property.
@@ -71,6 +79,8 @@ public class DefaultLockRepository
 	private final String id;
 
 	private final JdbcTemplate template;
+
+	private final AtomicBoolean started = new AtomicBoolean();
 
 	private Duration ttl = DEFAULT_TTL;
 
@@ -114,6 +124,10 @@ public class DefaultLockRepository
 			UPDATE %sLOCK
 			SET CREATED_DATE=?
 			WHERE REGION=? AND LOCK_KEY=? AND CLIENT_ID=?
+			""";
+
+	private String countAllQuery = """
+			SELECT COUNT(REGION) FROM %sLOCK
 			""";
 
 	private ApplicationContext applicationContext;
@@ -293,6 +307,7 @@ public class DefaultLockRepository
 		this.insertQuery = String.format(this.insertQuery, this.prefix);
 		this.countQuery = String.format(this.countQuery, this.prefix);
 		this.renewQuery = String.format(this.renewQuery, this.prefix);
+		this.countAllQuery = String.format(this.countAllQuery, this.prefix);
 	}
 
 	@Override
@@ -323,6 +338,23 @@ public class DefaultLockRepository
 		transactionDefinition.setIsolationLevel(TransactionDefinition.ISOLATION_SERIALIZABLE);
 
 		this.serializableTransactionTemplate = new TransactionTemplate(this.transactionManager, transactionDefinition);
+	}
+
+	@Override
+	public void start() {
+		if (this.started.compareAndSet(false, true)) {
+			this.template.queryForObject(this.countAllQuery, Integer.class); // If no table in DB, an exception is thrown
+		}
+	}
+
+	@Override
+	public void stop() {
+		this.started.set(false);
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.started.get();
 	}
 
 	@Override

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
@@ -347,8 +347,8 @@ public class DefaultLockRepository
 	}
 
 	/**
-	 * The flag to perform database check query on start or not.
-	 * @param checkDatabaseOnStart false to not perform database check.
+	 * The flag to perform a database check query on start or not.
+	 * @param checkDatabaseOnStart false to not perform the database check.
 	 * @since 6.2
 	 */
 	public void setCheckDatabaseOnStart(boolean checkDatabaseOnStart) {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/metadata/JdbcMetadataStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/metadata/JdbcMetadataStore.java
@@ -178,8 +178,8 @@ public class JdbcMetadataStore implements ConcurrentMetadataStore, InitializingB
 	}
 
 	/**
-	 * The flag to perform database check query on start or not.
-	 * @param checkDatabaseOnStart false to not perform database check.
+	 * The flag to perform a database check query on start or not.
+	 * @param checkDatabaseOnStart false to not perform the database check.
 	 * @since 6.2
 	 */
 	public void setCheckDatabaseOnStart(boolean checkDatabaseOnStart) {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/metadata/JdbcMetadataStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/metadata/JdbcMetadataStore.java
@@ -41,7 +41,7 @@ import org.springframework.util.Assert;
  * This class implements {@link SmartLifecycle} and calls
  * {@code SELECT COUNT(METADATA_KEY) FROM %sMETADATA_STORE} query
  * according to the provided prefix on {@link #start()} to check if required table is present in DB.
- * The application context is going to fail starting if table is not present.
+ * The application context will fail to start if the table is not present.
  *
  * @author Bojan Vukasovic
  * @author Artem Bilan
@@ -151,7 +151,7 @@ public class JdbcMetadataStore implements ConcurrentMetadataStore, InitializingB
 	 * Specify a row lock hint for the query in the lock-based operations.
 	 * Defaults to {@code FOR UPDATE}. Can be specified as an empty string,
 	 * if the target RDBMS doesn't support locking on tables from queries.
-	 * The value depends on RDBMS vendor, e.g. SQL Server requires {@code WITH (ROWLOCK)}.
+	 * The value depends on the RDBMS vendor, e.g. SQL Server requires {@code WITH (ROWLOCK)}.
 	 * @param lockHint the RDBMS vendor-specific lock hint.
 	 * @since 5.0.7
 	 */
@@ -194,7 +194,7 @@ public class JdbcMetadataStore implements ConcurrentMetadataStore, InitializingB
 		Assert.notNull(key, KEY_CANNOT_BE_NULL);
 		Assert.notNull(value, "'value' cannot be null");
 		while (true) {
-			//try to insert if entry does not exist
+			//try to insert if the entry does not exist
 			int affectedRows = tryToPutIfAbsent(key, value);
 			if (affectedRows > 0) {
 				//it was not in the table, so we have just inserted
@@ -250,7 +250,7 @@ public class JdbcMetadataStore implements ConcurrentMetadataStore, InitializingB
 		Assert.notNull(key, KEY_CANNOT_BE_NULL);
 		Assert.notNull(value, "'value' cannot be null");
 		while (true) {
-			//try to insert if entry does not exist, if exists we will try to update it
+			//try to insert if the entry does not exist, if it exists we will try to update it
 			int affectedRows = tryToPutIfAbsent(key, value);
 			if (affectedRows == 0) {
 				//since value is not inserted, means it is already present

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -423,8 +423,8 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 	}
 
 	/**
-	 * The flag to perform database check query on start or not.
-	 * @param checkDatabaseOnStart false to not perform database check.
+	 * The flag to perform a database check query on start or not.
+	 * @param checkDatabaseOnStart false to not perform the database check.
 	 * @since 6.2
 	 */
 	public void setCheckDatabaseOnStart(boolean checkDatabaseOnStart) {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -31,6 +32,7 @@ import java.util.function.Supplier;
 import javax.sql.DataSource;
 
 import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.core.log.LogMessage;
 import org.springframework.core.serializer.Deserializer;
@@ -73,6 +75,10 @@ import org.springframework.util.StringUtils;
  * The SQL scripts for creating the table are packaged
  * under {@code org/springframework/integration/jdbc/schema-*.sql},
  * where {@code *} denotes the target database type.
+ * <p>
+ * This class implements {@link SmartLifecycle} and calls {@link #getMessageGroupCount()}
+ * on {@link #start()} to check if required table is present in DB.
+ * The application context is going to fail starting if table is not present.
  *
  * @author Gunnar Hillert
  * @author Artem Bilan
@@ -83,7 +89,7 @@ import org.springframework.util.StringUtils;
  * @since 2.2
  */
 @ManagedResource
-public class JdbcChannelMessageStore implements PriorityCapableChannelMessageStore, InitializingBean {
+public class JdbcChannelMessageStore implements PriorityCapableChannelMessageStore, InitializingBean, SmartLifecycle {
 
 	private static final LogAccessor LOGGER = new LogAccessor(JdbcChannelMessageStore.class);
 
@@ -120,6 +126,8 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 	private final Lock idCacheReadLock = this.idCacheLock.readLock();
 
 	private final Lock idCacheWriteLock = this.idCacheLock.writeLock();
+
+	private final AtomicBoolean started = new AtomicBoolean();
 
 	private ChannelMessageStoreQueryProvider channelMessageStoreQueryProvider;
 
@@ -409,6 +417,23 @@ public class JdbcChannelMessageStore implements PriorityCapableChannelMessageSto
 					this.lobHandler);
 		}
 		this.jdbcTemplate.afterPropertiesSet();
+	}
+
+	@Override
+	public void start() {
+		if (this.started.compareAndSet(false, true)) {
+			getMessageGroupCount(); // If no table in DB, an exception is thrown
+		}
+	}
+
+	@Override
+	public void stop() {
+		this.started.set(false);
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.started.get();
 	}
 
 	/**

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcChannelMessageStore.java
@@ -78,7 +78,7 @@ import org.springframework.util.StringUtils;
  * <p>
  * This class implements {@link SmartLifecycle} and calls {@link #getMessageGroupCount()}
  * on {@link #start()} to check if required table is present in DB.
- * The application context is going to fail starting if table is not present.
+ * The application context will fail to start if the table is not present.
  *
  * @author Gunnar Hillert
  * @author Artem Bilan

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcMessageStore.java
@@ -71,7 +71,7 @@ import org.springframework.util.StringUtils;
  * <p>
  * This class implements {@link SmartLifecycle} and calls {@link #getMessageGroupCount()}
  * on {@link #start()} to check if required tables are present in DB.
- * The application context is going to fail starting if tables are not present.
+ * The application context will fail to start if the table is not present.
  *
  * @author Dave Syer
  * @author Oleg Zhurakousky

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcMessageStore.java
@@ -344,8 +344,8 @@ public class JdbcMessageStore extends AbstractMessageGroupStore
 	}
 
 	/**
-	 * The flag to perform database check query on start or not.
-	 * @param checkDatabaseOnStart false to not perform database check.
+	 * The flag to perform a database check query on start or not.
+	 * @param checkDatabaseOnStart false to not perform the database check.
 	 * @since 6.2
 	 */
 	public void setCheckDatabaseOnStart(boolean checkDatabaseOnStart) {

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcMessageStoreParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcMessageStoreParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.serializer.DefaultDeserializer;
@@ -77,11 +77,11 @@ public class JdbcMessageStoreParserTests {
 		setUp("soupedUpJdbcMessageStore.xml", getClass());
 		MessageStore store = context.getBean("messageStore", MessageStore.class);
 		assertThat(ReflectionTestUtils.getField(store, "region")).isEqualTo("FOO");
-		assertThat(ReflectionTestUtils.getField(store, "tablePrefix")).isEqualTo("BAR_");
+		assertThat(ReflectionTestUtils.getField(store, "tablePrefix")).isEqualTo("int_");
 		assertThat(ReflectionTestUtils.getField(store, "lobHandler")).isEqualTo(context.getBean(LobHandler.class));
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (context != null) {
 			context.close();

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcMessageStoreParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcMessageStoreParserTests.java
@@ -77,7 +77,7 @@ public class JdbcMessageStoreParserTests {
 		setUp("soupedUpJdbcMessageStore.xml", getClass());
 		MessageStore store = context.getBean("messageStore", MessageStore.class);
 		assertThat(ReflectionTestUtils.getField(store, "region")).isEqualTo("FOO");
-		assertThat(ReflectionTestUtils.getField(store, "tablePrefix")).isEqualTo("int_");
+		assertThat(ReflectionTestUtils.getField(store, "tablePrefix")).isEqualTo("BAR_");
 		assertThat(ReflectionTestUtils.getField(store, "lobHandler")).isEqualTo(context.getBean(LobHandler.class));
 	}
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcMessageHandlerParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcMessageHandlerParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,8 @@ package org.springframework.integration.jdbc.config;
 import java.sql.Types;
 import java.util.List;
 
-import org.junit.After;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -42,6 +42,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.1
  *
  */
@@ -54,7 +56,7 @@ public class StoredProcMessageHandlerParserTests {
 	private static volatile int adviceCalled;
 
 	@Test
-	public void testProcedureNameIsSet() throws Exception {
+	public void testProcedureNameIsSet() {
 		setUp("basicStoredProcOutboundChannelAdapterTest.xml", getClass());
 
 		DirectFieldAccessor accessor = new DirectFieldAccessor(this.consumer);
@@ -72,7 +74,7 @@ public class StoredProcMessageHandlerParserTests {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void testProcedurepParametersAreSet() throws Exception {
+	public void testProcedureParametersAreSet() {
 		setUp("basicStoredProcOutboundChannelAdapterTest.xml", getClass());
 
 		DirectFieldAccessor accessor = new DirectFieldAccessor(this.consumer);
@@ -114,7 +116,7 @@ public class StoredProcMessageHandlerParserTests {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void testSqlParametersAreSet() throws Exception {
+	public void testSqlParametersAreSet() {
 		setUp("basicStoredProcOutboundChannelAdapterTest.xml", getClass());
 
 		DirectFieldAccessor accessor = new DirectFieldAccessor(this.consumer);
@@ -161,15 +163,15 @@ public class StoredProcMessageHandlerParserTests {
 	}
 
 	@Test
-	public void adviceCalled() throws Exception {
+	public void adviceCalled() {
 		setUp("advisedStoredProcOutboundChannelAdapterTest.xml", getClass());
 
 		MessageHandler handler = TestUtils.getPropertyValue(this.consumer, "handler", MessageHandler.class);
-		handler.handleMessage(new GenericMessage<String>("foo"));
+		handler.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}
 
-	@After
+	@AfterEach
 	public void tearDown() {
 		if (context != null) {
 			context.close();

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/advisedStoredProcOutboundChannelAdapterTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/advisedStoredProcOutboundChannelAdapterTest.xml
@@ -12,9 +12,7 @@
 <int:channel id="target"/>
     <jdbc:embedded-database id="dataSource" type="HSQL"/>
     
-    <int-jdbc:message-store id="messageStore" data-source="dataSource"/>
-
-	<int-jdbc:stored-proc-outbound-channel-adapter id="storedProcedureOutboundChannelAdapter" 
+	<int-jdbc:stored-proc-outbound-channel-adapter id="storedProcedureOutboundChannelAdapter"
 	                                               data-source="dataSource" channel="target"
 	                                               stored-procedure-name="testProcedure1">
 	    <int-jdbc:sql-parameter-definition name="username" direction="IN"    type="VARCHAR"/>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/basicStoredProcOutboundChannelAdapterTest.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/basicStoredProcOutboundChannelAdapterTest.xml
@@ -1,30 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xmlns:int-jdbc="http://www.springframework.org/schema/integration/jdbc"
-	xmlns:int="http://www.springframework.org/schema/integration"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	   xmlns:int-jdbc="http://www.springframework.org/schema/integration/jdbc"
+	   xmlns:int="http://www.springframework.org/schema/integration"
+	   xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
 		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/integration/jdbc https://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-<int:channel id="target"/>
-    <jdbc:embedded-database id="dataSource" type="HSQL"/>
-    
-    <int-jdbc:message-store id="messageStore" data-source="dataSource"/>
+	<int:channel id="target"/>
 
-	<int-jdbc:stored-proc-outbound-channel-adapter id="storedProcedureOutboundChannelAdapter" 
-	                                               data-source="dataSource" channel="target"
-	                                               stored-procedure-name="testProcedure1">
-	    <int-jdbc:sql-parameter-definition name="username" direction="IN"    type="VARCHAR"/>
-	    <int-jdbc:sql-parameter-definition name="password" direction="OUT"                            />
-	    <int-jdbc:sql-parameter-definition name="age"      direction="INOUT" type="INTEGER"  scale="5"/>    
-	    <int-jdbc:sql-parameter-definition name="description" />                                          
-	    <int-jdbc:parameter name="username"    value="kenny"   type="java.lang.String"/>
-	    <int-jdbc:parameter name="description" value="Who killed Kenny?"/>
-	    <int-jdbc:parameter name="password"    expression="payload.username"/>
-	    <int-jdbc:parameter name="age"         value="30"      type="java.lang.Integer"/>
+	<jdbc:embedded-database id="dataSource" type="HSQL"/>
+
+	<int-jdbc:stored-proc-outbound-channel-adapter id="storedProcedureOutboundChannelAdapter"
+												   data-source="dataSource" channel="target"
+												   stored-procedure-name="testProcedure1">
+		<int-jdbc:sql-parameter-definition name="username" direction="IN" type="VARCHAR"/>
+		<int-jdbc:sql-parameter-definition name="password" direction="OUT"/>
+		<int-jdbc:sql-parameter-definition name="age" direction="INOUT" type="INTEGER" scale="5"/>
+		<int-jdbc:sql-parameter-definition name="description"/>
+		<int-jdbc:parameter name="username" value="kenny" type="java.lang.String"/>
+		<int-jdbc:parameter name="description" value="Who killed Kenny?"/>
+		<int-jdbc:parameter name="password" expression="payload.username"/>
+		<int-jdbc:parameter name="age" value="30" type="java.lang.Integer"/>
 	</int-jdbc:stored-proc-outbound-channel-adapter>
-	
+
 </beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/defaultJdbcMessageStore.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/defaultJdbcMessageStore.xml
@@ -7,7 +7,10 @@
 			http://www.springframework.org/schema/integration/jdbc https://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd
 			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<jdbc:embedded-database id="dataSource" type="HSQL"/>
+	<jdbc:embedded-database id="dataSource">
+		<jdbc:script location="org/springframework/integration/jdbc/schema-drop-h2.sql"/>
+		<jdbc:script location="org/springframework/integration/jdbc/schema-h2.sql" />
+	</jdbc:embedded-database>
 	
 	<int-jdbc:message-store id="messageStore" data-source="dataSource"/>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/jdbcOperationsJdbcMessageStore.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/jdbcOperationsJdbcMessageStore.xml
@@ -7,8 +7,11 @@
 			http://www.springframework.org/schema/integration/jdbc https://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd
 			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<jdbc:embedded-database id="dataSource" type="HSQL"/>
-	
+	<jdbc:embedded-database id="dataSource">
+		<jdbc:script location="org/springframework/integration/jdbc/schema-drop-h2.sql"/>
+		<jdbc:script location="org/springframework/integration/jdbc/schema-h2.sql" />
+	</jdbc:embedded-database>
+
 	<bean id="jdbcTemplate" class="org.springframework.jdbc.core.JdbcTemplate">
 		<constructor-arg ref="dataSource"/>
 	</bean>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/serializerJdbcMessageStore.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/serializerJdbcMessageStore.xml
@@ -5,7 +5,10 @@
 			http://www.springframework.org/schema/integration/jdbc https://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd
 			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<jdbc:embedded-database id="dataSource" type="HSQL" />
+	<jdbc:embedded-database id="dataSource">
+		<jdbc:script location="org/springframework/integration/jdbc/schema-drop-h2.sql"/>
+		<jdbc:script location="org/springframework/integration/jdbc/schema-h2.sql" />
+	</jdbc:embedded-database>
 
 	<bean id="serializer" class="org.springframework.integration.jdbc.config.JdbcMessageStoreParserTests$EnhancedSerializer" />
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/soupedUpJdbcMessageStore.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/soupedUpJdbcMessageStore.xml
@@ -2,18 +2,19 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xmlns:int-jdbc="http://www.springframework.org/schema/integration/jdbc"
 	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-			http://www.springframework.org/schema/integration/jdbc https://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd
 			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<jdbc:embedded-database id="dataSource">
-		<jdbc:script location="org/springframework/integration/jdbc/schema-drop-h2.sql"/>
-		<jdbc:script location="org/springframework/integration/jdbc/schema-h2.sql" />
-	</jdbc:embedded-database>
+	<jdbc:embedded-database id="dataSource" type="HSQL"/>
 
-	<int-jdbc:message-store id="messageStore" data-source="dataSource" lob-handler="lobHandler" region="FOO" table-prefix="int_"/>
-	
+	<bean id="messageStore" class="org.springframework.integration.jdbc.store.JdbcMessageStore">
+		<constructor-arg ref="dataSource"/>
+		<property name="lobHandler" ref="lobHandler"/>
+		<property name="region" value="FOO"/>
+		<property name="tablePrefix" value="BAR_"/>
+		<property name="checkDatabaseOnStart" value="false"/>
+	</bean>
+
 	<bean id="lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler"/>
 
 </beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/soupedUpJdbcMessageStore.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/soupedUpJdbcMessageStore.xml
@@ -7,9 +7,12 @@
 			http://www.springframework.org/schema/integration/jdbc https://www.springframework.org/schema/integration/jdbc/spring-integration-jdbc.xsd
 			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<jdbc:embedded-database id="dataSource" type="HSQL"/>
-	
-	<int-jdbc:message-store id="messageStore" data-source="dataSource" lob-handler="lobHandler" region="FOO" table-prefix="BAR_"/>
+	<jdbc:embedded-database id="dataSource">
+		<jdbc:script location="org/springframework/integration/jdbc/schema-drop-h2.sql"/>
+		<jdbc:script location="org/springframework/integration/jdbc/schema-h2.sql" />
+	</jdbc:embedded-database>
+
+	<int-jdbc:message-store id="messageStore" data-source="dataSource" lob-handler="lobHandler" region="FOO" table-prefix="int_"/>
 	
 	<bean id="lobHandler" class="org.springframework.jdbc.support.lob.DefaultLobHandler"/>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlContainerTest.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlContainerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 package org.springframework.integration.jdbc.mysql;
 
+import javax.sql.DataSource;
+
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -55,6 +58,15 @@ public interface MySqlContainerTest {
 
 	static String getPassword() {
 		return MY_SQL_CONTAINER.getPassword();
+	}
+
+	static DataSource dataSource() {
+		BasicDataSource dataSource = new BasicDataSource();
+		dataSource.setDriverClassName(getDriverClassName());
+		dataSource.setUrl(getJdbcUrl());
+		dataSource.setUsername(getUsername());
+		dataSource.setPassword(getPassword());
+		return dataSource;
 	}
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import java.util.UUID;
 
 import javax.sql.DataSource;
 
-import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.AfterEach;
@@ -509,12 +508,7 @@ public class MySqlJdbcMessageStoreTests implements MySqlContainerTest {
 
 		@Bean
 		DataSource dataSource() {
-			BasicDataSource dataSource = new BasicDataSource();
-			dataSource.setDriverClassName(MySqlContainerTest.getDriverClassName());
-			dataSource.setUrl(MySqlContainerTest.getJdbcUrl());
-			dataSource.setUsername(MySqlContainerTest.getUsername());
-			dataSource.setPassword(MySqlContainerTest.getPassword());
-			return dataSource;
+			return MySqlContainerTest.dataSource();
 		}
 
 		@Bean

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/JdbcMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,11 +37,13 @@ import org.apache.commons.dbcp2.PoolingDataSource;
 import org.apache.commons.pool2.ObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.hsqldb.HsqlException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.context.ApplicationContextException;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.annotation.SynthesizingMethodParameter;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
@@ -51,6 +53,7 @@ import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.predicate.MessagePredicate;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.util.UUIDConverter;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementSetter;
@@ -62,6 +65,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Dave Syer
@@ -575,6 +579,19 @@ public class JdbcMessageStoreTests {
 		}
 
 		pooledMessageStore.removeMessageGroup(groupId);
+	}
+
+	@Test
+	void noTableThrowsExceptionOnStart() {
+		try (TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext()) {
+			JdbcMessageStore jdbcMessageStore = new JdbcMessageStore(this.dataSource);
+			jdbcMessageStore.setTablePrefix("TEST_");
+			testApplicationContext.registerBean("jdbcMessageStore", jdbcMessageStore);
+			assertThatExceptionOfType(ApplicationContextException.class)
+					.isThrownBy(testApplicationContext::refresh)
+					.withRootCauseExactlyInstanceOf(HsqlException.class)
+					.withStackTraceContaining("user lacks privilege or object not found: TEST_MESSAGE_GROUP");
+		}
 	}
 
 	public void methodForCollectionOfPayloads(Collection<String> payloads) {

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/AbstractJdbcChannelMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/AbstractJdbcChannelMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,9 +21,8 @@ import java.sql.SQLException;
 
 import javax.sql.DataSource;
 
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.serializer.support.SerializingConverter;
@@ -33,7 +32,7 @@ import org.springframework.jdbc.support.lob.DefaultLobHandler;
 import org.springframework.jdbc.support.lob.LobHandler;
 import org.springframework.messaging.Message;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
@@ -50,13 +49,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  */
 
-@RunWith(SpringRunner.class)
+@SpringJUnitConfig
 @DirtiesContext
 public abstract class AbstractJdbcChannelMessageStoreTests {
 
 	protected static final String TEST_MESSAGE_GROUP = "AbstractJdbcChannelMessageStoreTests";
 
-	private static final String REGION = "AbstractJdbcChannelMessageStoreTests";
+	protected static final String REGION = "AbstractJdbcChannelMessageStoreTests";
 
 	@Autowired
 	protected DataSource dataSource;
@@ -69,8 +68,8 @@ public abstract class AbstractJdbcChannelMessageStoreTests {
 	@Autowired
 	protected ChannelMessageStoreQueryProvider queryProvider;
 
-	@Before
-	public void init() throws Exception {
+	@BeforeEach
+	public void init() {
 		messageStore = new JdbcChannelMessageStore(dataSource);
 		messageStore.setRegion(REGION);
 		messageStore.setChannelMessageStoreQueryProvider(queryProvider);

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-common-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-common-context.xml
@@ -1,16 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-			http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="transactionManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
 		<property name="dataSource" ref="dataSource" />
-		<!-- <property name="defaultTimeout" value="2000" /> -->
-		<!-- Postgres 9 does not support send timeouts. You may see an exception like:
-		"java.sql.SQLFeatureNotSupportedException: Method org.postgresql.jdbc4.Jdbc4PreparedStatement.setQueryTimeout(int) is not yet implemented."
-		-->
+		 <property name="defaultTimeout" value="2000" />
 	</bean>
 
 </beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-mysql-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-mysql-context.xml
@@ -4,7 +4,7 @@
 	   xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	   xsi:schemaLocation="
 	   http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-	   http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
+	   http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
 	<import resource="classpath:org/springframework/integration/jdbc/store/channel/DataSource-common-context.xml"/>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-mysql-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-mysql-context.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="
-		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	   xsi:schemaLocation="
+	   http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   http://www.springframework.org/schema/jdbc http://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
-	<import resource="classpath:org/springframework/integration/jdbc/store/channel/DataSource-common-context.xml" />
+	<import resource="classpath:org/springframework/integration/jdbc/store/channel/DataSource-common-context.xml"/>
 
-	<bean id="dataSource" destroy-method="close"
-		class="org.apache.commons.dbcp2.BasicDataSource">
-		<property name="driverClassName" value="com.mysql.jdbc.Driver" />
-		<property name="url" value="jdbc:mysql://localhost/test" />
-		<property name="username" value="root" />
-		<property name="password" value="" />
-		<property name="initialSize" value="10" />
-	</bean>
+	<bean id="dataSource" class="org.springframework.integration.jdbc.mysql.MySqlContainerTest"
+		  factory-method="dataSource"/>
 
-	<bean id="queryProvider" class="org.springframework.integration.jdbc.store.channel.MySqlChannelMessageStoreQueryProvider"/>
+	<jdbc:initialize-database ignore-failures="ALL">
+		<jdbc:script location="classpath:org/springframework/integration/jdbc/schema-drop-mysql.sql" />
+		<jdbc:script location="classpath:org/springframework/integration/jdbc/schema-mysql.sql" />
+	</jdbc:initialize-database>
+
+	<bean id="queryProvider"
+		  class="org.springframework.integration.jdbc.store.channel.MySqlChannelMessageStoreQueryProvider"/>
 
 </beans>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/H2JdbcChannelMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/H2JdbcChannelMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,37 @@
 
 package org.springframework.integration.jdbc.store.channel;
 
+import org.h2.jdbc.JdbcSQLSyntaxErrorException;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.context.ApplicationContextException;
+import org.springframework.integration.jdbc.store.JdbcChannelMessageStore;
+import org.springframework.integration.test.util.TestUtils;
+import org.springframework.test.context.ContextConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
 /**
  * @author Gunnar Hillert
  * @author Manuel Jordan
  * @since 4.3
  */
+@ContextConfiguration
 public class H2JdbcChannelMessageStoreTests extends AbstractJdbcChannelMessageStoreTests {
+
+	@Test
+	void noTableThrowsExceptionOnStart() {
+		try (TestUtils.TestApplicationContext testApplicationContext = TestUtils.createTestApplicationContext()) {
+			JdbcChannelMessageStore jdbcChannelMessageStore = new JdbcChannelMessageStore(this.dataSource);
+			jdbcChannelMessageStore.setTablePrefix("TEST_");
+			jdbcChannelMessageStore.setRegion(REGION);
+			jdbcChannelMessageStore.setChannelMessageStoreQueryProvider(this.queryProvider);
+			testApplicationContext.registerBean("jdbcChannelMessageStore", jdbcChannelMessageStore);
+			assertThatExceptionOfType(ApplicationContextException.class)
+					.isThrownBy(testApplicationContext::refresh)
+					.withRootCauseExactlyInstanceOf(JdbcSQLSyntaxErrorException.class)
+					.withStackTraceContaining("Table \"TEST_CHANNEL_MESSAGE\" not found");
+		}
+	}
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/MySqlJdbcChannelMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/MySqlJdbcChannelMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,15 +16,15 @@
 
 package org.springframework.integration.jdbc.store.channel;
 
-import org.junit.Ignore;
-
+import org.springframework.integration.jdbc.mysql.MySqlContainerTest;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
  * @author Gunnar Hillert
+ * @author Artem Bilan
  */
-@Ignore
 @ContextConfiguration
-public class MySqlJdbcChannelMessageStoreTests extends AbstractJdbcChannelMessageStoreTests {
+public class MySqlJdbcChannelMessageStoreTests extends AbstractJdbcChannelMessageStoreTests
+		implements MySqlContainerTest {
 
 }

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -400,6 +400,7 @@ You may find that you need to enhance them for production use (for, example, by 
 
 Starting with version 6.2, the `JdbcMessageStore`, `JdbcChannelMessageStore`, `JdbcMetadataStore`, and `DefaultLockRepository` implement `SmartLifecycle` and perform a`SELECT COUNT` query, on their respective tables, in the `start()` method to ensure that the required table (according to the provided prefix) is present in the target database.
 If the required table does not exist, the application context fails to start.
+The check can be disabled via `setCheckDatabaseOnStart(false)`.
 
 [[jdbc-message-store-generic]]
 ==== The Generic JDBC Message Store

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -386,6 +386,7 @@ Furthermore, the index for `PriorityChannel` is commented out because it is not 
 
 NOTE: When using the `OracleChannelMessageStoreQueryProvider`, the priority channel index **must** be added because it is included in a hint in the query.
 
+[[jdbc-db-init]]
 ==== Initializing the Database
 
 Before starting to use JDBC message store components, you should provision a target database with the appropriate objects.
@@ -396,6 +397,9 @@ It provides an example create and an example drop script for a range of common d
 A common way to use these scripts is to reference them in a https://docs.spring.io/spring/docs/current/spring-framework-reference/html/jdbc.html#jdbc-intializing-datasource[Spring JDBC data source initializer].
 Note that the scripts are provided as samples and as specifications of the required table and column names.
 You may find that you need to enhance them for production use (for, example, by adding index declarations).
+
+Starting with version 6.2, the `JdbcMessageStore`, `JdbcChannelMessageStore`, `JdbcMetadataStore`, and `DefaultLockRepository` implement `SmartLifecycle` and perform `SELECT COUNT` query in their `start()` method to be sure that required table (according to the provided prefix) is present in the target database.
+If tables don't exist, the application context fails to start.
 
 [[jdbc-message-store-generic]]
 ==== The Generic JDBC Message Store

--- a/src/reference/asciidoc/jdbc.adoc
+++ b/src/reference/asciidoc/jdbc.adoc
@@ -398,8 +398,8 @@ A common way to use these scripts is to reference them in a https://docs.spring.
 Note that the scripts are provided as samples and as specifications of the required table and column names.
 You may find that you need to enhance them for production use (for, example, by adding index declarations).
 
-Starting with version 6.2, the `JdbcMessageStore`, `JdbcChannelMessageStore`, `JdbcMetadataStore`, and `DefaultLockRepository` implement `SmartLifecycle` and perform `SELECT COUNT` query in their `start()` method to be sure that required table (according to the provided prefix) is present in the target database.
-If tables don't exist, the application context fails to start.
+Starting with version 6.2, the `JdbcMessageStore`, `JdbcChannelMessageStore`, `JdbcMetadataStore`, and `DefaultLockRepository` implement `SmartLifecycle` and perform a`SELECT COUNT` query, on their respective tables, in the `start()` method to ensure that the required table (according to the provided prefix) is present in the target database.
+If the required table does not exist, the application context fails to start.
 
 [[jdbc-message-store-generic]]
 ==== The Generic JDBC Message Store

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -49,5 +49,5 @@ See <<./kafka.adoc#kafka-inbound-pollable, Kafka Inbound Channel Adapter>> for m
 [[x6.2-jdbc]]
 === JDBC Support Changes
 
-The `JdbcMessageStore`, `JdbcChannelMessageStore`, `JdbcMetadataStore`, and `DefaultLockRepository` implement `SmartLifecycle` and perform `SELECT COUNT` query in their `start()` method to be sure that required table (according to the provided prefix) is present in the target database.
+The `JdbcMessageStore`, `JdbcChannelMessageStore`, `JdbcMetadataStore`, and `DefaultLockRepository` implement `SmartLifecycle` and perform a`SELECT COUNT` query, on their respective tables, in the `start()` method to ensure that the required table (according to the provided prefix) is present in the target database.
 See <<./jdbc.adoc#jdbc-db-init, Initializing the Database>> for more information.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -45,3 +45,9 @@ See <<./web-sockets.adoc#websocket-client-container-attributes, WebSockets Suppo
 
 The `KafkaMessageSource` now extracts an `ErrorHandlingDeserializer` configuration from the consumer properties and re-throws `DeserializationException` extracted from failed record headers.
 See <<./kafka.adoc#kafka-inbound-pollable, Kafka Inbound Channel Adapter>> for more information.
+
+[[x6.2-jdbc]]
+=== JDBC Support Changes
+
+The `JdbcMessageStore`, `JdbcChannelMessageStore`, `JdbcMetadataStore`, and `DefaultLockRepository` implement `SmartLifecycle` and perform `SELECT COUNT` query in their `start()` method to be sure that required table (according to the provided prefix) is present in the target database.
+See <<./jdbc.adoc#jdbc-db-init, Initializing the Database>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8680

If database is not initialized properly before application start, we may lose messages at runtime when we fail to insert data into DB

* Implement `SmartLifecycle` on `JdbcMessageStore`, `JdbcChannelMessageStore`, `JdbcMetadataStore`, and `DefaultLockRepository` to perform `SELECT COUNT` query in `start()` to fail fast if no required table is present.
* Refactor `AbstractJdbcChannelMessageStoreTests` into JUnit 5 and use `MySqlContainerTest` for more coverage
* Fix newly failed tests which had DB not initialized before
* Exclude `commons-logging` from `commons-dbcp2` dependency to avoid classpath conflict
* Document the new feature

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
