### PR TITLE
Refactor to Eliminate Repetitive Mock Object Creation(more exmple with #9271)

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Gengwu Zhao
  *
  * @since 2.2
  *
@@ -505,17 +506,13 @@ public class CachingClientConnectionFactoryTests {
 	@Test
 	public void testCachedFailover() throws Exception {
 		// Failover
-		AbstractClientConnectionFactory factory1 = mock(AbstractClientConnectionFactory.class);
-		AbstractClientConnectionFactory factory2 = mock(AbstractClientConnectionFactory.class);
+		TcpConnectionSupport mockConn1 = makeMockConnection();
+		TcpConnectionSupport mockConn2 = makeMockConnection();
+		AbstractClientConnectionFactory factory1 = createFactoryWithMockConnection(mockConn1);
+		AbstractClientConnectionFactory factory2 = createFactoryWithMockConnection(mockConn2);
 		List<AbstractClientConnectionFactory> factories = new ArrayList<>();
 		factories.add(factory1);
 		factories.add(factory2);
-		TcpConnectionSupport mockConn1 = makeMockConnection();
-		TcpConnectionSupport mockConn2 = makeMockConnection();
-		when(factory1.getConnection()).thenReturn(mockConn1);
-		when(factory2.getConnection()).thenReturn(mockConn2);
-		when(factory1.isActive()).thenReturn(true);
-		when(factory2.isActive()).thenReturn(true);
 		doThrow(new UncheckedIOException(new IOException("fail"))).when(mockConn1).send(Mockito.any(Message.class));
 		doAnswer(invocation -> null).when(mockConn2).send(Mockito.any(Message.class));
 		FailoverClientConnectionFactory failoverFactory = new FailoverClientConnectionFactory(factories);
@@ -820,6 +817,13 @@ public class CachingClientConnectionFactoryTests {
 		TcpConnectionSupport connection = mock(TcpConnectionSupport.class);
 		when(connection.isOpen()).thenReturn(true);
 		return connection;
+	}
+
+	private static AbstractClientConnectionFactory createFactoryWithMockConnection(TcpConnectionSupport mockConn) throws Exception {
+		AbstractClientConnectionFactory factory = mock(AbstractClientConnectionFactory.class);
+		when(factory.getConnection()).thenReturn(mockConn);
+		when(factory.isActive()).thenReturn(true);
+		return factory;
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Gengwu Zhao
  *
  * @since 2.2
  *
@@ -93,17 +94,13 @@ public class FailoverClientConnectionFactoryTests {
 
 	@Test
 	public void testFailoverGood() throws Exception {
-		AbstractClientConnectionFactory factory1 = mock(AbstractClientConnectionFactory.class);
-		AbstractClientConnectionFactory factory2 = mock(AbstractClientConnectionFactory.class);
+		TcpConnectionSupport conn1 = makeMockConnection();
+		TcpConnectionSupport conn2 = makeMockConnection();
+		AbstractClientConnectionFactory factory1 = createFactoryWithMockConnection(conn1);
+		AbstractClientConnectionFactory factory2 = createFactoryWithMockConnection(conn2);
 		List<AbstractClientConnectionFactory> factories = new ArrayList<AbstractClientConnectionFactory>();
 		factories.add(factory1);
 		factories.add(factory2);
-		TcpConnectionSupport conn1 = makeMockConnection();
-		TcpConnectionSupport conn2 = makeMockConnection();
-		when(factory1.getConnection()).thenReturn(conn1);
-		when(factory2.getConnection()).thenReturn(conn2);
-		when(factory1.isActive()).thenReturn(true);
-		when(factory2.isActive()).thenReturn(true);
 		doThrow(new UncheckedIOException(new IOException("fail")))
 				.when(conn1).send(Mockito.any(Message.class));
 		doAnswer(invocation -> null).when(conn2).send(Mockito.any(Message.class));
@@ -181,17 +178,13 @@ public class FailoverClientConnectionFactoryTests {
 
 	@Test
 	public void testFailoverAllDead() throws Exception {
-		AbstractClientConnectionFactory factory1 = mock(AbstractClientConnectionFactory.class);
-		AbstractClientConnectionFactory factory2 = mock(AbstractClientConnectionFactory.class);
+		TcpConnectionSupport conn1 = makeMockConnection();
+		TcpConnectionSupport conn2 = makeMockConnection();
+		AbstractClientConnectionFactory factory1 = createFactoryWithMockConnection(conn1);
+		AbstractClientConnectionFactory factory2 = createFactoryWithMockConnection(conn2);
 		List<AbstractClientConnectionFactory> factories = new ArrayList<AbstractClientConnectionFactory>();
 		factories.add(factory1);
 		factories.add(factory2);
-		TcpConnectionSupport conn1 = makeMockConnection();
-		TcpConnectionSupport conn2 = makeMockConnection();
-		when(factory1.getConnection()).thenReturn(conn1);
-		when(factory2.getConnection()).thenReturn(conn2);
-		when(factory1.isActive()).thenReturn(true);
-		when(factory2.isActive()).thenReturn(true);
 		doThrow(new UncheckedIOException(new IOException("fail")))
 				.when(conn1).send(Mockito.any(Message.class));
 		doThrow(new UncheckedIOException(new IOException("fail")))
@@ -243,17 +236,13 @@ public class FailoverClientConnectionFactoryTests {
 
 	@Test
 	public void testFailoverAllDeadButOriginalOkAgain() throws Exception {
-		AbstractClientConnectionFactory factory1 = mock(AbstractClientConnectionFactory.class);
-		AbstractClientConnectionFactory factory2 = mock(AbstractClientConnectionFactory.class);
+		TcpConnectionSupport conn1 = makeMockConnection();
+		TcpConnectionSupport conn2 = makeMockConnection();
+		AbstractClientConnectionFactory factory1 = createFactoryWithMockConnection(conn1);
+		AbstractClientConnectionFactory factory2 = createFactoryWithMockConnection(conn2);
 		List<AbstractClientConnectionFactory> factories = new ArrayList<AbstractClientConnectionFactory>();
 		factories.add(factory1);
 		factories.add(factory2);
-		TcpConnectionSupport conn1 = makeMockConnection();
-		TcpConnectionSupport conn2 = makeMockConnection();
-		when(factory1.getConnection()).thenReturn(conn1);
-		when(factory2.getConnection()).thenReturn(conn2);
-		when(factory1.isActive()).thenReturn(true);
-		when(factory2.isActive()).thenReturn(true);
 		final AtomicBoolean failedOnce = new AtomicBoolean();
 		doAnswer(invocation -> {
 			if (!failedOnce.get()) {
@@ -315,17 +304,13 @@ public class FailoverClientConnectionFactoryTests {
 
 	@Test
 	public void testOkAgainAfterCompleteFailure() throws Exception {
-		AbstractClientConnectionFactory factory1 = mock(AbstractClientConnectionFactory.class);
-		AbstractClientConnectionFactory factory2 = mock(AbstractClientConnectionFactory.class);
+		TcpConnectionSupport conn1 = makeMockConnection();
+		TcpConnectionSupport conn2 = makeMockConnection();
+		AbstractClientConnectionFactory factory1 = createFactoryWithMockConnection(conn1);
+		AbstractClientConnectionFactory factory2 = createFactoryWithMockConnection(conn2);
 		List<AbstractClientConnectionFactory> factories = new ArrayList<AbstractClientConnectionFactory>();
 		factories.add(factory1);
 		factories.add(factory2);
-		TcpConnectionSupport conn1 = makeMockConnection();
-		TcpConnectionSupport conn2 = makeMockConnection();
-		when(factory1.getConnection()).thenReturn(conn1);
-		when(factory2.getConnection()).thenReturn(conn2);
-		when(factory1.isActive()).thenReturn(true);
-		when(factory2.isActive()).thenReturn(true);
 		final AtomicInteger failCount = new AtomicInteger();
 		doAnswer(invocation -> {
 			if (failCount.incrementAndGet() < 3) {
@@ -708,6 +693,13 @@ public class FailoverClientConnectionFactoryTests {
 
 		private AbstractServerConnectionFactory server1;
 
+	}
+
+	private static AbstractClientConnectionFactory createFactoryWithMockConnection(TcpConnectionSupport mockConn) throws Exception {
+		AbstractClientConnectionFactory factory = mock(AbstractClientConnectionFactory.class);
+		when(factory.getConnection()).thenReturn(mockConn);
+		when(factory.isActive()).thenReturn(true);
+		return factory;
 	}
 
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/OutboundGatewayFunctionTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/OutboundGatewayFunctionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Gengwu Zhao
  *
  * @since 2.2
  *
@@ -72,12 +73,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void testContainerWithDest() throws Exception {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		when(beanFactory.containsBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)).thenReturn(true);
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.initialize();
-		when(beanFactory.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class))
-				.thenReturn(scheduler);
+		BeanFactory beanFactory = createFactoryWithMockScheduler(scheduler);
 		final JmsOutboundGateway gateway = new JmsOutboundGateway();
 		gateway.setBeanFactory(beanFactory);
 		gateway.setConnectionFactory(connectionFactory);
@@ -118,12 +116,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void testContainerWithDestNoCorrelation() throws Exception {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		when(beanFactory.containsBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)).thenReturn(true);
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.initialize();
-		when(beanFactory.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class))
-				.thenReturn(scheduler);
+		BeanFactory beanFactory = createFactoryWithMockScheduler(scheduler);
 		final JmsOutboundGateway gateway = new JmsOutboundGateway();
 		gateway.setBeanFactory(beanFactory);
 		gateway.setConnectionFactory(connectionFactory);
@@ -166,12 +161,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void testContainerWithDestName() throws Exception {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		when(beanFactory.containsBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)).thenReturn(true);
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.initialize();
-		when(beanFactory.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class))
-				.thenReturn(scheduler);
+		BeanFactory beanFactory = createFactoryWithMockScheduler(scheduler);
 		final JmsOutboundGateway gateway = new JmsOutboundGateway();
 		gateway.setBeanFactory(beanFactory);
 		gateway.setConnectionFactory(connectionFactory);
@@ -212,12 +204,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void testContainerWithDestNameNoCorrelation() throws Exception {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		when(beanFactory.containsBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)).thenReturn(true);
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.initialize();
-		when(beanFactory.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class))
-				.thenReturn(scheduler);
+		BeanFactory beanFactory = createFactoryWithMockScheduler(scheduler);
 		final JmsOutboundGateway gateway = new JmsOutboundGateway();
 		gateway.setBeanFactory(beanFactory);
 		gateway.setConnectionFactory(connectionFactory);
@@ -260,12 +249,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void testContainerWithTemporary() throws Exception {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		when(beanFactory.containsBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)).thenReturn(true);
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.initialize();
-		when(beanFactory.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class))
-				.thenReturn(scheduler);
+		BeanFactory beanFactory = createFactoryWithMockScheduler(scheduler);
 		final JmsOutboundGateway gateway = new JmsOutboundGateway();
 		gateway.setBeanFactory(beanFactory);
 		gateway.setConnectionFactory(connectionFactory);
@@ -306,12 +292,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void testContainerWithTemporaryNoCorrelation() throws Exception {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		when(beanFactory.containsBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)).thenReturn(true);
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.initialize();
-		when(beanFactory.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class))
-				.thenReturn(scheduler);
+		BeanFactory beanFactory = createFactoryWithMockScheduler(scheduler);
 		final JmsOutboundGateway gateway = new JmsOutboundGateway();
 		gateway.setBeanFactory(beanFactory);
 		gateway.setConnectionFactory(connectionFactory);
@@ -353,12 +336,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void testLazyContainerWithDest() throws Exception {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		when(beanFactory.containsBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)).thenReturn(true);
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.initialize();
-		when(beanFactory.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class))
-				.thenReturn(scheduler);
+		BeanFactory beanFactory = createFactoryWithMockScheduler(scheduler);
 		final JmsOutboundGateway gateway = new JmsOutboundGateway();
 		gateway.setBeanFactory(beanFactory);
 		gateway.setConnectionFactory(connectionFactory);
@@ -407,4 +387,11 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 		}
 	}
 
+	private static BeanFactory createFactoryWithMockScheduler(ThreadPoolTaskScheduler scheduler) {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		when(beanFactory.containsBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)).thenReturn(true);
+		when(beanFactory.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class))
+				.thenReturn(scheduler);
+		return beanFactory;
+	}
 }


### PR DESCRIPTION
### Pull Request Description:
This pull request addresses issue #9283 , which is essentially doing the same thing as issue #9271. It refactors the 4 classes to eliminate redundant mock creations and simplify the testing code. Specifically, it introduces helper methods to centralize the creation and configuration of mocks for `AbstractClientConnectionFactory`, and `BeanFactory`, reducing code duplication and enhancing readability.