### PR TITLE
GH-9401 Fix lock issue in RedisLockRegistry runRedisMessageListenerContainer

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -87,6 +87,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Eddie Cho
  * @author Myeonghyeon Lee
  * @author Roman Zabaluev
+ * @author Alex Peelman
  *
  * @since 4.0
  *
@@ -658,7 +659,7 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 		}
 
 		private void runRedisMessageListenerContainer() {
-			RedisLockRegistry.this.lock.tryLock();
+			RedisLockRegistry.this.lock.lock();
 			try {
 				if (!(RedisLockRegistry.this.isRunningRedisMessageListenerContainer
 						&& RedisLockRegistry.this.redisMessageListenerContainer != null


### PR DESCRIPTION
Switched `tryLock()` with `lock()` in RedisLockRegistry in `runRedisMessageListenerContainer` method for correct synchronization.
