### PR TITLE
GH-9428: Emit MQTT delivery events even if share client instance

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/event/MqttMessageNotDeliveredEvent.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/event/MqttMessageNotDeliveredEvent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mqtt.event;
+
+import java.io.Serial;
+
+/**
+ * An event emitted (when using aysnc) when the client indicates the message
+ * was not delivered on publish operation.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.4
+ *
+ */
+public class MqttMessageNotDeliveredEvent extends MqttMessageDeliveryEvent {
+
+	@Serial
+	private static final long serialVersionUID = 8983514811627569920L;
+
+	private final Throwable exception;
+
+	public MqttMessageNotDeliveredEvent(Object source, int messageId, String clientId,
+			int clientInstance, Throwable exception) {
+
+		super(source, messageId, clientId, clientInstance);
+		this.exception = exception;
+	}
+
+	public Throwable getException() {
+		return this.exception;
+	}
+
+}

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -52,6 +52,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * @author Artem Vozhdayenko
@@ -123,9 +124,8 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 			if (ctx.containsBean("deliveryEvents")) {
 				List<MqttMessageDeliveryEvent> deliveryEvents = ctx.getBean("deliveryEvents", List.class);
 				// MqttMessageSentEvent and  MqttMessageDeliveredEvent
-				assertThat(deliveryEvents).hasSize(2);
+				await().untilAsserted(() -> assertThat(deliveryEvents).hasSize(2));
 			}
-
 		}
 	}
 

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
@@ -182,7 +182,7 @@ public class MqttAdapterTests {
 			assertThat(new String(message.getPayload())).isEqualTo("Hello, world!");
 			publishCalled.set(true);
 			return deliveryToken;
-		}).given(client).publish(anyString(), any(MqttMessage.class));
+		}).given(client).publish(anyString(), any(), any(), any());
 
 		handler.handleMessage(new GenericMessage<>("Hello, world!"));
 
@@ -204,7 +204,7 @@ public class MqttAdapterTests {
 		given(clientManager.getClient()).willReturn(client);
 
 		var deliveryToken = mock(MqttDeliveryToken.class);
-		given(client.publish(anyString(), any(MqttMessage.class))).willReturn(deliveryToken);
+		given(client.publish(anyString(), any(), any(), any())).willReturn(deliveryToken);
 
 		var handler = new MqttPahoMessageHandler(clientManager);
 		handler.setDefaultTopic("mqtt-foo");
@@ -218,7 +218,7 @@ public class MqttAdapterTests {
 
 		// then
 		verify(client, never()).connect(any(MqttConnectOptions.class));
-		verify(client).publish(anyString(), any(MqttMessage.class));
+		verify(client).publish(anyString(), any(), any(), any());
 		verify(client, never()).disconnect();
 		verify(client, never()).disconnect(anyLong());
 		verify(client, never()).close();

--- a/src/reference/antora/modules/ROOT/pages/mqtt.adoc
+++ b/src/reference/antora/modules/ROOT/pages/mqtt.adoc
@@ -399,6 +399,7 @@ Certain application events are published by the adapters.
 For the MQTT v5 Paho client, this event is also emitted when the server performs a normal disconnection, in which case the `cause` of the lost connection is `null`.
 * `MqttMessageSentEvent` - published by the outbound adapter when a message has been sent, if running in asynchronous mode.
 * `MqttMessageDeliveredEvent` - published by the outbound adapter when the client indicates that a message has been delivered, if running in asynchronous mode.
+* `MqttMessageNotDeliveredEvent` - published by the outbound adapter when the client indicates that a message has not been delivered, if running in asynchronous mode.
 * `MqttSubscribedEvent` - published by the inbound adapter after subscribing to the topics.
 
 These events can be received by an `ApplicationListener<MqttIntegrationEvent>` or with an `@EventListener` method.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -72,5 +72,6 @@ See xref:sftp/session-factory.adoc[SFTP Session Factory] for more information.
 === MQTT Support Changes
 
 Multiple instances of `MqttPahoMessageDrivenChannelAdapter` and `Mqttv5PahoMessageDrivenChannelAdapter` can now be added at runtime using corresponding `ClientManager` through `IntegrationFlowContext`
+Also a `MqttMessageNotDeliveredEvent` event has been introduced to emit when action callback reacts to the delivery failure.
 See xref:mqtt.adoc[MQTT Support] for more information.
 


### PR DESCRIPTION
Fixes: #9428

Issue link: https://github.com/spring-projects/spring-integration/issues/9428

When `ClientManager` is used for MQTT channel adapters, a `MqttMessageDeliveredEvent` is not emitted since callback for the `ClientManager` is not aware about `deliveryComplete`

* Use a `MqttActionListener` abstraction for the `publish` operation instead of a `deliveryComplete` from a common callback
* Make some other refactoring into the `MqttPahoMessageHandler` and `Mqttv5PahoMessageHandler` extracting a common logic into their `AbstractMqttMessageHandler` superclass
* Introduce an `MqttMessageNotDeliveredEvent` to be emitted from the `MqttActionListener.onFailure()` callback
* Adapt mocks in the `MqttAdapterTests` for a new code flow
* Add delivery events verification into the `ClientManagerBackToBackTests`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
