### PR TITLE
GH-8705 Expose errorOnTimeout on MessagingGateway

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
@@ -167,7 +167,7 @@ public @interface MessagingGateway {
 	boolean proxyDefaultMethods() default false;
 
 	/**
-	 * If errorOnTimeout is true, the null won't be returned as a result of a gateway method invocation.
+	 * If errorOnTimeout is true, null won't be returned as a result of a gateway method invocation when a timeout occurs.
 	 * Instead, a {@link org.springframework.integration.MessageTimeoutException} is thrown
 	 * or an error message is published to the error channel.
 	 * @since 6.2

--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/MessagingGateway.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Target;
 
 import org.springframework.core.annotation.AliasFor;
 import org.springframework.integration.context.IntegrationContextUtils;
+import org.springframework.integration.gateway.MessagingGatewaySupport;
 
 /**
  * A stereotype annotation to provide an Integration Messaging Gateway Proxy
@@ -164,5 +165,14 @@ public @interface MessagingGateway {
 	 * @since 5.3
 	 */
 	boolean proxyDefaultMethods() default false;
+
+	/**
+	 * If errorOnTimeout is true, the null won't be returned as a result of a gateway method invocation.
+	 * Instead, a {@link org.springframework.integration.MessageTimeoutException} is thrown
+	 * or an error message is published to the error channel.
+	 * @since 6.2
+	 * @see MessagingGatewaySupport#setErrorOnTimeout(boolean)
+	 */
+	boolean errorOnTimeout() default false;
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/GatewayEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/GatewayEndpointSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,6 +95,18 @@ public class GatewayEndpointSpec extends ConsumerEndpointSpec<GatewayEndpointSpe
 	 */
 	public GatewayEndpointSpec replyTimeout(Long replyTimeout) {
 		this.handler.setReplyTimeout(replyTimeout);
+		return this;
+	}
+
+	/**
+	 * Set a error on timeout flag.
+	 * @param errorOnTimeout true to produce an error in case on reply timeout.
+	 * @return the spec
+	 * @since 6.2
+	 * @see org.springframework.integration.gateway.GatewayProxyFactoryBean#setErrorOnTimeout(boolean)
+	 */
+	public GatewayEndpointSpec errorOnTimeout(boolean errorOnTimeout) {
+		this.handler.setErrorOnTimeout(errorOnTimeout);
 		return this;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/GatewayEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/GatewayEndpointSpec.java
@@ -100,8 +100,8 @@ public class GatewayEndpointSpec extends ConsumerEndpointSpec<GatewayEndpointSpe
 
 	/**
 	 * Set a error on timeout flag.
-	 * @param errorOnTimeout true to produce an error in case on reply timeout.
-	 * @return the spec
+	 * @param errorOnTimeout true to produce an error in case of a reply timeout.
+	 * @return the spec.
 	 * @since 6.2
 	 * @see org.springframework.integration.gateway.GatewayProxyFactoryBean#setErrorOnTimeout(boolean)
 	 */

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/AnnotationGatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/AnnotationGatewayProxyFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,6 +127,8 @@ public class AnnotationGatewayProxyFactoryBean<T> extends GatewayProxyFactoryBea
 						this::setDefaultReplyTimeout);
 
 		populateAsyncExecutorIfAny();
+
+		setErrorOnTimeout(this.gatewayAttributes.getBoolean("errorOnTimeout"));
 
 		boolean proxyDefaultMethods = this.gatewayAttributes.getBoolean("proxyDefaultMethods");
 		if (proxyDefaultMethods) { // Override only if annotation attribute is different

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayMessageHandler.java
@@ -81,6 +81,10 @@ public class GatewayMessageHandler extends AbstractReplyProducingMessageHandler 
 		this.gatewayProxyFactoryBean.setDefaultReplyTimeout(replyTimeout);
 	}
 
+	public void setErrorOnTimeout(boolean errorOnTimeout) {
+		this.gatewayProxyFactoryBean.setErrorOnTimeout(errorOnTimeout);
+	}
+
 	@Override
 	protected Object handleRequestMessage(Message<?> requestMessage) {
 		if (this.exchanger == null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -458,7 +458,7 @@ public class GatewayProxyFactoryBean<T> extends AbstractEndpoint
 	}
 
 	/**
-	 * If errorOnTimeout is true, the null won't be returned as a result of a gateway method invocation.
+	 * If errorOnTimeout is true, null won't be returned as a result of a gateway method invocation, when a timeout occurs.
 	 * Instead, a {@link org.springframework.integration.MessageTimeoutException} is thrown
 	 * or an error message is published to the error channel.
 	 * @param errorOnTimeout true to create the error message on reply timeout.

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/GatewayProxyFactoryBean.java
@@ -166,6 +166,8 @@ public class GatewayProxyFactoryBean<T> extends AbstractEndpoint
 
 	private MetricsCaptor metricsCaptor;
 
+	private boolean errorOnTimeout;
+
 	/**
 	 * Create a Factory whose service interface type can be configured by setter injection.
 	 * If none is set, it will fall back to the default service interface type,
@@ -453,6 +455,18 @@ public class GatewayProxyFactoryBean<T> extends AbstractEndpoint
 	public void registerMetricsCaptor(MetricsCaptor metricsCaptorToRegister) {
 		this.metricsCaptor = metricsCaptorToRegister;
 		this.gatewayMap.values().forEach(gw -> gw.registerMetricsCaptor(metricsCaptorToRegister));
+	}
+
+	/**
+	 * If errorOnTimeout is true, the null won't be returned as a result of a gateway method invocation.
+	 * Instead, a {@link org.springframework.integration.MessageTimeoutException} is thrown
+	 * or an error message is published to the error channel.
+	 * @param errorOnTimeout true to create the error message on reply timeout.
+	 * @since 6.2
+	 * @see MessagingGatewaySupport#setErrorOnTimeout(boolean)
+	 */
+	public void setErrorOnTimeout(boolean errorOnTimeout) {
+		this.errorOnTimeout = errorOnTimeout;
 	}
 
 	@Override
@@ -881,6 +895,7 @@ public class GatewayProxyFactoryBean<T> extends AbstractEndpoint
 		gateway.setBeanFactory(getBeanFactory());
 		gateway.setShouldTrack(this.shouldTrack);
 		gateway.registerMetricsCaptor(this.metricsCaptor);
+		gateway.setErrorOnTimeout(this.errorOnTimeout);
 		gateway.afterPropertiesSet();
 
 		return gateway;

--- a/src/reference/antora/modules/ROOT/pages/gateway.adoc
+++ b/src/reference/antora/modules/ROOT/pages/gateway.adoc
@@ -794,6 +794,8 @@ If a component downstream is still running (perhaps because of an infinite loop 
 However, if the timeout has been reached before the actual reply was produced, it could result in a 'null' return from the gateway method.
 You should understand that the reply message (if produced) is sent to a reply channel after the gateway method invocation might have returned, so you must be aware of that and design your flow with it in mind.
 
+Also see an `errorOnTimeout` option to throw a `MessageTimeoutException` instead of returning `null`.
+
 [[downstream-component-returns-null-]]
 === Downstream Component Returns 'null'
 
@@ -837,5 +839,9 @@ IMPORTANT: You should understand that the timer starts when the thread returns t
 At that time, the calling thread starts waiting for the reply.
 If the flow was completely synchronous, the reply is immediately available.
 For asynchronous flows, the thread waits for up to this time.
+
+Starting with version 6.2, the `errorOnTimeout` option of an internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport` is exposed to the `@MessagingGateway` and `GatewayEndpointSpec`.
+This option has exactly the same meaning as for any inbound gateway explained in the end of xref:endpoint-summary.adoc#endpoint-summary[Endpoint Summary] chapter.
+In other words, setting this option to `true`, would lead to the `MessageTimeoutException` being thrown from a send-and-receive gateway operation instead of returning `null` when receive timeout is exhausted.
 
 See xref:dsl/integration-flow-as-gateway.adoc[`IntegrationFlow` as Gateway] in the Java DSL chapter for options to define gateways through `IntegrationFlow`.

--- a/src/reference/antora/modules/ROOT/pages/gateway.adoc
+++ b/src/reference/antora/modules/ROOT/pages/gateway.adoc
@@ -794,7 +794,7 @@ If a component downstream is still running (perhaps because of an infinite loop 
 However, if the timeout has been reached before the actual reply was produced, it could result in a 'null' return from the gateway method.
 You should understand that the reply message (if produced) is sent to a reply channel after the gateway method invocation might have returned, so you must be aware of that and design your flow with it in mind.
 
-Also see an `errorOnTimeout` option to throw a `MessageTimeoutException` instead of returning `null`.
+Also see the `errorOnTimeout` property to throw a `MessageTimeoutException` instead of returning `null`, when a timeout occurs.
 
 [[downstream-component-returns-null-]]
 === Downstream Component Returns 'null'
@@ -840,8 +840,8 @@ At that time, the calling thread starts waiting for the reply.
 If the flow was completely synchronous, the reply is immediately available.
 For asynchronous flows, the thread waits for up to this time.
 
-Starting with version 6.2, the `errorOnTimeout` option of an internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport` is exposed to the `@MessagingGateway` and `GatewayEndpointSpec`.
+Starting with version 6.2, the `errorOnTimeout` property of the internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport` is exposed on the `@MessagingGateway` and `GatewayEndpointSpec`.
 This option has exactly the same meaning as for any inbound gateway explained in the end of xref:endpoint-summary.adoc#endpoint-summary[Endpoint Summary] chapter.
-In other words, setting this option to `true`, would lead to the `MessageTimeoutException` being thrown from a send-and-receive gateway operation instead of returning `null` when receive timeout is exhausted.
+In other words, setting this option to `true`, would lead to the `MessageTimeoutException` being thrown from a send-and-receive gateway operation instead of returning `null` when the receive timeout is exhausted.
 
 See xref:dsl/integration-flow-as-gateway.adoc[`IntegrationFlow` as Gateway] in the Java DSL chapter for options to define gateways through `IntegrationFlow`.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -33,7 +33,7 @@ See xref:endpoint.adoc#endpoint-pollingconsumer[Polling Consumer] for more infor
 - Java, Groovy and Kotlin DSLs have now context-specific methods in the `IntegrationFlowDefinition` with a single `Consumer` argument to configure an endpoint and its handler with one builder and readable options.
 See, for example, `transformWith()`, `splitWith()` in xref:dsl.adoc#java-dsl[ Java DSL Chapter].
 
-- The `@MessagingGateway` and `GatewayEndpointSpec` for Java DSL expose now an `errorOnTimeout` option of an internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport`.
+- The `@MessagingGateway` and `GatewayEndpointSpec` provided by the Java DSL now expose the `errorOnTimeout` property of the internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport`.
 See xref:gateway.adoc#gateway-no-response[ Gateway Behavior When No response Arrives] for more information.
 
 [[x6.2-websockets]]

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -33,6 +33,9 @@ See xref:endpoint.adoc#endpoint-pollingconsumer[Polling Consumer] for more infor
 - Java, Groovy and Kotlin DSLs have now context-specific methods in the `IntegrationFlowDefinition` with a single `Consumer` argument to configure an endpoint and its handler with one builder and readable options.
 See, for example, `transformWith()`, `splitWith()` in xref:dsl.adoc#java-dsl[ Java DSL Chapter].
 
+- The `@MessagingGateway` and `GatewayEndpointSpec` for Java DSL expose now an `errorOnTimeout` option of an internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport`.
+See xref:gateway.adoc#gateway-no-response[ Gateway Behavior When No response Arrives] for more information.
+
 [[x6.2-websockets]]
 === WebSockets Changes
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8705

an internal `MethodInvocationGateway` is a `MessagingGatewaySupport` extension with all the logic available there.
One of the option introduced in `5.2.2` to be able to throw a `MessageTimeoutException` instead of returning `null` when no reply received in time from downstream flow

* Expose an `errorOnTimeout` on the `@MessagingGateway` and `GatewayEndpointSpec`
* Propagate this option from a `GatewayProxyFactoryBean` down to its internal `MethodInvocationGateway` implementation
* Modify couple tests to react for `errorOnTimeout` set to `true`
* Document the feature

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
