### PR TITLE
GH-8713: Support custom SftpClient

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -53,6 +53,11 @@ import org.springframework.util.Assert;
 
 /**
  * Factory for creating {@link SftpSession} instances.
+ * <p>
+ *     The {@link #createSftpClient(ClientSession, SftpVersionSelector, SftpErrorDataHandler)} can be overridden
+ *     to provide a custom {@link SftpClient}.
+ * </p>
+ * The {@link ConcurrentSftpClient} is used by default.
  *
  * @author Josh Long
  * @author Mario Gray
@@ -398,7 +403,21 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 		this.sharedSftpClient = null;
 	}
 
-	protected SftpClient createSftpClient(ClientSession clientSession, SftpVersionSelector initialVersionSelector, SftpErrorDataHandler errorDataHandler) throws IOException {
+	/**
+	 * This method allows the end-user to provide a custom {@link SftpClient}
+	 * to {@link #getSession()}.
+	 * @param clientSession the {@link ClientSession}
+	 * @param initialVersionSelector the initial {@link SftpVersionSelector}
+	 * @param errorDataHandler the {@link SftpErrorDataHandler} to handle incoming data
+	 *                         through the error stream.
+	 * @return {@link SftpClient}
+	 * @throws IOException if failed to initialize
+	 *
+	 * @since 6.2
+	 */
+	protected SftpClient createSftpClient(
+			ClientSession clientSession, SftpVersionSelector initialVersionSelector,
+			SftpErrorDataHandler errorDataHandler) throws IOException {
 
 		return new ConcurrentSftpClient(clientSession, initialVersionSelector, errorDataHandler);
 	}
@@ -407,11 +426,11 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 	 * The {@link DefaultSftpClient} extension to lock the {@link #send(int, Buffer)}
 	 * for concurrent interaction.
 	 */
-	private static class ConcurrentSftpClient extends DefaultSftpClient {
+	protected static class ConcurrentSftpClient extends DefaultSftpClient {
 
 		private final Lock sendLock = new ReentrantLock();
 
-		ConcurrentSftpClient(ClientSession clientSession, SftpVersionSelector initialVersionSelector,
+		protected ConcurrentSftpClient(ClientSession clientSession, SftpVersionSelector initialVersionSelector,
 				SftpErrorDataHandler errorDataHandler) throws IOException {
 
 			super(clientSession, initialVersionSelector, errorDataHandler);

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -404,7 +404,7 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 	}
 
 	/**
-	 * This method allows the end-user to provide a custom {@link SftpClient}
+	 * Can be overridden to provide a custom {@link SftpClient}
 	 * to {@link #getSession()}.
 	 * @param clientSession the {@link ClientSession}
 	 * @param initialVersionSelector the initial {@link SftpVersionSelector}
@@ -412,7 +412,6 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 	 *                         through the error stream.
 	 * @return {@link SftpClient}
 	 * @throws IOException if failed to initialize
-	 *
 	 * @since 6.2
 	 */
 	protected SftpClient createSftpClient(

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -65,6 +65,7 @@ import org.springframework.util.Assert;
  * @author Krzysztof Debski
  * @author Auke Zaaiman
  * @author Christian Tzolov
+ * @author Adama Sorho
  *
  * @since 2.0
  */
@@ -283,7 +284,7 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 			boolean freshSftpClient = false;
 			if (sftpClient == null || !sftpClient.isOpen()) {
 				sftpClient =
-						new ConcurrentSftpClient(initClientSession(), this.sftpVersionSelector,
+						createSftpClient(initClientSession(), this.sftpVersionSelector,
 								SftpErrorDataHandler.EMPTY);
 				freshSftpClient = true;
 			}
@@ -395,6 +396,11 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 	public void resetSharedSession() {
 		Assert.state(this.isSharedSession, "Shared sessions are not being used");
 		this.sharedSftpClient = null;
+	}
+
+	protected SftpClient createSftpClient(ClientSession clientSession, SftpVersionSelector initialVersionSelector, SftpErrorDataHandler errorDataHandler) throws IOException {
+
+		return new ConcurrentSftpClient(clientSession, initialVersionSelector, errorDataHandler);
 	}
 
 	/**

--- a/src/reference/antora/modules/ROOT/pages/sftp/session-factory.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sftp/session-factory.adoc
@@ -45,6 +45,21 @@ Now all you need to do is inject this SFTP session factory into your adapters.
 
 NOTE: A more practical way to provide values for the SFTP session factory is to use Spring's https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-factory-placeholderconfigurer[property placeholder support].
 
+Starting with version 6.2, spring integration introduces a `createSftpClient(...)` to support a custom `SftpClient`.
+See a sample below of how to override `createSftpChannelSubsystem()` method in your custom `SftpClient` to add, for example, some custom RequestHandler for SFTP sub-system requests and replies:
+
+[source, java]
+----
+@Override
+protected ChannelSubsystem createSftpChannelSubsystem(ClientSession clientSession) {
+    ChannelSubsystem sftpChannelSubsystem = super.createSftpChannelSubsystem(clientSession);
+    sftpChannelSubsystem.addRequestHandler((channel, request, wantReply, buffer) -> ...);
+    return sftpChannelSubsystem;
+}
+----
+
+NOTE: `createSftpClient(...)` can be overridden to create your custom `SftpClient` which will be used by `getSession()`.
+
 [[sftp-session-factory-properties]]
 == Configuration Properties
 

--- a/src/reference/antora/modules/ROOT/pages/sftp/session-factory.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sftp/session-factory.adoc
@@ -45,8 +45,8 @@ Now all you need to do is inject this SFTP session factory into your adapters.
 
 NOTE: A more practical way to provide values for the SFTP session factory is to use Spring's https://docs.spring.io/spring/docs/current/spring-framework-reference/core.html#beans-factory-placeholderconfigurer[property placeholder support].
 
-Starting with version 6.2, spring integration introduces a `createSftpClient(...)` to support a custom `SftpClient`.
-See a sample below of how to override `createSftpChannelSubsystem()` method in your custom `SftpClient` to add, for example, some custom RequestHandler for SFTP sub-system requests and replies:
+Starting with version 6.2, the `DefaultSftpSessionFactory` introduces a `createSftpClient(...)` to support a custom `SftpClient`.
+See a sample below of how to override `createSftpChannelSubsystem()` method in your custom `SftpClient` to add, for example, some custom `RequestHandler` for SFTP sub-system requests and replies:
 
 [source, java]
 ----
@@ -57,8 +57,6 @@ protected ChannelSubsystem createSftpChannelSubsystem(ClientSession clientSessio
     return sftpChannelSubsystem;
 }
 ----
-
-NOTE: `createSftpClient(...)` can be overridden to create your custom `SftpClient` which will be used by `getSession()`.
 
 [[sftp-session-factory-properties]]
 == Configuration Properties

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -74,7 +74,7 @@ See xref:mongodb.adoc#mongodb-message-store[MongoDB Message Store] for an exampl
 See xref:ftp/inbound.adoc#ftp-inbound[FTP Inbound Channel Adapter], xref:sftp/inbound.adoc#sftp-inbound[SFTP Inbound Channel Adapter], and xref:smb.adoc#smb-inbound[SMB Inbound Channel Adapter] for more information.
 
 [[x6.2-sftp-changes]]
-=== SFTP session support changes
+=== SFTP Support Changes
 
-A new `createSftpClient(...)` has been introduced to support a custom `SftpClient`.
+A new `DefaultSftpSessionFactory.createSftpClient(...)` method has been introduced to support a custom `SftpClient` when overridden.
 See xref:sftp/session-factory.adoc#sftp-session-factory[SFTP Session Factory] for more information.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -72,3 +72,9 @@ See xref:mongodb.adoc#mongodb-message-store[MongoDB Message Store] for an exampl
 
 `FtpLastModifiedFileListFilter`, `SftpLastModifiedFileListFilter` and `SmbLastModifiedFileListFilter` have been introduced to allow files filtering based on a last-modified strategy respectively for `FTP`, `SFTP` and `SMB`.
 See xref:ftp/inbound.adoc#ftp-inbound[FTP Inbound Channel Adapter], xref:sftp/inbound.adoc#sftp-inbound[SFTP Inbound Channel Adapter], and xref:smb.adoc#smb-inbound[SMB Inbound Channel Adapter] for more information.
+
+[[x6.2-sftp-changes]]
+=== SFTP session support changes
+
+A new `createSftpClient(...)` has been introduced to support a custom `SftpClient`.
+See xref:sftp/session-factory.adoc#sftp-session-factory[SFTP Session Factory] for more information.


### PR DESCRIPTION
Fixes #8713 

Introduce `protected createSftpClient(...)` to support custom sftpClient. It can be overridden by the end-user