### PR TITLE
Fix Issue of removeLockKey() Method of RedisLock

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -478,6 +478,7 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 			if (RedisLockRegistry.this.unlinkAvailable) {
 				Boolean unlinkResult = null;
 				try {
+					// Attempt to UNLINK the lock key; an exception indicates lack of UNLINK support
 					unlinkResult = removeLockKeyInnerUnlink();
 				}
 				catch (Exception ex) {
@@ -492,7 +493,8 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 					}
 				}
 
-				if(Boolean.TRUE.equals(unlinkResult)) {
+				if (Boolean.TRUE.equals(unlinkResult)) {
+					// Lock key successfully unlinked
 					return;
 				}
 				else if (Boolean.FALSE.equals(unlinkResult)) {


### PR DESCRIPTION
### Issue
In the current code, an IllegalStateException might be thrown from the try block while invoking the `removeLockKeyInnerUnlink()` method, especially when caused by key expiration (resulting in unlinkResult == false).

This triggers the catch block, which incorrectly sets the unlinkAvailable flag to false, even if the Redis server supports the unlink operation.

As a consequence, the subsequent `removeLockKeyInnerDelete()` method is invoked when it should not be.

### Solution

To address this issue, a Boolean flag should be introduced to accurately represent the outcome of the key unlink operation:

If the flag is null, it signifies that an exception was thrown during the execution of `the removeLockKeyInnerUnlink()` method.
If the flag is true, it indicates successful unlocking of the lock key.
If the flag is false, it indicates that the lock key expired, leading to the throwing of the IllegalStateException.

By implementing this flag-based approach, the behavior can be more precisely controlled, ensuring that the flow is correctly handled and that exceptions do not lead to incorrect state changes.