### PR TITLE
ZeroMQ: optional topic wrap

### DIFF
--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageHandlerSpec.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageHandlerSpec.java
@@ -36,6 +36,7 @@ import org.springframework.messaging.converter.MessageConverter;
  * The {@link ReactiveMessageHandlerSpec} extension for {@link ZeroMqMessageHandler}.
  *
  * @author Artem Bilan
+ * @author Alessio Matricardi
  *
  * @since 5.4
  */
@@ -123,6 +124,19 @@ public class ZeroMqMessageHandlerSpec
 	 */
 	public ZeroMqMessageHandlerSpec topic(String topic) {
 		this.reactiveMessageHandler.setTopic(topic);
+		return this;
+	}
+
+	/**
+	 * Specify if the topic that {@link SocketType#PUB} socket is going to use for distributing messages into the
+	 * subscriptions must be wrapped with an additional empty frame.
+	 * It is ignored for all other {@link SocketType}s supported.
+	 * @param wrapTopic true iff the topic must be wrapped with an additional empty frame.
+	 * @return the spec
+	 * @since 6.2.6
+	 */
+	public ZeroMqMessageHandlerSpec wrapTopic(boolean wrapTopic) {
+		this.reactiveMessageHandler.wrapTopic(wrapTopic);
 		return this;
 	}
 

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageHandlerSpec.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageHandlerSpec.java
@@ -131,7 +131,8 @@ public class ZeroMqMessageHandlerSpec
 	 * Specify if the topic that {@link SocketType#PUB} socket is going to use for distributing messages into the
 	 * subscriptions must be wrapped with an additional empty frame.
 	 * It is ignored for all other {@link SocketType}s supported.
-	 * @param wrapTopic true iff the topic must be wrapped with an additional empty frame.
+	 * This attribute is set to {@code true} by default.
+	 * @param wrapTopic true if the topic must be wrapped with an additional empty frame.
 	 * @return the spec
 	 * @since 6.2.6
 	 */

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageProducerSpec.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageProducerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.messaging.converter.MessageConverter;
 
 /**
  * @author Artem Bilan
+ * @author Alessio Matricardi
  *
  * @since 5.4
  */
@@ -105,6 +106,19 @@ public class ZeroMqMessageProducerSpec
 	 */
 	public ZeroMqMessageProducerSpec topics(String... topics) {
 		this.target.setTopics(topics);
+		return this;
+	}
+
+	/**
+	 * Specify if the topic
+	 * that {@link SocketType#SUB} socket is going to receive is wrapped with an additional empty frame.
+	 * It is ignored for all other {@link SocketType}s supported.
+	 * @param wrapTopic true iff the received topic is wrapped with an additional empty frame.
+	 * @return the spec
+	 * @since 6.2.6
+	 */
+	public ZeroMqMessageProducerSpec wrapTopic(boolean wrapTopic) {
+		this.target.wrapTopic(wrapTopic);
 		return this;
 	}
 

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageProducerSpec.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/dsl/ZeroMqMessageProducerSpec.java
@@ -113,12 +113,13 @@ public class ZeroMqMessageProducerSpec
 	 * Specify if the topic
 	 * that {@link SocketType#SUB} socket is going to receive is wrapped with an additional empty frame.
 	 * It is ignored for all other {@link SocketType}s supported.
-	 * @param wrapTopic true iff the received topic is wrapped with an additional empty frame.
+	 * This attribute is set to {@code true} by default.
+	 * @param unwrapTopic true if the received topic is wrapped with an additional empty frame.
 	 * @return the spec
 	 * @since 6.2.6
 	 */
-	public ZeroMqMessageProducerSpec wrapTopic(boolean wrapTopic) {
-		this.target.wrapTopic(wrapTopic);
+	public ZeroMqMessageProducerSpec unwrapTopic(boolean unwrapTopic) {
+		this.target.unwrapTopic(unwrapTopic);
 		return this;
 	}
 

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 
 import org.zeromq.SocketType;
 import org.zeromq.ZContext;
+import org.zeromq.ZFrame;
 import org.zeromq.ZMQ;
 import org.zeromq.ZMsg;
 import reactor.core.publisher.Flux;
@@ -54,6 +55,7 @@ import org.springframework.util.Assert;
  * When the {@link SocketType#SUB} is used, the received topic is stored in the {@link ZeroMqHeaders#TOPIC}.
  *
  * @author Artem Bilan
+ * @author Alessio Matricardi
  *
  * @since 5.4
  */
@@ -89,6 +91,8 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 	private String connectUrl;
 
 	private volatile Mono<ZMQ.Socket> socketMono;
+
+	private volatile boolean wrapTopic = true;
 
 	public ZeroMqMessageProducer(ZContext context) {
 		this(context, SocketType.PAIR);
@@ -189,6 +193,17 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 		return this.bindPort.get();
 	}
 
+	/**
+	 * Specify if the topic
+	 * that {@link SocketType#SUB} socket is going to receive is wrapped with an additional empty frame.
+	 * It is ignored for all other {@link SocketType}s supported.
+	 * @param wrapTopic true iff the received topic is wrapped with an additional empty frame.
+	 * @since 6.2.6
+	 */
+	public void wrapTopic(boolean wrapTopic) {
+		this.wrapTopic = wrapTopic;
+	}
+
 	@Override
 	public String getComponentType() {
 		return "zeromq:inbound-channel-adapter";
@@ -284,7 +299,14 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 		return msgMono.map((msg) -> {
 			Map<String, Object> headers = null;
 			if (msg.size() > 1) {
-				headers = Collections.singletonMap(ZeroMqHeaders.TOPIC, msg.unwrap().getString(ZMQ.CHARSET));
+				ZFrame frame;
+				if (this.wrapTopic) {
+					frame = msg.unwrap();
+				}
+				else {
+					frame = msg.pop();
+				}
+				headers = Collections.singletonMap(ZeroMqHeaders.TOPIC, frame.getString(ZMQ.CHARSET));
 			}
 			return this.messageMapper.toMessage(msg.getLast().getData(), headers); // NOSONAR
 		});

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
@@ -92,7 +92,7 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 
 	private volatile Mono<ZMQ.Socket> socketMono;
 
-	private volatile boolean wrapTopic = true;
+	private volatile boolean unwrapTopic = true;
 
 	public ZeroMqMessageProducer(ZContext context) {
 		this(context, SocketType.PAIR);
@@ -197,11 +197,12 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 	 * Specify if the topic
 	 * that {@link SocketType#SUB} socket is going to receive is wrapped with an additional empty frame.
 	 * It is ignored for all other {@link SocketType}s supported.
-	 * @param wrapTopic true iff the received topic is wrapped with an additional empty frame.
+	 * This attribute is set to {@code true} by default.
+	 * @param unwrapTopic true if the received topic is wrapped with an additional empty frame.
 	 * @since 6.2.6
 	 */
-	public void wrapTopic(boolean wrapTopic) {
-		this.wrapTopic = wrapTopic;
+	public void unwrapTopic(boolean unwrapTopic) {
+		this.unwrapTopic = unwrapTopic;
 	}
 
 	@Override
@@ -299,14 +300,14 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 		return msgMono.map((msg) -> {
 			Map<String, Object> headers = null;
 			if (msg.size() > 1) {
-				ZFrame frame;
-				if (this.wrapTopic) {
-					frame = msg.unwrap();
+				ZFrame topicFrame;
+				if (this.unwrapTopic) {
+					topicFrame = msg.unwrap();
 				}
 				else {
-					frame = msg.pop();
+					topicFrame = msg.pop();
 				}
-				headers = Collections.singletonMap(ZeroMqHeaders.TOPIC, frame.getString(ZMQ.CHARSET));
+				headers = Collections.singletonMap(ZeroMqHeaders.TOPIC, topicFrame.getString(ZMQ.CHARSET));
 			}
 			return this.messageMapper.toMessage(msg.getLast().getData(), headers); // NOSONAR
 		});

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducer.java
@@ -300,13 +300,7 @@ public class ZeroMqMessageProducer extends MessageProducerSupport {
 		return msgMono.map((msg) -> {
 			Map<String, Object> headers = null;
 			if (msg.size() > 1) {
-				ZFrame topicFrame;
-				if (this.unwrapTopic) {
-					topicFrame = msg.unwrap();
-				}
-				else {
-					topicFrame = msg.pop();
-				}
+				ZFrame topicFrame = this.unwrapTopic ? msg.unwrap() : msg.pop();
 				headers = Collections.singletonMap(ZeroMqHeaders.TOPIC, topicFrame.getString(ZMQ.CHARSET));
 			}
 			return this.messageMapper.toMessage(msg.getLast().getData(), headers); // NOSONAR

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
@@ -60,6 +60,7 @@ import org.springframework.util.Assert;
  * the {@link ZMsg} is sent into a socket as is and it is not destroyed for possible further reusing.
  *
  * @author Artem Bilan
+ * @author Alessio Matricardi
  *
  * @since 5.4
  */
@@ -196,7 +197,9 @@ public class ZeroMqMessageHandler extends AbstractReactiveMessageHandler
 	/**
 	 * Specify if the topic that {@link SocketType#PUB} socket is going to use for distributing messages into the
 	 * subscriptions must be wrapped with an additional empty frame.
+	 * It is ignored for all other {@link SocketType}s supported.
 	 * @param wrapTopic true iff the topic must be wrapped with an additional empty frame.
+	 * @since 6.2.6
 	 */
 	public void wrapTopic(boolean wrapTopic) {
 		this.wrapTopic = wrapTopic;
@@ -256,9 +259,10 @@ public class ZeroMqMessageHandler extends AbstractReactiveMessageHandler
 							String topic = this.topicExpression.getValue(this.evaluationContext, message, String.class);
 							if (topic != null) {
 								var frame = new ZFrame(topic);
-								if (wrapTopic) {
+								if (this.wrapTopic) {
 									msg.wrap(frame);
-								} else {
+								}
+								else {
 									msg.push(frame);
 								}
 							}

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
@@ -256,7 +256,11 @@ public class ZeroMqMessageHandler extends AbstractReactiveMessageHandler
 							String topic = this.topicExpression.getValue(this.evaluationContext, message, String.class);
 							if (topic != null) {
 								var frame = new ZFrame(topic);
-								wrapTopic ? msg.wrap(frame) : msg.push(frame);
+								if(wrapTopic) {
+									msg.wrap(frame);
+								} else {
+									msg.push(frame);
+								}
 							}
 						}
 					}

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
@@ -256,7 +256,7 @@ public class ZeroMqMessageHandler extends AbstractReactiveMessageHandler
 							String topic = this.topicExpression.getValue(this.evaluationContext, message, String.class);
 							if (topic != null) {
 								var frame = new ZFrame(topic);
-								if(wrapTopic) {
+								if (wrapTopic) {
 									msg.wrap(frame);
 								} else {
 									msg.push(frame);

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandler.java
@@ -198,7 +198,8 @@ public class ZeroMqMessageHandler extends AbstractReactiveMessageHandler
 	 * Specify if the topic that {@link SocketType#PUB} socket is going to use for distributing messages into the
 	 * subscriptions must be wrapped with an additional empty frame.
 	 * It is ignored for all other {@link SocketType}s supported.
-	 * @param wrapTopic true iff the topic must be wrapped with an additional empty frame.
+	 * This attribute is set to {@code true} by default.
+	 * @param wrapTopic true if the topic must be wrapped with an additional empty frame.
 	 * @since 6.2.6
 	 */
 	public void wrapTopic(boolean wrapTopic) {
@@ -258,12 +259,12 @@ public class ZeroMqMessageHandler extends AbstractReactiveMessageHandler
 						if (socket.base() instanceof Pub) {
 							String topic = this.topicExpression.getValue(this.evaluationContext, message, String.class);
 							if (topic != null) {
-								var frame = new ZFrame(topic);
+								ZFrame topicFrame = new ZFrame(topic);
 								if (this.wrapTopic) {
-									msg.wrap(frame);
+									msg.wrap(topicFrame);
 								}
 								else {
-									msg.push(frame);
+									msg.push(topicFrame);
 								}
 							}
 						}

--- a/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducerTests.java
+++ b/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducerTests.java
@@ -149,7 +149,7 @@ public class ZeroMqMessageProducerTests {
 
 	@Test
 	void testMessageProducerForPubSubDisabledWrapTopic() {
-		String socketAddress = "inproc://messageProducer.test";
+		String socketAddress = "inproc://messageProducerWrapTopic.test";
 		ZMQ.Socket socket = CONTEXT.createSocket(SocketType.XPUB);
 		socket.bind(socketAddress);
 		socket.setReceiveTimeOut(10_000);

--- a/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducerTests.java
+++ b/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducerTests.java
@@ -173,7 +173,7 @@ public class ZeroMqMessageProducerTests {
 		messageProducer.setConnectUrl(socketAddress);
 		messageProducer.setConsumeDelay(Duration.ofMillis(10));
 		messageProducer.setBeanFactory(mock(BeanFactory.class));
-		messageProducer.wrapTopic(false);
+		messageProducer.unwrapTopic(false);
 		messageProducer.afterPropertiesSet();
 		messageProducer.start();
 

--- a/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducerTests.java
+++ b/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducerTests.java
@@ -90,7 +90,7 @@ public class ZeroMqMessageProducerTests {
 
 		stepVerifier.verify();
 
-		messageProducer.destroy();
+		messageProducer.stop();
 		socket.close();
 	}
 
@@ -144,7 +144,7 @@ public class ZeroMqMessageProducerTests {
 
 		stepVerifier.verify(Duration.ofSeconds(10));
 
-		messageProducer.destroy();
+		messageProducer.stop();
 		socket.close();
 	}
 
@@ -153,7 +153,6 @@ public class ZeroMqMessageProducerTests {
 		String socketAddress = "inproc://messageProducerWrapTopic.test";
 		ZMQ.Socket socket = CONTEXT.createSocket(SocketType.XPUB);
 		socket.bind(socketAddress);
-		socket.setReceiveTimeOut(10_000);
 
 		FluxMessageChannel outputChannel = new FluxMessageChannel();
 
@@ -167,7 +166,6 @@ public class ZeroMqMessageProducerTests {
 		messageProducer.setOutputChannel(outputChannel);
 		messageProducer.setTopics("test");
 		messageProducer.setConnectUrl(socketAddress);
-		messageProducer.setConsumeDelay(Duration.ofMillis(10));
 		messageProducer.setBeanFactory(mock(BeanFactory.class));
 		messageProducer.unwrapTopic(false);
 		messageProducer.afterPropertiesSet();
@@ -179,9 +177,9 @@ public class ZeroMqMessageProducerTests {
 		msg.push("testTopicWithNonWrappedTopic");
 		msg.send(socket);
 
-		stepVerifier.verify(Duration.ofSeconds(10));
+		stepVerifier.verify();
 
-		messageProducer.destroy();
+		messageProducer.stop();
 		socket.close();
 	}
 

--- a/src/reference/antora/modules/ROOT/pages/zeromq.adoc
+++ b/src/reference/antora/modules/ROOT/pages/zeromq.adoc
@@ -119,6 +119,12 @@ If the `receiveRaw` option is set to `true`, a `ZMsg`, consumed from the socket,
 Otherwise, an `InboundMessageMapper` is used to convert the consumed data into a `Message`.
 If the received `ZMsg` is multi-frame, the first frame is treated as the `ZeroMqHeaders.TOPIC` header this ZeroMQ message was published to.
 
+If the `unwrapTopic` option is set to `false`,
+the incoming message is considered to consist of two frames: the topic and the ZeroMQ message.
+Otherwise, by default, the `ZMsg` is considered to consist of three frames:
+the first one containing the topic, the last frame containing the message,
+with an empty frame in the middle.
+
 With `SocketType.SUB`, the `ZeroMqMessageProducer` uses the provided `topics` option for subscriptions; defaults to subscribe to all.
 Subscriptions can be adjusted at runtime using `subscribeToTopics()` and `unsubscribeFromTopics()` `@ManagedOperation` s.
 
@@ -146,6 +152,11 @@ Only `SocketType.PAIR`, `SocketType.PUSH` and `SocketType.PUB` are supported.
 The `ZeroMqMessageHandler` only supports connecting the ZeroMQ socket; binding is not supported.
 When the `SocketType.PUB` is used, the `topicExpression` is evaluated against a request message to inject a topic frame into a ZeroMQ message if it is not null.
 The subscriber side (`SocketType.SUB`) must receive the topic frame first before parsing the actual data.
+
+If the `wrapTopic` option is set to `false`,
+the ZeroMQ message frame is sent after the injected topic, if present.
+By default, an additional empty frame is sent between the topic and the message.
+
 When the payload of the request message is a `ZMsg`, no conversion or topic extraction is performed: the `ZMsg` is sent into a socket as is and it is not destroyed for possible further reuse.
 Otherwise, an `OutboundMessageMapper<byte[]>` is used to convert a request message (or just its payload) into a ZeroMQ frame to publish.
 By default, a `ConvertingBytesMessageMapper` is used supplied with a `ConfigurableCompositeMessageConverter`.

--- a/src/reference/antora/modules/ROOT/pages/zeromq.adoc
+++ b/src/reference/antora/modules/ROOT/pages/zeromq.adoc
@@ -119,11 +119,8 @@ If the `receiveRaw` option is set to `true`, a `ZMsg`, consumed from the socket,
 Otherwise, an `InboundMessageMapper` is used to convert the consumed data into a `Message`.
 If the received `ZMsg` is multi-frame, the first frame is treated as the `ZeroMqHeaders.TOPIC` header this ZeroMQ message was published to.
 
-If the `unwrapTopic` option is set to `false`,
-the incoming message is considered to consist of two frames: the topic and the ZeroMQ message.
-Otherwise, by default, the `ZMsg` is considered to consist of three frames:
-the first one containing the topic, the last frame containing the message,
-with an empty frame in the middle.
+If the `unwrapTopic` option is set to `false`, the incoming message is considered to consist of two frames: the topic and the ZeroMQ message.
+Otherwise, by default, the `ZMsg` is considered to consist of three frames: the first one containing the topic, the last frame containing the message, with an empty frame in the middle.
 
 With `SocketType.SUB`, the `ZeroMqMessageProducer` uses the provided `topics` option for subscriptions; defaults to subscribe to all.
 Subscriptions can be adjusted at runtime using `subscribeToTopics()` and `unsubscribeFromTopics()` `@ManagedOperation` s.
@@ -153,8 +150,7 @@ The `ZeroMqMessageHandler` only supports connecting the ZeroMQ socket; binding i
 When the `SocketType.PUB` is used, the `topicExpression` is evaluated against a request message to inject a topic frame into a ZeroMQ message if it is not null.
 The subscriber side (`SocketType.SUB`) must receive the topic frame first before parsing the actual data.
 
-If the `wrapTopic` option is set to `false`,
-the ZeroMQ message frame is sent after the injected topic, if present.
+If the `wrapTopic` option is set to `false`, the ZeroMQ message frame is sent after the injected topic, if present.
 By default, an additional empty frame is sent between the topic and the message.
 
 When the payload of the request message is a `ZMsg`, no conversion or topic extraction is performed: the `ZMsg` is sent into a socket as is and it is not destroyed for possible further reuse.


### PR DESCRIPTION
When a topic is specified to the the ZeroMqMessageHandler, it sends a message with the following format
Frame 1: byte array of the topic
Frame 2: empty byte array
Frame 3: byte array representing the message payload

Is there a reason over this choice?
The official ZeroMQ documentation doesn't offer a clear view of the better approach which has to be followed, however it provides some code examples of how send/receive ZeroMQ packets.
Here an example (taken from [here](https://zeromq.org/socket-api/#Topics))
```
//  Send a message on the 'status' topic
zmq_send (pub, "status", 6, ZMQ_SNDMORE);
zmq_send (pub, "All is well", 11, 0);
```
This example could suggest that no empty frames are needed, but choseable.

My PR addresses this issue (yes, for me this is a bug) keeping the default behaviour (wrap the topic with an additional empty ZeroMQ frame)