### PR TITLE
spring-integration-event minor changes

### DIFF
--- a/spring-integration-event/src/main/java/org/springframework/integration/event/outbound/ApplicationEventPublishingMessageHandler.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/outbound/ApplicationEventPublishingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,8 @@ import org.springframework.util.Assert;
  * Spring's {@link ApplicationEvent} used by this adapter to simply wrap the
  * {@link Message}.
  * <p>
- * If the {@link #publishPayload} flag is specified to {@code true}, the {@code payload}
+ * However, if the {@code payload} is an instance of {@link ApplicationEvent}, or
+ * if the {@link #publishPayload} flag is specified to {@code true}, the {@code payload}
  * will be published as is without wrapping to any {@link ApplicationEvent}.
  *
  * @author Mark Fisher
@@ -63,8 +64,8 @@ public class ApplicationEventPublishingMessageHandler extends AbstractMessageHan
 	@Override
 	protected void handleMessageInternal(Message<?> message) {
 		Assert.notNull(this.applicationEventPublisher, "applicationEventPublisher is required");
-		if (message.getPayload() instanceof ApplicationEvent) {
-			this.applicationEventPublisher.publishEvent((ApplicationEvent) message.getPayload());
+		if (message.getPayload() instanceof ApplicationEvent applicationEvent) {
+			this.applicationEventPublisher.publishEvent(applicationEvent);
 		}
 		else if (this.publishPayload) {
 			this.applicationEventPublisher.publishEvent(message.getPayload());

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/outbound/ApplicationEventPublishingMessageHandlerTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/outbound/ApplicationEventPublishingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Ma Jiandong
  */
 public class ApplicationEventPublishingMessageHandlerTests {
 
@@ -40,7 +41,7 @@ public class ApplicationEventPublishingMessageHandlerTests {
 		assertThat(publisher.getLastEvent()).isNull();
 		Message<?> message = new GenericMessage<>("testing");
 		handler.handleMessage(message);
-		ApplicationEvent event = publisher.getLastEvent();
+		Object event = publisher.getLastEvent();
 		assertThat(event.getClass()).isEqualTo(MessagingEvent.class);
 		assertThat(((MessagingEvent) event).getMessage()).isEqualTo(message);
 	}
@@ -53,27 +54,36 @@ public class ApplicationEventPublishingMessageHandlerTests {
 		assertThat(publisher.getLastEvent()).isNull();
 		Message<?> message = new GenericMessage<>(new TestEvent("foo"));
 		handler.handleMessage(message);
-		ApplicationEvent event = publisher.getLastEvent();
+		Object event = publisher.getLastEvent();
 		assertThat(event.getClass()).isEqualTo(TestEvent.class);
-		assertThat((event).getSource()).isEqualTo("foo");
+		assertThat(((ApplicationEvent) event).getSource()).isEqualTo("foo");
+	}
+
+	@Test
+	public void payloadAsIs() {
+		TestApplicationEventPublisher publisher = new TestApplicationEventPublisher();
+		ApplicationEventPublishingMessageHandler handler = new ApplicationEventPublishingMessageHandler();
+		handler.setApplicationEventPublisher(publisher);
+		handler.setPublishPayload(true);
+		assertThat(publisher.getLastEvent()).isNull();
+		Message<?> message = new GenericMessage<>("testing");
+		handler.handleMessage(message);
+		Object event = publisher.getLastEvent();
+		assertThat(event.getClass()).isEqualTo(String.class);
+		assertThat(((String) event)).isEqualTo("testing");
 	}
 
 	private static class TestApplicationEventPublisher implements ApplicationEventPublisher {
 
-		private volatile ApplicationEvent lastEvent;
+		private volatile Object lastEvent;
 
-		public ApplicationEvent getLastEvent() {
-			return this.lastEvent;
-		}
-
-		@Override
-		public void publishEvent(ApplicationEvent event) {
-			this.lastEvent = event;
+		public Object getLastEvent() {
+			return lastEvent;
 		}
 
 		@Override
 		public void publishEvent(Object event) {
-
+			this.lastEvent = event;
 		}
 
 	}


### PR DESCRIPTION
1. Fix Javadoc & use pattern matching for instanceof
2. Polish unit tests

if the Javadoc for `ApplicationEventPublishingMessageHandler`  is not clear to you, let me know how to describe it correctly.
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
