### PR TITLE
GH-9694: Remove duplicate SocketChannel initialization

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -116,8 +116,11 @@ public class TcpNioClientConnectionFactory extends
 		}
 		catch (IOException e) {
 			try {
-				socketChannel.close();
-			} catch (IOException e2) {
+				if (socketChannel != null) {
+					socketChannel.close();
+				}
+			}
+			catch (IOException e2) {
 				logger.error(e2, "Error closing socket channel");
 			}
 			throw new UncheckedIOException(e);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Christian Tzolov
  * @author Ngoc Nhan
+ * @author Jooyoung Pyoung
  *
  * @since 2.0
  *
@@ -85,8 +86,9 @@ public class TcpNioClientConnectionFactory extends
 
 	@Override
 	protected TcpConnectionSupport buildNewConnection() {
+		SocketChannel socketChannel = null;
 		try {
-			SocketChannel socketChannel = SocketChannel.open();
+			socketChannel = SocketChannel.open();
 			setSocketAttributes(socketChannel.socket());
 			connect(socketChannel);
 			TcpNioConnection connection =
@@ -113,6 +115,11 @@ public class TcpNioClientConnectionFactory extends
 			return wrappedConnection;
 		}
 		catch (IOException e) {
+			try {
+				socketChannel.close();
+			} catch (IOException e2) {
+				logger.error(e2, "Error closing socket channel");
+			}
 			throw new UncheckedIOException(e);
 		}
 		catch (InterruptedException e) {


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/9694
Issue link: https://github.com/spring-projects/spring-integration/issues/9694

- Remove duplicate socketChannel initialization
- Properly close the SocketChannel when connection fails
- Prevents socket resource leakage during connection retries