### PR TITLE
GH-9988: Add FileExistsMode expression support

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileOutboundGatewaySpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileOutboundGatewaySpec.java
@@ -388,6 +388,20 @@ public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutbo
 	}
 
 	/**
+	 * Specify a {@link Function} to determine the action to take when files already exist.
+	 * Expression evaluation should return a {@link FileExistsMode} or a String representation.
+	 * Used for GET and MGET operations when the file already exists locally,
+	 * or PUT and MPUT when the file exists on the remote system.
+	 * @param fileExistsModeFunction the {@link Function} to use.
+	 * @param <P> the expected payload type.
+	 * @return the Spec.
+	 * @since 6.5
+	 */
+	public <P> S fileExistsModeFunction(Function<Message<P>, String> fileExistsModeFunction) {
+		return remoteDirectoryExpression(new FunctionExpression<>(fileExistsModeFunction));
+	}
+
+	/**
 	 * Determine whether the remote directory should automatically be created when
 	 * sending files to the remote system.
 	 * @param autoCreateDirectory true to create the directory.

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileOutboundGatewaySpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileOutboundGatewaySpec.java
@@ -397,8 +397,8 @@ public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutbo
 	 * @return the Spec.
 	 * @since 6.5
 	 */
-	public <P> S fileExistsModeFunction(Function<Message<P>, String> fileExistsModeFunction) {
-		return remoteDirectoryExpression(new FunctionExpression<>(fileExistsModeFunction));
+	public <P> S fileExistsModeFunction(Function<Message<P>, Object> fileExistsModeFunction) {
+		return fileExistsModeExpression(new FunctionExpression<>(fileExistsModeFunction));
 	}
 
 	/**

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileOutboundGatewaySpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/RemoteFileOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ import org.springframework.messaging.Message;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Jooyoung Pyoung
  *
  * @since 5.0
  */
@@ -355,6 +356,34 @@ public abstract class RemoteFileOutboundGatewaySpec<F, S extends RemoteFileOutbo
 	 */
 	public S fileExistsMode(FileExistsMode fileExistsMode) {
 		this.target.setFileExistsMode(fileExistsMode);
+		return _this();
+	}
+
+	/**
+	 * Specify a SpEL expression to determine the action to take when files already exist.
+	 * Expression evaluation should return a {@link FileExistsMode} or a String representation.
+	 * Used for GET and MGET operations when the file already exists locally,
+	 * or PUT and MPUT when the file exists on the remote system.
+	 * @param fileExistsModeExpression a SpEL expression to evaluate the file exists mode
+	 * @return the Spec.
+	 * @since 6.5
+	 */
+	public S fileExistsModeExpression(Expression fileExistsModeExpression) {
+		this.target.setFileExistsModeExpression(fileExistsModeExpression);
+		return _this();
+	}
+
+	/**
+	 * Specify a SpEL expression to determine the action to take when files already exist.
+	 * Expression evaluation should return a {@link FileExistsMode} or a String representation.
+	 * Used for GET and MGET operations when the file already exists locally,
+	 * or PUT and MPUT when the file exists on the remote system.
+	 * @param fileExistsModeExpression the String in SpEL syntax.
+	 * @return the Spec.
+	 * @since 6.5
+	 */
+	public S fileExistsModeExpression(String fileExistsModeExpression) {
+		this.target.setFileExistsModeExpressionString(fileExistsModeExpression);
 		return _this();
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -565,8 +565,8 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 		// write remote file first with temporary file extension if enabled
 
 		String tempFilePath = tempRemoteFilePath;
-		if (!FileExistsMode.APPEND.equals(mode)) {
-			tempFilePath += this.useTemporaryFileName ? this.temporaryFileSuffix : "";
+		if (!FileExistsMode.APPEND.equals(mode) && this.useTemporaryFileName) {
+			tempFilePath += this.temporaryFileSuffix;
 		}
 
 		if (this.autoCreateDirectory) {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/RemoteFileTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Alen Turkovic
+ * @author Jooyoung Pyoung
  *
  * @since 3.0
  *
@@ -303,8 +304,6 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 
 	private String send(Message<?> message, String subDirectory, FileExistsMode mode) {
 		Assert.notNull(this.directoryExpressionProcessor, "'remoteDirectoryExpression' is required");
-		Assert.isTrue(!FileExistsMode.APPEND.equals(mode) || !this.useTemporaryFileName,
-				"Cannot append when using a temporary file name");
 		Assert.isTrue(!FileExistsMode.REPLACE_IF_MODIFIED.equals(mode),
 				"FilExistsMode.REPLACE_IF_MODIFIED can only be used for local files");
 		final StreamHolder inputStreamHolder = payloadToInputStream(message);
@@ -565,7 +564,10 @@ public class RemoteFileTemplate<F> implements RemoteFileOperations<F>, Initializ
 		String tempRemoteFilePath = temporaryRemoteDirectory + fileName;
 		// write remote file first with temporary file extension if enabled
 
-		String tempFilePath = tempRemoteFilePath + (this.useTemporaryFileName ? this.temporaryFileSuffix : "");
+		String tempFilePath = tempRemoteFilePath;
+		if (!FileExistsMode.APPEND.equals(mode)) {
+			tempFilePath += this.useTemporaryFileName ? this.temporaryFileSuffix : "";
+		}
 
 		if (this.autoCreateDirectory) {
 			try {

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -1390,10 +1390,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	private FileExistsMode resolveFileExistsMode(Message<?> message) {
 		if (this.fileExistsModeExpression != null) {
 			Object evaluationResult = this.fileExistsModeExpression.getValue(this.standardEvaluationContext, message);
-			if (evaluationResult == null) {
-				return this.fileExistsMode;
-			}
-			else if (evaluationResult instanceof FileExistsMode resolvedMode) {
+			if (evaluationResult instanceof FileExistsMode resolvedMode) {
 				return resolvedMode;
 			}
 			else if (evaluationResult instanceof String modeAsString) {
@@ -1406,7 +1403,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 									Arrays.toString(FileExistsMode.values()), ex);
 				}
 			}
-			else {
+			else if (evaluationResult != null) {
 				throw new MessagingException(message,
 						"Expression returned invalid type for FileExistsMode: " +
 								evaluationResult.getClass().getName() + ". Expected FileExistsMode or String.");

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -524,9 +524,6 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	 */
 	public void setFileExistsMode(FileExistsMode fileExistsMode) {
 		this.fileExistsMode = fileExistsMode;
-		if (FileExistsMode.APPEND.equals(fileExistsMode)) {
-			this.remoteFileTemplate.setUseTemporaryFileName(false);
-		}
 	}
 
 	/**

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -647,7 +647,8 @@ public class RemoteFileOutboundGatewayTests {
 	public void testGetExistsExpression() throws Exception {
 		SessionFactory sessionFactory = mock(SessionFactory.class);
 		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(sessionFactory, "get", "payload");
-		gw.setFileExistsModeExpression("headers[\"file.exists.mode\"]");
+		gw.setFileExistsModeExpressionString("headers[\"file.exists.mode\"]");
+
 		gw.setLocalDirectory(new File(this.tmpDir));
 		gw.afterPropertiesSet();
 		File outFile = new File(this.tmpDir + "/f1");
@@ -684,12 +685,12 @@ public class RemoteFileOutboundGatewayTests {
 				.withMessageContaining("already exists");
 
 		out = (MessageBuilder<File>) gw.handleRequestMessage(
-				new GenericMessage<>("f1", Map.of("file.exists.mode", FileExistsMode.IGNORE)));
+				new GenericMessage<>("f1", Map.of("file.exists.mode", "IGNORE")));
 		assertThat(out.getPayload()).isEqualTo(outFile);
 		assertContents("foo", outFile);
 
 		out = (MessageBuilder<File>) gw.handleRequestMessage(
-				new GenericMessage<>("f1", Map.of("file.exists.mode", FileExistsMode.APPEND)));
+				new GenericMessage<>("f1", Map.of("file.exists.mode", "append")));
 		assertThat(out.getPayload()).isEqualTo(outFile);
 		assertContents("footestfile", outFile);
 
@@ -939,7 +940,7 @@ public class RemoteFileOutboundGatewayTests {
 		handler.setBeanFactory(mock(BeanFactory.class));
 		handler.afterPropertiesSet();
 		gw.afterPropertiesSet();
-		gw.setFileExistsModeExpression("headers[\"file.exists.mode\"]");
+		gw.setFileExistsModeExpressionString("headers[\"file.exists.mode\"]");
 		when(sessionFactory.getSession()).thenReturn(session);
 		MessageBuilder<String> requestMessageBuilder = MessageBuilder.withPayload("hello")
 				.setHeader(FileHeaders.FILENAME, "bar.txt");
@@ -958,7 +959,7 @@ public class RemoteFileOutboundGatewayTests {
 				.isThrownBy(() -> gw.handleRequestMessage(failMessage))
 				.withStackTraceContaining("The destination file already exists");
 
-		Message<String> replaceMessage = requestMessageBuilder.setHeader("file.exists.mode", FileExistsMode.REPLACE)
+		Message<String> replaceMessage = requestMessageBuilder.setHeader("file.exists.mode", "replace")
 				.build();
 		path = (String) gw.handleRequestMessage(replaceMessage);
 		assertThat(path).isEqualTo("foo/bar.txt");
@@ -967,7 +968,7 @@ public class RemoteFileOutboundGatewayTests {
 		assertThat(captor.getValue()).isEqualTo("foo/bar.txt.writing");
 		verify(session, times(2)).rename("foo/bar.txt.writing", "foo/bar.txt");
 
-		Message<String> appendMessage = requestMessageBuilder.setHeader("file.exists.mode", FileExistsMode.APPEND)
+		Message<String> appendMessage = requestMessageBuilder.setHeader("file.exists.mode", "APPEND")
 				.build();
 		path = (String) gw.handleRequestMessage(appendMessage);
 		assertThat(path).isEqualTo("foo/bar.txt");

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -968,10 +968,11 @@ public class RemoteFileOutboundGatewayTests {
 
 		Message<String> appendMessage = requestMessageBuilder.setHeader("file.exists.mode", FileExistsMode.APPEND)
 				.build();
-
-		assertThatExceptionOfType(IllegalArgumentException.class)
-				.isThrownBy(() -> gw.handleRequestMessage(appendMessage))
-				.withStackTraceContaining("Cannot append when using a temporary file name");
+		path = (String) gw.handleRequestMessage(appendMessage);
+		assertThat(path).isEqualTo("foo/bar.txt");
+		captor = ArgumentCaptor.forClass(String.class);
+		verify(session).append(any(InputStream.class), captor.capture());
+		assertThat(captor.getValue()).isEqualTo("foo/bar.txt");
 
 		Message<String> ignoreMessage = requestMessageBuilder.setHeader("file.exists.mode", FileExistsMode.IGNORE)
 				.build();
@@ -979,7 +980,7 @@ public class RemoteFileOutboundGatewayTests {
 		assertThat(path).isEqualTo("foo/bar.txt");
 		// no more writes/appends
 		verify(session, times(2)).write(any(InputStream.class), anyString());
-		verify(session, times(0)).append(any(InputStream.class), anyString());
+		verify(session, times(1)).append(any(InputStream.class), anyString());
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -71,6 +71,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Liu Jiong
  * @author Artem Bilan
+ * @author Jooyoung Pyoung
  *
  * @since 2.1
  */

--- a/src/reference/antora/modules/ROOT/pages/ftp/rft.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ftp/rft.adoc
@@ -37,9 +37,8 @@ This is useful when you need to perform several high-level operations of the `Re
 For example, `AbstractRemoteFileOutboundGateway` uses it with the `mput` command implementation, where we perform a `put` operation for each file in the provided directory and recursively for its sub-directories.
 See the https://docs.spring.io/spring-integration/api/org/springframework/integration/file/remote/RemoteFileOperations.html#invoke[Javadoc] for more information.
 
-Starting with version 6.5, the `AbstractRemoteFileOutboundGateway` supports dynamic resolution of `FileExistsMode`
-at runtime via SpEL expressions. This allows you to determine the action to take when files already
-exist based on message content or other conditions.
+Starting with version 6.5, the `AbstractRemoteFileOutboundGateway` supports dynamic resolution of `FileExistsMode` at runtime via SpEL expressions.
+This allows you to determine the action to take when files already exist based on message content or other conditions.
 
 To use this feature, configure the `fileExistsModeExpression` property on the gateway.
 The expression can evaluate to:
@@ -53,7 +52,6 @@ See the https://docs.spring.io/spring-integration/api/org/springframework/integr
 
 [IMPORTANT]
 ====
-When using `FileExistsMode.APPEND`, temporary filename functionality is automatically disabled
-regardless of the `useTemporaryFileName` setting. This is because appending to a temporary file
-and then renaming it would not achieve the intended append behavior.
+When using `FileExistsMode.APPEND`, temporary filename functionality is automatically disabled regardless of the `useTemporaryFileName` setting.
+This is because appending to a temporary file and then renaming it would not achieve the intended append behavior.
 ====

--- a/src/reference/antora/modules/ROOT/pages/ftp/rft.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ftp/rft.adoc
@@ -37,3 +37,23 @@ This is useful when you need to perform several high-level operations of the `Re
 For example, `AbstractRemoteFileOutboundGateway` uses it with the `mput` command implementation, where we perform a `put` operation for each file in the provided directory and recursively for its sub-directories.
 See the https://docs.spring.io/spring-integration/api/org/springframework/integration/file/remote/RemoteFileOperations.html#invoke[Javadoc] for more information.
 
+Starting with version 6.5, the `AbstractRemoteFileOutboundGateway` supports dynamic resolution of `FileExistsMode`
+at runtime via SpEL expressions. This allows you to determine the action to take when files already
+exist based on message content or other conditions.
+
+To use this feature, configure the `fileExistsModeExpression` property on the gateway.
+The expression can evaluate to:
+
+* A `FileExistsMode` enum value (e.g., `FileExistsMode.REPLACE`)
+* A string representation of a `FileExistsMode` (case-insensitive, e.g., "REPLACE", "append")
+
+If the expression returns `null`, the default `fileExistsMode` configured on the gateway will be used.
+
+See the https://docs.spring.io/spring-integration/api/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.html#setFileExistsModeExpression(org.springframework.expression.Expression)[Javadoc] for more information.
+
+[IMPORTANT]
+====
+When using `FileExistsMode.APPEND`, temporary filename functionality is automatically disabled
+regardless of the `useTemporaryFileName` setting. This is because appending to a temporary file
+and then renaming it would not achieve the intended append behavior.
+====

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -79,6 +79,13 @@ The `AbstractRecentFileListFilter` strategy has been introduced to accept only t
 The respective implementations are provided: `RecentFileListFilter`, `FtpRecentFileListFilter`, `SftpRecentFileListFilter` and `SmbRecentFileListFilter`.
 See xref:file/reading.adoc[Reading Files] for more information.
 
+[[x6.5-file-exists-mode-expression]]
+== FileExistsMode Expression Support
+
+The remote file gateways (`AbstractRemoteFileOutboundGateway`) now support dynamic resolution of `FileExistsMode` at runtime via SpEL expressions. This allows determining the action to take when files already exist based on message content or other conditions.
+The expression can evaluate to a `FileExistsMode` enum value or a string representation (case-insensitive). If the expression returns `null`, the default `fileExistsMode` configured on the gateway will be used.
+See xref:ftp/rft.adoc[Remote File Gateways] for more information.
+
 [[x6.5-hazelcast-changes]]
 == Hazelcast Module Deprecations
 

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -82,8 +82,7 @@ See xref:file/reading.adoc[Reading Files] for more information.
 [[x6.5-file-exists-mode-expression]]
 == FileExistsMode Expression Support
 
-The remote file gateways (`AbstractRemoteFileOutboundGateway`) now support dynamic resolution of `FileExistsMode` at runtime via SpEL expressions. This allows determining the action to take when files already exist based on message content or other conditions.
-The expression can evaluate to a `FileExistsMode` enum value or a string representation (case-insensitive). If the expression returns `null`, the default `fileExistsMode` configured on the gateway will be used.
+The remote file gateways (`AbstractRemoteFileOutboundGateway`) now support dynamic resolution of `FileExistsMode` at runtime via SpEL expressions.
 See xref:ftp/rft.adoc[Remote File Gateways] for more information.
 
 [[x6.5-hazelcast-changes]]


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/9988

In `AbstractRemoteFileOutboundGateway`:
- Add `fileExistsModeExpression` field and setter methods
- Use `resolveFileExistsMode` in put and get operations
- Remove logic that disabled temporary filenames when setting `APPEND` mode

In `RemoteFileTemplate`:
- Remove exception validation when APPEND mode is used with temporary filenames
- Modify logic to skip applying temporaryFileSuffix in APPEND mode
