### PR TITLE
Flag and maybe delete messages after messages have been copied

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -503,17 +503,27 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 	}
 
 	private void postProcessFilteredMessages(Message[] filteredMessages) throws MessagingException {
-		setMessageFlags(filteredMessages);
-
-		if (shouldDeleteMessages()) {
-			deleteMessages(filteredMessages);
-		}
 		// Copy messages to cause an eager fetch
 		if (this.headerMapper == null && (this.autoCloseFolder || this.simpleContent)) {
+			Message[] originalMessages = new Message[filteredMessages.length];
 			for (int i = 0; i < filteredMessages.length; i++) {
-				MimeMessage mimeMessage = new IntegrationMimeMessage((MimeMessage) filteredMessages[i]);
+				Message originalMessage = filteredMessages[i];
+				originalMessages[i] = originalMessage;
+				MimeMessage mimeMessage = new IntegrationMimeMessage((MimeMessage) originalMessage);
 				filteredMessages[i] = mimeMessage;
 			}
+			setMessageFlagsAndMaybeDeleteMessages(originalMessages);
+		}
+		else {
+			setMessageFlagsAndMaybeDeleteMessages(filteredMessages);
+		}
+	}
+
+	private void setMessageFlagsAndMaybeDeleteMessages(Message[] messages) throws MessagingException {
+		setMessageFlags(messages);
+
+		if (shouldDeleteMessages()) {
+			deleteMessages(messages);
 		}
 	}
 

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -504,26 +504,19 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 	}
 
 	private void postProcessFilteredMessages(Message[] filteredMessages) throws MessagingException {
-		// It is more intuitive use a local variable Message[] messages = filteredMessages;
-		// and then call setMessageFlagsAndMaybeDeleteMessages(messages); after the if, i.e. remove the else.
-		// However, in setMessageFlagsAndMaybeDeleteMessages we are calling Message#setFlag and Message#setFlags
-		// which have different implementations in different implementations of Message.
-		// e.g. IMAPMessage has a different implementation of those two methods.
-
 		// Copy messages to cause an eager fetch
+		Message[] messages = filteredMessages;
 		if (this.headerMapper == null && (this.autoCloseFolder || this.simpleContent)) {
-			Message[] originalMessages = new Message[filteredMessages.length];
+			messages = new Message[filteredMessages.length];
 			for (int i = 0; i < filteredMessages.length; i++) {
 				Message originalMessage = filteredMessages[i];
-				originalMessages[i] = originalMessage;
+				messages[i] = originalMessage;
 				MimeMessage mimeMessage = new IntegrationMimeMessage((MimeMessage) originalMessage);
 				filteredMessages[i] = mimeMessage;
 			}
-			setMessageFlagsAndMaybeDeleteMessages(originalMessages);
 		}
-		else {
-			setMessageFlagsAndMaybeDeleteMessages(filteredMessages);
-		}
+
+		setMessageFlagsAndMaybeDeleteMessages(messages);
 	}
 
 	private void setMessageFlagsAndMaybeDeleteMessages(Message[] messages) throws MessagingException {

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -68,6 +68,7 @@ import org.springframework.util.ObjectUtils;
  * @author Dominik Simmen
  * @author Yuxin Wang
  * @author Ngoc Nhan
+ * @author Filip Hrisafov
  */
 public abstract class AbstractMailReceiver extends IntegrationObjectSupport implements MailReceiver, DisposableBean {
 
@@ -503,6 +504,12 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 	}
 
 	private void postProcessFilteredMessages(Message[] filteredMessages) throws MessagingException {
+		// It is more intuitive use a local variable Message[] messages = filteredMessages;
+		// and then call setMessageFlagsAndMaybeDeleteMessages(messages); after the if, i.e. remove the else.
+		// However, in setMessageFlagsAndMaybeDeleteMessages we are calling Message#setFlag and Message#setFlags
+		// which have different implementations in different implementations of Message.
+		// e.g. IMAPMessage has a different implementation of those two methods.
+
 		// Copy messages to cause an eager fetch
 		if (this.headerMapper == null && (this.autoCloseFolder || this.simpleContent)) {
 			Message[] originalMessages = new Message[filteredMessages.length];

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -1005,10 +1005,12 @@ public class ImapMailReceiverTests {
 				.hasMessage("Simulated exception");
 		assertThat(msg1.getFlags().contains(Flag.SEEN)).isFalse();
 		assertThat(msg2.getFlags().contains(Flag.SEEN)).isFalse();
+		assertThat(msg2.getMyTestFlags().contains(Flag.SEEN)).isFalse();
 
 		receiver.receive();
 		assertThat(msg1.getFlags().contains(Flag.SEEN)).isTrue();
 		assertThat(msg2.getFlags().contains(Flag.SEEN)).isTrue();
+		assertThat(msg2.getMyTestFlags().contains(Flag.SEEN)).isTrue();
 		verify(receiver, times(0)).deleteMessages(Mockito.any());
 	}
 
@@ -1051,6 +1053,8 @@ public class ImapMailReceiverTests {
 
 		protected final AtomicInteger exceptionsBeforeWrite;
 
+		protected final Flags myTestFlags = new Flags();
+
 		private TestThrowingMimeMessage(MimeMessage source, int exceptionsBeforeWrite) throws MessagingException {
 			super(source);
 			this.exceptionsBeforeWrite = new AtomicInteger(exceptionsBeforeWrite);
@@ -1062,6 +1066,21 @@ public class ImapMailReceiverTests {
 				throw new IOException("Simulated exception");
 			}
 			super.writeTo(os);
+		}
+
+		@Override
+		public synchronized void setFlags(Flags flag, boolean set) throws MessagingException {
+			super.setFlags(flag, set);
+			if (set) {
+				myTestFlags.add(flag);
+			}
+			else {
+				myTestFlags.remove(flag);
+			}
+		}
+
+		private Flags getMyTestFlags() {
+			return myTestFlags;
 		}
 	}
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -109,6 +109,7 @@ import static org.mockito.Mockito.when;
  * @author Artem Bilan
  * @author Alexander Pinske
  * @author Dominik Simmen
+ * @author Filip Hrisafov
  */
 @SpringJUnitConfig
 @ContextConfiguration(

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailReceiverTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.mail;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,6 +89,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -299,6 +301,11 @@ public class ImapMailReceiverTests {
 
 	private AbstractMailReceiver receiveAndMarkAsReadDontDeleteGuts(AbstractMailReceiver receiver, Message msg1,
 			Message msg2) throws NoSuchFieldException, IllegalAccessException, MessagingException {
+		return receiveAndMarkAsReadDontDeleteGuts(receiver, msg1, msg2, true);
+	}
+
+	private AbstractMailReceiver receiveAndMarkAsReadDontDeleteGuts(AbstractMailReceiver receiver, Message msg1,
+			Message msg2, boolean receive) throws NoSuchFieldException, IllegalAccessException, MessagingException {
 
 		((ImapMailReceiver) receiver).setShouldMarkMessagesAsRead(true);
 		receiver = spy(receiver);
@@ -326,7 +333,9 @@ public class ImapMailReceiverTests {
 		willAnswer(invocation -> messages).given(folder).search(any(SearchTerm.class));
 
 		willAnswer(invocation -> null).given(receiver).fetchMessages(messages);
-		receiver.receive();
+		if (receive) {
+			receiver.receive();
+		}
 		return receiver;
 	}
 
@@ -980,6 +989,28 @@ public class ImapMailReceiverTests {
 		mailReceiver.setBeanFactory(bf);
 	}
 
+	@Test
+	public void receiveAndMarkAsReadDontDeleteWithThrowingWhenCopying() throws Exception {
+		AbstractMailReceiver receiver = new ImapMailReceiver();
+		MimeMessage msg1 = GreenMailUtil.newMimeMessage("test1");
+		MimeMessage greenMailMsg2 = GreenMailUtil.newMimeMessage("test2");
+		TestThrowingMimeMessage msg2 = new TestThrowingMimeMessage(greenMailMsg2, 1);
+		receiver = receiveAndMarkAsReadDontDeleteGuts(receiver, msg1, msg2, false);
+		assertThatThrownBy(receiver::receive)
+				.isInstanceOf(MessagingException.class)
+				.hasMessage("IOException while copying message")
+				.cause()
+				.isInstanceOf(IOException.class)
+				.hasMessage("Simulated exception");
+		assertThat(msg1.getFlags().contains(Flag.SEEN)).isFalse();
+		assertThat(msg2.getFlags().contains(Flag.SEEN)).isFalse();
+
+		receiver.receive();
+		assertThat(msg1.getFlags().contains(Flag.SEEN)).isTrue();
+		assertThat(msg2.getFlags().contains(Flag.SEEN)).isTrue();
+		verify(receiver, times(0)).deleteMessages(Mockito.any());
+	}
+
 	private static class ImapSearchLoggingHandler extends Handler {
 
 		private final List<String> searches = new ArrayList<>();
@@ -1013,6 +1044,24 @@ public class ImapMailReceiverTests {
 		public void close() throws SecurityException {
 		}
 
+	}
+
+	private static class TestThrowingMimeMessage extends MimeMessage {
+
+		protected final AtomicInteger exceptionsBeforeWrite;
+
+		private TestThrowingMimeMessage(MimeMessage source, int exceptionsBeforeWrite) throws MessagingException {
+			super(source);
+			this.exceptionsBeforeWrite = new AtomicInteger(exceptionsBeforeWrite);
+		}
+
+		@Override
+		public void writeTo(OutputStream os) throws IOException, MessagingException {
+			if (this.exceptionsBeforeWrite.decrementAndGet() >= 0) {
+				throw new IOException("Simulated exception");
+			}
+			super.writeTo(os);
+		}
 	}
 
 }


### PR DESCRIPTION
The reason for this pull request is due to the fact that we have noticed that sometimes the IMAP connection breaks just after the message flags have been set, but the message has not been copied yet. This then leads to the message never being received by (as it has been flagged and the next search will not return it).

e.g.

```
2024-08-08T13:16:02.888-04:00 ERROR 5820 --- [able-mail-30971] c.f.p.e.i.e.mail.MailMessageHandler : Unexpected error occurred in when handling messages for channel processinMailChannel

org.springframework.messaging.MessagingException: failure occurred while polling for mail
at org.springframework.integration.mail.MailReceivingMessageSource.doReceive(MailReceivingMessageSource.java:74) ~[spring-integration-mail-6.1.8.jar:6.1.8]
at org.springframework.integration.endpoint.AbstractMessageSource.receive(AbstractMessageSource.java:142) ~[spring-integration-core-6.1.8.jar:6.1.8]
at org.springframework.integration.endpoint.SourcePollingChannelAdapter.receiveMessage(SourcePollingChannelAdapter.java:212) ~[spring-integration-core-6.1.8.jar:6.1.8]
at org.springframework.integration.endpoint.AbstractPollingEndpoint.doPoll(AbstractPollingEndpoint.java:443) ~[spring-integration-core-6.1.8.jar:6.1.8]
at org.springframework.integration.endpoint.AbstractPollingEndpoint.pollForMessage(AbstractPollingEndpoint.java:412) ~[spring-integration-core-6.1.8.jar:6.1.8]
at org.springframework.integration.endpoint.AbstractPollingEndpoint.lambda$createPoller$4(AbstractPollingEndpoint.java:348) ~[spring-integration-core-6.1.8.jar:6.1.8]
at org.springframework.integration.util.ErrorHandlingTaskExecutor.lambda$execute$0(ErrorHandlingTaskExecutor.java:57) ~[spring-integration-core-6.1.8.jar:6.1.8]
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[na:na]
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[na:na]
at java.base/java.lang.Thread.run(Thread.java:840) ~[na:na]
Caused by: jakarta.mail.MessagingException: IOException while copying message
at jakarta.mail.internet.MimeMessage.<init>(MimeMessage.java:254) ~[jakarta.mail-api-2.1.3.jar:na]
at org.springframework.integration.mail.AbstractMailReceiver$IntegrationMimeMessage.<init>(AbstractMailReceiver.java:658) ~[spring-integration-mail-6.1.8.jar:6.1.8]
at org.springframework.integration.mail.AbstractMailReceiver.postProcessFilteredMessages(AbstractMailReceiver.java:513) ~[spring-integration-mail-6.1.8.jar:6.1.8]
at org.springframework.integration.mail.AbstractMailReceiver.searchAndFilterMessages(AbstractMailReceiver.java:427) ~[spring-integration-mail-6.1.8.jar:6.1.8]
at org.springframework.integration.mail.AbstractMailReceiver.receive(AbstractMailReceiver.java:380) ~[spring-integration-mail-6.1.8.jar:6.1.8]
at org.springframework.integration.mail.MailReceivingMessageSource.doReceive(MailReceivingMessageSource.java:62) ~[spring-integration-mail-6.1.8.jar:6.1.8]
... 9 common frames omitted
Caused by: java.io.IOException: jakarta.mail.FolderClosedException
at com.sun.mail.imap.IMAPInputStream.fill(IMAPInputStream.java:141) ~[angus-mail-1.1.0.jar:na]
at com.sun.mail.imap.IMAPInputStream.read(IMAPInputStream.java:245) ~[angus-mail-1.1.0.jar:na]
at com.sun.mail.imap.IMAPInputStream.read(IMAPInputStream.java:272) ~[angus-mail-1.1.0.jar:na]
at com.sun.mail.imap.IMAPMessage.writeTo(IMAPMessage.java:892) ~[angus-mail-1.1.0.jar:na]
at jakarta.mail.internet.MimeMessage.<init>(MimeMessage.java:246) ~[jakarta.mail-api-2.1.3.jar:na]
... 14 common frames omitted
Caused by: jakarta.mail.FolderClosedException: null
... 19 common frames omitted
```

I could reproduce a similar exception while debuging in the `IntegrationMimeMessage` constructor. If I put a break point there, wait a minute and then continue I would get this exception.

While debugging I could find some things such as

```
java.io.IOException: Connection dropped by server?
	at org.eclipse.angus.mail.iap.ResponseInputStream.readResponse(ResponseInputStream.java:96)
	at org.eclipse.angus.mail.iap.Response.<init>(Response.java:113)
```

I know that it says Spring Integration 6.1.8 here. However, I could reproduce the same with 6.3.5 as well.

I've added a test trying to mimic the behaviour (an `IOException`) when copying the message contents.