### PR TITLE
Change the default polling trigger to 1 second

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -87,7 +87,7 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 	/**
 	 * A default polling period for {@link PeriodicTrigger}.
 	 */
-	public static final long DEFAULT_POLLING_PERIOD = 10;
+	public static final long DEFAULT_POLLING_PERIOD = 1000;
 
 	private final Collection<Advice> appliedAdvices = new HashSet<>();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/configuration/EnableIntegrationTests.java
@@ -667,12 +667,15 @@ public class EnableIntegrationTests {
 		assertThat(testMessage).isSameAs(receive);
 		assertThat(this.bridgeOutput.receive(10)).isNull();
 
+		PollingConsumer pollableBridge = this.context.getBean("pollableBridge", PollingConsumer.class);
+		PeriodicTrigger periodicTrigger = TestUtils.getPropertyValue(pollableBridge, "trigger", PeriodicTrigger.class);
+		assertThat(periodicTrigger.getPeriodDuration()).isEqualTo(Duration.ofSeconds(1));
+
 		this.pollableBridgeInput.send(testMessage);
 		receive = this.pollableBridgeOutput.receive(10_000);
 		assertThat(receive).isNotNull();
 		assertThat(testMessage).isSameAs(receive);
 		assertThat(this.pollableBridgeOutput.receive(10)).isNull();
-
 
 		assertThatExceptionOfType(MessageDeliveryException.class)
 				.isThrownBy(() -> this.metaBridgeInput.send(testMessage))
@@ -948,7 +951,8 @@ public class EnableIntegrationTests {
 
 
 		@Bean
-		@BridgeFrom(value = "pollableBridgeInput", poller = @Poller(fixedDelay = "1000"))
+		@BridgeFrom(value = "pollableBridgeInput", poller = @Poller)
+		@EndpointId("pollableBridge")
 		public QueueChannel pollableBridgeOutput() {
 			return new QueueChannel();
 		}

--- a/src/reference/antora/modules/ROOT/pages/channel-adapter.adoc
+++ b/src/reference/antora/modules/ROOT/pages/channel-adapter.adoc
@@ -89,7 +89,7 @@ See also xref:channel-adapter.adoc#channel-adapter-expressions-and-scripts[Chann
 NOTE: If no poller is provided, then a single default poller must be registered within the context.
 See xref:endpoint.adoc#endpoint-namespace[Endpoint Namespace Support] for more detail.
 
-NOTE: The default trigger for polling endpoint is a `PeriodicTrigger` instance of 1-second fixed delay period.
+NOTE: The default trigger for polling endpoint is a `PeriodicTrigger` instance with a 1 second fixed delay period.
 
 [IMPORTANT]
 .Important: Poller Configuration

--- a/src/reference/antora/modules/ROOT/pages/channel-adapter.adoc
+++ b/src/reference/antora/modules/ROOT/pages/channel-adapter.adoc
@@ -89,6 +89,8 @@ See also xref:channel-adapter.adoc#channel-adapter-expressions-and-scripts[Chann
 NOTE: If no poller is provided, then a single default poller must be registered within the context.
 See xref:endpoint.adoc#endpoint-namespace[Endpoint Namespace Support] for more detail.
 
+NOTE: The default trigger for polling endpoint is a `PeriodicTrigger` instance of 1-second fixed delay period.
+
 [IMPORTANT]
 .Important: Poller Configuration
 =====

--- a/src/reference/antora/modules/ROOT/pages/endpoint.adoc
+++ b/src/reference/antora/modules/ROOT/pages/endpoint.adoc
@@ -79,7 +79,6 @@ PollingConsumer consumer = new PollingConsumer(channel, exampleHandler);
 NOTE: For more information regarding polling consumers, see xref:overview.adoc#overview-endpoints-channeladapter[Channel Adapter] and xref:channel-adapter.adoc#channel-adapter[Channel Adapter].
 
 There are many other configuration options for the polling consumer.
-For example, the trigger is a required property.
 The following example shows how to set the trigger:
 
 [source,java]
@@ -111,6 +110,8 @@ CronTrigger trigger = new CronTrigger("*/10 * * * * MON-FRI");
 ----
 
 The result of the trigger defined in the previous example is a trigger that triggers every ten seconds, Monday through Friday.
+
+NOTE: The default trigger for polling endpoint is a `PeriodicTrigger` instance of 1-second fixed delay period.
 
 In addition to the trigger, you can specify two other polling-related configuration properties: `maxMessagesPerPoll` and `receiveTimeout`.
 The following example shows how to set these two properties:

--- a/src/reference/antora/modules/ROOT/pages/endpoint.adoc
+++ b/src/reference/antora/modules/ROOT/pages/endpoint.adoc
@@ -111,7 +111,7 @@ CronTrigger trigger = new CronTrigger("*/10 * * * * MON-FRI");
 
 The result of the trigger defined in the previous example is a trigger that triggers every ten seconds, Monday through Friday.
 
-NOTE: The default trigger for polling endpoint is a `PeriodicTrigger` instance of 1-second fixed delay period.
+NOTE: The default trigger for polling endpoint is a `PeriodicTrigger` instance with a 1 second fixed delay period.
 
 In addition to the trigger, you can specify two other polling-related configuration properties: `maxMessagesPerPoll` and `receiveTimeout`.
 The following example shows how to set these two properties:

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -42,7 +42,7 @@ See xref:gateway.adoc#gateway-no-response[Gateway Behavior When No response Arri
 - The `LockRegistry` provides template-like API to execute provided task while locked.
 See xref:distributed-locks.adoc[Distributed Locks] for more information.
 
-- The default trigger for polling endpoint is now a `PeriodicTrigger` instance of 1-second fixed delay period instead of very tight 10 milliseconds before.
+- The default trigger for polling endpoint is now a `PeriodicTrigger` instance with a 1 second fixed delay period; previously, the default was 10 milliseconds.
 See xref:endpoint.adoc#endpoint-pollingconsumer[Polling Consumer] for more information.
 
 [[x6.2-websockets]]

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -42,6 +42,9 @@ See xref:gateway.adoc#gateway-no-response[Gateway Behavior When No response Arri
 - The `LockRegistry` provides template-like API to execute provided task while locked.
 See xref:distributed-locks.adoc[Distributed Locks] for more information.
 
+- The default trigger for polling endpoint is now a `PeriodicTrigger` instance of 1-second fixed delay period instead of very tight 10 milliseconds before.
+See xref:endpoint.adoc#endpoint-pollingconsumer[Polling Consumer] for more information.
+
 [[x6.2-websockets]]
 === WebSockets Changes
 


### PR DESCRIPTION
The current default trigger for the poller is 10 milliseconds fixed delay. This is very tight policy for Microservices where we might not have too many scheduled threads to distribute polling endpoint jobs evenly.

* Change the default trigger to 1 second to align with what Spring Boot already claims.
Same 1 second policy is used in Spring Cloud Stream as well

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
