### PR TITLE
Support DelayedMessageWrapper Deserialized

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -31,6 +31,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Stream;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.aopalliance.aop.Advice;
 
 import org.springframework.aop.framework.ProxyFactory;
@@ -97,6 +99,7 @@ import org.springframework.util.ObjectUtils;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Christian Tzolov
+ * @author Youbin Wu
  *
  * @since 1.0.3
  */
@@ -689,7 +692,9 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 		@SuppressWarnings("serial")
 		private final Message<?> original;
 
-		DelayedMessageWrapper(Message<?> original, long requestDate) {
+		@JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+		DelayedMessageWrapper(@JsonProperty("original") Message<?> original,
+							@JsonProperty("requestDate") long requestDate) {
 			this.original = original;
 			this.requestDate = requestDate;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonJsonUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import org.springframework.messaging.support.GenericMessage;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Youbin Wu
  *
  * @since 3.0
  *
@@ -63,7 +64,8 @@ public final class JacksonJsonUtils {
 					"org.springframework.integration.support",
 					"org.springframework.integration.message",
 					"org.springframework.integration.store",
-					"org.springframework.integration.history"
+					"org.springframework.integration.history",
+					"org.springframework.integration.handler"
 			);
 
 	private JacksonJsonUtils() {


### PR DESCRIPTION
DelayedMessageWrapper cannot be deserialized when using RedisMessageStore and JSON serialization

```java
org.springframework.data.redis.serializer.SerializationException: Could not read JSON:Cannot construct instance of `org.springframework.integration.handler.DelayHandler$DelayedMessageWrapper` (no Creators, like default constructor, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: UNKNOWN; byte offset: #UNKNOWN] 
	at org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer.deserialize(GenericJackson2JsonRedisSerializer.java:311)
	at org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer.deserialize(GenericJackson2JsonRedisSerializer.java:281)
	at org.springframework.data.redis.serializer.SerializationUtils.deserializeValues(SerializationUtils.java:54)
	at org.springframework.data.redis.serializer.SerializationUtils.deserialize(SerializationUtils.java:68)
	at org.springframework.data.redis.core.AbstractOperations.deserializeValues(AbstractOperations.java:306)
	at org.springframework.data.redis.core.DefaultListOperations.lambda$range$9(DefaultListOperations.java:159)
	at org.springframework.data.redis.core.RedisTemplate.execute(RedisTemplate.java:411)
	at org.springframework.data.redis.core.RedisTemplate.execute(RedisTemplate.java:378)
	at org.springframework.data.redis.core.AbstractOperations.execute(AbstractOperations.java:117)
	at org.springframework.data.redis.core.DefaultListOperations.range(DefaultListOperations.java:159)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at org.springframework.data.redis.core.BoundOperationsProxyFactory$BoundOperationsMethodInterceptor.doInvoke(BoundOperationsProxyFactory.java:177)
	at org.springframework.data.redis.core.BoundOperationsProxyFactory$BoundOperationsMethodInterceptor.invoke(BoundOperationsProxyFactory.java:148)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.data.projection.DefaultMethodInvokingMethodInterceptor.invoke(DefaultMethodInvokingMethodInterceptor.java:69)
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:223)
```