### PR TITLE
GH-9705 Prevent logging when no reply is provided for an AbstractReplyProducingMessageHandler if logging is disabled

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -155,7 +155,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 			throw new ReplyRequiredException(message, "No reply produced by handler '" +
 					getComponentName() + "', and its 'requiresReply' property is set to true.");
 		}
-		else if (!isAsync()) {
+		else if (!isAsync() && isLoggingEnabled()) {
 			logger.debug(LogMessage.format("handler '%s' produced no reply for request Message: %s", this, message));
 		}
 	}


### PR DESCRIPTION
GH-9705: Avoid logging message if logging isn't enabled for AbstractReplyProducingMessageHandler where no reply is required

Fixes: gh-9705

