### PR TITLE
Add lock acquisition log message for RedisLockRegistry

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -85,6 +85,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Christian Tzolov
  * @author Eddie Cho
  * @author Myeonghyeon Lee
+ * @author Roman Zabaluev
  *
  * @since 4.0
  *
@@ -432,11 +433,14 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 		}
 
 		private boolean tryRedisLock(long time) throws ExecutionException, InterruptedException {
-			final boolean result = tryRedisLockInner(time);
-			if (result) {
+			final boolean acquired = tryRedisLockInner(time);
+			if (acquired) {
+				if (LOGGER.isDebugEnabled()) {
+					LOGGER.debug("Acquired lock; " + this);
+				}
 				this.lockedAt = System.currentTimeMillis();
 			}
-			return result;
+			return acquired;
 		}
 
 		protected final Boolean obtainLock() {


### PR DESCRIPTION
Added lock acquisition log message for RedisLockRegistry. Resolves #8803 

Log example:
```
2023-12-12T03:47:57.762+07:00 DEBUG 47765 --- [   scheduling-1] o.s.i.redis.util.RedisLockRegistry       : Acquired lock; RedisLock [lockKey=lock:closeUnansweredIssues,lockedAt=1970-01-01@07:00:00.000, clientId=681096ad-0c3c-415f-9fee-93da8211d240]
2023-12-12T03:48:07.385+07:00 DEBUG 47765 --- [   scheduling-1] o.s.i.redis.util.RedisLockRegistry       : Released lock; RedisLock [lockKey=lock:closeUnansweredIssues,lockedAt=2023-12-12@03:47:57.764, clientId=681096ad-0c3c-415f-9fee-93da8211d240]
```