### PR TITLE
Solving SSHD's issue, when the verify method is not found when passin…

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -313,7 +313,7 @@ public class DefaultSftpSessionFactory implements SessionFactory<SftpClient.DirE
 
 		initClient();
 
-		Duration verifyTimeout = this.timeout != null ? Duration.ofMillis(this.timeout) : null;
+		long verifyTimeout = this.timeout != null ? this.timeout : null;
 		HostConfigEntry config = this.hostConfig;
 		if (config == null) {
 			config = new HostConfigEntry(SshdSocketAddress.isIPv6Address(this.host) ? "" : this.host, this.host,


### PR DESCRIPTION
Solving SSHD's issue, when the verify method is not found when passing duration from version 2.10
java.lang.Object org.apache.sshd.client.future.ConnectFuture.verify(java.time.Duration)'