### PR TITLE
GH-8734: expose JmsLisConSpec.observationRegistry

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsListenerContainerSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsListenerContainerSpec.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.jms.dsl;
 
+import io.micrometer.observation.ObservationRegistry;
 import jakarta.jms.Destination;
 import jakarta.jms.ExceptionListener;
 
@@ -155,6 +156,17 @@ public class JmsListenerContainerSpec<S extends JmsListenerContainerSpec<S, C>,
 	 */
 	public S clientId(String clientId) {
 		this.target.setClientId(clientId);
+		return _this();
+	}
+
+	/**
+	 * @param observationRegistry the observationRegistry.
+	 * @return the spec.
+	 * @see AbstractMessageListenerContainer#setObservationRegistry(ObservationRegistry)
+	 * @since 6.2
+	 */
+	public S observationRegistry(ObservationRegistry observationRegistry) {
+		this.target.setObservationRegistry(observationRegistry);
 		return _this();
 	}
 

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsListenerContainerSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsListenerContainerSpec.java
@@ -160,10 +160,11 @@ public class JmsListenerContainerSpec<S extends JmsListenerContainerSpec<S, C>,
 	}
 
 	/**
+	 * Configure an {@link ObservationRegistry} to use in the target listener container.
 	 * @param observationRegistry the observationRegistry.
 	 * @return the spec.
-	 * @see AbstractMessageListenerContainer#setObservationRegistry(ObservationRegistry)
 	 * @since 6.2
+	 * @see AbstractMessageListenerContainer#setObservationRegistry(ObservationRegistry)
 	 */
 	public S observationRegistry(ObservationRegistry observationRegistry) {
 		this.target.setObservationRegistry(observationRegistry);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8734

Expose `JmsListenerContainerSpec.observationRegistry(ObservationRegistry observationRegistry)` option

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
