### PR TITLE
MQTT: Use subscription identifiers. Fixes #8879.

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -339,10 +339,10 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 				this.subscriptions.add(subscription);
 			}
 			if (this.mqttClient != null && this.mqttClient.isConnected()) {
-				MqttProperties subsProperties = new MqttProperties();
-				subsProperties.setSubscriptionIdentifier(this.subIdCounter.incrementAndGet());
+				MqttProperties subscriptionProperties = new MqttProperties();
+				subscriptionProperties.setSubscriptionIdentifier(this.subIdCounter.incrementAndGet());
 				this.mqttClient.subscribe(new MqttSubscription[] { subscription },
-								null, null, new IMqttMessageListener[] { this::messageArrived }, subsProperties)
+								null, null, new IMqttMessageListener[] { this::messageArrived }, subscriptionProperties)
 						.waitForCompletion(getCompletionTimeout());
 			}
 		}
@@ -472,11 +472,11 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 			IMqttMessageListener[] listeners = IntStream.range(0, mqttSubscriptions.length)
 					.mapToObj(t -> listener)
 					.toArray(IMqttMessageListener[]::new);
-			MqttProperties subsProperties = new MqttProperties();
-			subsProperties.setSubscriptionIdentifiers(IntStream.range(0, mqttSubscriptions.length)
+			MqttProperties subscriptionProperties = new MqttProperties();
+			subscriptionProperties.setSubscriptionIdentifiers(IntStream.range(0, mqttSubscriptions.length)
 					.mapToObj(i -> this.subIdCounter.incrementAndGet())
 					.toList());
-			this.mqttClient.subscribe(mqttSubscriptions, null, null, listeners, subsProperties)
+			this.mqttClient.subscribe(mqttSubscriptions, null, null, listeners, subscriptionProperties)
 					.waitForCompletion(getCompletionTimeout());
 			String message = "Connected and subscribed to " + Arrays.toString(mqttSubscriptions);
 			logger.debug(message);

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -108,7 +108,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 
 	private volatile boolean readyToSubscribeOnStart;
 
-	private final AtomicInteger subIdCounter = new AtomicInteger(0);
+	private final AtomicInteger subscriptionIdentifierCounter = new AtomicInteger(0);
 
 	/**
 	 * Create an instance based on the MQTT url, client id and subscriptions.
@@ -340,7 +340,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 			}
 			if (this.mqttClient != null && this.mqttClient.isConnected()) {
 				MqttProperties subscriptionProperties = new MqttProperties();
-				subscriptionProperties.setSubscriptionIdentifier(this.subIdCounter.incrementAndGet());
+				subscriptionProperties.setSubscriptionIdentifier(this.subscriptionIdentifierCounter.incrementAndGet());
 				this.mqttClient.subscribe(new MqttSubscription[] { subscription },
 								null, null, new IMqttMessageListener[] { this::messageArrived }, subscriptionProperties)
 						.waitForCompletion(getCompletionTimeout());
@@ -474,7 +474,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 					.toArray(IMqttMessageListener[]::new);
 			MqttProperties subscriptionProperties = new MqttProperties();
 			subscriptionProperties.setSubscriptionIdentifiers(IntStream.range(0, mqttSubscriptions.length)
-					.mapToObj(i -> this.subIdCounter.incrementAndGet())
+					.mapToObj(i -> this.subscriptionIdentifierCounter.incrementAndGet())
 					.toList());
 			this.mqttClient.subscribe(mqttSubscriptions, null, null, listeners, subscriptionProperties)
 					.waitForCompletion(getCompletionTimeout());

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
@@ -137,6 +137,22 @@ public class Mqttv5BackToBackTests implements MosquittoContainerTest {
 		assertThat(receive.getPayload()).isEqualTo(testPayload);
 	}
 
+	@Test
+	public void testSharedTopicMqttv5Interaction() {
+		this.mqttv5MessageDrivenChannelAdapter.addTopic("$share/group/testTopic");
+
+		String testPayload = "shared topic payload";
+		this.mqttOutFlowInput.send(
+				MessageBuilder.withPayload(testPayload)
+						.setHeader(MqttHeaders.TOPIC, "testTopic")
+						.build());
+
+		Message<?> receive = this.fromMqttChannel.receive(10_000);
+
+		assertThat(receive).isNotNull();
+		assertThat(receive.getPayload()).isEqualTo(testPayload);
+	}
+
 
 	@Configuration
 	@EnableIntegration


### PR DESCRIPTION
This works around eclipse/paho.mqtt.java/issues/827 issue because it avoids textual comparison of subscription topics.