### PR TITLE
GH-8785: Propagate WebSocket client connect fail

### DIFF
--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/ClientWebSocketContainer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/ClientWebSocketContainer.java
@@ -192,6 +192,20 @@ public final class ClientWebSocketContainer extends IntegrationWebSocketContaine
 				this.openConnectionException = null;
 				this.connectionLatch = new CountDownLatch(1);
 				this.connectionManager.start();
+
+				try {
+					this.connectionLatch.await(this.connectionTimeout, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException ex) {
+					logger.error("'clientSession' has not been established during 'openConnection'");
+				}
+
+				if (this.openConnectionException != null) {
+					// The next 'this.connectionManager.stop()' call resets 'this.openConnectionException' to null
+					IllegalStateException exceptionToRethrow = new IllegalStateException(this.openConnectionException);
+					this.connectionManager.stop();
+					throw exceptionToRethrow;
+				}
 			}
 		}
 		finally {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8785

The `ClientWebSocketContainer.start()` delegates to the `IntegrationWebSocketConnectionManager` which performs an async connection to the server.

* Wait for `connectionLatch` in the `ClientWebSocketContainer.start()` and check for `this.openConnectionException != null` to re-throw. Mark `ClientWebSocketContainer` as stopped in that case

**Cherry-pick to `6.1.x` & `6.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
