### PR TITLE
GH-8750: mark getRegistrationById() as @Nullable

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
@@ -70,6 +70,7 @@ public interface IntegrationFlowContext {
 	 * @param flowId the bean name to obtain
 	 * @return the IntegrationFlowRegistration for provided {@code id} or {@code null}
 	 */
+	@Nullable
 	IntegrationFlowRegistration getRegistrationById(String flowId);
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
@@ -178,6 +178,7 @@ public final class StandardIntegrationFlowContext implements IntegrationFlowCont
 	 * @return the IntegrationFlowRegistration for provided {@code id} or {@code null}
 	 */
 	@Override
+	@Nullable
 	public IntegrationFlowRegistration getRegistrationById(String flowId) {
 		return this.registry.get(flowId);
 	}


### PR DESCRIPTION
Fixes #8750

* annotate `IntegrationFlowRegistration.getRegistrationById(String flowId)` with `@org.springframework.lang.Nullable`
* annotate `StandardIntegrationFlowContext.getRegistrationById(String flowId)` with `@org.springframework.lang.Nullable`
