### PR TITLE
GH-7925: Make message history header as mutable

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
@@ -160,7 +160,7 @@ public class BroadcastingDispatcher extends AbstractDispatcher implements BeanFa
 		Message<?> messageToSend = message;
 		MessageHeaders messageHeaders = message.getHeaders();
 		UUID correlationKey = messageHeaders.getId();
-		boolean hasMessageHistory = messageHeaders.containsKey(MessageHistory.HEADER_NAME);
+		boolean hasMessageHistory = messageHeaders.containsKey(MessageHistory.HEADER_NAME) && sequenceSize > 1;
 		for (MessageHandler handler : handlers) {
 			if (this.applySequence || hasMessageHistory) {
 				AbstractIntegrationMessageBuilder<?> builder =
@@ -173,7 +173,11 @@ public class BroadcastingDispatcher extends AbstractDispatcher implements BeanFa
 							sequenceNumber++, sequenceSize);
 				}
 
-				messageToSend = builder.cloneMessageHistoryIfAny().build();
+				if (hasMessageHistory) {
+					builder.cloneMessageHistoryIfAny();
+				}
+
+				messageToSend = builder.build();
 			}
 
 			if (message instanceof MessageDecorator messageDecorator) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,23 @@
 package org.springframework.integration.dispatcher;
 
 import java.util.Collection;
+import java.util.UUID;
 import java.util.concurrent.Executor;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.integration.MessageDispatchingException;
+import org.springframework.integration.context.IntegrationObjectSupport;
+import org.springframework.integration.history.MessageHistory;
+import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.DefaultMessageBuilderFactory;
 import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.MessageDecorator;
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageHandlingRunnable;
 import org.springframework.util.Assert;
@@ -153,13 +158,24 @@ public class BroadcastingDispatcher extends AbstractDispatcher implements BeanFa
 		}
 		int sequenceSize = handlers.size();
 		Message<?> messageToSend = message;
+		MessageHeaders messageHeaders = message.getHeaders();
+		UUID correlationKey = messageHeaders.getId();
+		boolean hasMessageHistory = messageHeaders.containsKey(MessageHistory.HEADER_NAME);
 		for (MessageHandler handler : handlers) {
-			if (this.applySequence) {
-				messageToSend = getMessageBuilderFactory()
-						.fromMessage(message)
-						.pushSequenceDetails(message.getHeaders().getId(), sequenceNumber++, sequenceSize)
-						.build();
+			if (this.applySequence || hasMessageHistory) {
+				AbstractIntegrationMessageBuilder<?> builder =
+						getMessageBuilderFactory()
+								.fromMessage(message);
+
+				if (this.applySequence) {
+					builder.pushSequenceDetails(
+							correlationKey == null ? IntegrationObjectSupport.generateId() : correlationKey,
+							sequenceNumber++, sequenceSize);
+				}
+
+				messageToSend = builder.cloneMessageHistoryIfAny().build();
 			}
+
 			if (message instanceof MessageDecorator messageDecorator) {
 				messageToSend = messageDecorator.decorateMessage(messageToSend);
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -465,6 +466,13 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		}
 		else {
 			builder = getMessageBuilderFactory().withPayload(output);
+			// Assuming that message in the payload collection is a copy of request message.
+			if (output instanceof Iterable<?> iterable) {
+				Iterator<?> iterator = iterable.iterator();
+				if (iterator.hasNext() && iterator.next() instanceof Message<?>) {
+					builder = builder.cloneMessageHistoryIfAny();
+				}
+			}
 		}
 		if (!this.noHeadersPropagation &&
 				(shouldCopyRequestHeaders() ||

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageRouter.java
@@ -197,7 +197,7 @@ public abstract class AbstractMessageRouter extends AbstractMessageHandler imple
 			int sequenceNumber = 1;
 			Message<?> messageToSend = message;
 			UUID correlationKey = message.getHeaders().getId();
-			boolean hasMessageHistory = message.getHeaders().containsKey(MessageHistory.HEADER_NAME);
+			boolean hasMessageHistory = message.getHeaders().containsKey(MessageHistory.HEADER_NAME) && sequenceSize > 1;
 			for (MessageChannel channel : results) {
 				if (this.applySequence || hasMessageHistory) {
 					AbstractIntegrationMessageBuilder<?> builder =
@@ -209,7 +209,11 @@ public abstract class AbstractMessageRouter extends AbstractMessageHandler imple
 								sequenceNumber++, sequenceSize);
 					}
 
-					messageToSend = builder.cloneMessageHistoryIfAny().build();
+					if (hasMessageHistory) {
+						builder.cloneMessageHistoryIfAny();
+					}
+
+					messageToSend = builder.build();
 				}
 
 				if (channel != null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/AbstractMessageSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ import org.springframework.integration.IntegrationPatternType;
 import org.springframework.integration.channel.ReactiveStreamsSubscribableChannel;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.DiscardingMessageHandler;
+import org.springframework.integration.history.MessageHistory;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.json.JacksonPresent;
 import org.springframework.integration.util.FunctionIterator;
@@ -276,10 +277,14 @@ public abstract class AbstractMessageSplitter extends AbstractReplyProducingMess
 			Object correlationId, int sequenceNumber, int sequenceSize) {
 
 		AbstractIntegrationMessageBuilder<?> builder = messageBuilderForReply(item);
-		builder.copyHeadersIfAbsent(headers);
+		builder.setHeader(MessageHistory.HEADER_NAME, headers.get(MessageHistory.HEADER_NAME))
+				.copyHeadersIfAbsent(headers)
+				.cloneMessageHistoryIfAny();
+
 		if (this.applySequence) {
 			builder.pushSequenceDetails(correlationId, sequenceNumber, sequenceSize);
 		}
+
 		return builder;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/AbstractIntegrationMessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/AbstractIntegrationMessageBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.history.MessageHistory;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
@@ -163,6 +164,22 @@ public abstract class AbstractIntegrationMessageBuilder<T> {
 		}
 
 		return copyHeadersIfAbsent(headers);
+	}
+
+	/**
+	 * Make a copy of {@link MessageHistory} header (if present) for a new message to build.
+	 * @return the current {@link AbstractIntegrationMessageBuilder}.
+	 * @since 6.3
+	 */
+	public AbstractIntegrationMessageBuilder<T> cloneMessageHistoryIfAny() {
+		MessageHistory messageHistory = getHeader(MessageHistory.HEADER_NAME, MessageHistory.class);
+
+		if (messageHistory != null) {
+			return removeHeader(MessageHistory.HEADER_NAME)
+					.setHeader(MessageHistory.HEADER_NAME, messageHistory.clone());
+		}
+
+		return this;
 	}
 
 	@Nullable

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,10 +186,8 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 			assertThat(messageHistory).isNotNull();
 			String messageHistoryString = messageHistory.toString();
 			assertThat(messageHistoryString)
-					.contains("routerChannel", "filterChannel", "aggregatorChannel", "serviceChannel")
-					.doesNotContain("discardChannel")
-					// history header is not overridden in splitter for individual message from message group emitted before
-					.doesNotContain("splitterChannel");
+					.contains("routerChannel", "filterChannel", "aggregatorChannel", "splitterChannel", "serviceChannel")
+					.doesNotContain("discardChannel");
 		}
 
 		assertThat(this.skippedServiceActivator).isNull();

--- a/spring-integration-core/src/test/java/org/springframework/integration/core/MessageHistoryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/core/MessageHistoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ public class MessageHistoryTests {
 		Message<Throwable> result2 = MessageHistory.write(result1, new TestComponent(2));
 		assertThat(result2).isInstanceOf(ErrorMessage.class);
 		assertThat(result2).isNotSameAs(original);
-		assertThat(result2).isNotSameAs(result1);
+		assertThat(result2).isSameAs(result1);
 		assertThat(result2.getPayload()).isSameAs(original.getPayload());
 		assertThat(result1).extracting("originalMessage").isSameAs(originalMessage);
 		MessageHistory history2 = MessageHistory.read(result2);
@@ -122,20 +122,14 @@ public class MessageHistoryTests {
 		assertThat(result2).isNotSameAs(original);
 		assertThat(result2.getPayload()).isSameAs(original.getPayload());
 		assertThat(((AdviceMessage<?>) result2).getInputMessage()).isSameAs(original.getInputMessage());
-		assertThat(result2).isNotSameAs(result1);
+		assertThat(result2).isSameAs(result1);
 		MessageHistory history2 = MessageHistory.read(result2);
 		assertThat(history2).isNotNull();
 		assertThat(history2.toString()).isEqualTo("testComponent-1,testComponent-2");
 	}
 
 
-	private static class TestComponent implements NamedComponent {
-
-		private final int id;
-
-		TestComponent(int id) {
-			this.id = id;
-		}
+	private record TestComponent(int id) implements NamedComponent {
 
 		@Override
 		public String getComponentName() {

--- a/src/reference/antora/modules/ROOT/pages/message-history.adoc
+++ b/src/reference/antora/modules/ROOT/pages/message-history.adoc
@@ -129,7 +129,9 @@ The MBean's object name is `<domain>:name=messageHistoryConfigurer,type=MessageH
 IMPORTANT: Only one `@EnableMessageHistory` (or `<message-history/>`) must be declared in the application context as single source for components tracking configuration.
 Do not use a generic bean definition for the `MessageHistoryConfigurer`.
 
-NOTE: By definition, the message history header is immutable (you cannot re-write history).
-Therefore, when writing message history values, the components either create new messages (when the component is an origin) or they copy the history from a request message, modifying it and setting the new list on a reply message.
-In either case, the values can be appended even if the message itself is crossing thread boundaries.
-That means that the history values can greatly simplify debugging in an asynchronous message flow.
+NOTE: Prior to version 6.3, the message history header was immutable (you cannot re-write history): every single track created not only new instance of the `MessageHistory`, but a fully new message copy.
+Now it works in append-only mode: the first track creates a new message with a new `MessageHistory` container.
+All the rest `MessageHistory.write()` calls add new entries to existing header - and no new message created.
+This significantly improves an application performance.
+All the components in the framework, where same message can be sent to several consumers (`PublishSubscribeChannel`, `AbstractMessageRouter`, `WireTap` etc.) (or splitter produces several outputs based on input message), are now cloning an existing `MessageHistory` header into those new messages.
+For any other multi-producing use-cases, outside the framework scope, the `AbstractIntegrationMessageBuilder.cloneMessageHistoryIfAny()` API is recommended to ensure that parallel downstream sub-flows contribute their own message history traces.

--- a/src/reference/antora/modules/ROOT/pages/message-history.adoc
+++ b/src/reference/antora/modules/ROOT/pages/message-history.adoc
@@ -132,6 +132,6 @@ Do not use a generic bean definition for the `MessageHistoryConfigurer`.
 NOTE: Prior to version 6.3, the message history header was immutable (you cannot re-write history): every single track created not only new instance of the `MessageHistory`, but a fully new message copy.
 Now it works in append-only mode: the first track creates a new message with a new `MessageHistory` container.
 All the rest `MessageHistory.write()` calls add new entries to existing header - and no new message created.
-This significantly improves an application performance.
-All the components in the framework, where same message can be sent to several consumers (`PublishSubscribeChannel`, `AbstractMessageRouter`, `WireTap` etc.) (or splitter produces several outputs based on input message), are now cloning an existing `MessageHistory` header into those new messages.
+This significantly improves the application performance.
+All the components in the framework, where same message can be sent to several consumers (`PublishSubscribeChannel`, `AbstractMessageRouter`, `WireTap` etc.), or splitter produces several outputs based on the input message, are now cloning an existing `MessageHistory` header into those new messages.
 For any other multi-producing use-cases, outside the framework scope, the `AbstractIntegrationMessageBuilder.cloneMessageHistoryIfAny()` API is recommended to ensure that parallel downstream sub-flows contribute their own message history traces.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -19,6 +19,10 @@ In general the project has been moved to the latest dependency versions.
 [[x6.3-general]]
 === General Changes
 
+The `MessageHistory` header is now mutable, append-only container.
+And all the subsequent tracks don't create new message - only their entry is added to existing message history header.
+See xref:message-history.adoc[Message History Chapter] for more information.
+
 [[x6.3-security-changes]]
 === Security Support Changes
 


### PR DESCRIPTION
Fixes: #7925

The `MessageHistory.write()` creates not only a new instance of the `MessageHistory`, but also a new copy of the whole message.
This significantly impacts the performance when we have too many components to track

* Make `MessageHistory` as append-only container and create a new instance (plus message) only on the first track when no prior history is present
* Change `WireTap`, `BroadcastingDispatcher`, `AbstractMessageRouter` and `AbstractMessageSplitter` to use a new `AbstractIntegrationMessageBuilder.cloneMessageHistoryIfAny()` API for every branch a message is produced.
Essentially, create a new message with copy of the message history to let that downstream sub-flow have its own trace
* Modify failed unit tests for a new logic where message history header is not immutable anymore
* This also fixes an `AbstractMessageSplitter` for propagating its track into messages it emits

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
