### PR TITLE
GH:9398: Possibility to have multiple leaders

### DIFF
--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/leader/LeaderInitiator.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/leader/LeaderInitiator.java
@@ -56,6 +56,7 @@ import org.springframework.util.Assert;
  * @author Alexey Tsoy
  * @author Robert Höglund
  * @author Christian Tzolov
+ * @author Emil Palm
  */
 public class LeaderInitiator implements SmartLifecycle, DisposableBean, ApplicationEventPublisherAware {
 
@@ -316,6 +317,10 @@ public class LeaderInitiator implements SmartLifecycle, DisposableBean, Applicat
 								// Success: we are now leader
 								this.leader = true;
 								handleGranted();
+							}
+							if (!acquired && this.leader) {
+								//If we no longer can acquire the lock but still have the leader status
+								revokeLeadership();
 							}
 						}
 					}


### PR DESCRIPTION
Fixes: gh-9398

Adding a check if the node have the leader property set but can't acquire the leadership lock. If this happens, the node should revoke the leadership since another node is the "true leader"

As described in issue #9398, there is a possibility that multiple nodes have the leader field set to true while only one node can actually get the distributed fenced lock.
