### PR TITLE
GH-9442: Register dynamic flows as singletons

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/context/ComponentSourceAware.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/ComponentSourceAware.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.context;
+
+import org.springframework.beans.factory.BeanNameAware;
+import org.springframework.lang.Nullable;
+
+/**
+ * The contract to supply and provide useful information about
+ * a bean definition (or singleton) source - the place where this bean is declared.
+ * Usually populated from a respective {@link org.springframework.beans.factory.config.BeanDefinition}
+ * or via Spring Integration infrastructure.
+ * <p>
+ * The information from this contract is typically used from exceptions to easy determine
+ * the place in the application resources where this bean is declared.
+ *
+ * @author Artem Bilan
+ *
+ * @since 6.4
+ *
+ * @see org.springframework.beans.factory.config.BeanDefinition
+ */
+public interface ComponentSourceAware extends BeanNameAware {
+
+	/**
+	 * Set a configuration source {@code Object} for this bean definition.
+	 * For normal {@link org.springframework.beans.factory.config.BeanDefinition} this is supplied
+	 * by application context automatically.
+	 * Could be useful when bean is registered at runtime via
+	 * {@link org.springframework.beans.factory.config.SingletonBeanRegistry#registerSingleton(String, Object)}
+	 * @param source the configuration source
+	 */
+	void setComponentSource(Object source);
+
+	/**
+	 * Return the configuration source {@code Object} for this bean (maybe {@code null}).
+	 * Usually (if not set explicitly) a {@link org.springframework.beans.factory.config.BeanDefinition#getSource()}.
+	 * @return the configuration source for the bean (if any).
+	 */
+	@Nullable
+	Object getComponentSource();
+
+	/**
+	 * Set a human-readable description of this bean.
+	 * For normal bean definition a {@link org.springframework.beans.factory.config.BeanDefinition#getDescription()}
+	 * is used.
+	 * @param description the bean description
+	 */
+	void setComponentDescription(String description);
+
+	/**
+	 * Return a human-readable description of this bean.
+	 * Usually (if not set explicitly) a {@link org.springframework.beans.factory.config.BeanDefinition#getDescription()}.
+	 * @return the bean description (if any).
+	 */
+	@Nullable
+	String getComponentDescription();
+
+	/**
+	 * Return the bean name populated by the {@link BeanNameAware#setBeanName(String)}.
+	 * @return the bean name.
+	 */
+	@Nullable
+	String getBeanName();
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.function.Supplier;
 
 import org.reactivestreams.Publisher;
 
+import org.springframework.integration.context.ComponentSourceAware;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.gateway.MessagingGatewaySupport;
@@ -59,11 +60,51 @@ import org.springframework.util.Assert;
  *
  * @since 5.0
  */
-public abstract class IntegrationFlowAdapter implements IntegrationFlow, ManageableSmartLifecycle {
+public abstract class IntegrationFlowAdapter
+		implements IntegrationFlow, ManageableSmartLifecycle, ComponentSourceAware {
 
 	private final AtomicBoolean running = new AtomicBoolean();
 
 	private StandardIntegrationFlow targetIntegrationFlow;
+
+	private String beanName;
+
+	private Object beanSource;
+
+	private String beanDescription;
+
+	@Override
+	public void setBeanName(String name) {
+		this.beanName = name;
+	}
+
+	@Nullable
+	@Override
+	public String getBeanName() {
+		return this.beanName;
+	}
+
+	@Override
+	public void setComponentSource(Object source) {
+		this.beanSource = source;
+	}
+
+	@Nullable
+	@Override
+	public Object getComponentSource() {
+		return this.beanSource;
+	}
+
+	@Override
+	public void setComponentDescription(String description) {
+		this.beanDescription = description;
+	}
+
+	@Nullable
+	@Override
+	public String getComponentDescription() {
+		return this.beanDescription;
+	}
 
 	@Override
 	public final void configure(IntegrationFlowDefinition<?> flow) {
@@ -71,6 +112,12 @@ public abstract class IntegrationFlowAdapter implements IntegrationFlow, Managea
 		flow.integrationComponents.clear();
 		flow.integrationComponents.putAll(targetFlow.integrationComponents);
 		this.targetIntegrationFlow = flow.get();
+		if (this.beanSource != null) {
+			this.targetIntegrationFlow.setComponentSource(this.beanSource);
+		}
+		if (this.beanDescription != null) {
+			this.targetIntegrationFlow.setComponentDescription(this.beanDescription);
+		}
 	}
 
 	@Nullable

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ import java.util.ListIterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.context.SmartLifecycle;
+import org.springframework.integration.context.ComponentSourceAware;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageChannel;
@@ -69,7 +69,7 @@ import org.springframework.messaging.MessageChannel;
  * @see SmartLifecycle
  */
 public class StandardIntegrationFlow
-		implements IntegrationFlow, SmartLifecycle, BeanNameAware, NamedComponent {
+		implements IntegrationFlow, SmartLifecycle, ComponentSourceAware, NamedComponent {
 
 	private final Map<Object, String> integrationComponents;
 
@@ -78,6 +78,10 @@ public class StandardIntegrationFlow
 	private boolean running;
 
 	private String beanName;
+
+	private Object beanSource;
+
+	private String beanDescription;
 
 	StandardIntegrationFlow(Map<Object, String> integrationComponents) {
 		this.integrationComponents = new LinkedHashMap<>(integrationComponents);
@@ -96,6 +100,34 @@ public class StandardIntegrationFlow
 	@Override
 	public String getComponentType() {
 		return "integration-flow";
+	}
+
+	@Override
+	public void setComponentSource(Object source) {
+		this.beanSource = source;
+	}
+
+	@Nullable
+	@Override
+	public Object getComponentSource() {
+		return this.beanSource;
+	}
+
+	@Override
+	public void setComponentDescription(String description) {
+		this.beanDescription = description;
+	}
+
+	@Nullable
+	@Override
+	public String getComponentDescription() {
+		return this.beanDescription;
+	}
+
+	@Nullable
+	@Override
+	public String getBeanName() {
+		return this.beanName;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -213,6 +213,14 @@ public interface IntegrationFlowContext {
 		 * @since 5.2
 		 */
 		IntegrationFlowRegistrationBuilder setSource(Object source);
+
+		/**
+		 * Set a human-readable description of this integration flow.
+		 * @param description the description for integration flow instance.
+		 * @return the current builder instance
+		 * @since 6.4
+		 */
+		IntegrationFlowRegistrationBuilder setDescription(String description);
 
 		/**
 		 * Invoke this method to prefix bean names in the flow with the (required) flow id

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
@@ -48,6 +48,7 @@ import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -59,6 +60,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @since 5.1.3
  */
 @SpringJUnitConfig
+@DirtiesContext
 public class GatewayDslTests {
 
 	@Autowired
@@ -96,9 +98,8 @@ public class GatewayDslTests {
 		String exceptionMessage = ((Exception) receive.getPayload()).getMessage();
 		assertThat(exceptionMessage)
 				.contains("message has been rejected in filter")
-				.contains("defined in: " +
-						"'org.springframework.integration.dsl.gateway.GatewayDslTests$ContextConfiguration'; " +
-						"from source: 'bean method gatewayRequestFlow'");
+				.contains("from source: 'public org.springframework.integration.dsl.IntegrationFlow " +
+						"org.springframework.integration.dsl.gateway.GatewayDslTests$ContextConfiguration.gatewayRequestFlow()'");
 	}
 
 	@Autowired


### PR DESCRIPTION
Fixes: #9442
Issue link: https://github.com/spring-projects/spring-integration/issues/9442

When we register a `BeanDefinition`, its metadata is cached in the `DefaultListableBeanFactory.mergedBeanDefinitionHolders` and it is not removed when we destroy bean.
This causes a memory leak with dynamic integration flows where even we destroy beans, their metadata is still cached. This has more serious impact when random ids are used for dynamic integration flows.

* Rework `IntegrationFlowContext` logic to register singletons instead of `BeanDefinition`
* Adjust `IntegrationFlowBeanPostProcessor` logic to register singletons or `BeanDefinition` according to the presence of `BeanDefinition` of the `IntegrationFlow` we are processing
* Introduce `ComponentSourceAware` to mimic a `BeanDefinition` metadata logic for bean source and its description. This info helps a lot with exceptions where class in the `IntegrationFlow` might be fully from a Spring Integration package. So, to give a clue what end-user code is related to the exception, such a `ComponentSourceAware` is there to preserver and transfer "bean source"
* Implement `ComponentSourceAware` in the `IntegrationObjectSupport` since this is a central place where we generate info for the Spring Integration exceptions
* Implement `ComponentSourceAware` in the `StandardIntegrationFlow` to propagate bean source info down to its components for the mentioned `IntegrationObjectSupport` logic
* Introduce inner `StandardIntegrationFlowContext.IntegrationFlowComponentSourceAwareAdapter` to be able to transfer "bean source" info from builder down to the target `IntegrationFlow` bean

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
