### PR TITLE
Fix `FileTailingMessageProducerTests.testOS` for MacOS

### DIFF
--- a/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,7 @@ public class FileTailingMessageProducerTests {
 	public void testOS() throws Exception {
 		OSDelegatingFileTailingMessageProducer adapter = new OSDelegatingFileTailingMessageProducer();
 		adapter.setOptions(TAIL_OPTIONS_FOLLOW_NAME_ALL_LINES);
+		adapter.setIdleEventInterval(1000);
 		testGuts(adapter, "stdOutReader");
 	}
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->

for `org.springframework.integration.file.tail.FileTailingMessageProducerTests#testOS`

on MacOS, it is failed at `assertThat(tailEventLatch.await(20, TimeUnit.SECONDS)).isTrue();`  which expect the latch to be released, but actually not. as per the test case, latch will be released if we publish an event.

by setting adapter.setIdleEventInterval(1000); to omit an idle event to ensure the latch being released.

