### PR TITLE
Fix LogMessage formatting placeholders in MqttHeaderMapper.java

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/MqttHeaderMapper.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/MqttHeaderMapper.java
@@ -122,7 +122,7 @@ public class MqttHeaderMapper implements HeaderMapper<MqttProperties> {
 		if (patterns != null && patterns.length > 0) {
 			for (String pattern : patterns) {
 				if (PatternMatchUtils.simpleMatch(pattern, headerName)) {
-					LOGGER.debug(LogMessage.format("headerName=[{0}] WILL be mapped, matched pattern={1}",
+					LOGGER.debug(LogMessage.format("headerName=[%s] WILL be mapped, matched pattern=%s",
 							headerName, pattern));
 					return true;
 				}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/MqttHeaderMapper.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/support/MqttHeaderMapper.java
@@ -128,7 +128,7 @@ public class MqttHeaderMapper implements HeaderMapper<MqttProperties> {
 				}
 			}
 		}
-		LOGGER.debug(LogMessage.format("headerName=[{0}] WILL NOT be mapped", headerName));
+		LOGGER.debug(LogMessage.format("headerName=[%s] WILL NOT be mapped", headerName));
 		return false;
 	}
 


### PR DESCRIPTION
The placeholders are wrong and result in log messages like this:
```
o.s.i.mqtt.support.MqttHeaderMapper      : headerName=[{0}] WILL be mapped, matched pattern={1}
```
