### PR TITLE
GH-9369: Fix MutableMessageHeaders not being editable after deserialization

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageHeaders.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.support;
 
+import java.io.ObjectStreamException;
+import java.io.Serial;
 import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.UUID;
@@ -31,6 +33,7 @@ import org.springframework.messaging.MessageHeaders;
  * @author David Turanski
  * @author Artem Bilan
  * @author Nathan Kurtyka
+ * @author Mitchell McDonald
  *
  * @since 4.2
  */
@@ -71,6 +74,11 @@ public class MutableMessageHeaders extends MessageHeaders {
 	@Override
 	public Object remove(Object key) {
 		return super.getRawHeaders().remove(key);
+	}
+
+	@Serial
+	private Object readResolve() throws ObjectStreamException {
+		return new MutableMessageHeaders(this);
 	}
 
 	@Nullable


### PR DESCRIPTION
Fixes: #9369

* Fix MutableMessageHeaders not being editable after deserialization
