### PR TITLE
reduce log noise for AbstractCorrelatingMessageHandler

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -863,7 +863,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	}
 
 	protected void expireGroup(Object correlationKey, MessageGroup group, Lock lock) {
-		this.logger.info(() -> "Expiring MessageGroup with correlationKey[" + correlationKey + "]");
+		this.logger.debug(() -> "Expiring MessageGroup with correlationKey[" + correlationKey + "]");
 		if (this.sendPartialResultOnExpiry) {
 			this.logger.debug(() -> "Prematurely releasing partially complete group with key ["
 					+ correlationKey + "] to: " + getOutputChannel());


### PR DESCRIPTION
We use an aggregate handler that uses a group timeout. 
It's expected that this timeout will be hit frequently. 
However, this causes an info log message to be emitted every time. 
I suggest logging this message on debug.
