### PR TITLE
GH-8745: Add RFT.shouldMarkSessionAsDirty()

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -474,10 +474,10 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 
 	/**
 	 * Determine whether {@link Session#dirty()} should be called
-	 * in the {@link #execute(SessionCallback)} when exception is thrown from the callback.
+	 * in the {@link #execute(SessionCallback)} when an exception is thrown from the callback.
 	 * By default, this method returns {@code true}.
 	 * Remote file protocol extensions can override this method to provide
-	 * a specific strategy against thrown exception, e.g. {@code file not found} error
+	 * a specific strategy against the thrown exception, e.g. {@code file not found} error
 	 * is not a signal that session is broken.
 	 * @param ex the exception to check if {@link Session} must be marked as dirty.
 	 * @return true if {@link Session#dirty()} should be called.

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/FtpRemoteFileTemplateTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/FtpRemoteFileTemplateTests.java
@@ -34,6 +34,7 @@ import org.springframework.expression.common.LiteralExpression;
 import org.springframework.integration.file.DefaultFileNameGenerator;
 import org.springframework.integration.file.remote.ClientCallbackWithoutResult;
 import org.springframework.integration.file.remote.SessionCallbackWithoutResult;
+import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.ftp.FtpTestSupport;
@@ -53,9 +54,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
- *
  * @since 4.1
- *
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -140,6 +139,22 @@ public class FtpRemoteFileTemplateTests extends FtpTestSupport {
 
 		SimplePool<?> pool = TestUtils.getPropertyValue(this.sessionFactory, "pool", SimplePool.class);
 		assertThat(pool.getActiveCount()).isEqualTo(0);
+	}
+
+	@Test
+	public void sessionIsNotDirtyOnNoSuchFileError() {
+		Session<FTPFile> session = this.sessionFactory.getSession();
+		session.close();
+
+		FtpRemoteFileTemplate template = new FtpRemoteFileTemplate(this.sessionFactory);
+
+		assertThatExceptionOfType(MessagingException.class)
+				.isThrownBy(() -> template.rename("No_such_file1", "No_such_file2"))
+				.withRootCauseInstanceOf(IOException.class)
+				.withStackTraceContaining("553 : No such file or directory");
+
+		assertThat(TestUtils.getPropertyValue(this.sessionFactory.getSession(), "targetSession"))
+				.isSameAs(TestUtils.getPropertyValue(session, "targetSession"));
 	}
 
 	@Configuration

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/FtpRemoteFileTemplateTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/FtpRemoteFileTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,8 +153,11 @@ public class FtpRemoteFileTemplateTests extends FtpTestSupport {
 				.withRootCauseInstanceOf(IOException.class)
 				.withStackTraceContaining("553 : No such file or directory");
 
-		assertThat(TestUtils.getPropertyValue(this.sessionFactory.getSession(), "targetSession"))
+		Session<FTPFile> newSession = this.sessionFactory.getSession();
+		assertThat(TestUtils.getPropertyValue(newSession, "targetSession"))
 				.isSameAs(TestUtils.getPropertyValue(session, "targetSession"));
+
+		newSession.close();
 	}
 
 	@Configuration

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplate.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplate.java
@@ -39,7 +39,7 @@ import org.springframework.lang.Nullable;
  */
 public class SftpRemoteFileTemplate extends RemoteFileTemplate<SftpClient.DirEntry> {
 
-	protected static final List<Integer> NOT_DIRTY_STATUSES =
+	protected static final List<Integer> NOT_DIRTY_STATUSES = // NOSONAR
 			List.of(
 					SftpConstants.SSH_FX_NO_SUCH_FILE,
 					SftpConstants.SSH_FX_NO_SUCH_PATH,
@@ -49,8 +49,9 @@ public class SftpRemoteFileTemplate extends RemoteFileTemplate<SftpClient.DirEnt
 					SftpConstants.SSH_FX_DIR_NOT_EMPTY,
 					SftpConstants.SSH_FX_NOT_A_DIRECTORY,
 					SftpConstants.SSH_FX_EOF,
-					SftpConstants.SSH_FX_INVALID_FILENAME,
-					SftpConstants.SSH_FX_INVALID_FILENAME
+					SftpConstants.SSH_FX_CANNOT_DELETE,
+					SftpConstants.SSH_FX_FILE_IS_A_DIRECTORY,
+					SftpConstants.SSH_FX_FILE_CORRUPT
 			);
 
 	public SftpRemoteFileTemplate(SessionFactory<SftpClient.DirEntry> sessionFactory) {

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplate.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplate.java
@@ -16,11 +16,16 @@
 
 package org.springframework.integration.sftp.session;
 
+import java.util.List;
+
 import org.apache.sshd.sftp.client.SftpClient;
+import org.apache.sshd.sftp.common.SftpConstants;
+import org.apache.sshd.sftp.common.SftpException;
 
 import org.springframework.integration.file.remote.ClientCallback;
 import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.session.SessionFactory;
+import org.springframework.lang.Nullable;
 
 /**
  * SFTP version of {@code RemoteFileTemplate} providing type-safe access to
@@ -34,6 +39,20 @@ import org.springframework.integration.file.remote.session.SessionFactory;
  */
 public class SftpRemoteFileTemplate extends RemoteFileTemplate<SftpClient.DirEntry> {
 
+	protected static final List<Integer> NOT_DIRTY_STATUSES =
+			List.of(
+					SftpConstants.SSH_FX_NO_SUCH_FILE,
+					SftpConstants.SSH_FX_NO_SUCH_PATH,
+					SftpConstants.SSH_FX_INVALID_FILENAME,
+					SftpConstants.SSH_FX_INVALID_HANDLE,
+					SftpConstants.SSH_FX_FILE_ALREADY_EXISTS,
+					SftpConstants.SSH_FX_DIR_NOT_EMPTY,
+					SftpConstants.SSH_FX_NOT_A_DIRECTORY,
+					SftpConstants.SSH_FX_EOF,
+					SftpConstants.SSH_FX_INVALID_FILENAME,
+					SftpConstants.SSH_FX_INVALID_FILENAME
+			);
+
 	public SftpRemoteFileTemplate(SessionFactory<SftpClient.DirEntry> sessionFactory) {
 		super(sessionFactory);
 	}
@@ -46,6 +65,37 @@ public class SftpRemoteFileTemplate extends RemoteFileTemplate<SftpClient.DirEnt
 
 	protected <T> T doExecuteWithClient(final ClientCallback<SftpClient, T> callback) {
 		return execute(session -> callback.doWithClient((SftpClient) session.getClientInstance()));
+	}
+
+	@Override
+	protected boolean shouldMarkSessionAsDirty(Exception ex) {
+		SftpException sftpException = findSftpException(ex);
+		if (sftpException != null) {
+			return isStatusDirty(sftpException.getStatus());
+		}
+		else {
+			return super.shouldMarkSessionAsDirty(ex);
+		}
+	}
+
+	/**
+	 * Check if {@link SftpException#getStatus()} is treated as fatal.
+	 * @param status the value from {@link SftpException#getStatus()}.
+	 * @return true if {@link SftpException#getStatus()} is treated as fatal.
+	 * @since 6.0.8
+	 */
+	protected boolean isStatusDirty(int status) {
+		return !NOT_DIRTY_STATUSES.contains(status);
+	}
+
+	@Nullable
+	private static SftpException findSftpException(Throwable ex) {
+		if (ex == null || ex instanceof SftpException) {
+			return (SftpException) ex;
+		}
+		else {
+			return findSftpException(ex.getCause());
+		}
 	}
 
 }

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
@@ -176,8 +176,11 @@ public class SftpRemoteFileTemplateTests extends SftpTestSupport {
 				.withRootCauseInstanceOf(SftpException.class)
 				.withStackTraceContaining("(SSH_FX_NO_SUCH_FILE): No such file or directory");
 
-		assertThat(TestUtils.getPropertyValue(this.sessionFactory.getSession(), "targetSession"))
+		Session<SftpClient.DirEntry> newSession = this.sessionFactory.getSession();
+		assertThat(TestUtils.getPropertyValue(newSession, "targetSession"))
 				.isSameAs(TestUtils.getPropertyValue(session, "targetSession"));
+
+		newSession.close();
 	}
 
 	@Configuration

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.sshd.sftp.client.SftpClient;
 import org.apache.sshd.sftp.client.SftpVersionSelector;
+import org.apache.sshd.sftp.common.SftpException;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanFactory;
@@ -38,6 +39,7 @@ import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.support.FileExistsMode;
 import org.springframework.integration.sftp.SftpTestSupport;
 import org.springframework.integration.test.condition.LogLevels;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.GenericMessage;
@@ -52,9 +54,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Gary Russell
  * @author Artem Bilan
- *
  * @since 4.1
- *
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -63,7 +63,7 @@ public class SftpRemoteFileTemplateTests extends SftpTestSupport {
 	@Autowired
 	private CachingSessionFactory<SftpClient.DirEntry> sessionFactory;
 
-	@LogLevels(level = "trace", categories = { "org.apache.sshd", "org.springframework.integration.sftp" })
+	@LogLevels(level = "trace", categories = {"org.apache.sshd", "org.springframework.integration.sftp"})
 	@Test
 	public void testINT3412AppendStatRmdir() {
 		SftpRemoteFileTemplate template = new SftpRemoteFileTemplate(sessionFactory);
@@ -162,6 +162,22 @@ public class SftpRemoteFileTemplateTests extends SftpTestSupport {
 								"sftpSource/subSftpSource/subSftpSource1.txt"));
 
 		oldVersionSession.close();
+	}
+
+	@Test
+	public void sessionIsNotDirtyOnNoSuchFileError() {
+		Session<SftpClient.DirEntry> session = this.sessionFactory.getSession();
+		session.close();
+
+		SftpRemoteFileTemplate template = new SftpRemoteFileTemplate(this.sessionFactory);
+
+		assertThatExceptionOfType(MessagingException.class)
+				.isThrownBy(() -> template.list("No_such_dir"))
+				.withRootCauseInstanceOf(SftpException.class)
+				.withStackTraceContaining("(SSH_FX_NO_SUCH_FILE): No such file or directory");
+
+		assertThat(TestUtils.getPropertyValue(this.sessionFactory.getSession(), "targetSession"))
+				.isSameAs(TestUtils.getPropertyValue(session, "targetSession"));
 	}
 
 	@Configuration

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbRemoteFileTemplate.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbRemoteFileTemplate.java
@@ -35,7 +35,7 @@ import org.springframework.lang.Nullable;
  */
 public class SmbRemoteFileTemplate extends RemoteFileTemplate<SmbFile> {
 
-	protected static final List<Integer> NOT_DIRTY_STATUSES =
+	protected static final List<Integer> NOT_DIRTY_STATUSES = // NOSONAR
 			List.of(
 					NtStatus.NT_STATUS_INVALID_HANDLE,
 					NtStatus.NT_STATUS_END_OF_FILE,
@@ -49,7 +49,8 @@ public class SmbRemoteFileTemplate extends RemoteFileTemplate<SmbFile> {
 					NtStatus.NT_STATUS_OBJECT_NAME_NOT_FOUND,
 					NtStatus.NT_STATUS_OBJECT_PATH_INVALID,
 					NtStatus.NT_STATUS_OBJECT_PATH_NOT_FOUND,
-					NtStatus.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+					NtStatus.NT_STATUS_OBJECT_PATH_SYNTAX_BAD,
+					NtStatus.NT_STATUS_CANNOT_DELETE
 			);
 
 	/**

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbRemoteFileTemplate.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbRemoteFileTemplate.java
@@ -16,10 +16,15 @@
 
 package org.springframework.integration.smb.session;
 
+import java.util.List;
+
+import jcifs.smb.NtStatus;
+import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
 
 import org.springframework.integration.file.remote.RemoteFileTemplate;
 import org.springframework.integration.file.remote.session.SessionFactory;
+import org.springframework.lang.Nullable;
 
 /**
  * The SMB-specific {@link RemoteFileTemplate} implementation.
@@ -30,12 +35,60 @@ import org.springframework.integration.file.remote.session.SessionFactory;
  */
 public class SmbRemoteFileTemplate extends RemoteFileTemplate<SmbFile> {
 
+	protected static final List<Integer> NOT_DIRTY_STATUSES =
+			List.of(
+					NtStatus.NT_STATUS_INVALID_HANDLE,
+					NtStatus.NT_STATUS_END_OF_FILE,
+					NtStatus.NT_STATUS_NO_SUCH_FILE,
+					NtStatus.NT_STATUS_DUPLICATE_NAME,
+					NtStatus.NT_STATUS_FILE_IS_A_DIRECTORY,
+					NtStatus.NT_STATUS_NOT_A_DIRECTORY,
+					NtStatus.NT_STATUS_NOT_FOUND,
+					NtStatus.NT_STATUS_OBJECT_NAME_COLLISION,
+					NtStatus.NT_STATUS_OBJECT_NAME_INVALID,
+					NtStatus.NT_STATUS_OBJECT_NAME_NOT_FOUND,
+					NtStatus.NT_STATUS_OBJECT_PATH_INVALID,
+					NtStatus.NT_STATUS_OBJECT_PATH_NOT_FOUND,
+					NtStatus.NT_STATUS_OBJECT_PATH_SYNTAX_BAD
+			);
+
 	/**
 	 * Construct a {@link SmbRemoteFileTemplate} with the supplied session factory.
+	 *
 	 * @param sessionFactory the session factory.
 	 */
 	public SmbRemoteFileTemplate(SessionFactory<SmbFile> sessionFactory) {
 		super(sessionFactory);
 	}
 
+	@Override
+	protected boolean shouldMarkSessionAsDirty(Exception ex) {
+		SmbException smbException = findSmbException(ex);
+		if (smbException != null) {
+			return isStatusDirty(smbException.getNtStatus());
+		}
+		else {
+			return super.shouldMarkSessionAsDirty(ex);
+		}
+	}
+
+	/**
+	 * Check if {@link SmbException#getNtStatus()} is treated as fatal.
+	 * @param status the value from {@link SmbException#getNtStatus()}.
+	 * @return true if {@link SmbException#getNtStatus()} is treated as fatal.
+	 * @since 6.0.8
+	 */
+	protected boolean isStatusDirty(int status) {
+		return !NOT_DIRTY_STATUSES.contains(status);
+	}
+
+	@Nullable
+	private static SmbException findSmbException(Throwable ex) {
+		if (ex == null || ex instanceof SmbException) {
+			return (SmbException) ex;
+		}
+		else {
+			return findSmbException(ex.getCause());
+		}
+	}
 }

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2022 the original author or authors.
+ * Copyright 2012-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -103,8 +103,11 @@ public class SmbSessionTests extends SmbTestSupport {
 				.withRootCauseInstanceOf(IOException.class)
 				.withStackTraceContaining("The system cannot find the file specified");
 
-		assertThat(TestUtils.getPropertyValue(cachingSessionFactory.getSession(), "targetSession"))
+		Session<SmbFile> newSession = cachingSessionFactory.getSession();
+		assertThat(TestUtils.getPropertyValue(newSession, "targetSession"))
 				.isSameAs(TestUtils.getPropertyValue(session, "targetSession"));
+
+		newSession.close();
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8745

Not all errors caught in the `RemoteFileTemplate.execute()` are fatal to mark session as dirty and physically close the target session in the cache

* Introduce a `RemoteFileTemplate.shouldMarkSessionAsDirty()` to consult with an exception if it is really a fatal error to close the session in the end.
* Override `shouldMarkSessionAsDirty()` in the `RemoteFileTemplate` implementations to check statuses of respective protocol errors

**Cherry-pick to `6.1.x` & `6.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
