### PR TITLE
Deprecate AbstractChannelMessageStoreQueryProvider

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/AbstractChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/AbstractChannelMessageStoreQueryProvider.java
@@ -20,35 +20,11 @@ package org.springframework.integration.jdbc.store.channel;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Adama Sorho
  *
  * @since 2.2
+ * @deprecated in favor of default methods in ChannelMessageStoreQueryProvider
  */
 @Deprecated
 public abstract class AbstractChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
-
-	public String getCountAllMessagesInGroupQuery() {
-		return "SELECT COUNT(MESSAGE_ID) from %PREFIX%CHANNEL_MESSAGE where GROUP_KEY=? and REGION=?";
-	}
-
-	public String getMessageQuery() {
-		return "SELECT MESSAGE_ID, CREATED_DATE, MESSAGE_BYTES from %PREFIX%CHANNEL_MESSAGE where MESSAGE_ID=? and GROUP_KEY=? and REGION=?";
-	}
-
-	public String getMessageCountForRegionQuery() {
-		return "SELECT COUNT(MESSAGE_ID) from %PREFIX%CHANNEL_MESSAGE where REGION=?";
-	}
-
-	public String getDeleteMessageQuery() {
-		return "DELETE from %PREFIX%CHANNEL_MESSAGE where MESSAGE_ID=? and GROUP_KEY=? and REGION=?";
-	}
-
-	public String getCreateMessageQuery() {
-		return "INSERT into %PREFIX%CHANNEL_MESSAGE(MESSAGE_ID, GROUP_KEY, REGION, CREATED_DATE, MESSAGE_PRIORITY, MESSAGE_BYTES)"
-				+ " values (?, ?, ?, ?, ?, ?)";
-	}
-
-	public String getDeleteMessageGroupQuery() {
-		return "DELETE from %PREFIX%CHANNEL_MESSAGE where GROUP_KEY=? and REGION=?";
-	}
-
 }

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/AbstractChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/AbstractChannelMessageStoreQueryProvider.java
@@ -23,6 +23,7 @@ package org.springframework.integration.jdbc.store.channel;
  *
  * @since 2.2
  */
+@Deprecated
 public abstract class AbstractChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
 
 	public String getCountAllMessagesInGroupQuery() {

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/ChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/ChannelMessageStoreQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ package org.springframework.integration.jdbc.store.channel;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Adama Sorho
+ *
  * @since 2.2
  */
 public interface ChannelMessageStoreQueryProvider {
@@ -34,7 +36,9 @@ public interface ChannelMessageStoreQueryProvider {
 	 *
 	 * @return Sql Query
 	 */
-	String getCountAllMessagesInGroupQuery();
+	default String getCountAllMessagesInGroupQuery() {
+		return "SELECT COUNT(MESSAGE_ID) from %PREFIX%CHANNEL_MESSAGE where GROUP_KEY=? and REGION=?";
+	}
 
 	/**
 	 * Get the query used to retrieve the oldest message for a channel excluding
@@ -72,34 +76,45 @@ public interface ChannelMessageStoreQueryProvider {
 	 *
 	 * @return Sql Query
 	 */
-	String getMessageQuery();
+	default String getMessageQuery() {
+		return "SELECT MESSAGE_ID, CREATED_DATE, MESSAGE_BYTES from %PREFIX%CHANNEL_MESSAGE where MESSAGE_ID=? and GROUP_KEY=? and REGION=?";
+	}
 
 	/**
 	 * Query that retrieve a count of all messages for a region.
 	 *
 	 * @return Sql Query
 	 */
-	String getMessageCountForRegionQuery();
+	default String getMessageCountForRegionQuery() {
+		return "SELECT COUNT(MESSAGE_ID) from %PREFIX%CHANNEL_MESSAGE where REGION=?";
+	}
 
 	/**
 	 * Query to delete a single message from the database.
 	 *
 	 * @return Sql Query
 	 */
-	String getDeleteMessageQuery();
+	default String getDeleteMessageQuery() {
+		return "DELETE from %PREFIX%CHANNEL_MESSAGE where MESSAGE_ID=? and GROUP_KEY=? and REGION=?";
+	}
 
 	/**
 	 * Query to add a single message to the database.
 	 *
 	 * @return Sql Query
 	 */
-	String getCreateMessageQuery();
+	default String getCreateMessageQuery() {
+		return "INSERT into %PREFIX%CHANNEL_MESSAGE(MESSAGE_ID, GROUP_KEY, REGION, CREATED_DATE, MESSAGE_PRIORITY, MESSAGE_BYTES)"
+				+ " values (?, ?, ?, ?, ?, ?)";
+	}
 
 	/**
 	 * Query to delete all messages that belong to a specific channel.
 	 *
 	 * @return Sql Query
 	 */
-	String getDeleteMessageGroupQuery();
+	default String getDeleteMessageGroupQuery() {
+		return "DELETE from %PREFIX%CHANNEL_MESSAGE where GROUP_KEY=? and REGION=?";
+	}
 
 }

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/DerbyChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/DerbyChannelMessageStoreQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,12 @@ package org.springframework.integration.jdbc.store.channel;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Adama Sorho
  * @since 2.2
  *
  * https://blogs.oracle.com/kah/entry/derby_10_5_preview_fetch
  */
-public class DerbyChannelMessageStoreQueryProvider extends AbstractChannelMessageStoreQueryProvider {
+public class DerbyChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
 
 	private static final String SELECT_COMMON =
 			"SELECT %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID, %PREFIX%CHANNEL_MESSAGE.MESSAGE_BYTES "

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/H2ChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/H2ChannelMessageStoreQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,10 +21,11 @@ package org.springframework.integration.jdbc.store.channel;
  * @author Artem Bilan
  * @author Manuel Jordan
  * @author Gary Russell
+ * @author Adama Sorho
  * @since 4.3
  *
  */
-public class H2ChannelMessageStoreQueryProvider extends AbstractChannelMessageStoreQueryProvider {
+public class H2ChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
 
 	private static final String SELECT_COMMON =
 			"SELECT %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID, %PREFIX%CHANNEL_MESSAGE.MESSAGE_BYTES "

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/HsqlChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/HsqlChannelMessageStoreQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,11 @@ package org.springframework.integration.jdbc.store.channel;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Adama Sorho
  * @since 2.2
  *
  */
-public class HsqlChannelMessageStoreQueryProvider extends AbstractChannelMessageStoreQueryProvider {
+public class HsqlChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
 
 	private static final String SELECT_COMMON =
 			"SELECT %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID, %PREFIX%CHANNEL_MESSAGE.MESSAGE_BYTES "

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/MySqlChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/MySqlChannelMessageStoreQueryProvider.java
@@ -23,7 +23,7 @@ package org.springframework.integration.jdbc.store.channel;
  *
  * @since 2.2
  */
-public class MySqlChannelMessageStoreQueryProvider extends AbstractChannelMessageStoreQueryProvider {
+public class MySqlChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
 
 	private static final String SELECT_COMMON =
 			"SELECT %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID, %PREFIX%CHANNEL_MESSAGE.MESSAGE_BYTES "

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/OracleChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/OracleChannelMessageStoreQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ package org.springframework.integration.jdbc.store.channel;
  *
  * @since 2.2
  */
-public class OracleChannelMessageStoreQueryProvider extends AbstractChannelMessageStoreQueryProvider {
+public class OracleChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
 
 	private static final String SELECT_COMMON =
 			"SELECT %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID, %PREFIX%CHANNEL_MESSAGE.MESSAGE_BYTES "

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/PostgresChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/PostgresChannelMessageStoreQueryProvider.java
@@ -23,7 +23,7 @@ package org.springframework.integration.jdbc.store.channel;
  *
  * @since 2.2
  */
-public class PostgresChannelMessageStoreQueryProvider extends AbstractChannelMessageStoreQueryProvider {
+public class PostgresChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
 
 	private static final String SELECT_COMMON =
 			"SELECT %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID, %PREFIX%CHANNEL_MESSAGE.MESSAGE_BYTES "

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/SqlServerChannelMessageStoreQueryProvider.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/channel/SqlServerChannelMessageStoreQueryProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,10 @@ package org.springframework.integration.jdbc.store.channel;
 /**
  * Channel message store query provider for Microsoft SQL Server / Azure SQL database.
  * @author Sundara Balaji
+ * @author Adama Sorho
  * @since 5.1
  */
-public class SqlServerChannelMessageStoreQueryProvider extends AbstractChannelMessageStoreQueryProvider {
+public class SqlServerChannelMessageStoreQueryProvider implements ChannelMessageStoreQueryProvider {
 
 	private static final String SELECT_COMMON =
 			"SELECT TOP 1 %PREFIX%CHANNEL_MESSAGE.MESSAGE_ID, %PREFIX%CHANNEL_MESSAGE.MESSAGE_BYTES "

--- a/src/reference/antora/modules/ROOT/pages/jdbc/message-store.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jdbc/message-store.adoc
@@ -77,7 +77,7 @@ Spring Integration provides support for the following relational databases:
 * Sybase
 * DB2
 
-If your database is not listed, you can extend the `AbstractChannelMessageStoreQueryProvider` class and provide your own custom queries.
+If your database is not listed, you can implement the `ChannelMessageStoreQueryProvider` interface and provide your own custom queries.
 
 Version 4.0 added the `MESSAGE_SEQUENCE` column to the table to ensure first-in-first-out (FIFO) queueing even when messages are stored in the same millisecond.
 


### PR DESCRIPTION

Deprecate that `AbstractChannelMessageStoreQueryProvider` in favor of default method impls in the `ChannelMessageStoreQueryProvider` interface.

Take advantage of default interface methods.