### PR TITLE
GH-9368: Support for adding MqttMessageDrivenChannelAdapter at runtime

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -74,7 +74,7 @@ public interface ClientManager<T, C> extends SmartLifecycle, MqttComponent<C> {
 	 * @return the managed clients isConnected.
 	 * @since 6.4
 	 */
-	boolean isConnection();
+	boolean isConnected();
 
 	/**
 	 * A contract for a custom callback on {@code connectComplete} event from the client.

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -28,6 +28,7 @@ import org.springframework.context.SmartLifecycle;
  *
  * @author Artem Vozhdayenko
  * @author Artem Bilan
+ * @author Jiri Soucek
  *
  * @since 6.0
  */
@@ -71,6 +72,7 @@ public interface ClientManager<T, C> extends SmartLifecycle, MqttComponent<C> {
 	/**
 	 * Return the managed clients isConnected.
 	 * @return the managed clients isConnected.
+	 * @since 6.4
 	 */
 	boolean isConnection();
 

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,12 @@ public interface ClientManager<T, C> extends SmartLifecycle, MqttComponent<C> {
 	 * @return true if callback was removed.
 	 */
 	boolean removeCallback(ConnectCallback connectCallback);
+
+	/**
+	 * Return the managed clients isConnected.
+	 * @return the managed clients isConnected.
+	 */
+	boolean isConnection();
 
 	/**
 	 * A contract for a custom callback on {@code connectComplete} event from the client.

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
@@ -200,7 +200,9 @@ public class Mqttv3ClientManager
 
 	@Override
 	public boolean isConnection() {
-		if(getClient()!=null) return getClient().isConnected();
+		if (getClient() != null) {
+			return getClient().isConnected();
+		}
 		return false;
 	}
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
@@ -198,4 +198,9 @@ public class Mqttv3ClientManager
 		// nor this manager concern
 	}
 
+	@Override
+	public boolean isConnection() {
+		if(getClient()!=null) return getClient().isConnected();
+		return false;
+	}
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
@@ -38,6 +38,7 @@ import org.springframework.util.Assert;
  * @author Artem Vozhdayenko
  * @author Artem Bilan
  * @author Christian Tzolov
+ * @author Jiri Soucek
  *
  * @since 6.0
  */
@@ -200,9 +201,17 @@ public class Mqttv3ClientManager
 
 	@Override
 	public boolean isConnection() {
-		if (getClient() != null) {
-			return getClient().isConnected();
+		this.lock.lock();
+		try {
+			IMqttAsyncClient client = getClient();
+			if (client != null) {
+				return client.isConnected();
+			}
+			return false;
 		}
-		return false;
+		finally {
+			this.lock.unlock();
+		}
+
 	}
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
@@ -200,7 +200,7 @@ public class Mqttv3ClientManager
 	}
 
 	@Override
-	public boolean isConnection() {
+	public boolean isConnected() {
 		this.lock.lock();
 		try {
 			IMqttAsyncClient client = getClient();

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  * @author Artem Vozhdayenko
  * @author Artem Bilan
  * @author Christian Tzolov
+ * @author Jiri Soucek
  *
  * @since 6.0
  */
@@ -208,9 +209,16 @@ public class Mqttv5ClientManager
 
 	@Override
 	public boolean isConnection() {
-		if (getClient() != null) {
-			return getClient().isConnected();
+		this.lock.lock();
+		try {
+			IMqttAsyncClient client = getClient();
+			if (client != null) {
+				return client.isConnected();
+			}
+			return false;
 		}
-		return false;
+		finally {
+			this.lock.unlock();
+		}
 	}
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -206,4 +206,9 @@ public class Mqttv5ClientManager
 		logger.error("MQTT error occurred", exception);
 	}
 
+	@Override
+	public boolean isConnection() {
+		if(getClient()!=null) return getClient().isConnected();
+		return false;
+	}
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -208,7 +208,9 @@ public class Mqttv5ClientManager
 
 	@Override
 	public boolean isConnection() {
-		if(getClient()!=null) return getClient().isConnected();
+		if (getClient() != null) {
+			return getClient().isConnected();
+		}
 		return false;
 	}
 }

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -208,7 +208,7 @@ public class Mqttv5ClientManager
 	}
 
 	@Override
-	public boolean isConnection() {
+	public boolean isConnected() {
 		this.lock.lock();
 		try {
 			IMqttAsyncClient client = getClient();

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -203,6 +203,9 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 		super.onInit();
 		if (this.clientManager != null) {
 			this.clientManager.addCallback(this);
+			if (this.clientManager.isConnection()){
+				connectComplete(true);
+			}
 		}
 	}
 

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -49,6 +49,7 @@ import org.springframework.util.Assert;
  * @author Trung Pham
  * @author Mikhail Polivakha
  * @author Artem Vozhdayenko
+ * @author Jiri Soucek
  *
  * @since 4.0
  *
@@ -204,7 +205,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 		if (this.clientManager != null) {
 			this.clientManager.addCallback(this);
 			if (this.clientManager.isConnection()) {
-				connectComplete(true);
+				connectComplete(false);
 			}
 		}
 	}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -203,7 +203,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 		super.onInit();
 		if (this.clientManager != null) {
 			this.clientManager.addCallback(this);
-			if (this.clientManager.isConnection()){
+			if (this.clientManager.isConnection()) {
 				connectComplete(true);
 			}
 		}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/AbstractMqttMessageDrivenChannelAdapter.java
@@ -204,7 +204,7 @@ public abstract class AbstractMqttMessageDrivenChannelAdapter<T, C> extends Mess
 		super.onInit();
 		if (this.clientManager != null) {
 			this.clientManager.addCallback(this);
-			if (this.clientManager.isConnection()) {
+			if (this.clientManager.isConnected()) {
 				connectComplete(false);
 			}
 		}

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -188,6 +188,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		}
 
 	}
+
 	@Configuration
 	@EnableIntegration
 	public static class Mqttv3ConfigWithStartedManager {
@@ -328,7 +329,6 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		}
 
 	}
-
 
 	record ClientV3Disconnector(Mqttv3ClientManager clientManager) {
 

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -16,7 +16,9 @@
 
 package org.springframework.integration.mqtt;
 
+import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -29,8 +31,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
 import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.dsl.context.IntegrationFlowContext;
+import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.mqtt.core.ClientManager;
 import org.springframework.integration.mqtt.core.Mqttv3ClientManager;
 import org.springframework.integration.mqtt.core.Mqttv5ClientManager;
 import org.springframework.integration.mqtt.event.MqttSubscribedEvent;
@@ -77,6 +83,12 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 	}
 
 	@Test
+	void testV3ClientManagerRuntime() throws Exception{
+		testSubscribeAndPublishRuntime(Mqttv3ConfigRuntime.class, Mqttv3ConfigRuntime.TOPIC_NAME,
+				Mqttv3ConfigRuntime.subscribedLatch, Mqttv3ConfigRuntime.adapter);
+	}
+
+	@Test
 	void testV5ClientManagerReconnect() throws Exception {
 		testSubscribeAndPublish(Mqttv5ConfigWithDisconnect.class, Mqttv5ConfigWithDisconnect.TOPIC_NAME,
 				Mqttv5ConfigWithDisconnect.subscribedLatch);
@@ -88,6 +100,12 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 				Mqttv5ConfigWithStartedManager.subscribedLatch);
 	}
 
+	@Test
+	void testV5ClientManagerRuntime() throws Exception{
+		testSubscribeAndPublishRuntime(Mqttv5ConfigRuntime.class, Mqttv5ConfigRuntime.TOPIC_NAME,
+				Mqttv5ConfigRuntime.subscribedLatch, Mqttv5ConfigRuntime.adapter);
+	}
+
 	private void testSubscribeAndPublish(Class<?> configClass, String topicName, CountDownLatch subscribedLatch)
 			throws Exception {
 
@@ -95,6 +113,40 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 			// given
 			var input = ctx.getBean("mqttOutFlow.input", MessageChannel.class);
 			var output = ctx.getBean("fromMqttChannel", PollableChannel.class);
+			String testPayload = "foo";
+			assertThat(subscribedLatch.await(20, TimeUnit.SECONDS)).isTrue();
+
+			// when
+			input.send(MessageBuilder.withPayload(testPayload).setHeader(MqttHeaders.TOPIC, topicName).build());
+			Message<?> receive = output.receive(20_000);
+
+			// then
+			assertThat(receive).isNotNull();
+			Object payload = receive.getPayload();
+			if (payload instanceof String sp) {
+				assertThat(sp).isEqualTo(testPayload);
+			}
+			else {
+				assertThat(payload).isEqualTo(testPayload.getBytes(StandardCharsets.UTF_8));
+			}
+		}
+	}
+
+	private void testSubscribeAndPublishRuntime(Class<?> configClass, String topicName, CountDownLatch subscribedLatch, Class<?> adapter)
+			throws Exception {
+
+		try (var ctx = new AnnotationConfigApplicationContext(configClass)) {
+			// given
+			var input = ctx.getBean("mqttOutFlow.input", MessageChannel.class);
+			var flowContext = ctx.getBean(IntegrationFlowContext.class);
+			var clientManager = ctx.getBean(ClientManager.class);
+			var output = new QueueChannel();
+			Class<?>[] parameterTypes = {ClientManager.class, String[].class};
+			Constructor<?> declaredConstructor = adapter.getConstructor(parameterTypes);
+			flowContext.registration(IntegrationFlow
+					.from((MessageProducerSupport) declaredConstructor.newInstance(clientManager,new String[] {topicName}))
+					.channel(output)
+					.get()).register();
 			String testPayload = "foo";
 			assertThat(subscribedLatch.await(20, TimeUnit.SECONDS)).isTrue();
 
@@ -208,6 +260,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 			connectionOptions.setServerURIs(new String[] {MosquittoContainerTest.mqttUrl()});
 			connectionOptions.setAutomaticReconnect(true);
 			Mqttv3ClientManager manager = new Mqttv3ClientManager(connectionOptions, "client-manager-client-id-v3");
+			manager.start();
 			return manager;
 		}
 
@@ -221,6 +274,35 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 			return IntegrationFlow.from(new MqttPahoMessageDrivenChannelAdapter(mqttv3ClientManager, TOPIC_NAME))
 					.channel(c -> c.queue("fromMqttChannel"))
 					.get();
+		}
+
+	}
+	@Configuration
+	@EnableIntegration
+	public static class Mqttv3ConfigRuntime {
+
+		static final String TOPIC_NAME = "test-topic-v3";
+
+		static final CountDownLatch subscribedLatch = new CountDownLatch(1);
+
+		static final Class<?> adapter = MqttPahoMessageDrivenChannelAdapter.class;
+
+		@EventListener
+		public void onSubscribed(MqttSubscribedEvent e) {
+			subscribedLatch.countDown();
+		}
+
+		@Bean
+		public Mqttv3ClientManager mqttv3ClientManager() {
+			MqttConnectOptions connectionOptions = new MqttConnectOptions();
+			connectionOptions.setServerURIs(new String[] {MosquittoContainerTest.mqttUrl()});
+			connectionOptions.setAutomaticReconnect(true);
+            return new Mqttv3ClientManager(connectionOptions, "client-manager-client-id-v3");
+		}
+
+		@Bean
+		public IntegrationFlow mqttOutFlow(Mqttv3ClientManager mqttv3ClientManager) {
+			return f -> f.handle(new MqttPahoMessageHandler(mqttv3ClientManager));
 		}
 
 	}
@@ -326,6 +408,33 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 			return IntegrationFlow.from(new Mqttv5PahoMessageDrivenChannelAdapter(mqttv5ClientManager, TOPIC_NAME))
 					.channel(c -> c.queue("fromMqttChannel"))
 					.get();
+		}
+
+	}
+	@Configuration
+	@EnableIntegration
+	public static class Mqttv5ConfigRuntime {
+
+		static final String TOPIC_NAME = "test-topic-v5";
+
+		static final CountDownLatch subscribedLatch = new CountDownLatch(1);
+
+		static final Class<?> adapter = Mqttv5PahoMessageDrivenChannelAdapter.class;
+
+		@EventListener
+		public void onSubscribed(MqttSubscribedEvent e) {
+			subscribedLatch.countDown();
+		}
+
+		@Bean
+		public Mqttv5ClientManager mqttv5ClientManager() {
+			return new Mqttv5ClientManager(MosquittoContainerTest.mqttUrl(), "client-manager-client-id-v5");
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "mqttOutFlow.input")
+		public Mqttv5PahoMessageHandler mqttv5PahoMessageHandler(Mqttv5ClientManager mqttv5ClientManager) {
+			return new Mqttv5PahoMessageHandler(mqttv5ClientManager);
 		}
 
 	}

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -18,7 +18,6 @@ package org.springframework.integration.mqtt;
 
 import java.lang.reflect.Constructor;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -83,7 +82,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 	}
 
 	@Test
-	void testV3ClientManagerRuntime() throws Exception{
+	void testV3ClientManagerRuntime() throws Exception {
 		testSubscribeAndPublishRuntime(Mqttv3ConfigRuntime.class, Mqttv3ConfigRuntime.TOPIC_NAME,
 				Mqttv3ConfigRuntime.subscribedLatch, Mqttv3ConfigRuntime.adapter);
 	}
@@ -101,7 +100,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 	}
 
 	@Test
-	void testV5ClientManagerRuntime() throws Exception{
+	void testV5ClientManagerRuntime() throws Exception {
 		testSubscribeAndPublishRuntime(Mqttv5ConfigRuntime.class, Mqttv5ConfigRuntime.TOPIC_NAME,
 				Mqttv5ConfigRuntime.subscribedLatch, Mqttv5ConfigRuntime.adapter);
 	}
@@ -144,7 +143,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 			Class<?>[] parameterTypes = {ClientManager.class, String[].class};
 			Constructor<?> declaredConstructor = adapter.getConstructor(parameterTypes);
 			flowContext.registration(IntegrationFlow
-					.from((MessageProducerSupport) declaredConstructor.newInstance(clientManager,new String[] {topicName}))
+					.from((MessageProducerSupport) declaredConstructor.newInstance(clientManager, new String[] {topicName}))
 					.channel(output)
 					.get()).register();
 			String testPayload = "foo";
@@ -277,6 +276,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		}
 
 	}
+
 	@Configuration
 	@EnableIntegration
 	public static class Mqttv3ConfigRuntime {
@@ -297,7 +297,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 			MqttConnectOptions connectionOptions = new MqttConnectOptions();
 			connectionOptions.setServerURIs(new String[] {MosquittoContainerTest.mqttUrl()});
 			connectionOptions.setAutomaticReconnect(true);
-            return new Mqttv3ClientManager(connectionOptions, "client-manager-client-id-v3");
+			return new Mqttv3ClientManager(connectionOptions, "client-manager-client-id-v3");
 		}
 
 		@Bean
@@ -411,6 +411,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		}
 
 	}
+
 	@Configuration
 	@EnableIntegration
 	public static class Mqttv5ConfigRuntime {

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -75,12 +75,6 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 	}
 
 	@Test
-	void testV3ClientManagerStarted() throws Exception {
-		testSubscribeAndPublish(Mqttv3ConfigWithStartedManager.class, Mqttv3ConfigWithStartedManager.TOPIC_NAME,
-				Mqttv3ConfigWithStartedManager.subscribedLatch);
-	}
-
-	@Test
 	void testV3ClientManagerRuntime() throws Exception {
 		testSubscribeAndPublishRuntime(Mqttv3ConfigRuntime.class, Mqttv3ConfigRuntime.TOPIC_NAME,
 				Mqttv3ConfigRuntime.subscribedLatch);
@@ -90,12 +84,6 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 	void testV5ClientManagerReconnect() throws Exception {
 		testSubscribeAndPublish(Mqttv5ConfigWithDisconnect.class, Mqttv5ConfigWithDisconnect.TOPIC_NAME,
 				Mqttv5ConfigWithDisconnect.subscribedLatch);
-	}
-
-	@Test
-	void testV5ClientManagerStarted() throws Exception {
-		testSubscribeAndPublish(Mqttv5ConfigWithStartedManager.class, Mqttv5ConfigWithStartedManager.TOPIC_NAME,
-				Mqttv5ConfigWithStartedManager.subscribedLatch);
 	}
 
 	@Test
@@ -240,43 +228,6 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 
 	@Configuration
 	@EnableIntegration
-	public static class Mqttv3ConfigWithStartedManager {
-
-		static final String TOPIC_NAME = "test-topic-v3";
-
-		static final CountDownLatch subscribedLatch = new CountDownLatch(1);
-
-		@EventListener
-		public void onSubscribed(MqttSubscribedEvent e) {
-			subscribedLatch.countDown();
-		}
-
-		@Bean
-		public Mqttv3ClientManager mqttv3ClientManager() {
-			MqttConnectOptions connectionOptions = new MqttConnectOptions();
-			connectionOptions.setServerURIs(new String[] {MosquittoContainerTest.mqttUrl()});
-			connectionOptions.setAutomaticReconnect(true);
-			Mqttv3ClientManager manager = new Mqttv3ClientManager(connectionOptions, "client-manager-client-id-v3");
-			manager.start();
-			return manager;
-		}
-
-		@Bean
-		public IntegrationFlow mqttOutFlow(Mqttv3ClientManager mqttv3ClientManager) {
-			return f -> f.handle(new MqttPahoMessageHandler(mqttv3ClientManager));
-		}
-
-		@Bean
-		public IntegrationFlow mqttInFlow(Mqttv3ClientManager mqttv3ClientManager) {
-			return IntegrationFlow.from(new MqttPahoMessageDrivenChannelAdapter(mqttv3ClientManager, TOPIC_NAME))
-					.channel(c -> c.queue("fromMqttChannel"))
-					.get();
-		}
-
-	}
-
-	@Configuration
-	@EnableIntegration
 	public static class Mqttv3ConfigRuntime implements MessageDrivenChannelAdapterFactory {
 
 		static final String TOPIC_NAME = "test-topic-v3";
@@ -367,41 +318,6 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		@Bean
 		public IntegrationFlow mqttOutFlow(Mqttv5ClientManager mqttv5ClientManager) {
 			return f -> f.handle(new Mqttv5PahoMessageHandler(MosquittoContainerTest.mqttUrl(), "old-client-v5"));
-		}
-
-		@Bean
-		public IntegrationFlow mqttInFlow(Mqttv5ClientManager mqttv5ClientManager) {
-			return IntegrationFlow.from(new Mqttv5PahoMessageDrivenChannelAdapter(mqttv5ClientManager, TOPIC_NAME))
-					.channel(c -> c.queue("fromMqttChannel"))
-					.get();
-		}
-
-	}
-
-	@Configuration
-	@EnableIntegration
-	public static class Mqttv5ConfigWithStartedManager {
-
-		static final String TOPIC_NAME = "test-topic-v5";
-
-		static final CountDownLatch subscribedLatch = new CountDownLatch(1);
-
-		@EventListener
-		public void onSubscribed(MqttSubscribedEvent e) {
-			subscribedLatch.countDown();
-		}
-
-		@Bean
-		public Mqttv5ClientManager mqttv5ClientManager() {
-			Mqttv5ClientManager manager = new Mqttv5ClientManager(MosquittoContainerTest.mqttUrl(), "client-manager-client-id-v5");
-			manager.start();
-			return manager;
-		}
-
-		@Bean
-		@ServiceActivator(inputChannel = "mqttOutFlow.input")
-		public Mqttv5PahoMessageHandler mqttv5PahoMessageHandler(Mqttv5ClientManager mqttv5ClientManager) {
-			return new Mqttv5PahoMessageHandler(mqttv5ClientManager);
 		}
 
 		@Bean

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -71,9 +71,21 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 	}
 
 	@Test
+	void testV3ClientManagerStarted() throws Exception {
+		testSubscribeAndPublish(Mqttv3ConfigWithStartedManager.class, Mqttv3ConfigWithStartedManager.TOPIC_NAME,
+				Mqttv3ConfigWithStartedManager.subscribedLatch);
+	}
+
+	@Test
 	void testV5ClientManagerReconnect() throws Exception {
 		testSubscribeAndPublish(Mqttv5ConfigWithDisconnect.class, Mqttv5ConfigWithDisconnect.TOPIC_NAME,
 				Mqttv5ConfigWithDisconnect.subscribedLatch);
+	}
+
+	@Test
+	void testV5ClientManagerStarted() throws Exception {
+		testSubscribeAndPublish(Mqttv5ConfigWithStartedManager.class, Mqttv5ConfigWithStartedManager.TOPIC_NAME,
+				Mqttv5ConfigWithStartedManager.subscribedLatch);
 	}
 
 	private void testSubscribeAndPublish(Class<?> configClass, String topicName, CountDownLatch subscribedLatch)
@@ -176,6 +188,41 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		}
 
 	}
+	@Configuration
+	@EnableIntegration
+	public static class Mqttv3ConfigWithStartedManager {
+
+		static final String TOPIC_NAME = "test-topic-v3";
+
+		static final CountDownLatch subscribedLatch = new CountDownLatch(1);
+
+		@EventListener
+		public void onSubscribed(MqttSubscribedEvent e) {
+			subscribedLatch.countDown();
+		}
+
+		@Bean
+		public Mqttv3ClientManager mqttv3ClientManager() {
+			MqttConnectOptions connectionOptions = new MqttConnectOptions();
+			connectionOptions.setServerURIs(new String[] {MosquittoContainerTest.mqttUrl()});
+			connectionOptions.setAutomaticReconnect(true);
+			Mqttv3ClientManager manager = new Mqttv3ClientManager(connectionOptions, "client-manager-client-id-v3");
+			return manager;
+		}
+
+		@Bean
+		public IntegrationFlow mqttOutFlow(Mqttv3ClientManager mqttv3ClientManager) {
+			return f -> f.handle(new MqttPahoMessageHandler(mqttv3ClientManager));
+		}
+
+		@Bean
+		public IntegrationFlow mqttInFlow(Mqttv3ClientManager mqttv3ClientManager) {
+			return IntegrationFlow.from(new MqttPahoMessageDrivenChannelAdapter(mqttv3ClientManager, TOPIC_NAME))
+					.channel(c -> c.queue("fromMqttChannel"))
+					.get();
+		}
+
+	}
 
 	@Configuration
 	@EnableIntegration
@@ -246,6 +293,42 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		}
 
 	}
+
+	@Configuration
+	@EnableIntegration
+	public static class Mqttv5ConfigWithStartedManager {
+
+		static final String TOPIC_NAME = "test-topic-v5";
+
+		static final CountDownLatch subscribedLatch = new CountDownLatch(1);
+
+		@EventListener
+		public void onSubscribed(MqttSubscribedEvent e) {
+			subscribedLatch.countDown();
+		}
+
+		@Bean
+		public Mqttv5ClientManager mqttv5ClientManager() {
+			Mqttv5ClientManager manager = new Mqttv5ClientManager(MosquittoContainerTest.mqttUrl(), "client-manager-client-id-v5");
+			manager.start();
+			return manager;
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "mqttOutFlow.input")
+		public Mqttv5PahoMessageHandler mqttv5PahoMessageHandler(Mqttv5ClientManager mqttv5ClientManager) {
+			return new Mqttv5PahoMessageHandler(mqttv5ClientManager);
+		}
+
+		@Bean
+		public IntegrationFlow mqttInFlow(Mqttv5ClientManager mqttv5ClientManager) {
+			return IntegrationFlow.from(new Mqttv5PahoMessageDrivenChannelAdapter(mqttv5ClientManager, TOPIC_NAME))
+					.channel(c -> c.queue("fromMqttChannel"))
+					.get();
+		}
+
+	}
+
 
 	record ClientV3Disconnector(Mqttv3ClientManager clientManager) {
 

--- a/src/reference/antora/modules/ROOT/pages/mqtt.adoc
+++ b/src/reference/antora/modules/ROOT/pages/mqtt.adoc
@@ -382,9 +382,9 @@ public class MqttJavaApplication {
             .run(args);
     }
 
-   	@Bean
-   	public IntegrationFlow mqttOutboundFlow() {
-   	    return f -> f.handle(new MqttPahoMessageHandler("tcp://host1:1883", "someMqttClient"));
+       @Bean
+       public IntegrationFlow mqttOutboundFlow() {
+           return f -> f.handle(new MqttPahoMessageHandler("tcp://host1:1883", "someMqttClient"));
     }
 
 }
@@ -553,14 +553,14 @@ NOTE: Starting with version 6.4, multiple instances of `MqttPahoMessageDrivenCha
 
 [source,java]
 ----
-private void addAddRuntimeAdapter(IntegrationFlowContext flowContext,Mqttv5ClientManager clientManager,
-								  String topic,MessageChannel channel){
-	flowContext
-		.registration(
-			IntegrationFlow
-				.from(new Mqttv5PahoMessageDrivenChannelAdapter(clientManager, topic))
-				.channel(channel)
-				.get())
-		.register();
+private void addAddRuntimeAdapter(IntegrationFlowContext flowContext, Mqttv5ClientManager clientManager,
+                                  String topic, MessageChannel channel) {
+    flowContext
+        .registration(
+            IntegrationFlow
+                .from(new Mqttv5PahoMessageDrivenChannelAdapter(clientManager, topic))
+                .channel(channel)
+                .get())
+        .register();
 }
 ----

--- a/src/reference/antora/modules/ROOT/pages/mqtt.adoc
+++ b/src/reference/antora/modules/ROOT/pages/mqtt.adoc
@@ -548,3 +548,19 @@ public IntegrationFlow mqttOutFlow(
     return f -> f.handle(new Mqttv5PahoMessageHandler(clientManager));
 }
 ----
+
+NOTE: Starting with version 6.4, multiple instances of `MqttPahoMessageDrivenChannelAdapter` and `Mqttv5PahoMessageDrivenChannelAdapter` can now be added at runtime using corresponding `ClientManager` through `IntegrationFlowContext`
+
+[source,java]
+----
+private void addAddRuntimeAdapter(IntegrationFlowContext flowContext,Mqttv5ClientManager clientManager,
+								  String topic,MessageChannel channel){
+	flowContext
+		.registration(
+			IntegrationFlow
+				.from(new Mqttv5PahoMessageDrivenChannelAdapter(clientManager, topic))
+				.channel(channel)
+				.get())
+		.register();
+}
+----

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -61,8 +61,16 @@ See xref:redis.adoc[Redis Support] for more information.
 The `ControlBusFactoryBean` (and respective `<int-groovy:control-bus>` XML tag) has been deprecated (for removal) in favor of new introduced `ControlBusFactoryBean` based on a new model implemented in the `ControlBusCommandRegistry`.
 See xref:control-bus.adoc[Control Bus] for more information.
 
+
 [[x6.4-sftp-changes]]
 === SFTP Support Changes
 
 The `DefaultSftpSessionFactory` now exposes a `Consumer<SshClient>` configurer property to further customize an internal `SshClient`.
 See xref:sftp/session-factory.adoc[SFTP Session Factory] for more information.
+
+[[x6.4-mqtt-changes]]
+=== mqtt Changes
+
+Multiple instances of `MqttPahoMessageDrivenChannelAdapter` and `Mqttv5PahoMessageDrivenChannelAdapter` can now be added at runtime using corresponding `ClientManager` through `IntegrationFlowContext`
+See xref:mqtt.adoc[MQTT Support] for more information.
+

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -68,8 +68,8 @@ See xref:control-bus.adoc[Control Bus] for more information.
 The `DefaultSftpSessionFactory` now exposes a `Consumer<SshClient>` configurer property to further customize an internal `SshClient`.
 See xref:sftp/session-factory.adoc[SFTP Session Factory] for more information.
 
-[[x6.4-mqtt-changes]]
-=== mqtt Changes
+[[x6.4-mqtt-support-changes]]
+=== MQTT Support Changes
 
 Multiple instances of `MqttPahoMessageDrivenChannelAdapter` and `Mqttv5PahoMessageDrivenChannelAdapter` can now be added at runtime using corresponding `ClientManager` through `IntegrationFlowContext`
 See xref:mqtt.adoc[MQTT Support] for more information.


### PR DESCRIPTION
Fixes: #9368 

Currently, it is not possible to add `MqttMessageDrivenChannelAdapter` after `MqttClient` is connected, using `ClientManager` in constructor.

* Exposed `isConnection()` in `ClientManager` 
* Implemented `isConnection()` in `Mqttv3ClientManager` and `Mqttv5ClientManager`
* Modified `OnInit()` in `AbstractMqttMessageDrivenChannelAdapter` to set `readyToSubscribeOnStart` = true
* Added tests to `ClientManagerBackToBackTests` to check functionality (`testV3ClientManagerStarted`, `testV5ClientManagerStarted`) 
