### PR TITLE
GH-8797: Fix DefSftpSessionFactory.timeout logic

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/sftp/session-factory.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sftp/session-factory.adoc
@@ -97,7 +97,8 @@ The passphrase is obtained from that object.
 Optional.
 
 `timeout`::The timeout property is used as the socket timeout parameter, as well as the default connection timeout.
-Defaults to `0`, which means, that no timeout will occur.
+Defaults to `30 seconds`.
+Setting to `0` means no timeout; to `null` - infinite wait.
 
 [[sftp-unk-keys]]
 `allowUnknownKeys`::Set to `true` to allow connections to hosts with unknown (or changed) keys.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/8797

After migration to Apache MINA we have missed to fix `DefaultSftpSessionFactory.timeout` to be `0` by default as it states in its Javadocs and reference manual It is `null` by default which really means an infinite wait.

* Fix `DefaultSftpSessionFactory.timeout` to be a reasonable 30 seconds by default
* Fix `setTimeout()` Javadocs and respective `session-factory.adoc`
* Propagate this `timeout` down to the `SftpClient` for its commands interactions

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
