### PR TITLE
add a new redis lock type that renewal expire

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/locks/RenewableLockRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/locks/RenewableLockRegistry.java
@@ -16,12 +16,15 @@
 
 package org.springframework.integration.support.locks;
 
+import org.springframework.scheduling.TaskScheduler;
+
 /**
  * A {@link LockRegistry} implementing this interface supports the renewal
  * of the time to live of a lock.
  *
  * @author Alexandre Strubel
  * @author Artem Bilan
+ * @author Youbin Wu
  *
  * @since 5.4
  */
@@ -33,5 +36,15 @@ public interface RenewableLockRegistry extends LockRegistry {
 	 * @param lockKey The object with which the lock is associated.
 	 */
 	void renewLock(Object lockKey);
+
+	/**
+	 * Set the {@link TaskScheduler} to use for the renewal task.
+	 * When renewalTaskScheduler is set, it will be used to periodically renew the lock to ensure that
+	 * the lock does not expire while the thread is working.
+	 * @param renewalTaskScheduler renew task scheduler
+	 * @since 6.4.0
+	 */
+	default void setRenewalTaskScheduler(TaskScheduler renewalTaskScheduler) {
+	}
 
 }

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Condition;
@@ -54,6 +55,8 @@ import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.Topic;
 import org.springframework.integration.support.locks.ExpirableLockRegistry;
+import org.springframework.integration.support.locks.RenewableLockRegistry;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.util.Assert;
 import org.springframework.util.ReflectionUtils;
@@ -89,11 +92,12 @@ import org.springframework.util.ReflectionUtils;
  * @author Myeonghyeon Lee
  * @author Roman Zabaluev
  * @author Alex Peelman
+ * @author Youbin Wu
  *
  * @since 4.0
  *
  */
-public final class RedisLockRegistry implements ExpirableLockRegistry, DisposableBean {
+public final class RedisLockRegistry implements ExpirableLockRegistry, DisposableBean, RenewableLockRegistry {
 
 	private static final Log LOGGER = LogFactory.getLog(RedisLockRegistry.class);
 
@@ -137,6 +141,8 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 	 */
 	private Executor executor =
 			Executors.newCachedThreadPool(new CustomizableThreadFactory("redis-lock-registry-"));
+
+	private TaskScheduler renewalTaskScheduler;
 
 	/**
 	 * Flag to denote whether the {@link ExecutorService} was provided via the setter and
@@ -205,6 +211,12 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 	public void setExecutor(Executor executor) {
 		this.executor = executor;
 		this.executorExplicitlySet = true;
+	}
+
+	@Override
+	public void setRenewalTaskScheduler(TaskScheduler renewalTaskScheduler) {
+		Assert.notNull(renewalTaskScheduler, "'renewalTaskScheduler' must not be null");
+		this.renewalTaskScheduler = renewalTaskScheduler;
 	}
 
 	/**
@@ -291,6 +303,26 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 		}
 	}
 
+	@Override
+	public void renewLock(Object lockKey) {
+		String path = (String) lockKey;
+		RedisLock redisLock;
+		this.lock.lock();
+		try {
+			redisLock = this.locks.computeIfAbsent(path, getRedisLockConstructor(this.redisLockType));
+		}
+		finally {
+			this.lock.unlock();
+		}
+		if (redisLock == null) {
+			throw new IllegalStateException("Could not renew mutex at " + path);
+		}
+
+		if (!redisLock.renew()) {
+			throw new IllegalStateException("Could not renew mutex at " + path);
+		}
+	}
+
 	/**
 	 * The mode in which this registry is going to work with locks.
 	 */
@@ -328,14 +360,27 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 				return false
 				""";
 
+		private static final String RENEW_SCRIPT = """
+				if (redis.call('GET', KEYS[1]) == ARGV[1]) then
+					redis.call('PEXPIRE', KEYS[1], ARGV[2])
+					return true
+				end
+				return false
+				""";
+
 		protected static final RedisScript<Boolean>
 				OBTAIN_LOCK_REDIS_SCRIPT = new DefaultRedisScript<>(OBTAIN_LOCK_SCRIPT, Boolean.class);
+
+		public static final RedisScript<Boolean>
+				RENEW_REDIS_SCRIPT = new DefaultRedisScript<>(RENEW_SCRIPT, Boolean.class);
 
 		protected final String lockKey;
 
 		private final ReentrantLock localLock = new ReentrantLock();
 
 		private volatile long lockedAt;
+
+		private volatile ScheduledFuture<?> renewFuture;
 
 		private RedisLock(String path) {
 			this.lockKey = constructLockKey(path);
@@ -454,6 +499,10 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 					LOGGER.debug("Acquired lock; " + this);
 				}
 				this.lockedAt = System.currentTimeMillis();
+				if (RedisLockRegistry.this.renewalTaskScheduler != null) {
+					Duration delay = Duration.ofMillis(RedisLockRegistry.this.expireAfter / 3);
+					this.renewFuture = RedisLockRegistry.this.renewalTaskScheduler.scheduleWithFixedDelay(this::renew, delay);
+				}
 			}
 			return acquired;
 		}
@@ -515,6 +564,7 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 
 				if (Boolean.TRUE.equals(unlinkResult)) {
 					// Lock key successfully unlinked
+					this.stopRenew();
 					return;
 				}
 				else if (Boolean.FALSE.equals(unlinkResult)) {
@@ -525,6 +575,26 @@ public final class RedisLockRegistry implements ExpirableLockRegistry, Disposabl
 			if (!removeLockKeyInnerDelete()) {
 				throw new ConcurrentModificationException("Lock was released in the store due to expiration. " +
 						"The integrity of data protected by this lock may have been compromised.");
+			}
+			else {
+				this.stopRenew();
+			}
+		}
+
+		protected final boolean renew() {
+			boolean res = Boolean.TRUE.equals(RedisLockRegistry.this.redisTemplate.execute(
+					RENEW_REDIS_SCRIPT, Collections.singletonList(this.lockKey),
+					RedisLockRegistry.this.clientId, String.valueOf(RedisLockRegistry.this.expireAfter)));
+			if (!res) {
+				this.stopRenew();
+			}
+			return res;
+		}
+
+		protected final void stopRenew() {
+			if (this.renewFuture != null) {
+				this.renewFuture.cancel(true);
+				this.renewFuture = null;
 			}
 		}
 

--- a/src/reference/antora/modules/ROOT/pages/redis.adoc
+++ b/src/reference/antora/modules/ROOT/pages/redis.adoc
@@ -857,3 +857,6 @@ The pub-sub is preferred mode - less network chatter between client Redis server
 However, the Redis does not support pub-sub in the Master/Replica connections (for example in AWS ElastiCache environment), therefore a busy-spin mode is chosen as a default to make the registry working in any environment.
 
 Starting with version 6.4, instead of throwing `IllegalStateException`, the `RedisLockRegistry.RedisLock.unlock()` method throws `ConcurrentModificationException` if the ownership of the lock is expired.
+
+Starting with version 6.4, a method `RedisLockRegistry.setRenewalTaskScheduler` is added to configure the scheduler for automatic renewal of locks.
+When it is set, the lock will be automatically renewed every 1/3 of the expiration time after the lock is successfully acquired, until unlocked or the redis key is removed.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -61,6 +61,9 @@ See xref:zeromq.adoc[ZeroMQ Support] for more information.
 Instead of throwing `IllegalStateException`, the `RedisLockRegistry.RedisLock.unlock()` method throws `ConcurrentModificationException` if the ownership of the lock is expired.
 See xref:redis.adoc[Redis Support] for more information.
 
+Add a `RedisLockRegistry.setRenewalTaskScheduler` to automatic renewal lock.
+See xref:redis.adoc[Redis Support] for more information.
+
 [[x6.4-groovy-changes]]
 === Groovy Changes
 


### PR DESCRIPTION
link https://github.com/spring-projects/spring-integration/issues/3636

add a new redis lock type that renewal expire like redission.

Although RenewableLockRegistry provides a renew interface, it is inconvenient for users. Developers hope to have a lock that can be automatically renewed. On the one hand, it can avoid subsequent failures caused by locks that will not expire when abnormal exits, and on the other hand, it can avoid unlock failures caused by lock expired.

In earlier issues, such as https://github.com/spring-projects/spring-integration/issues/2894, some users mentioned this problem, but because it needs to follow the constraints of java.util.concurrent.locks.Lock, and in order to maintain the abstract interface, different lock implementations are not exposed to the outside world (they are all private)

So I hope to add a Redis Lock Type to solve this problem