### PR TITLE
GH-9294: Set permissions to target file on rename

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/FileWritingMessageHandler.java
@@ -629,6 +629,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 
 		if (!FileExistsMode.APPEND.equals(this.fileExistsMode) && this.deleteSourceFiles) {
 			rename(sourceFile, resultFile);
+			setPermissions(resultFile);
 			return resultFile;
 		}
 		else {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
@@ -309,7 +309,7 @@ public class FileWritingMessageHandlerTests {
 		QueueChannel output = new QueueChannel();
 		handler.setDeleteSourceFiles(true);
 		handler.setOutputChannel(output);
-		handler.setChmod(0444);
+		handler.setChmod(0400);
 		Message<?> message = MessageBuilder.withPayload(sourceFile).build();
 		handler.handleMessage(message);
 		Message<?> result = output.receive(0);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/FileWritingMessageHandlerTests.java
@@ -36,6 +36,8 @@ import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
 
 import org.springframework.beans.DirectFieldAccessor;
@@ -298,6 +300,23 @@ public class FileWritingMessageHandlerTests {
 		handler.handleMessage(message);
 		Message<?> result = output.receive(0);
 		assertFileContentIsMatching(result);
+		assertThat(sourceFile.exists()).isFalse();
+	}
+
+	@Test
+	@DisabledOnOs(OS.WINDOWS)
+	public void deleteFilesWithChmod() throws Exception {
+		QueueChannel output = new QueueChannel();
+		handler.setDeleteSourceFiles(true);
+		handler.setOutputChannel(output);
+		handler.setChmod(0444);
+		Message<?> message = MessageBuilder.withPayload(sourceFile).build();
+		handler.handleMessage(message);
+		Message<?> result = output.receive(0);
+		assertFileContentIsMatching(result);
+		File resultFile = messageToFile(result);
+		Set<PosixFilePermission> posixFilePermissions = Files.getPosixFilePermissions(resultFile.toPath());
+		assertThat(posixFilePermissions).containsOnly(PosixFilePermission.OWNER_READ);
 		assertThat(sourceFile.exists()).isFalse();
 	}
 


### PR DESCRIPTION
Fixes: #9294

When the `deleteSourceFiles` property of `FileWritingMessageHandler` is `true`, the `chmod` is not set on the target file.

* Fix `FileWritingMessageHandler.handleFileMessage()` logic to `setPermissions(resultFile)` after `move` operation

**Auto-cherry-pick to `6.3.x` & `6.2.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
