### PR TITLE
GH-9713: mark `IntegrationEvent.getCause()` as  `@Nullable`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/events/IntegrationEvent.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/events/IntegrationEvent.java
@@ -43,6 +43,7 @@ public abstract class IntegrationEvent extends ApplicationEvent {
 		this.cause = cause;
 	}
 
+	@Nullable
 	public Throwable getCause() {
 		return this.cause;
 	}


### PR DESCRIPTION
Fixes: #9713