### PR TITLE
Remove not used private variable from ImapIdleChannelAdapter

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapIdleChannelAdapter.java
@@ -19,7 +19,6 @@ package org.springframework.integration.mail;
 import java.io.Serial;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ScheduledFuture;
 import java.util.function.Consumer;
 
 import jakarta.mail.Folder;
@@ -78,8 +77,6 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 	private Consumer<Object> messageSender;
 
 	private long reconnectDelay = DEFAULT_RECONNECT_DELAY; // milliseconds
-
-	private volatile ScheduledFuture<?> receivingTask;
 
 	public ImapIdleChannelAdapter(ImapMailReceiver mailReceiver) {
 		Assert.notNull(mailReceiver, "'mailReceiver' must not be null");
@@ -171,10 +168,6 @@ public class ImapIdleChannelAdapter extends MessageProducerSupport implements Be
 	@Override
 	// guarded by super#lifecycleLock
 	protected void doStop() {
-		if (this.receivingTask != null) {
-			this.receivingTask.cancel(true);
-			this.receivingTask = null;
-		}
 		this.mailReceiver.cancelPing();
 	}
 


### PR DESCRIPTION
In e4c1851c070e05ba14979851509c6312ec88d932 the logic for the `ImapIdleChannelAdapter` was changed. When that was done the `ScheduledFuture<?> receivingTask` from the `ImapIdleChannelAdapter` was not removed. This PR just removes the no longer used private variable `receivingTask`