### PR TITLE
Remove direct initialization of IntegrationProperties In IntegrationObjectSupport

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -81,7 +81,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 
 	private TaskScheduler taskScheduler;
 
-	private IntegrationProperties integrationProperties = new IntegrationProperties();
+	private IntegrationProperties integrationProperties;
 
 	private ConversionService conversionService;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ExpressionEvaluatingMessageSourceIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/ExpressionEvaluatingMessageSourceIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,7 @@ public class ExpressionEvaluatingMessageSourceIntegrationTests {
 		adapter.setErrorHandler(t -> {
 			throw new IllegalStateException("unexpected exception in test", t);
 		});
+		adapter.afterPropertiesSet();
 		adapter.start();
 		List<Message<?>> messages = new ArrayList<>();
 		for (int i = 0; i < 3; i++) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MessageHandlerChainTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MessageHandlerChainTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ public class MessageHandlerChainTests {
 		chain.setHandlers(handlers);
 		chain.setOutputChannel(outputChannel);
 		chain.setBeanFactory(mock(BeanFactory.class));
+		chain.afterPropertiesSet();
 		chain.handleMessage(message);
 		Mockito.verify(outputChannel).send(Mockito.eq(message), eq(30000L));
 	}
@@ -107,6 +108,7 @@ public class MessageHandlerChainTests {
 		chain.setBeanName("testChain");
 		chain.setHandlers(handlers);
 		chain.setBeanFactory(mock(BeanFactory.class));
+		chain.afterPropertiesSet();
 		chain.handleMessage(message);
 	}
 
@@ -121,6 +123,7 @@ public class MessageHandlerChainTests {
 		chain.setBeanName("testChain");
 		chain.setHandlers(handlers);
 		chain.setBeanFactory(mock(BeanFactory.class));
+		chain.afterPropertiesSet();
 		chain.handleMessage(message);
 		Mockito.verify(outputChannel).send(Mockito.any(Message.class), eq(30000L));
 	}
@@ -138,6 +141,7 @@ public class MessageHandlerChainTests {
 		chain.setBeanName("testChain");
 		chain.setHandlers(handlers);
 		chain.setBeanFactory(beanFactory);
+		chain.afterPropertiesSet();
 		chain.handleMessage(message);
 		Mockito.verify(outputChannel).send(Mockito.eq(message), eq(30000L));
 	}

--- a/spring-integration-stream/src/test/java/org/springframework/integration/stream/ByteStreamWritingMessageHandlerTests.java
+++ b/spring-integration-stream/src/test/java/org/springframework/integration/stream/ByteStreamWritingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,6 +92,7 @@ public class ByteStreamWritingMessageHandlerTests {
 	public void maxMessagesPerTaskSameAsMessageCount() {
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(3);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<byte[]>(new byte[] {1, 2, 3}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {4, 5, 6}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {7, 8, 9}), 0);
@@ -108,6 +109,7 @@ public class ByteStreamWritingMessageHandlerTests {
 	public void maxMessagesPerTaskLessThanMessageCount() {
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(2);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<byte[]>(new byte[] {1, 2, 3}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {4, 5, 6}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {7, 8, 9}), 0);
@@ -124,6 +126,7 @@ public class ByteStreamWritingMessageHandlerTests {
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(5);
 		endpoint.setReceiveTimeout(0);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<byte[]>(new byte[] {1, 2, 3}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {4, 5, 6}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {7, 8, 9}), 0);
@@ -140,6 +143,7 @@ public class ByteStreamWritingMessageHandlerTests {
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(2);
 		endpoint.setReceiveTimeout(0);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<byte[]>(new byte[] {1, 2, 3}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {4, 5, 6}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {7, 8, 9}), 0);
@@ -164,6 +168,7 @@ public class ByteStreamWritingMessageHandlerTests {
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(5);
 		endpoint.setReceiveTimeout(0);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<byte[]>(new byte[] {1, 2, 3}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {4, 5, 6}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {7, 8, 9}), 0);
@@ -187,6 +192,7 @@ public class ByteStreamWritingMessageHandlerTests {
 		endpoint.setMaxMessagesPerPoll(2);
 		endpoint.setTrigger(trigger);
 		endpoint.setReceiveTimeout(0);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<byte[]>(new byte[] {1, 2, 3}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {4, 5, 6}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {7, 8, 9}), 0);
@@ -210,6 +216,7 @@ public class ByteStreamWritingMessageHandlerTests {
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(2);
 		endpoint.setReceiveTimeout(0);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<byte[]>(new byte[] {1, 2, 3}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {4, 5, 6}), 0);
 		channel.send(new GenericMessage<byte[]>(new byte[] {7, 8, 9}), 0);

--- a/spring-integration-stream/src/test/java/org/springframework/integration/stream/CharacterStreamWritingMessageHandlerTests.java
+++ b/spring-integration-stream/src/test/java/org/springframework/integration/stream/CharacterStreamWritingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +85,7 @@ public class CharacterStreamWritingMessageHandlerTests {
 	public void twoStringsAndNoNewLinesByDefault() {
 		endpoint.setMaxMessagesPerPoll(1);
 		endpoint.setTrigger(trigger);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<>("foo"), 0);
 		channel.send(new GenericMessage<>("bar"), 0);
 		endpoint.start();
@@ -103,6 +104,7 @@ public class CharacterStreamWritingMessageHandlerTests {
 		handler.setShouldAppendNewLine(true);
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(1);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<>("foo"), 0);
 		channel.send(new GenericMessage<>("bar"), 0);
 		endpoint.start();
@@ -121,6 +123,7 @@ public class CharacterStreamWritingMessageHandlerTests {
 	public void maxMessagesPerTaskSameAsMessageCount() {
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(2);
+		endpoint.afterPropertiesSet();
 		channel.send(new GenericMessage<>("foo"), 0);
 		channel.send(new GenericMessage<>("bar"), 0);
 		endpoint.start();
@@ -134,10 +137,12 @@ public class CharacterStreamWritingMessageHandlerTests {
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(10);
 		endpoint.setReceiveTimeout(0);
+		endpoint.afterPropertiesSet();
 		handler.setShouldAppendNewLine(true);
 		channel.send(new GenericMessage<>("foo"), 0);
 		channel.send(new GenericMessage<>("bar"), 0);
 		endpoint.start();
+		endpoint.afterPropertiesSet();
 		trigger.await();
 		endpoint.stop();
 		String newLine = System.getProperty("line.separator");
@@ -148,6 +153,7 @@ public class CharacterStreamWritingMessageHandlerTests {
 	public void singleNonStringObject() {
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(1);
+		endpoint.afterPropertiesSet();
 		TestObject testObject = new TestObject("foo");
 		channel.send(new GenericMessage<>(testObject));
 		endpoint.start();
@@ -161,6 +167,7 @@ public class CharacterStreamWritingMessageHandlerTests {
 		endpoint.setReceiveTimeout(0);
 		endpoint.setTrigger(trigger);
 		endpoint.setMaxMessagesPerPoll(2);
+		endpoint.afterPropertiesSet();
 		TestObject testObject1 = new TestObject("foo");
 		TestObject testObject2 = new TestObject("bar");
 		channel.send(new GenericMessage<>(testObject1), 0);
@@ -177,6 +184,7 @@ public class CharacterStreamWritingMessageHandlerTests {
 		endpoint.setReceiveTimeout(0);
 		endpoint.setMaxMessagesPerPoll(2);
 		endpoint.setTrigger(trigger);
+		endpoint.afterPropertiesSet();
 		TestObject testObject1 = new TestObject("foo");
 		TestObject testObject2 = new TestObject("bar");
 		channel.send(new GenericMessage<>(testObject1), 0);


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->

In class `IntegrationObjectSupport`,  the field `integrationProperties` is directly initialized when the class is instantiated.
`private IntegrationProperties integrationProperties = new IntegrationProperties();`

I think it is redundant,  it will be replaced in method `afterPropertiesSet()`.
```
@Override
public final void afterPropertiesSet() {
    this.integrationProperties = IntegrationContextUtils.getIntegrationProperties(this.beanFactory);
    ....
}
```

based on this, I made the changes. and fix the broken unit tests after this change.

I assume any instance of IntegrationObjectSupport will be a Bean in Spring ApplicationContext.  

correct me if wrong.

