### PR TITLE
Remove request FILENAME header for MPUT

### DIFF
--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -398,7 +398,13 @@ public class FtpServerOutboundTests extends FtpTestSupport {
 		session = TestUtils.getPropertyValue(session, "targetSession", Session.class);
 		FTPClient client = spy(TestUtils.getPropertyValue(session, "client", FTPClient.class));
 		new DirectFieldAccessor(session).setPropertyValue("client", client);
-		this.inboundMPut.send(new GenericMessage<>(getSourceLocalDirectory()));
+		// The FileHeaders.FILENAME is removed by the AbstractRemoteFileOutboundGateway
+		// when MPUT item is prepared for its specific PUT
+		Message<File> mputRequestMessage =
+				MessageBuilder.withPayload(getSourceLocalDirectory())
+						.setHeader(FileHeaders.FILENAME, "inbound_file_name")
+						.build();
+		this.inboundMPut.send(mputRequestMessage);
 		@SuppressWarnings("unchecked")
 		Message<List<String>> out = (Message<List<String>>) this.output.receive(1000);
 		assertThat(out).isNotNull();


### PR DESCRIPTION
Related to: https://stackoverflow.com/questions/77268009/how-to-use-sftp-spring-integration-mput-with-sftpoutboundgateway-when-file-objec

In some scenarios when the flow starts with a file inbound channel adapter and then an MPUT operation is performed for remote file outbound gateway, the populated in the beginning `FileHeaders.FILENAME` is used from the `DefaultFileNameGenerator` for all the files from local directory to upload.
Such a behaviour leads only to the last file in the target remote directory and only with the name from that header.

* Fix the `AbstractRemoteFileOutboundGateway` to remove a `FileHeaders.FILENAME` header when message is build for specific item from MPUT request. This way an original local file is used when we upload directory.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
