### PR TITLE
KafkaInbounds should not mutate an externally provided RetryTemplate.

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
@@ -17,8 +17,8 @@
 package org.springframework.integration.kafka.inbound;
 
 import org.apache.kafka.clients.consumer.Consumer;
-
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+
 import org.springframework.core.AttributeAccessor;
 import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.support.Acknowledgment;

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
@@ -77,7 +77,8 @@ public interface KafkaInboundEndpoint {
 		}
 		catch (Exception ex) {
 			throw new KafkaException("Failed to execute runnable", ex);
-		} finally {
+		}
+		finally {
 			getAttributesHolder().remove();
 		}
 	}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
@@ -33,7 +33,7 @@ import org.springframework.retry.support.RetryTemplate;
  * @since 6.0
  *
  */
-public interface KafkaInboundEndpoint<K, V> {
+public interface KafkaInboundEndpoint {
 
 	/**
 	 * {@link org.springframework.retry.RetryContext} attribute key for an acknowledgment
@@ -63,7 +63,7 @@ public interface KafkaInboundEndpoint<K, V> {
 	 * @param consumer the consumer.
 	 * @param runnable the runnable.
 	 */
-	default void doWithRetry(RetryTemplate template, RecoveryCallback<?> callback, ConsumerRecord<K, V> record,
+	default void doWithRetry(RetryTemplate template, RecoveryCallback<?> callback, ConsumerRecord<?, ?> record,
 			Acknowledgment acknowledgment, Consumer<?, ?> consumer, Runnable runnable) {
 
 		try {

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -74,9 +74,7 @@ import org.springframework.util.Assert;
  *
  */
 public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
-		implements KafkaInboundEndpoint, Pausable, OrderlyShutdownCapable {
-
-	private static final ThreadLocal<AttributeAccessor> ATTRIBUTES_HOLDER = new ThreadLocal<>();
+		implements KafkaInboundEndpoint<K, V>, Pausable, OrderlyShutdownCapable {
 
 	private final IntegrationRecordMessageListener listener = new IntegrationRecordMessageListener();
 
@@ -244,11 +242,6 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 	@Override
 	public int afterShutdown() {
 		return getPhase();
-	}
-
-	@Override
-	public ThreadLocal<AttributeAccessor> getAttributesHolder() {
-		return ATTRIBUTES_HOLDER;
 	}
 
 	/**

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -74,7 +74,7 @@ import org.springframework.util.Assert;
  *
  */
 public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
-		implements KafkaInboundEndpoint<K, V>, Pausable, OrderlyShutdownCapable {
+		implements KafkaInboundEndpoint, Pausable, OrderlyShutdownCapable {
 
 	private final IntegrationRecordMessageListener listener = new IntegrationRecordMessageListener();
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -74,7 +74,7 @@ import org.springframework.util.Assert;
  *
  */
 public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
-		implements KafkaInboundEndpoint, Pausable, OrderlyShutdownCapable {
+		implements Pausable, OrderlyShutdownCapable {
 
 	private static final ThreadLocal<AttributeAccessor> ATTRIBUTES_HOLDER = new ThreadLocal<>();
 
@@ -282,12 +282,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 		}
 	}
 
-	@Override
-	public ThreadLocal<AttributeAccessor> getAttributesHolder() {
-		return ATTRIBUTES_HOLDER;
-	}
-
-	private class IntegrationRecordMessageListener extends RecordMessagingMessageListenerAdapter<K, V> {
+	private class IntegrationRecordMessageListener extends RecordMessagingMessageListenerAdapter<K, V> implements KafkaInboundEndpoint {
 
 		IntegrationRecordMessageListener() {
 			super(null, null); // NOSONAR - out of use
@@ -426,6 +421,11 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 				return builder.build();
 			}
 			return reply;
+		}
+
+		@Override
+		public ThreadLocal<AttributeAccessor> getAttributesHolder() {
+			return ATTRIBUTES_HOLDER;
 		}
 
 	}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -258,7 +258,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 	private void setAttributesIfNecessary(Object record, @Nullable Message<?> message, boolean conversionError) {
 		boolean needHolder = ATTRIBUTES_HOLDER.get() == null
 				&& (getErrorChannel() != null && (this.retryTemplate == null || conversionError));
-		boolean needAttributes = needHolder | this.retryTemplate != null;
+		boolean needAttributes = needHolder || this.retryTemplate != null;
 		if (needHolder) {
 			ATTRIBUTES_HOLDER.set(ErrorMessageUtils.getAttributeAccessor(null, null));
 		}
@@ -328,9 +328,8 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 			RetryTemplate template = KafkaInboundGateway.this.retryTemplate;
 			if (template != null) {
 				doWithRetry(template, KafkaInboundGateway.this.recoveryCallback, record, acknowledgment, consumer,
-						() -> {
-							doSendAndReceive(enhanceHeadersAndSaveAttributes(message, record));
-						});
+						() -> doSendAndReceive(enhanceHeadersAndSaveAttributes(message, record))
+				);
 			}
 			else {
 				doSendAndReceive(enhanceHeadersAndSaveAttributes(message, record));

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -74,7 +74,7 @@ import org.springframework.util.Assert;
  *
  */
 public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
-		implements Pausable, OrderlyShutdownCapable {
+		implements KafkaInboundEndpoint, Pausable, OrderlyShutdownCapable {
 
 	private static final ThreadLocal<AttributeAccessor> ATTRIBUTES_HOLDER = new ThreadLocal<>();
 
@@ -246,6 +246,11 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 		return getPhase();
 	}
 
+	@Override
+	public ThreadLocal<AttributeAccessor> getAttributesHolder() {
+		return ATTRIBUTES_HOLDER;
+	}
+
 	/**
 	 * If there's a retry template, it will set the attributes holder via the listener. If
 	 * there's no retry template, but there's an error channel, we create a new attributes
@@ -282,7 +287,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 		}
 	}
 
-	private class IntegrationRecordMessageListener extends RecordMessagingMessageListenerAdapter<K, V> implements KafkaInboundEndpoint {
+	private class IntegrationRecordMessageListener extends RecordMessagingMessageListenerAdapter<K, V> {
 
 		IntegrationRecordMessageListener() {
 			super(null, null); // NOSONAR - out of use
@@ -420,11 +425,6 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 				return builder.build();
 			}
 			return reply;
-		}
-
-		@Override
-		public ThreadLocal<AttributeAccessor> getAttributesHolder() {
-			return ATTRIBUTES_HOLDER;
 		}
 
 	}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -81,7 +81,7 @@ import org.springframework.util.Assert;
  * @since 5.4
  */
 public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSupport
-		implements OrderlyShutdownCapable, Pausable {
+		implements KafkaInboundEndpoint, OrderlyShutdownCapable, Pausable {
 
 	private static final ThreadLocal<AttributeAccessor> ATTRIBUTES_HOLDER = new ThreadLocal<>();
 
@@ -351,6 +351,11 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 		return getPhase();
 	}
 
+	@Override
+	public ThreadLocal<AttributeAccessor> getAttributesHolder() {
+		return ATTRIBUTES_HOLDER;
+	}
+
 	/**
 	 * If there's a retry template, it will set the attributes holder via the listener. If
 	 * there's no retry template, but there's an error channel, we create a new attributes
@@ -421,7 +426,7 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 		batch
 	}
 
-	private class IntegrationRecordMessageListener extends RecordMessagingMessageListenerAdapter<K, V> implements KafkaInboundEndpoint {
+	private class IntegrationRecordMessageListener extends RecordMessagingMessageListenerAdapter<K, V> {
 
 		IntegrationRecordMessageListener() {
 			super(null, null); // NOSONAR - out of use
@@ -507,11 +512,6 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 			return messageToReturn;
 		}
 
-		@Override
-		public ThreadLocal<AttributeAccessor> getAttributesHolder() {
-			return ATTRIBUTES_HOLDER;
-		}
-
 	}
 
 	private class IntegrationBatchMessageListener extends BatchMessagingMessageListenerAdapter<K, V> {
@@ -536,8 +536,31 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 				message = toMessage(records, acknowledgment, consumer);
 			}
 			if (message != null) {
-				sendMessageIfAny(message, records);
+				RetryTemplate template = KafkaMessageDrivenChannelAdapter.this.retryTemplate;
+				if (template != null) {
+					doWIthRetry(records, acknowledgment, consumer, message, template);
+				}
+				else {
+					sendMessageIfAny(message, records);
+				}
 			}
+		}
+
+		private void doWIthRetry(List<ConsumerRecord<K, V>> records, Acknowledgment acknowledgment,
+				Consumer<?, ?> consumer, Message<?> message, RetryTemplate template) {
+
+			doWithRetry(template, KafkaMessageDrivenChannelAdapter.this.recoveryCallback, records, acknowledgment,
+					consumer, () -> {
+						if (KafkaMessageDrivenChannelAdapter.this.filterInRetry) {
+							List<ConsumerRecord<K, V>> filtered =
+									KafkaMessageDrivenChannelAdapter.this.recordFilterStrategy.filterBatch(records);
+							Message<?> toSend = message;
+							if (filtered.size() != records.size()) {
+								toSend = toMessage(filtered, acknowledgment, consumer);
+							}
+							sendMessageIfAny(toSend, filtered);
+						}
+					});
 		}
 
 		@Nullable

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -81,7 +81,7 @@ import org.springframework.util.Assert;
  * @since 5.4
  */
 public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSupport
-		implements KafkaInboundEndpoint<K,V>, OrderlyShutdownCapable, Pausable {
+		implements KafkaInboundEndpoint, OrderlyShutdownCapable, Pausable {
 
 	private final AbstractMessageListenerContainer<K, V> messageListenerContainer;
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -81,7 +81,7 @@ import org.springframework.util.Assert;
  * @since 5.4
  */
 public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSupport
-		implements KafkaInboundEndpoint, OrderlyShutdownCapable, Pausable {
+		implements OrderlyShutdownCapable, Pausable {
 
 	private static final ThreadLocal<AttributeAccessor> ATTRIBUTES_HOLDER = new ThreadLocal<>();
 
@@ -404,11 +404,6 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 		}
 	}
 
-	@Override
-	public ThreadLocal<AttributeAccessor> getAttributesHolder() {
-		return ATTRIBUTES_HOLDER;
-	}
-
 	/**
 	 * The listener mode for the container, record or batch.
 	 */
@@ -426,7 +421,7 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 		batch
 	}
 
-	private class IntegrationRecordMessageListener extends RecordMessagingMessageListenerAdapter<K, V> {
+	private class IntegrationRecordMessageListener extends RecordMessagingMessageListenerAdapter<K, V> implements KafkaInboundEndpoint {
 
 		IntegrationRecordMessageListener() {
 			super(null, null); // NOSONAR - out of use
@@ -512,9 +507,14 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 			return messageToReturn;
 		}
 
+		@Override
+		public ThreadLocal<AttributeAccessor> getAttributesHolder() {
+			return ATTRIBUTES_HOLDER;
+		}
+
 	}
 
-	private class IntegrationBatchMessageListener extends BatchMessagingMessageListenerAdapter<K, V> {
+	private class IntegrationBatchMessageListener extends BatchMessagingMessageListenerAdapter<K, V> implements KafkaInboundEndpoint {
 
 		IntegrationBatchMessageListener() {
 			super(null, null); // NOSONAR - out if use
@@ -584,6 +584,11 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 				}
 			}
 			return message;
+		}
+
+		@Override
+		public ThreadLocal<AttributeAccessor> getAttributesHolder() {
+			return ATTRIBUTES_HOLDER;
 		}
 
 	}

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
@@ -281,65 +281,6 @@ class MessageDrivenAdapterTests {
 		pf.reset();
 	}
 
-	@Test
-	void testInboundBatchRetryInListenerWithSharedRetryTemplate() {
-		RetryTemplate retryTemplate = new RetryTemplate();
-		SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy();
-		retryPolicy.setMaxAttempts(2);
-		retryTemplate.setRetryPolicy(retryPolicy);
-
-		Map<String, Object> props1 = KafkaTestUtils.consumerProps(EMBEDDED_BROKERS, "test4", "true");
-		props1.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-		DefaultKafkaConsumerFactory<Integer, String> cf1 = new DefaultKafkaConsumerFactory<>(props1);
-		ContainerProperties containerProps1 = new ContainerProperties(topic4);
-		KafkaMessageListenerContainer<Integer, String> container1 =
-				new KafkaMessageListenerContainer<>(cf1, containerProps1);
-		KafkaMessageDrivenChannelAdapter<Integer, String> adapter1 = new KafkaMessageDrivenChannelAdapter<>(container1);
-		adapter1.setRetryTemplate(retryTemplate);
-		adapter1.afterPropertiesSet();
-
-		Map<String, Object> props = KafkaTestUtils.consumerProps(EMBEDDED_BROKERS, "test2", "true");
-		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(props);
-		ContainerProperties containerProps = new ContainerProperties(topic2);
-		containerProps.setIdleEventInterval(100L);
-		KafkaMessageListenerContainer<Integer, String> container =
-				new KafkaMessageListenerContainer<>(cf, containerProps);
-		KafkaMessageDrivenChannelAdapter<Integer, String> adapter = new KafkaMessageDrivenChannelAdapter<>(container,
-				ListenerMode.batch);
-		MessageChannel out = new DirectChannel() {
-
-			@Override
-			protected boolean doSend(Message<?> message, long timeout) {
-				return retryTemplate.execute(retryContext -> {
-					throw new RuntimeException("intended");
-				});
-			}
-
-		};
-		adapter.setOutputChannel(out);
-		PollableChannel errorChannel = new QueueChannel();
-		adapter.setErrorChannel(errorChannel);
-
-		adapter.afterPropertiesSet();
-		adapter.start();
-		ContainerTestUtils.waitForAssignment(container, 1);
-
-		Map<String, Object> senderProps = KafkaTestUtils.producerProps(EMBEDDED_BROKERS);
-		ProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
-		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
-		template.setDefaultTopic(topic2);
-
-		template.sendDefault(1, "foo");
-
-		Message<?> errorMessage = errorChannel.receive(10000);
-		assertThat(errorMessage).isNotNull();
-		List<Message<?>> sourceData = StaticMessageHeaderAccessor.getSourceData(errorMessage);
-		assertThat(sourceData).isNotNull();
-
-		adapter.stop();
-		pf.reset();
-	}
 
 	/**
 	 * the recovery callback is not mandatory, if not set and retries are exhausted the last throwable is rethrown


### PR DESCRIPTION
In order to achieve custom retry in batch mode, we may to use a RetryTemplate in listener itself. But if the RetryTemplate is shared with another KafkaMessageDrivenChannelAdapter, batch mode's ATTRIBUTES_HOLDER might be over-written by another KafkaMessageDrivenChannelAdapter's IntegrationRecordMessageListener. 

The situation is like shown below.
- There is only one RetryTemple bean in the application.
- There are two KafkaMessageDrivenChannelAdapters(A,B) in the application.
- A KafkaMessageDrivenChannelAdapter is batch mode and utilizing the retryTemplate in the listener.
- B KafkaMessageDrivenChannelAdapter is record mode and using the retryTemplate itself.
- (B KafkaMessageDrivenChannelAdapter's recordListener is registered in the retryTemplate.)
- When A retry is attempted in the listener, it will trigger B KafkaMessageDrivenChannelAdapter's recordListener.
- B KafkaMessageDrivenChannelAdapter's recordListener will overwrite A KafkaMessageDrivenChannelAdapter's ATTRIBUTES_HOLDER.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
