### PR TITLE
Do not set the redisMessageListenerContainer's executor in the setter

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,8 +198,6 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 	public void setExecutor(Executor executor) {
 		this.executor = executor;
 		this.executorExplicitlySet = true;
-		this.redisMessageListenerContainer.setTaskExecutor(this.executor);
-		this.redisMessageListenerContainer.setSubscriptionExecutor(this.executor);
 	}
 
 	/**

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -51,6 +52,7 @@ import org.springframework.integration.redis.util.RedisLockRegistry.RedisLockTyp
 import org.springframework.integration.test.util.TestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
@@ -873,6 +875,15 @@ class RedisLockRegistryTests implements RedisContainerTest {
 		}
 
 		registry.destroy();
+	}
+
+	@Test
+	void testInitialiseWithCustomExecutor() {
+		assertThatNoException().isThrownBy(() -> {
+			RedisLockRegistry redisLockRegistry = new RedisLockRegistry(redisConnectionFactory, "registryKey");
+			redisLockRegistry.setRedisLockType(RedisLockType.PUB_SUB_LOCK);
+			redisLockRegistry.setExecutor(Executors.newFixedThreadPool(2));
+		});
 	}
 
 	private Long getExpire(RedisLockRegistry registry, String lockKey) {


### PR DESCRIPTION
The pull request follows a discussion related to issue #8869 .

the `RedisLockRegistry.setExecutor` method no longer attempts to set the executors for the `redisMessageListenerContainer` since it is lazy initialised in method `setupUnlockMessageListener`.