### PR TITLE
GH-9453: Correct separator when checking smb path

### DIFF
--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
-import java.nio.file.FileSystems;
 import java.util.Arrays;
 
 import jcifs.smb.SmbException;
@@ -54,14 +53,13 @@ import org.springframework.util.StringUtils;
  * @author Prafull Kumar Soni
  * @author Gregory Bragg
  * @author Adam Jones
+ * @author Paolo Fosser
  *
  * @since 6.0
  */
 public class SmbSession implements Session<SmbFile> {
 
 	private static final LogAccessor logger = new LogAccessor(SmbSession.class);
-
-	private static final String FILE_SEPARATOR = FileSystems.getDefault().getSeparator();
 
 	private static final String SMB_FILE_SEPARATOR = "/";
 
@@ -338,7 +336,7 @@ public class SmbSession implements Session<SmbFile> {
 	 * @throws IOException on error conditions returned by a CIFS server
 	 */
 	String mkdirs(String _path) throws IOException {
-		int idxPath = _path.lastIndexOf(FILE_SEPARATOR);
+		int idxPath = _path.lastIndexOf(SMB_FILE_SEPARATOR);
 		if (idxPath > -1) {
 			String path = _path.substring(0, idxPath + 1);
 			mkdir(path);


### PR DESCRIPTION
Fixes: #9453
Issue link: https://github.com/spring-projects/spring-integration/issues/9453

On a smb file upload, to detect the need for new remote directories, the remote path was checked for the local filesystem path separator. On Windows that is \\ which is never found in a smb path, so the necessary remote path was not created and the operation failed.

Use the correct separator which was already available as a constant.

@pivotal-cla This is an Obvious Fix

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
