### PR TITLE
GH-9794: Allow usage of '@' in SMB domain, username and password

### DIFF
--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.integration.smb.session;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 import jcifs.DialectVersion;
 
@@ -163,16 +165,19 @@ public class SmbConfig {
 		this.smbMaxVersion = _smbMaxVersion;
 	}
 
-	String getDomainUserPass(boolean _includePassword) {
+	String getDomainUserPass(boolean _includePassword, boolean _urlEncode) {
 		String domainUserPass;
+		String username = _urlEncode ? URLEncoder.encode(this.username, StandardCharsets.UTF_8) : this.username;
+		String password = _urlEncode ? URLEncoder.encode(this.password, StandardCharsets.UTF_8) : this.password;
 		if (StringUtils.hasText(this.domain)) {
-			domainUserPass = String.format("%s;%s", this.domain, this.username);
+			String domain = _urlEncode ? URLEncoder.encode(this.domain, StandardCharsets.UTF_8) : this.domain;
+			domainUserPass = String.format("%s;%s", domain, username);
 		}
 		else {
-			domainUserPass = this.username;
+			domainUserPass = username;
 		}
-		if (StringUtils.hasText(this.password)) {
-			domainUserPass += ":" + (_includePassword ? this.password : "********");
+		if (StringUtils.hasText(password)) {
+			domainUserPass += ":" + (_includePassword ? password : "********");
 		}
 		return domainUserPass;
 	}
@@ -211,20 +216,24 @@ public class SmbConfig {
 	}
 
 	/**
-	 * Return the url string for the share connection without encoding.
+	 * Return the url string for the share connection without encoding
+	 * the host and path. The {@code domainUserPass} is encoded, as
+	 * {@link java.net.URL} identifies the host part by looking
+	 * for the first {@code @} character, which fails if the
+	 * domain, username or password contains that character.
 	 * Used in the {@link SmbShare} constructor delegation.
 	 * @param _includePassword whether password has to be masked in credentials of URL.
 	 * @return the url string for the share connection without encoding.
 	 * @since 6.3.8
 	 */
 	public final String rawUrl(boolean _includePassword) {
-		String domainUserPass = getDomainUserPass(_includePassword);
+		String domainUserPass = getDomainUserPass(_includePassword, true);
 		String path = cleanPath();
 		return "smb://%s@%s%s".formatted(domainUserPass, getHostPort(), path);
 	}
 
 	private URI createUri(boolean _includePassword) {
-		String domainUserPass = getDomainUserPass(_includePassword);
+		String domainUserPass = getDomainUserPass(_includePassword, false);
 		String path = cleanPath();
 		try {
 			return new URI("smb", domainUserPass, this.host, this.port, path, null, null);

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbMessageHistoryTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbMessageHistoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2024 the original author or authors.
+ * Copyright 2012-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,16 @@
 
 package org.springframework.integration.smb;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Properties;
 
+import jcifs.CIFSContext;
+import jcifs.CIFSException;
+import jcifs.config.PropertyConfiguration;
+import jcifs.context.BaseContext;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -36,7 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SmbMessageHistoryTests extends AbstractBaseTests {
 
 	@Test
-	public void testMessageHistory() throws URISyntaxException {
+	public void testMessageHistory() throws URISyntaxException, MalformedURLException, CIFSException {
 		try (ClassPathXmlApplicationContext applicationContext = getApplicationContext()) {
 			SourcePollingChannelAdapter adapter = applicationContext
 					.getBean("smbInboundChannelAdapter", SourcePollingChannelAdapter.class);
@@ -51,6 +58,12 @@ public class SmbMessageHistoryTests extends AbstractBaseTests {
 			assertThat(uri.getUserInfo()).isEqualTo("sambagu@est:sambag%uest");
 			assertThat(uri.getPath()).isEqualTo("/smb share/");
 			assertThat(uri.getRawPath()).isEqualTo("/smb%20share/");
+
+			CIFSContext context = new BaseContext(new PropertyConfiguration(new Properties()));
+			URL rawUrl = new URL(null, smbSessionFactory.rawUrl(true), context.getUrlHandler());
+			assertThat(rawUrl.getHost()).isEqualTo("localhost");
+			assertThat(rawUrl.getUserInfo()).isEqualTo("sambagu%40est:sambag%25uest");
+			assertThat(rawUrl.getPath()).isEqualTo("/smb share/");
 		}
 	}
 


### PR DESCRIPTION
Fixes: #9794

The `SmbConfig.rawUrl()` method doesn't apply any URL encoding, resulting in parts of the `domainUserPass` that may contain a `@` character to break the URL logic in regard to determining the hostname.

* Modify `SmbConfig.getDomainUserPass(_includePassword)` to conditionally encode the variables. Makes sure to encode the individual parts to not undesirably encode the `;` and `:` characters, breaking other logic.
* Modify `SmbConfig.rawUrl(_includePassword)` and `SmbConfig.createUri(_includePassword)` to call the modified method with the correct `_urlEncode` variable

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
