### PR TITLE
GH-8692 implementing MongoDbChannelMessageStore ignores auto index creation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,9 @@ ext {
     linkScmDevConnection = 'scm:git:ssh://git@github.com:spring-projects/spring-integration.git'
 
     modifiedFiles =
-            files(grgit.status().unstaged.modified).filter { f -> f.name.endsWith('.java') || f.name.endsWith('.kt') }
+            providers.provider {
+                files(grgit.status().unstaged.modified).filter { f -> f.name.endsWith('.java') || f.name.endsWith('.kt') }
+            }
 
     apacheSshdVersion = '2.10.0'
     artemisVersion = '2.29.0'
@@ -290,7 +292,7 @@ configure(javaProjects) { subproject ->
 
     tasks.register('updateCopyrights') {
         onlyIf { !isCI }
-        inputs.files(modifiedFiles.filter { f -> f.path.contains(subproject.name) })
+        inputs.files(modifiedFiles.map(files -> files.filter { f -> f.path.contains(subproject.name) }))
         outputs.dir('build/classes')
 
         doLast {
@@ -492,7 +494,7 @@ project('spring-integration-camel') {
         api 'org.apache.camel:camel-core-model'
 
         testImplementation 'org.apache.camel:camel-test-junit5'
-        testImplementation ('org.apache.camel:camel-spring') {
+        testImplementation('org.apache.camel:camel-spring') {
             exclude group: 'org.springframework'
         }
     }
@@ -505,7 +507,7 @@ project('spring-integration-cassandra') {
         api project(':spring-integration-core')
         api 'org.springframework.data:spring-data-cassandra'
 
-        testImplementation ('org.testcontainers:cassandra') {
+        testImplementation('org.testcontainers:cassandra') {
             exclude group: 'com.datastax.cassandra'
         }
     }
@@ -538,7 +540,7 @@ project('spring-integration-core') {
         optionalApi "com.jayway.jsonpath:json-path:$jsonpathVersion"
         optionalApi "com.esotericsoftware:kryo:$kryoVersion"
         optionalApi 'io.micrometer:micrometer-core'
-        optionalApi ('io.micrometer:micrometer-tracing') {
+        optionalApi('io.micrometer:micrometer-tracing') {
             exclude group: 'aopalliance'
         }
         optionalApi "io.github.resilience4j:resilience4j-ratelimiter:$resilience4jVersion"
@@ -548,7 +550,7 @@ project('spring-integration-core') {
         testImplementation "com.google.protobuf:protobuf-java-util:$protobufVersion"
         testImplementation "org.aspectj:aspectjweaver:$aspectjVersion"
         testImplementation 'io.micrometer:micrometer-observation-test'
-        testImplementation ('io.micrometer:micrometer-tracing-integration-test') {
+        testImplementation('io.micrometer:micrometer-tracing-integration-test') {
             exclude group: 'io.opentelemetry'
             exclude group: 'com.wavefront'
             exclude group: 'io.micrometer', module: 'micrometer-tracing-bridge-otel'
@@ -637,13 +639,13 @@ project('spring-integration-ftp') {
 }
 
 project('spring-integration-graphql') {
-	description = 'Spring Integration GraphQL Support'
-	dependencies {
-		api project(':spring-integration-core')
-		api "org.springframework.graphql:spring-graphql:$springGraphqlVersion"
+    description = 'Spring Integration GraphQL Support'
+    dependencies {
+        api project(':spring-integration-core')
+        api "org.springframework.graphql:spring-graphql:$springGraphqlVersion"
 
         testImplementation 'org.springframework:spring-web'
-	}
+    }
 }
 
 project('spring-integration-groovy') {
@@ -741,7 +743,7 @@ project('spring-integration-jdbc') {
         testImplementation "org.apache.derby:derbyclient:$derbyVersion"
         testImplementation "org.postgresql:postgresql:$postgresVersion"
         testImplementation "mysql:mysql-connector-java:$mysqlVersion"
-        testImplementation ("org.apache.commons:commons-dbcp2:$commonsDbcp2Version") {
+        testImplementation("org.apache.commons:commons-dbcp2:$commonsDbcp2Version") {
             exclude group: 'commons-logging'
         }
         testImplementation 'org.testcontainers:mysql'
@@ -922,7 +924,7 @@ project('spring-integration-sftp') {
     dependencies {
         api project(':spring-integration-file')
         api 'org.springframework:spring-context-support'
-        api ("org.apache.sshd:sshd-sftp:$apacheSshdVersion") {
+        api("org.apache.sshd:sshd-sftp:$apacheSshdVersion") {
             exclude group: 'org.slf4j', module: 'jcl-over-slf4j'
         }
 
@@ -1014,7 +1016,7 @@ project('spring-integration-webflux') {
         }
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
         testImplementation 'io.micrometer:micrometer-observation-test'
-        testImplementation ('io.micrometer:micrometer-tracing-integration-test') {
+        testImplementation('io.micrometer:micrometer-tracing-integration-test') {
             exclude group: 'io.opentelemetry'
             exclude group: 'com.wavefront'
             exclude group: 'io.micrometer', module: 'micrometer-tracing-bridge-otel'
@@ -1092,12 +1094,12 @@ project('spring-integration-xml') {
 }
 
 project('spring-integration-xmpp') {
-	description = 'Spring Integration XMPP Support'
-	dependencies {
-		api project(':spring-integration-core')
-		api "org.igniterealtime.smack:smack-tcp:$smackVersion"
-		api "org.igniterealtime.smack:smack-java8:$smackVersion"
-		api "org.igniterealtime.smack:smack-extensions:$smackVersion"
+    description = 'Spring Integration XMPP Support'
+    dependencies {
+        api project(':spring-integration-core')
+        api "org.igniterealtime.smack:smack-tcp:$smackVersion"
+        api "org.igniterealtime.smack:smack-java8:$smackVersion"
+        api "org.igniterealtime.smack:smack-extensions:$smackVersion"
 
         testImplementation project(':spring-integration-stream')
         testImplementation "org.igniterealtime.smack:smack-experimental:$smackVersion"

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ import org.springframework.util.Assert;
  * for implementations of this class.
  *
  * @author Artem Bilan
+ * @author Adama Sorho
  *
  * @since 4.0
  */
@@ -86,6 +87,8 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 
 	private MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
+	private boolean createIndex = true;
+
 	public AbstractConfigurableMongoDbMessageStore(MongoTemplate mongoTemplate, String collectionName) {
 		Assert.notNull(mongoTemplate, "'mongoTemplate' must not be null");
 		Assert.hasText(collectionName, "'collectionName' must not be empty");
@@ -105,6 +108,15 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 		this.collectionName = collectionName;
 		this.mongoDbFactory = mongoDbFactory;
 		this.mappingMongoConverter = mappingMongoConverter;
+	}
+
+	/**
+	 * Define the option to auto create indexes or not.
+	 * @param createIndex a boolean.
+	 * @since 6.0.8.
+	 */
+	public void setCreateIndex(boolean createIndex) {
+		this.createIndex = createIndex;
 	}
 
 	@Override
@@ -128,6 +140,10 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 		return this.messageBuilderFactory;
 	}
 
+	protected boolean getCreateIndex() {
+		return this.createIndex;
+	}
+
 	@Override
 	public void afterPropertiesSet() {
 		if (this.mongoTemplate == null) {
@@ -145,7 +161,9 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 		}
 
 		this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.applicationContext);
+	}
 
+	protected void createIndexes() {
 		IndexOperations indexOperations = this.mongoTemplate.indexOps(this.collectionName);
 
 		indexOperations.ensureIndex(new Index(MessageDocumentFields.MESSAGE_ID, Sort.Direction.ASC));

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -87,7 +87,7 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 
 	private MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
 
-	private boolean createIndex = true;
+	private boolean createIndexes = true;
 
 	public AbstractConfigurableMongoDbMessageStore(MongoTemplate mongoTemplate, String collectionName) {
 		Assert.notNull(mongoTemplate, "'mongoTemplate' must not be null");
@@ -112,11 +112,11 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 
 	/**
 	 * Define the option to auto create indexes or not.
-	 * @param createIndex a boolean.
+	 * @param createIndexes a boolean.
 	 * @since 6.0.8.
 	 */
-	public void setCreateIndex(boolean createIndex) {
-		this.createIndex = createIndex;
+	public void setCreateIndexes(boolean createIndexes) {
+		this.createIndexes = createIndexes;
 	}
 
 	@Override
@@ -140,10 +140,6 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 		return this.messageBuilderFactory;
 	}
 
-	protected boolean getCreateIndex() {
-		return this.createIndex;
-	}
-
 	@Override
 	public void afterPropertiesSet() {
 		if (this.mongoTemplate == null) {
@@ -162,8 +158,8 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 
 		this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.applicationContext);
 
-		if (getCreateIndex()) {
-			this.createIndexes();
+		if (this.createIndexes) {
+			createIndexes();
 		}
 	}
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -161,6 +161,10 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 		}
 
 		this.messageBuilderFactory = IntegrationUtils.getMessageBuilderFactory(this.applicationContext);
+
+		if (getCreateIndex()) {
+			this.createIndexes();
+		}
 	}
 
 	protected void createIndexes() {

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  * {@code priorityEnabled = true} option.
  *
  * @author Artem Bilan
+ * @author Adama Sorho
  *
  * @since 4.0
  */
@@ -55,6 +56,8 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 	public static final String DEFAULT_COLLECTION_NAME = "channelMessages";
 
 	private boolean priorityEnabled;
+
+	private boolean createIndex = true;
 
 	public MongoDbChannelMessageStore(MongoTemplate mongoTemplate) {
 		this(mongoTemplate, DEFAULT_COLLECTION_NAME);
@@ -96,12 +99,22 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 	@Override
 	public void afterPropertiesSet() {
 		super.afterPropertiesSet();
-		getMongoTemplate()
-				.indexOps(this.collectionName)
-				.ensureIndex(new Index(MessageDocumentFields.GROUP_ID, Sort.Direction.ASC)
-						.on(MessageDocumentFields.PRIORITY, Sort.Direction.DESC)
-						.on(MessageDocumentFields.LAST_MODIFIED_TIME, Sort.Direction.ASC)
-						.on(MessageDocumentFields.SEQUENCE, Sort.Direction.ASC));
+		if (this.getCreateIndex()) {
+			getMongoTemplate()
+					.indexOps(this.collectionName)
+					.ensureIndex(new Index(MessageDocumentFields.GROUP_ID, Sort.Direction.ASC)
+							.on(MessageDocumentFields.PRIORITY, Sort.Direction.DESC)
+							.on(MessageDocumentFields.LAST_MODIFIED_TIME, Sort.Direction.ASC)
+							.on(MessageDocumentFields.SEQUENCE, Sort.Direction.ASC));
+		}
+	}
+
+	public void setCreateIndex(boolean createIndex) {
+		this.createIndex = createIndex;
+	}
+
+	public boolean getCreateIndex() {
+		return this.createIndex;
 	}
 
 	@Override

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
@@ -99,7 +99,7 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 	@Override
 	public void afterPropertiesSet() {
 		super.afterPropertiesSet();
-		if (this.getCreateIndex()) {
+		if (this.createIndex) {
 			getMongoTemplate()
 					.indexOps(this.collectionName)
 					.ensureIndex(new Index(MessageDocumentFields.GROUP_ID, Sort.Direction.ASC)
@@ -109,12 +109,13 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 		}
 	}
 
+	/**
+	 * Define the option to auto create indexes or not.
+	 * @since 6.0.8
+	 * @param createIndex a boolean.
+	 */
 	public void setCreateIndex(boolean createIndex) {
 		this.createIndex = createIndex;
-	}
-
-	public boolean getCreateIndex() {
-		return this.createIndex;
 	}
 
 	@Override

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
@@ -95,14 +95,6 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 	}
 
 	@Override
-	public void afterPropertiesSet() {
-		super.afterPropertiesSet();
-		if (this.getCreateIndex()) {
-			createIndexes();
-		}
-	}
-
-	@Override
 	protected void createIndexes() {
 		super.createIndexes();
 		getMongoTemplate()

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbChannelMessageStore.java
@@ -57,8 +57,6 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 
 	private boolean priorityEnabled;
 
-	private boolean createIndex = true;
-
 	public MongoDbChannelMessageStore(MongoTemplate mongoTemplate) {
 		this(mongoTemplate, DEFAULT_COLLECTION_NAME);
 	}
@@ -99,23 +97,20 @@ public class MongoDbChannelMessageStore extends AbstractConfigurableMongoDbMessa
 	@Override
 	public void afterPropertiesSet() {
 		super.afterPropertiesSet();
-		if (this.createIndex) {
-			getMongoTemplate()
-					.indexOps(this.collectionName)
-					.ensureIndex(new Index(MessageDocumentFields.GROUP_ID, Sort.Direction.ASC)
-							.on(MessageDocumentFields.PRIORITY, Sort.Direction.DESC)
-							.on(MessageDocumentFields.LAST_MODIFIED_TIME, Sort.Direction.ASC)
-							.on(MessageDocumentFields.SEQUENCE, Sort.Direction.ASC));
+		if (this.getCreateIndex()) {
+			createIndexes();
 		}
 	}
 
-	/**
-	 * Define the option to auto create indexes or not.
-	 * @since 6.0.8
-	 * @param createIndex a boolean.
-	 */
-	public void setCreateIndex(boolean createIndex) {
-		this.createIndex = createIndex;
+	@Override
+	protected void createIndexes() {
+		super.createIndexes();
+		getMongoTemplate()
+				.indexOps(this.collectionName)
+				.ensureIndex(new Index(MessageDocumentFields.GROUP_ID, Sort.Direction.ASC)
+						.on(MessageDocumentFields.PRIORITY, Sort.Direction.DESC)
+						.on(MessageDocumentFields.LAST_MODIFIED_TIME, Sort.Direction.ASC)
+						.on(MessageDocumentFields.SEQUENCE, Sort.Direction.ASC));
 	}
 
 	@Override

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.mongodb.store;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.mongodb.store;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.bson.Document;
@@ -25,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.IndexInfo;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.PriorityChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -42,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Amol Nayak
  * @author Artem Bilan
  * @author Artem Vozhdayenko
+ * @author Adama Sorho
  *
  */
 class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMessageGroupStoreTests {
@@ -133,6 +138,11 @@ class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMessageGr
 				new ClassPathXmlApplicationContext("ConfigurableMongoDbMessageStore-CustomConverter.xml", this
 						.getClass());
 		context.refresh();
+
+		MongoTemplate mongoTemplate = new MongoTemplate(MONGO_DATABASE_FACTORY);
+		List<IndexInfo> indexesInfo = mongoTemplate.indexOps(MongoDbChannelMessageStore.DEFAULT_COLLECTION_NAME).getIndexInfo();
+
+		assertThat(indexesInfo.size()).isEqualTo(4);
 
 		TestGateway gateway = context.getBean(TestGateway.class);
 		String result = gateway.service("foo");

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageGroupStoreTests.java
@@ -28,6 +28,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.index.IndexInfo;
+import org.springframework.data.mongodb.core.index.IndexOperations;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.PriorityChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -133,15 +134,17 @@ class ConfigurableMongoDbMessageGroupStoreTests extends AbstractMongoDbMessageGr
 
 	@Test
 	void testWithCustomConverter() {
+		MongoTemplate mongoTemplate = new MongoTemplate(MONGO_DATABASE_FACTORY);
+		IndexOperations indexOperations = mongoTemplate.indexOps(MongoDbChannelMessageStore.DEFAULT_COLLECTION_NAME);
+		indexOperations.dropAllIndexes();
+
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("ConfigurableMongoDbMessageStore-CustomConverter.xml", this
 						.getClass());
 		context.refresh();
 
-		MongoTemplate mongoTemplate = new MongoTemplate(MONGO_DATABASE_FACTORY);
-		List<IndexInfo> indexesInfo = mongoTemplate.indexOps(MongoDbChannelMessageStore.DEFAULT_COLLECTION_NAME).getIndexInfo();
-
-		assertThat(indexesInfo.size()).isEqualTo(4);
+		List<IndexInfo> indexesInfo = indexOperations.getIndexInfo();
+		assertThat(indexesInfo).hasSize(0);
 
 		TestGateway gateway = context.getBean(TestGateway.class);
 		String result = gateway.service("foo");

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore-CustomConverter.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore-CustomConverter.xml
@@ -17,6 +17,7 @@
 	<beans:bean id="abstractMessageStore" class="org.springframework.integration.mongodb.store.MongoDbChannelMessageStore"
 				abstract="true">
 		<beans:constructor-arg name="mongoDbFactory" ref="mongoDbFactory"/>
+		<beans:property name="createIndex" value="false" />
 	</beans:bean>
 
 	<mongo:mapping-converter id="customConverter">
@@ -29,7 +30,6 @@
 
 	<beans:bean id="messageStore" parent="abstractMessageStore">
 		<beans:constructor-arg name="mappingMongoConverter" ref="customConverter"/>
-		<beans:property name="createIndex" value="false" />
 	</beans:bean>
 
 	<gateway id="gateway"

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore-CustomConverter.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore-CustomConverter.xml
@@ -17,7 +17,7 @@
 	<beans:bean id="abstractMessageStore" class="org.springframework.integration.mongodb.store.MongoDbChannelMessageStore"
 				abstract="true">
 		<beans:constructor-arg name="mongoDbFactory" ref="mongoDbFactory"/>
-		<beans:property name="createIndex" value="false" />
+		<beans:property name="createIndexes" value="false" />
 	</beans:bean>
 
 	<mongo:mapping-converter id="customConverter">

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore-CustomConverter.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore-CustomConverter.xml
@@ -29,6 +29,7 @@
 
 	<beans:bean id="messageStore" parent="abstractMessageStore">
 		<beans:constructor-arg name="mappingMongoConverter" ref="customConverter"/>
+		<beans:property name="createIndex" value="false" />
 	</beans:bean>
 
 	<gateway id="gateway"

--- a/src/reference/antora/modules/ROOT/pages/mongodb.adoc
+++ b/src/reference/antora/modules/ROOT/pages/mongodb.adoc
@@ -231,6 +231,22 @@ To configure that scenario, you can extend one message store bean from the other
     <int:priority-queue message-store="priorityStore"/>
 </int:channel>
 ----
+[[abstract-configurable-mongodb-message-store-with-auto-index-creation-disable]]
+=== Using AbstractConfigurableMongoDbMessageStore with auto index creation disable
+Starting with version 6.0.8, the `AbstractConfigurableMongoDbMessageStore` implements a `setCreateIndex(boolean)` which can be use to desable or enable (default) the auto index creation.
+The following example shows how to declare a bean and disable the auto index creation:
+
+[source, java]
+----
+@Bean
+public AbstractConfigurableMongoDbMessageStore mongoDbChannelMessageStore(MongoDatabaseFactory databaseFactory)
+{
+    AbstractConfigurableMongoDbMessageStore mongoDbChannelMessageStore = new MongoDbChannelMessageStore(databaseFactory);
+    mongoDbChannelMessageStore.setCreateIndex(false);
+
+    return mongoDbChannelMessageStore;
+}
+----
 
 [[mongodb-metadata-store]]
 === MongoDB Metadata Store

--- a/src/reference/antora/modules/ROOT/pages/mongodb.adoc
+++ b/src/reference/antora/modules/ROOT/pages/mongodb.adoc
@@ -197,6 +197,21 @@ It builds a `MongoTemplate` from the provided `MongoDbFactory` and `MappingMongo
 The default name for the collection stored by the `ConfigurableMongoDbMessageStore` is `configurableStoreMessages`.
 We recommend using this implementation to create robust and flexible solutions when messages contain complex data types.
 
+Starting with version 6.0.8, the `AbstractConfigurableMongoDbMessageStore` implements a `setCreateIndexes(boolean)` which can be use to disable or enable (default) the auto indexes creation.
+The following example shows how to declare a bean and disable the auto indexes creation:
+
+[source, java]
+----
+@Bean
+public AbstractConfigurableMongoDbMessageStore mongoDbChannelMessageStore(MongoDatabaseFactory databaseFactory)
+{
+    AbstractConfigurableMongoDbMessageStore mongoDbChannelMessageStore = new MongoDbChannelMessageStore(databaseFactory);
+    mongoDbChannelMessageStore.setCreateIndexes(false);
+
+    return mongoDbChannelMessageStore;
+}
+----
+
 [[mongodb-priority-channel-message-store]]
 === MongoDB Channel Message Store
 
@@ -230,22 +245,6 @@ To configure that scenario, you can extend one message store bean from the other
 <int:channel id="priorityChannel">
     <int:priority-queue message-store="priorityStore"/>
 </int:channel>
-----
-[[abstract-configurable-mongodb-message-store-with-auto-index-creation-disable]]
-=== Using AbstractConfigurableMongoDbMessageStore with auto index creation disable
-Starting with version 6.0.8, the `AbstractConfigurableMongoDbMessageStore` implements a `setCreateIndex(boolean)` which can be use to desable or enable (default) the auto index creation.
-The following example shows how to declare a bean and disable the auto index creation:
-
-[source, java]
-----
-@Bean
-public AbstractConfigurableMongoDbMessageStore mongoDbChannelMessageStore(MongoDatabaseFactory databaseFactory)
-{
-    AbstractConfigurableMongoDbMessageStore mongoDbChannelMessageStore = new MongoDbChannelMessageStore(databaseFactory);
-    mongoDbChannelMessageStore.setCreateIndex(false);
-
-    return mongoDbChannelMessageStore;
-}
 ----
 
 [[mongodb-metadata-store]]

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -39,9 +39,6 @@ See xref:configuration/global-properties.adoc[Global Properties] for more inform
 - The `@MessagingGateway` and `GatewayEndpointSpec` provided by the Java DSL now expose the `errorOnTimeout` property of the internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport`.
 See xref:gateway.adoc#gateway-no-response[ Gateway Behavior When No response Arrives] for more information.
 
-- A new method `setCreateIndex(boolean)` has been introduced in `org.springframework.integration.mongodb.store.AbstractConfigurableMongoDbMessageStore` to disable or enable (default) the auto index creation.
-See xref:mongodb.adoc#abstract-configurable-mongodb-message-store-with-auto-index-creation-disable[ Using AbstractConfigurableMongoDbMessageStore with auto index creation disable ] for an example.
-
 [[x6.2-websockets]]
 === WebSockets Changes
 
@@ -60,3 +57,9 @@ See xref:kafka.adoc#kafka-inbound-pollable[Kafka Inbound Channel Adapter] for mo
 
 The `JdbcMessageStore`, `JdbcChannelMessageStore`, `JdbcMetadataStore`, and `DefaultLockRepository` implement `SmartLifecycle` and perform a`SELECT COUNT` query, on their respective tables, in the `start()` method to ensure that the required table (according to the provided prefix) is present in the target database.
 See xref:jdbc/message-store.adoc#jdbc-db-init[Initializing the Database] for more information.
+
+[[x6.2-mongodb]]
+=== MongoDB support change
+
+A new method `setCreateIndexes(boolean)` has been introduced in `AbstractConfigurableMongoDbMessageStore` to disable or enable (default) the auto indexes creation.
+See xref:mongodb.adoc#mongodb-message-store[ MongoDB Message Store ] for an example.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -38,6 +38,10 @@ See xref:configuration/global-properties.adoc[Global Properties] for more inform
 
 - The `@MessagingGateway` and `GatewayEndpointSpec` provided by the Java DSL now expose the `errorOnTimeout` property of the internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport`.
 See xref:gateway.adoc#gateway-no-response[ Gateway Behavior When No response Arrives] for more information.
+
+- A new method `setCreateIndex(boolean)` has been introduced in `org.springframework.integration.mongodb.store.AbstractConfigurableMongoDbMessageStore` to disable or enable (default) the auto index creation.
+See xref:mongodb.adoc#abstract-configurable-mongodb-message-store-with-auto-index-creation-disable[ Using AbstractConfigurableMongoDbMessageStore with auto index creation disable ] for an example.
+
 [[x6.2-websockets]]
 === WebSockets Changes
 

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -37,14 +37,14 @@ See, for example, `transformWith()`, `splitWith()` in xref:dsl.adoc#java-dsl[ Ja
 See xref:configuration/global-properties.adoc[Global Properties] for more information.
 
 - The `@MessagingGateway` and `GatewayEndpointSpec` provided by the Java DSL now expose the `errorOnTimeout` property of the internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport`.
-See xref:gateway.adoc#gateway-no-response[ Gateway Behavior When No response Arrives] for more information.
+See xref:gateway.adoc#gateway-no-response[Gateway Behavior When No response Arrives] for more information.
+
 [[x6.2-websockets]]
 === WebSockets Changes
 
 - For the server and client WebSocket containers, the send buffer overflow strategy is now configurable in `IntegrationWebSocketContainer` and in XML via `send-buffer-overflow-strategy`.
 This strategy determines the behavior when a session's outbound message buffer has reached the configured limit.
 See xref:web-sockets.adoc#websocket-client-container-attributes[WebSockets Support] for more information.
-
 
 [[x6.2-kafka]]
 === Apache Kafka Support Changes

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -37,7 +37,10 @@ See, for example, `transformWith()`, `splitWith()` in xref:dsl.adoc#java-dsl[ Ja
 See xref:configuration/global-properties.adoc[Global Properties] for more information.
 
 - The `@MessagingGateway` and `GatewayEndpointSpec` provided by the Java DSL now expose the `errorOnTimeout` property of the internal `MethodInvocationGateway` extension of the `MessagingGatewaySupport`.
-See xref:gateway.adoc#gateway-no-response[Gateway Behavior When No response Arrives] for more information.
+See xref:gateway.adoc#gateway-no-response[ Gateway Behavior When No response Arrives] for more information.
+
+- A new method `setCreateIndex(boolean)` has been introduced in `org.springframework.integration.mongodb.store.AbstractConfigurableMongoDbMessageStore` to disable or enable (default) the auto index creation.
+See xref:mongodb.adoc#abstract-configurable-mongodb-message-store-with-auto-index-creation-disable[ Using AbstractConfigurableMongoDbMessageStore with auto index creation disable ] for an example.
 
 [[x6.2-websockets]]
 === WebSockets Changes


### PR DESCRIPTION
#8692 

- added `createIndex` field, setCreateIndex and getCreateIndex methods to `MongoDbChannelMessageStore` class
- updated `afterPropertiesSet` method of `MongoDbChannelMessageStore`
- Updating `testWithCustomConverter` of `ConfigurableMongoDbMessageGroupStoreTests`