### PR TITLE
GH-8981: Add `UnicastingDispatcher.failoverStrategy` option

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.channel;
+
+import java.util.function.Predicate;
 
 import org.springframework.integration.dispatcher.LoadBalancingStrategy;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
@@ -60,10 +62,24 @@ public class DirectChannel extends AbstractSubscribableChannel {
 	/**
 	 * Specify whether the channel's dispatcher should have failover enabled.
 	 * By default, it will. Set this value to 'false' to disable it.
+	 * Overrides {@link #setFailoverStrategy(Predicate)} option.
+	 * In other words: or this, or that option has to be set.
 	 * @param failover The failover boolean.
 	 */
 	public void setFailover(boolean failover) {
 		this.dispatcher.setFailover(failover);
+	}
+
+	/**
+	 * Configure a strategy whether the channel's dispatcher should have failover enabled
+	 * for the exception thrown.
+	 * Overrides {@link #setFailover(boolean)} option.
+	 * In other words: or this, or that option has to be set.
+	 * @param failoverStrategy The failover boolean.
+	 * @since 6.3
+	 */
+	public void setFailoverStrategy(Predicate<Exception> failoverStrategy) {
+		this.dispatcher.setFailoverStrategy(failoverStrategy);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.integration.channel;
 
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.dispatcher.LoadBalancingStrategy;
@@ -97,6 +98,18 @@ public class PartitionedChannel extends AbstractExecutorChannel {
 	 */
 	public void setFailover(boolean failover) {
 		getDispatcher().setFailover(failover);
+	}
+
+	/**
+	 * Configure a strategy whether the channel's dispatcher should have failover enabled
+	 * for the exception thrown.
+	 * Overrides {@link #setFailover(boolean)} option.
+	 * In other words: or this, or that option has to be set.
+	 * @param failoverStrategy The failover boolean.
+	 * @since 6.3
+	 */
+	public void setFailoverStrategy(Predicate<Exception> failoverStrategy) {
+		getDispatcher().setFailoverStrategy(failoverStrategy);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/DirectChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/DirectChannelSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,8 +28,8 @@ public class DirectChannelSpec extends LoadBalancingChannelSpec<DirectChannelSpe
 	@Override
 	protected DirectChannel doGet() {
 		this.channel = new DirectChannel(this.loadBalancingStrategy);
-		if (this.failover != null) {
-			this.channel.setFailover(this.failover);
+		if (this.failoverStrategy != null) {
+			this.channel.setFailoverStrategy(this.failoverStrategy);
 		}
 		if (this.maxSubscribers != null) {
 			this.channel.setMaxSubscribers(this.maxSubscribers);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/ExecutorChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/ExecutorChannelSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,8 +36,8 @@ public class ExecutorChannelSpec extends LoadBalancingChannelSpec<ExecutorChanne
 	@Override
 	protected ExecutorChannel doGet() {
 		this.channel = new ExecutorChannel(this.executor, this.loadBalancingStrategy);
-		if (this.failover != null) {
-			this.channel.setFailover(this.failover);
+		if (this.failoverStrategy != null) {
+			this.channel.setFailoverStrategy(this.failoverStrategy);
 		}
 		if (this.maxSubscribers != null) {
 			this.channel.setMaxSubscribers(this.maxSubscribers);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/LoadBalancingChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/LoadBalancingChannelSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.dsl;
+
+import java.util.function.Predicate;
 
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.dispatcher.LoadBalancingStrategy;
@@ -34,7 +36,7 @@ public abstract class LoadBalancingChannelSpec<S extends MessageChannelSpec<S, C
 
 	protected LoadBalancingStrategy loadBalancingStrategy = new RoundRobinLoadBalancingStrategy(); // NOSONAR
 
-	protected Boolean failover; // NOSONAR
+	protected Predicate<Exception> failoverStrategy; // NOSONAR
 
 	protected Integer maxSubscribers; // NOSONAR
 
@@ -46,8 +48,20 @@ public abstract class LoadBalancingChannelSpec<S extends MessageChannelSpec<S, C
 		return _this();
 	}
 
-	public S failover(Boolean failoverToSet) {
-		this.failover = failoverToSet;
+	public S failover(boolean failoverToSet) {
+		return failoverStrategy((exception) -> failoverToSet);
+	}
+
+	/**
+	 * Configure a strategy whether the channel's dispatcher should have failover enabled
+	 * for the exception thrown.
+	 * Overrides {@link #failover(boolean)} option.
+	 * In other words: or this, or that option has to be set.
+	 * @param failoverStrategy The failover boolean.
+	 * @since 6.3
+	 */
+	public S failoverStrategy(Predicate<Exception> failoverStrategy) {
+		this.failoverStrategy = failoverStrategy;
 		return _this();
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/PartitionedChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/PartitionedChannelSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,8 +63,8 @@ public class PartitionedChannelSpec extends LoadBalancingChannelSpec<Partitioned
 			this.channel = new PartitionedChannel(this.partitionCount);
 		}
 		this.channel.setLoadBalancingStrategy(this.loadBalancingStrategy);
-		if (this.failover != null) {
-			this.channel.setFailover(this.failover);
+		if (this.failoverStrategy != null) {
+			this.channel.setFailoverStrategy(this.failoverStrategy);
 		}
 		if (this.maxSubscribers != null) {
 			this.channel.setMaxSubscribers(this.maxSubscribers);

--- a/src/reference/antora/modules/ROOT/pages/channel/configuration.adoc
+++ b/src/reference/antora/modules/ROOT/pages/channel/configuration.adoc
@@ -112,6 +112,10 @@ XML::
 ----
 ======
 
+Starting with version 6.3, all the `MessageChannel` implementations based on the `UnicastingDispatcher` can be configured with a `Predicate<Exception> failoverStrategy` instead of plain `failover` option.
+This predicate makes a decision to failover or not to the next `MessageHandler` based on an exception thrown from the current one.
+The more complex error analysis should be done using xref:router/implementations.adoc#router-implementations-exception-router[`ErrorMessageExceptionTypeRouter`].
+
 [[channel-datatype-channel]]
 == Datatype Channel Configuration
 

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -23,6 +23,9 @@ The `MessageHistory` header is now mutable, append-only container.
 And all the subsequent tracks don't create new message - only their entry is added to existing message history header.
 See xref:message-history.adoc[Message History Chapter] for more information.
 
+All the `MessageChannel` implementations based on the `UnicastingDispatcher` now can be configured with a `Predicate<Exception> failoverStrategy` for dynamic decision for the failover on the exception thrown from the current `MessageHandler`.
+See xref:channel/configuration.adoc[Message Channel Configuration] for more information.
+
 [[x6.3-security-changes]]
 === Security Support Changes
 


### PR DESCRIPTION
Fixes: #8981

Sometime the simple `boolean failover` on the `MessageChannel` (default `true`) is not enough to be sure that we can dispatch to the next handler or not. Such a decision can be made using `ErrorMessageExceptionTypeRouter`, but that would require an overhaul for the whole integration flow

* Introduce a simple `Predicate<Exception> failoverStrategy` into `UnicastingDispatcher` and all its `MessageChannel` implementation consumers to allow to make a decision about next failover according to a thrown exception from the current `MessageHandler`
* Expose `failoverStrategy` on the `DirectChannel`, `ExecutorChannel` & `PartitionedChannel`, and add it into respective Java DSL specs
* Fix involved tests to rely on the `failoverStrategy` property from now on
* Document the new feature

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
