### PR TITLE
GH-8711: Allowing SKIP LOCKED in MySqlChannelMessageStoreQueryProvider and PostgresChannelMessageStoreQueryProvider

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/AbstractChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/AbstractChannelMessageStoreQueryProvider.java
@@ -20,26 +20,9 @@ package org.springframework.integration.jdbc.store.channel;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
- * @author Adama Sorho
  * @since 2.2
  */
 public abstract class AbstractChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
-
-	private boolean useSkipLocked = false;
-
-	/**
-	 * Enable the use of `SKIP LOCKED`.
-	 * Be sure your database support this functionality
-	 * @param useSkipLocked a boolean
-	 * @since 6.0.8
-	 */
-	public void setUseSkipLocked(boolean useSkipLocked) {
-		this.useSkipLocked = useSkipLocked;
-	}
-
-	protected boolean getUseSkipLocked() {
-		return this.useSkipLocked;
-	}
 
 	public String getCountAllMessagesInGroupQuery() {
 		return "SELECT COUNT(MESSAGE_ID) from %PREFIX%CHANNEL_MESSAGE where GROUP_KEY=? and REGION=?";

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/AbstractChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/AbstractChannelMessageStoreQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,9 +20,26 @@ package org.springframework.integration.jdbc.store.channel;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Adama Sorho
  * @since 2.2
  */
 public abstract class AbstractChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
+
+	private boolean useSkipLocked = false;
+
+	/**
+	 * Enable the use of `SKIP LOCKED`.
+	 * Be sure your database support this functionality
+	 * @param useSkipLocked a boolean
+	 * @since 6.0.8
+	 */
+	public void setUseSkipLocked(boolean useSkipLocked) {
+		this.useSkipLocked = useSkipLocked;
+	}
+
+	protected boolean getUseSkipLocked() {
+		return this.useSkipLocked;
+	}
 
 	public String getCountAllMessagesInGroupQuery() {
 		return "SELECT COUNT(MESSAGE_ID) from %PREFIX%CHANNEL_MESSAGE where GROUP_KEY=? and REGION=?";

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/MySqlChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/MySqlChannelMessageStoreQueryProvider.java
@@ -31,44 +31,28 @@ public class MySqlChannelMessageStoreQueryProvider extends AbstractChannelMessag
 
 	@Override
 	public String getPollFromGroupExcludeIdsQuery() {
-		String query =  SELECT_COMMON
+		return SELECT_COMMON
 				+ "and %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID not in (:message_ids) "
-				+ "order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1";
-
-		return addSkipLocked(query);
-	}
-
-	private String addSkipLocked(String query) {
-		if (getUseSkipLocked()) {
-			return query + " FOR UPDATE SKIP LOCKED";
-		}
-
-		return query;
+				+ "order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE SKIP LOCKED";
 	}
 
 	@Override
 	public String getPollFromGroupQuery() {
-		String query =  SELECT_COMMON +
-				"order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1";
-
-		return addSkipLocked(query);
+		return SELECT_COMMON +
+				"order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE SKIP LOCKED";
 	}
 
 	@Override
 	public String getPriorityPollFromGroupExcludeIdsQuery() {
-		String query = SELECT_COMMON +
+		return SELECT_COMMON +
 				"and %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID not in (:message_ids) " +
-				"order by MESSAGE_PRIORITY DESC, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1";
-
-		return addSkipLocked(query);
+				"order by MESSAGE_PRIORITY DESC, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE SKIP LOCKED";
 	}
 
 	@Override
 	public String getPriorityPollFromGroupQuery() {
-		String query = SELECT_COMMON +
-				"order by MESSAGE_PRIORITY DESC, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1";
-
-		return addSkipLocked(query);
+		return SELECT_COMMON +
+				"order by MESSAGE_PRIORITY DESC, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE SKIP LOCKED";
 	}
 
 }

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/MySqlChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/MySqlChannelMessageStoreQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.jdbc.store.channel;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Adama Sorho
  * @since 2.2
  */
 public class MySqlChannelMessageStoreQueryProvider extends AbstractChannelMessageStoreQueryProvider {
@@ -30,28 +31,44 @@ public class MySqlChannelMessageStoreQueryProvider extends AbstractChannelMessag
 
 	@Override
 	public String getPollFromGroupExcludeIdsQuery() {
-		return SELECT_COMMON
+		String query =  SELECT_COMMON
 				+ "and %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID not in (:message_ids) "
 				+ "order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1";
+
+		return addSkipLocked(query);
+	}
+
+	private String addSkipLocked(String query) {
+		if (getUseSkipLocked()) {
+			return query + " FOR UPDATE SKIP LOCKED";
+		}
+
+		return query;
 	}
 
 	@Override
 	public String getPollFromGroupQuery() {
-		return SELECT_COMMON +
+		String query =  SELECT_COMMON +
 				"order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1";
+
+		return addSkipLocked(query);
 	}
 
 	@Override
 	public String getPriorityPollFromGroupExcludeIdsQuery() {
-		return SELECT_COMMON +
+		String query = SELECT_COMMON +
 				"and %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID not in (:message_ids) " +
 				"order by MESSAGE_PRIORITY DESC, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1";
+
+		return addSkipLocked(query);
 	}
 
 	@Override
 	public String getPriorityPollFromGroupQuery() {
-		return SELECT_COMMON +
+		String query = SELECT_COMMON +
 				"order by MESSAGE_PRIORITY DESC, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1";
+
+		return addSkipLocked(query);
 	}
 
 }

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/PostgresChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/PostgresChannelMessageStoreQueryProvider.java
@@ -31,44 +31,28 @@ public class PostgresChannelMessageStoreQueryProvider extends AbstractChannelMes
 
 	@Override
 	public String getPollFromGroupExcludeIdsQuery() {
-		String query =  SELECT_COMMON
+		return SELECT_COMMON
 				+ "and %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID not in (:message_ids) "
-				+ "order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE";
-
-		return addSkipLocked(query);
-	}
-
-	private String addSkipLocked(String query) {
-		if (getUseSkipLocked()) {
-			return query + " SKIP LOCKED";
-		}
-
-		return query;
+				+ "order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE SKIP LOCKED";
 	}
 
 	@Override
 	public String getPollFromGroupQuery() {
-		String query = SELECT_COMMON +
-				"order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE";
-
-		return addSkipLocked(query);
+		return SELECT_COMMON +
+				"order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE SKIP LOCKED";
 	}
 
 	@Override
 	public String getPriorityPollFromGroupExcludeIdsQuery() {
-		String query = SELECT_COMMON +
+		return SELECT_COMMON +
 				"and %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID not in (:message_ids) " +
-				"order by MESSAGE_PRIORITY DESC NULLS LAST, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE";
-
-		return addSkipLocked(query);
+				"order by MESSAGE_PRIORITY DESC NULLS LAST, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE SKIP LOCKED";
 	}
 
 	@Override
 	public String getPriorityPollFromGroupQuery() {
-		String query = SELECT_COMMON +
-				"order by MESSAGE_PRIORITY DESC NULLS LAST, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE";
-
-		return addSkipLocked(query);
+		return SELECT_COMMON +
+				"order by MESSAGE_PRIORITY DESC NULLS LAST, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE SKIP LOCKED";
 	}
 
 }

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/PostgresChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/PostgresChannelMessageStoreQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.integration.jdbc.store.channel;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Adama Sorho
  * @since 2.2
  */
 public class PostgresChannelMessageStoreQueryProvider extends AbstractChannelMessageStoreQueryProvider {
@@ -30,28 +31,44 @@ public class PostgresChannelMessageStoreQueryProvider extends AbstractChannelMes
 
 	@Override
 	public String getPollFromGroupExcludeIdsQuery() {
-		return SELECT_COMMON
+		String query =  SELECT_COMMON
 				+ "and %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID not in (:message_ids) "
 				+ "order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE";
+
+		return addSkipLocked(query);
+	}
+
+	private String addSkipLocked(String query) {
+		if (getUseSkipLocked()) {
+			return query + " SKIP LOCKED";
+		}
+
+		return query;
 	}
 
 	@Override
 	public String getPollFromGroupQuery() {
-		return SELECT_COMMON +
+		String query = SELECT_COMMON +
 				"order by CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE";
+
+		return addSkipLocked(query);
 	}
 
 	@Override
 	public String getPriorityPollFromGroupExcludeIdsQuery() {
-		return SELECT_COMMON +
+		String query = SELECT_COMMON +
 				"and %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID not in (:message_ids) " +
 				"order by MESSAGE_PRIORITY DESC NULLS LAST, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE";
+
+		return addSkipLocked(query);
 	}
 
 	@Override
 	public String getPriorityPollFromGroupQuery() {
-		return SELECT_COMMON +
+		String query = SELECT_COMMON +
 				"order by MESSAGE_PRIORITY DESC NULLS LAST, CREATED_DATE, MESSAGE_SEQUENCE LIMIT 1 FOR UPDATE";
+
+		return addSkipLocked(query);
 	}
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/channel/PostgresChannelMessageTableSubscriberTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/channel/PostgresChannelMessageTableSubscriberTests.java
@@ -57,6 +57,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Rafael Winterhalter
  * @author Artem Bilan
  * @author Igor Lovich
+ * @author Adama Sorho
  *
  * @since 6.0
  */
@@ -184,6 +185,8 @@ public class PostgresChannelMessageTableSubscriberTests implements PostgresConta
 		messageStore.addMessageToGroup(groupId, new GenericMessage<>("2"));
 
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		postgresChannelMessageTableSubscriber.stop();
 
 		assertThat(messageStore.messageGroupSize(groupId)).isEqualTo(2);
 		assertThat(messageStore.pollMessageFromGroup(groupId).getPayload()).isEqualTo("1");


### PR DESCRIPTION
#8711 

- Added `useSkipLocked` property, `setUseSkipLocked(boolean)` and `getUseSkipLocked()` methods in `AbstractChannelMessageStoreQueryProvider`. I added `setUseSkipLocked(boolean)` in case there are some MySql and PostgresSql version which not support `SKIP LOCKED`. Let me know if we don't need it.
- Added `addSkipLocked(query)` and updated all methods in `PostgresChannelMessageStoreQueryProvider` and `MySqlChannelMessageStoreQueryProvider` classes.