### PR TITLE
GH-9427: Improve nullability for remote path expression

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -153,10 +153,14 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 	/**
 	 * Construct an instance with the supplied session factory,
-	 * a command ('ls', 'get' etc.), and an expression to determine the filename.
+	 * a command ('ls', 'get' etc.), and an expression to determine the remote path (file or directory).
+	 * The expression is treated as a remote directory for {@code ls} and {@code nlst} commands
+	 * and can be {@code null} if remote file protocol supports it with a meaning of root directory (or use home).
+	 * The {@code put} and {@code mput} commands ignore this expression and fully rely on the payload.
+	 * If expression is not provided, it falls back to the {@code payload}.
 	 * @param sessionFactory the session factory.
 	 * @param command the command.
-	 * @param expression the filename expression.
+	 * @param expression the remote path.
 	 */
 	public AbstractRemoteFileOutboundGateway(SessionFactory<F> sessionFactory, String command,
 			@Nullable String expression) {
@@ -166,10 +170,14 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 	/**
 	 * Construct an instance with the supplied session factory,
-	 * a command ('ls', 'get' etc.), and an expression to determine the filename.
+	 * a command ('ls', 'get' etc.), and an expression to determine the remote path (file or directory).
+	 * The expression is treated as a remote directory for {@code ls} and {@code nlst} commands
+	 * and can be {@code null} if remote file protocol supports it with a meaning of root directory (or use home).
+	 * The {@code put} and {@code mput} commands ignore this expression and fully rely on the payload.
+	 * If expression is not provided, it falls back to the {@code payload}.
 	 * @param sessionFactory the session factory.
 	 * @param command the command.
-	 * @param expression the filename expression.
+	 * @param expression the remote path.
 	 */
 	public AbstractRemoteFileOutboundGateway(SessionFactory<F> sessionFactory, Command command,
 			@Nullable String expression) {
@@ -180,10 +188,14 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 	/**
 	 * Construct an instance with the supplied remote file template,
-	 * a command ('ls', 'get' etc.), and an expression to determine the filename.
+	 * a command ('ls', 'get' etc.), and an expression to determine the remote path (file or directory).
+	 * The expression is treated as a remote directory for {@code ls} and {@code nlst} commands
+	 * and can be {@code null} if remote file protocol supports it with a meaning of root directory (or use home).
+	 * The {@code put} and {@code mput} commands ignore this expression and fully rely on the payload.
+	 * If expression is not provided, it falls back to the {@code payload}.
 	 * @param remoteFileTemplate the remote file template.
 	 * @param command the command.
-	 * @param expression the filename expression.
+	 * @param expression the remote path.
 	 */
 	public AbstractRemoteFileOutboundGateway(RemoteFileTemplate<F> remoteFileTemplate, String command,
 			@Nullable String expression) {
@@ -193,10 +205,14 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 	/**
 	 * Construct an instance with the supplied remote file template,
-	 * a command ('ls', 'get' etc.), and an expression to determine the filename.
+	 * a command ('ls', 'get' etc.), and an expression to determine the remote path (file or directory).
+	 * The expression is treated as a remote directory for {@code ls} and {@code nlst} commands
+	 * and can be {@code null} if remote file protocol supports it with a meaning of root directory (or use home).
+	 * The {@code put} and {@code mput} commands ignore this expression and fully rely on the payload.
+	 * If expression is not provided, it falls back to the {@code payload}.
 	 * @param remoteFileTemplate the remote file template.
 	 * @param command the command.
-	 * @param expressionArg the filename expression.
+	 * @param expressionArg the remote path.
 	 */
 	public AbstractRemoteFileOutboundGateway(RemoteFileTemplate<F> remoteFileTemplate, Command command,
 			@Nullable String expressionArg) {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/Ftp.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/dsl/Ftp.java
@@ -134,42 +134,84 @@ public final class Ftp {
 
 	/**
 	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link SessionFactory},
-	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
-	 * remoteFilePath.
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
 	 * @param sessionFactory the {@link SessionFactory}.
 	 * @param command the command to perform on the FTP.
-	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link FtpOutboundGatewaySpec}
+	 * @since 6.4
+	 */
+	public static FtpOutboundGatewaySpec outboundGateway(SessionFactory<FTPFile> sessionFactory,
+			AbstractRemoteFileOutboundGateway.Command command) {
+
+		return outboundGateway(sessionFactory, command.getCommand(), null);
+	}
+
+	/**
+	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link SessionFactory},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
+	 * remote path.
+	 * @param sessionFactory the {@link SessionFactory}.
+	 * @param command the command to perform on the FTP.
+	 * @param expression the remote path SpEL expression.
 	 * @return the {@link FtpOutboundGatewaySpec}
 	 */
 	public static FtpOutboundGatewaySpec outboundGateway(SessionFactory<FTPFile> sessionFactory,
-			AbstractRemoteFileOutboundGateway.Command command, String expression) {
+			AbstractRemoteFileOutboundGateway.Command command, @Nullable String expression) {
 
 		return outboundGateway(sessionFactory, command.getCommand(), expression);
 	}
 
 	/**
 	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link SessionFactory},
-	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
-	 * remoteFilePath.
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
 	 * @param sessionFactory the {@link SessionFactory}.
 	 * @param command the command to perform on the FTP.
-	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link FtpOutboundGatewaySpec}
+	 * @since 6.4
+	 * @see RemoteFileTemplate
+	 */
+	public static FtpOutboundGatewaySpec outboundGateway(SessionFactory<FTPFile> sessionFactory, String command) {
+		return outboundGateway(sessionFactory, command, null);
+	}
+
+	/**
+	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link SessionFactory},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
+	 * remote path.
+	 * @param sessionFactory the {@link SessionFactory}.
+	 * @param command the command to perform on the FTP.
+	 * @param expression the remote path SpEL expression.
 	 * @return the {@link FtpOutboundGatewaySpec}
 	 * @see RemoteFileTemplate
 	 */
 	public static FtpOutboundGatewaySpec outboundGateway(SessionFactory<FTPFile> sessionFactory,
-			String command, String expression) {
+			String command, @Nullable String expression) {
 
 		return new FtpOutboundGatewaySpec(new FtpOutboundGateway(sessionFactory, command, expression));
 	}
 
 	/**
 	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
-	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
-	 * remoteFilePath.
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
 	 * @param remoteFileTemplate the {@link RemoteFileTemplate}.
 	 * @param command the command to perform on the FTP.
-	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link FtpOutboundGatewaySpec}
+	 * @since 6.4
+	 * @see RemoteFileTemplate
+	 */
+	public static FtpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<FTPFile> remoteFileTemplate,
+			AbstractRemoteFileOutboundGateway.Command command) {
+
+		return outboundGateway(remoteFileTemplate, command, null);
+	}
+
+	/**
+	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
+	 * remote path.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate}.
+	 * @param command the command to perform on the FTP.
+	 * @param expression the remote path SpEL expression.
 	 * @return the {@link FtpOutboundGatewaySpec}
 	 * @see RemoteFileTemplate
 	 */
@@ -181,16 +223,31 @@ public final class Ftp {
 
 	/**
 	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
-	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
-	 * remoteFilePath.
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
 	 * @param remoteFileTemplate the {@link RemoteFileTemplate}.
 	 * @param command the command to perform on the FTP.
-	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link FtpOutboundGatewaySpec}
+	 * @since 6.4
+	 * @see RemoteFileTemplate
+	 */
+	public static FtpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<FTPFile> remoteFileTemplate,
+			String command) {
+
+		return outboundGateway(remoteFileTemplate, command, null);
+	}
+
+	/**
+	 * Produce a {@link FtpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
+	 * remote path.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate}.
+	 * @param command the command to perform on the FTP.
+	 * @param expression the remote path SpEL expression.
 	 * @return the {@link FtpOutboundGatewaySpec}
 	 * @see RemoteFileTemplate
 	 */
 	public static FtpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<FTPFile> remoteFileTemplate,
-			String command, String expression) {
+			String command, @Nullable String expression) {
 
 		return new FtpOutboundGatewaySpec(new FtpOutboundGateway(remoteFileTemplate, command, expression));
 	}

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.integration.file.remote.session.Session;
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.ftp.session.FtpFileInfo;
 import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 
 /**
@@ -85,12 +86,12 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 
 	/**
 	 * Construct an instance with the supplied session factory, a command ('ls', 'get'
-	 * etc), and an expression to determine the filename.
+	 * etc.), and an expression to determine the remote path.
 	 * @param sessionFactory the session factory.
 	 * @param command the command.
-	 * @param expression the filename expression.
+	 * @param expression the remote path expression.
 	 */
-	public FtpOutboundGateway(SessionFactory<FTPFile> sessionFactory, String command, String expression) {
+	public FtpOutboundGateway(SessionFactory<FTPFile> sessionFactory, String command, @Nullable String expression) {
 		this(new FtpRemoteFileTemplate(sessionFactory), command, expression);
 		((FtpRemoteFileTemplate) getRemoteFileTemplate()).setExistsMode(FtpRemoteFileTemplate.ExistsMode.NLST);
 		remoteFileTemplateExplicitlySet(false);
@@ -98,12 +99,14 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 
 	/**
 	 * Construct an instance with the supplied remote file template, a command ('ls',
-	 * 'get' etc), and an expression to determine the filename.
+	 * 'get' etc.), and an expression to determine the remote path.
 	 * @param remoteFileTemplate the remote file template.
 	 * @param command the command.
-	 * @param expression the filename expression.
+	 * @param expression the remote path expression.
 	 */
-	public FtpOutboundGateway(RemoteFileTemplate<FTPFile> remoteFileTemplate, String command, String expression) {
+	public FtpOutboundGateway(RemoteFileTemplate<FTPFile> remoteFileTemplate, String command,
+			@Nullable String expression) {
+
 		super(remoteFileTemplate, command, expression);
 	}
 

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/dsl/Sftp.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,6 +134,20 @@ public final class Sftp {
 
 	/**
 	 * Produce a {@link SftpOutboundGatewaySpec} based on the {@link SessionFactory},
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
+	 * @param sessionFactory the {@link SessionFactory}.
+	 * @param command the command to perform on the FTP.
+	 * @return the {@link SftpOutboundGatewaySpec}
+	 * @since 6.4
+	 */
+	public static SftpOutboundGatewaySpec outboundGateway(SessionFactory<SftpClient.DirEntry> sessionFactory,
+			AbstractRemoteFileOutboundGateway.Command command) {
+
+		return outboundGateway(sessionFactory, command, null);
+	}
+
+	/**
+	 * Produce a {@link SftpOutboundGatewaySpec} based on the {@link SessionFactory},
 	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
 	 * remoteFilePath.
 	 * @param sessionFactory the {@link SessionFactory}.
@@ -142,9 +156,24 @@ public final class Sftp {
 	 * @return the {@link SftpOutboundGatewaySpec}
 	 */
 	public static SftpOutboundGatewaySpec outboundGateway(SessionFactory<SftpClient.DirEntry> sessionFactory,
-			AbstractRemoteFileOutboundGateway.Command command, String expression) {
+			AbstractRemoteFileOutboundGateway.Command command, @Nullable String expression) {
 
 		return outboundGateway(sessionFactory, command.getCommand(), expression);
+	}
+
+	/**
+	 * Produce a {@link SftpOutboundGatewaySpec} based on the {@link SessionFactory},
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
+	 * @param sessionFactory the {@link SessionFactory}.
+	 * @param command the command to perform on the FTP.
+	 * @return the {@link SftpOutboundGatewaySpec}
+	 * @since 6.4
+	 * @see RemoteFileTemplate
+	 */
+	public static SftpOutboundGatewaySpec outboundGateway(SessionFactory<SftpClient.DirEntry> sessionFactory,
+			String command) {
+
+		return outboundGateway(sessionFactory, command, null);
 	}
 
 	/**
@@ -158,24 +187,54 @@ public final class Sftp {
 	 * @see RemoteFileTemplate
 	 */
 	public static SftpOutboundGatewaySpec outboundGateway(SessionFactory<SftpClient.DirEntry> sessionFactory,
-			String command, String expression) {
+			String command, @Nullable String expression) {
 
 		return new SftpOutboundGatewaySpec(new SftpOutboundGateway(sessionFactory, command, expression));
 	}
 
 	/**
 	 * Produce a {@link SftpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
-	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the remoteFilePath.
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
 	 * @param remoteFileTemplate the {@link RemoteFileTemplate} to be based on.
 	 * @param command the command to perform on the SFTP.
-	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link SftpOutboundGatewaySpec}
+	 * @since 6.4
+	 * @see RemoteFileTemplate
+	 */
+	public static SftpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<SftpClient.DirEntry> remoteFileTemplate,
+			AbstractRemoteFileOutboundGateway.Command command) {
+
+		return outboundGateway(remoteFileTemplate, command, null);
+	}
+
+	/**
+	 * Produce a {@link SftpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the remote path.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate} to be based on.
+	 * @param command the command to perform on the SFTP.
+	 * @param expression the remote path SpEL expression.
 	 * @return the {@link SftpOutboundGatewaySpec}
 	 * @see RemoteFileTemplate
 	 */
 	public static SftpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<SftpClient.DirEntry> remoteFileTemplate,
-			AbstractRemoteFileOutboundGateway.Command command, String expression) {
+			AbstractRemoteFileOutboundGateway.Command command, @Nullable String expression) {
 
 		return outboundGateway(remoteFileTemplate, command.getCommand(), expression);
+	}
+
+	/**
+	 * Produce a {@link SftpOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate} to be based on.
+	 * @param command the command to perform on the SFTP.
+	 * @return the {@link SftpOutboundGatewaySpec}
+	 * @since 6.4
+	 * @see RemoteFileTemplate
+	 */
+	public static SftpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<SftpClient.DirEntry> remoteFileTemplate,
+			String command) {
+
+		return outboundGateway(remoteFileTemplate, command, null);
 	}
 
 	/**
@@ -188,7 +247,7 @@ public final class Sftp {
 	 * @see RemoteFileTemplate
 	 */
 	public static SftpOutboundGatewaySpec outboundGateway(RemoteFileTemplate<SftpClient.DirEntry> remoteFileTemplate,
-			String command, String expression) {
+			String command, @Nullable String expression) {
 
 		return new SftpOutboundGatewaySpec(new SftpOutboundGateway(remoteFileTemplate, command, expression));
 	}

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOut
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.sftp.session.SftpFileInfo;
 import org.springframework.integration.sftp.session.SftpRemoteFileTemplate;
+import org.springframework.lang.Nullable;
 
 /**
  * Outbound Gateway for performing remote file operations via SFTP.
@@ -71,24 +72,28 @@ public class SftpOutboundGateway extends AbstractRemoteFileOutboundGateway<SftpC
 
 	/**
 	 * Construct an instance with the supplied session factory, a command ('ls', 'get'
-	 * etc), and an expression to determine the filename.
+	 * etc.), and an expression to determine the remote path.
 	 * @param sessionFactory the session factory.
 	 * @param command the command.
-	 * @param expression the filename expression.
+	 * @param expression the remote path expression.
 	 */
-	public SftpOutboundGateway(SessionFactory<SftpClient.DirEntry> sessionFactory, String command, String expression) {
+	public SftpOutboundGateway(SessionFactory<SftpClient.DirEntry> sessionFactory, String command,
+			@Nullable String expression) {
+
 		this(new SftpRemoteFileTemplate(sessionFactory), command, expression);
 		remoteFileTemplateExplicitlySet(false);
 	}
 
 	/**
 	 * Construct an instance with the supplied remote file template, a command ('ls',
-	 * 'get' etc), and an expression to determine the filename.
+	 * 'get' etc.), and an expression to determine the remote path.
 	 * @param remoteFileTemplate the remote file template.
 	 * @param command the command.
-	 * @param expression the filename expression.
+	 * @param expression the remote path expression.
 	 */
-	public SftpOutboundGateway(RemoteFileTemplate<SftpClient.DirEntry> remoteFileTemplate, String command, String expression) {
+	public SftpOutboundGateway(RemoteFileTemplate<SftpClient.DirEntry> remoteFileTemplate, String command,
+			@Nullable String expression) {
+
 		super(remoteFileTemplate, command, expression);
 	}
 

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/Smb.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/Smb.java
@@ -131,49 +131,75 @@ public final class Smb {
 
 	/**
 	 * Produce a {@link SmbOutboundGatewaySpec} based on the {@link SessionFactory},
-	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
-	 * remoteFilePath.
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
 	 * @param sessionFactory the {@link SessionFactory}.
 	 * @param command the command to perform on the SMB.
-	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link SmbOutboundGatewaySpec}
+	 * @since 6.4
+	 */
+	public static SmbOutboundGatewaySpec outboundGateway(SessionFactory<SmbFile> sessionFactory,
+			AbstractRemoteFileOutboundGateway.Command command) {
+
+		return outboundGateway(sessionFactory, command, null);
+	}
+
+	/**
+	 * Produce a {@link SmbOutboundGatewaySpec} based on the {@link SessionFactory},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
+	 * remote path.
+	 * @param sessionFactory the {@link SessionFactory}.
+	 * @param command the command to perform on the SMB.
+	 * @param expression the remote path SpEL expression.
 	 * @return the {@link SmbOutboundGatewaySpec}
 	 */
 	public static SmbOutboundGatewaySpec outboundGateway(SessionFactory<SmbFile> sessionFactory,
-			AbstractRemoteFileOutboundGateway.Command command, String expression) {
+			AbstractRemoteFileOutboundGateway.Command command, @Nullable String expression) {
 
 		return outboundGateway(sessionFactory, command.getCommand(), expression);
 	}
 
 	/**
 	 * Produce a {@link SmbOutboundGatewaySpec} based on the {@link SessionFactory},
-	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
-	 * remoteFilePath.
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
 	 * @param sessionFactory the {@link SessionFactory}.
 	 * @param command the command to perform on the SMB.
-	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link SmbOutboundGatewaySpec}
+	 * @since 6.4
+	 * @see RemoteFileTemplate
+	 */
+	public static SmbOutboundGatewaySpec outboundGateway(SessionFactory<SmbFile> sessionFactory, String command) {
+		return outboundGateway(sessionFactory, command, null);
+	}
+
+	/**
+	 * Produce a {@link SmbOutboundGatewaySpec} based on the {@link SessionFactory},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
+	 * remote path.
+	 * @param sessionFactory the {@link SessionFactory}.
+	 * @param command the command to perform on the SMB.
+	 * @param expression the remote path SpEL expression.
 	 * @return the {@link SmbOutboundGatewaySpec}
 	 * @see RemoteFileTemplate
 	 */
 	public static SmbOutboundGatewaySpec outboundGateway(SessionFactory<SmbFile> sessionFactory,
-			String command, String expression) {
+			String command, @Nullable String expression) {
 
 		return new SmbOutboundGatewaySpec(new SmbOutboundGateway(sessionFactory, command, expression));
 	}
 
 	/**
 	 * Produce a {@link SmbOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
-	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
-	 * remoteFilePath.
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
 	 * @param remoteFileTemplate the {@link RemoteFileTemplate}.
 	 * @param command the command to perform on the SMB.
-	 * @param expression the remoteFilePath SpEL expression.
 	 * @return the {@link SmbOutboundGatewaySpec}
+	 * @since 6.4
 	 * @see RemoteFileTemplate
 	 */
 	public static SmbOutboundGatewaySpec outboundGateway(RemoteFileTemplate<SmbFile> remoteFileTemplate,
-			AbstractRemoteFileOutboundGateway.Command command, String expression) {
+			AbstractRemoteFileOutboundGateway.Command command) {
 
-		return outboundGateway(remoteFileTemplate, command.getCommand(), expression);
+		return outboundGateway(remoteFileTemplate, command, null);
 	}
 
 	/**
@@ -187,7 +213,38 @@ public final class Smb {
 	 * @see RemoteFileTemplate
 	 */
 	public static SmbOutboundGatewaySpec outboundGateway(RemoteFileTemplate<SmbFile> remoteFileTemplate,
-			String command, String expression) {
+			AbstractRemoteFileOutboundGateway.Command command, @Nullable String expression) {
+
+		return outboundGateway(remoteFileTemplate, command.getCommand(), expression);
+	}
+
+	/**
+	 * Produce a {@link SmbOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command}.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate}.
+	 * @param command the command to perform on the SMB.
+	 * @return the {@link SmbOutboundGatewaySpec}
+	 * @since 6.4
+	 * @see RemoteFileTemplate
+	 */
+	public static SmbOutboundGatewaySpec outboundGateway(RemoteFileTemplate<SmbFile> remoteFileTemplate,
+			String command) {
+
+		return outboundGateway(remoteFileTemplate, command, null);
+	}
+
+	/**
+	 * Produce a {@link SmbOutboundGatewaySpec} based on the {@link RemoteFileTemplate},
+	 * {@link AbstractRemoteFileOutboundGateway.Command} and {@code expression} for the
+	 * remoteFilePath.
+	 * @param remoteFileTemplate the {@link RemoteFileTemplate}.
+	 * @param command the command to perform on the SMB.
+	 * @param expression the remoteFilePath SpEL expression.
+	 * @return the {@link SmbOutboundGatewaySpec}
+	 * @see RemoteFileTemplate
+	 */
+	public static SmbOutboundGatewaySpec outboundGateway(RemoteFileTemplate<SmbFile> remoteFileTemplate,
+			String command, @Nullable String expression) {
 
 		return new SmbOutboundGatewaySpec(new SmbOutboundGateway(remoteFileTemplate, command, expression));
 	}

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbOutboundGateway.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,6 @@ import java.util.List;
 
 import jcifs.smb.SmbException;
 import jcifs.smb.SmbFile;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.springframework.integration.file.remote.AbstractFileInfo;
 import org.springframework.integration.file.remote.MessageSessionCallback;
@@ -32,17 +30,17 @@ import org.springframework.integration.file.remote.gateway.AbstractRemoteFileOut
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.smb.session.SmbFileInfo;
 import org.springframework.integration.smb.session.SmbRemoteFileTemplate;
+import org.springframework.lang.Nullable;
 
 /**
  * Outbound Gateway for performing remote file operations via SMB.
  *
  * @author Gregory Bragg
+ * @author Artem Bilan
  *
  * @since 6.0
  */
 public class SmbOutboundGateway extends AbstractRemoteFileOutboundGateway<SmbFile> {
-
-	private static final Log logger = LogFactory.getLog(SmbOutboundGateway.class);
 
 	/**
 	 * Construct an instance using the provided session factory and callback for
@@ -71,24 +69,26 @@ public class SmbOutboundGateway extends AbstractRemoteFileOutboundGateway<SmbFil
 
 	/**
 	 * Construct an instance with the supplied session factory, a command ('ls', 'get'
-	 * etc), and an expression to determine the filename.
+	 * etc.), and an expression to determine the remote path.
 	 * @param sessionFactory the session factory.
 	 * @param command the command.
-	 * @param expression the filename expression.
+	 * @param expression the remote path expression.
 	 */
-	public SmbOutboundGateway(SessionFactory<SmbFile> sessionFactory, String command, String expression) {
+	public SmbOutboundGateway(SessionFactory<SmbFile> sessionFactory, String command, @Nullable String expression) {
 		this(new SmbRemoteFileTemplate(sessionFactory), command, expression);
 		remoteFileTemplateExplicitlySet(false);
 	}
 
 	/**
 	 * Construct an instance with the supplied remote file template, a command ('ls',
-	 * 'get' etc), and an expression to determine the filename.
+	 * 'get' etc.), and an expression to determine the remote path.
 	 * @param remoteFileTemplate the remote file template.
 	 * @param command the command.
-	 * @param expression the filename expression.
+	 * @param expression the remote path expression.
 	 */
-	public SmbOutboundGateway(RemoteFileTemplate<SmbFile> remoteFileTemplate, String command, String expression) {
+	public SmbOutboundGateway(RemoteFileTemplate<SmbFile> remoteFileTemplate, String command,
+			@Nullable String expression) {
+
 		super(remoteFileTemplate, command, expression);
 	}
 
@@ -127,7 +127,7 @@ public class SmbOutboundGateway extends AbstractRemoteFileOutboundGateway<SmbFil
 			return file.isDirectory();
 		}
 		catch (SmbException se) {
-			logger.error("Unable to determine if this SmbFile represents a directory", se);
+			logger.error(se, "Unable to determine if this SmbFile represents a directory");
 			return false;
 		}
 	}


### PR DESCRIPTION
Fixes: #9427

Issue link: https://github.com/spring-projects/spring-integration/issues/9427

The `expression` of the `AbstractRemoteFileOutboundGateway` could be `null` and ignored for some expressions making a DSL factories inconsistent

* Improve `AbstractRemoteFileOutboundGateway` constructor JavaDocs explaining `expression` argument in more details
* Add `@Nullable` for this `expression` arg in all the `AbstractRemoteFileOutboundGateway` implementations
* Add new DSL factory method for `outboundGateway()` without this `expression` for those commands when it is not needed

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
