### PR TITLE
Add 'milliseconds' unit to Javadoc for 'soTimeout' parameters in vari…

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/CommonSocketOptions.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/CommonSocketOptions.java
@@ -23,7 +23,7 @@ package org.springframework.integration.ip;
 public interface CommonSocketOptions {
 
 	/**
-	 * @param soTimeout The timeout.
+	 * @param soTimeout The timeout, in milliseconds.
 	 * @see java.net.Socket#setSoTimeout(int)
 	 * @see java.net.DatagramSocket#setSoTimeout(int)
 	 */

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBean.java
@@ -305,7 +305,7 @@ public class TcpConnectionFactoryFactoryBean extends AbstractFactoryBean<Abstrac
 	}
 
 	/**
-	 * @param soTimeout The timeout.
+	 * @param soTimeout The timeout, in milliseconds.
 	 * @see AbstractConnectionFactory#setSoTimeout(int)
 	 */
 	public void setSoTimeout(int soTimeout) {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/AbstractConnectionFactorySpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/AbstractConnectionFactorySpec.java
@@ -53,7 +53,7 @@ public abstract class AbstractConnectionFactorySpec
 	}
 
 	/**
-	 * @param soTimeout the timeout socket option.
+	 * @param soTimeout the timeout socket option, in milliseconds.
 	 * @return the spec.
 	 * @see AbstractConnectionFactory#setSoTimeout(int)
 	 */

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/UdpInboundChannelAdapterSpec.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/dsl/UdpInboundChannelAdapterSpec.java
@@ -45,7 +45,7 @@ public class UdpInboundChannelAdapterSpec
 	}
 
 	/**
-	 * @param soTimeout set the timeout socket option.
+	 * @param soTimeout set the timeout socket option, in milliseconds.
 	 * @return the spec.
 	 * @see UnicastReceivingChannelAdapter#setSoTimeout(int)
 	 */

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/AbstractConnectionFactory.java
@@ -198,7 +198,7 @@ public abstract class AbstractConnectionFactory extends IntegrationObjectSupport
 	}
 
 	/**
-	 * @param soTimeout the soTimeout to set
+	 * @param soTimeout the soTimeout to set, in milliseconds
 	 */
 	public void setSoTimeout(int soTimeout) {
 		this.soTimeout = soTimeout;


### PR DESCRIPTION
…ous socket-related classes.

Connection timeout's unit is specified as 'seconds' in the annotation, but soTimeout's unit is not specified as 'milliseconds', so people who do not know the parameter information of the java socket library may be confused.

