### PR TITLE
GH-8773: Fix MGS for removal from group

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@ package org.springframework.integration.store;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
@@ -72,6 +74,30 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	void removeMessagesFromGroup(Object key, Message<?>... messages);
 
 	/**
+	 * Retrieve a {@link Message} from a group by id.
+	 * Return {@code null} if message does not belong to the requested group.
+	 * @param groupId The groupId for the group containing the message.
+	 * @param messageId The message id.
+	 * @return message by id if it belongs to requested group.
+	 * @since 6.1.5
+	 */
+	@Nullable
+	default Message<?> getMessageFromGroup(Object groupId, UUID messageId) {
+		throw new UnsupportedOperationException("Not supported for this store");
+	}
+
+	/**
+	 * Deletion the message from the group.
+	 * @param groupId The groupId for the group containing the message.
+	 * @param messageId The message id to be removed.
+	 * @return true if message has been removed.
+	 * @since 6.1.5
+	 */
+	default boolean removeMessageFromGroupById(Object groupId, UUID messageId) {
+		throw new UnsupportedOperationException("Not supported for this store");
+	}
+
+	/**
 	 * Register a callback for when a message group is expired through {@link #expireMessageGroups(long)}.
 	 * @param callback A callback to execute when a message group is cleaned up.
 	 */
@@ -114,7 +140,7 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 
 	/**
 	 * Completes this MessageGroup. Completion of the MessageGroup generally means
-	 * that this group should not be allowing any more mutating operation to be performed on it.
+	 * that this group should not be allowing anymore mutating operation to be performed on it.
 	 * For example any attempt to add/remove new Message form the group should not be allowed.
 	 * @param groupId The group identifier.
 	 */

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -23,7 +23,7 @@
 	<delayer id="#{T (org.springframework.integration.jdbc.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
 			 input-channel="input"
 			 output-channel="output"
-			 default-delay="10000"
+			 default-delay="1000"
 			 message-store="messageStore"/>
 
 	<channel id="transactionalDelayerOutput"/>

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.store.SimpleMessageGroup;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.condition.LongRunningTest;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.util.UUIDConverter;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
@@ -47,13 +46,12 @@ import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
  * @author Artem Bilan
  * @author Gary Russell
  */
-@LongRunningTest
 public class DelayerHandlerRescheduleIntegrationTests {
 
 	public static final String DELAYER_ID = "delayerWithJdbcMS";
@@ -98,15 +96,9 @@ public class DelayerHandlerRescheduleIntegrationTests {
 		taskScheduler.getScheduledExecutor().awaitTermination(10, TimeUnit.SECONDS);
 		context.close();
 
-		try {
-			context.getBean("input", MessageChannel.class);
-			fail("IllegalStateException expected");
-		}
-		catch (Exception e) {
-			assertThat(e instanceof IllegalStateException).isTrue();
-			assertThat(e.getMessage().contains("BeanFactory not initialized or already closed - call 'refresh'"))
-					.isTrue();
-		}
+		assertThatIllegalStateException()
+				.isThrownBy(() -> context.getBean("input", MessageChannel.class))
+				.withMessageContaining("BeanFactory not initialized or already closed - call 'refresh'");
 
 		String delayerMessageGroupId = UUIDConverter.getUUID(DELAYER_ID + ".messageGroupId").toString();
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -358,6 +358,25 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 	}
 
 	@Override
+	@Nullable
+	public Message<?> getMessageFromGroup(Object groupId, UUID messageId) {
+		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
+		Assert.notNull(messageId, "'messageId' must not be null");
+		MessageWrapper messageWrapper =
+				this.template.findOne(whereMessageIdIsAndGroupIdIs(messageId, groupId),
+						MessageWrapper.class, this.collectionName);
+		return (messageWrapper != null) ? messageWrapper.getMessage() : null;
+	}
+
+	@Override
+	public boolean removeMessageFromGroupById(Object groupId, UUID messageId) {
+		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
+		Assert.notNull(messageId, "'messageId' must not be null");
+		return this.template.remove(whereMessageIdIsAndGroupIdIs(messageId, groupId), this.collectionName)
+				.wasAcknowledged();
+	}
+
+	@Override
 	public void removeMessageGroup(Object groupId) {
 		this.template.remove(whereGroupIdIs(groupId), this.collectionName);
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationConfigurableTests-context.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationConfigurableTests-context.xml
@@ -22,7 +22,7 @@
 
 	<delayer
 			id="#{T (org.springframework.integration.mongodb.store.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
-			input-channel="input" output-channel="output" default-delay="10000"
+			input-channel="input" output-channel="output" default-delay="1000"
 			message-store="messageStore"/>
 
 </beans:beans>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -22,7 +22,7 @@
 
 	<delayer
 			id="#{T (org.springframework.integration.mongodb.store.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
-			input-channel="input" output-channel="output" default-delay="10000"
+			input-channel="input" output-channel="output" default-delay="1000"
 			message-store="messageStore"/>
 
 </beans:beans>

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/store/DelayerHandlerRescheduleIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,6 @@ import org.springframework.integration.mongodb.MongoDbContainerTest;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.condition.LongRunningTest;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
@@ -43,7 +42,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @since 3.0
  */
-@LongRunningTest
 class DelayerHandlerRescheduleIntegrationTests implements MongoDbContainerTest {
 
 	public static final String DELAYER_ID = "delayerWithMongoMS";

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests-context.xml
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests-context.xml
@@ -7,7 +7,7 @@
 
 	<beans:bean id="messageStore" class="org.springframework.integration.redis.store.RedisMessageStore">
 		<beans:constructor-arg
-				value="#{T (org.springframework.integration.redis.RedisContainerTest).connectionFactory()}"/>
+				value="#{T (org.springframework.integration.redis.RedisContainerTest).connectionFactory() }"/>
 	</beans:bean>
 
 	<channel id="output">
@@ -17,7 +17,7 @@
 	<delayer id="#{T (org.springframework.integration.redis.store.DelayerHandlerRescheduleIntegrationTests).DELAYER_ID}"
 			 input-channel="input"
 			 output-channel="output"
-			 default-delay="5000"
+			 default-delay="1000"
 			 message-store="messageStore"/>
 
 </beans:beans>

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/DelayerHandlerRescheduleIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,14 +29,12 @@ import org.springframework.integration.redis.RedisContainerTest;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.store.MessageGroupStore;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.test.condition.LongRunningTest;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Artem Bilan
@@ -45,8 +43,8 @@ import static org.assertj.core.api.Assertions.fail;
  *
  * @since 3.0
  */
-@LongRunningTest
 class DelayerHandlerRescheduleIntegrationTests implements RedisContainerTest {
+
 	public static final String DELAYER_ID = "delayerWithRedisMS" + UUID.randomUUID();
 
 	@Test
@@ -72,15 +70,6 @@ class DelayerHandlerRescheduleIntegrationTests implements RedisContainerTest {
 		taskScheduler.shutdown();
 		assertThat(taskScheduler.getScheduledExecutor().awaitTermination(10, TimeUnit.SECONDS)).isTrue();
 		context.close();
-
-		try {
-			context.getBean("input", MessageChannel.class);
-			fail("IllegalStateException expected");
-		}
-		catch (Exception e) {
-			assertThat(e).isInstanceOf(IllegalStateException.class);
-			assertThat(e.getMessage()).contains("BeanFactory not initialized or already closed - call 'refresh'");
-		}
 
 		assertThat(messageStore.getMessageGroupCount()).isEqualTo(1);
 		assertThat(messageStore.iterator().next().getGroupId()).isEqualTo(delayerMessageGroupId);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8773

The https://github.com/spring-projects/spring-integration/issues/8732 introduced a filtering for messages in group. So, plain `removeMessage()` doesn't work any more if message is connected to some group yet. Therefore, `DelayHandler` is failing.

* Introduce `getMessageFromGroup()` and `removeMessageFromGroupById()` into `MessageGroupStore` API and implement it respectively in all the stores
* Remove `@LongRunningTest` from delayer integration tests and adjust its config to delay not for a long

**Cherry-pick to `6.1.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
