### PR TITLE
#10045: Enable JDBC test cases with TestContainers approach

### DIFF
--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreMultipleChannelTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreMultipleChannelTests-context.xml
@@ -19,14 +19,13 @@
 	<tx:annotation-driven/>
 	<int:annotation-config/>
 
-	<bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource" destroy-method="close">
-		<property name="driverClassName" value="com.mysql.jdbc.Driver"/>
-		<property name="url" value="jdbc:mysql://localhost:3306/int30"/>
-		<property name="username" value="root"/>
-		<property name="password" value="root"/>
-		<property name="maxActive" value="10"/>
-		<property name="defaultAutoCommit" value="false"/>
-	</bean>
+	<bean id="dataSource" class="org.springframework.integration.jdbc.mysql.MySqlContainerTest"
+		  factory-method="dataSource"/>
+
+	<jdbc:initialize-database>
+		<jdbc:script location="classpath:org/springframework/integration/jdbc/schema-drop-mysql.sql" />
+		<jdbc:script location="classpath:org/springframework/integration/jdbc/schema-mysql.sql" />
+	</jdbc:initialize-database>
 
 	<int-jdbc:message-store id="messageStore" data-source="dataSource" region="MessageStoreMultipleChannelTests"/>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreMultipleChannelTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreMultipleChannelTests.java
@@ -28,7 +28,6 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,8 +54,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringJUnitConfig
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
-@Disabled
-public class MySqlJdbcMessageStoreMultipleChannelTests {
+public class MySqlJdbcMessageStoreMultipleChannelTests implements MySqlContainerTest {
 
 	private static final Log LOG = LogFactory.getLog(MySqlJdbcMessageStoreMultipleChannelTests.class);
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlJdbcMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -545,8 +545,7 @@ public class MySqlJdbcMessageStoreTests implements MySqlContainerTest {
 		DataSourceInitializer dataSourceInitializer() {
 			DataSourceInitializer dataSourceInitializer = new DataSourceInitializer();
 			dataSourceInitializer.setDataSource(dataSource());
-			dataSourceInitializer.setDatabasePopulator(new ResourceDatabasePopulator(this.createSchemaScript));
-			dataSourceInitializer.setDatabaseCleaner(new ResourceDatabasePopulator(this.dropSchemaScript));
+			dataSourceInitializer.setDatabasePopulator(new ResourceDatabasePopulator(this.dropSchemaScript, this.createSchemaScript));
 			return dataSourceInitializer;
 		}
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlMetadataStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlMetadataStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,6 +75,9 @@ class MySqlMetadataStoreTests implements MySqlContainerTest {
 		@Value("org/springframework/integration/jdbc/schema-mysql.sql")
 		Resource createSchemaScript;
 
+		@Value("org/springframework/integration/jdbc/schema-drop-mysql.sql")
+		Resource dropSchemaScript;
+
 		@Bean
 		DataSource dataSource() {
 			return MySqlContainerTest.dataSource();
@@ -84,7 +87,7 @@ class MySqlMetadataStoreTests implements MySqlContainerTest {
 		DataSourceInitializer dataSourceInitializer(DataSource dataSource) {
 			DataSourceInitializer dataSourceInitializer = new DataSourceInitializer();
 			dataSourceInitializer.setDataSource(dataSource);
-			dataSourceInitializer.setDatabasePopulator(new ResourceDatabasePopulator(this.createSchemaScript));
+			dataSourceInitializer.setDatabasePopulator(new ResourceDatabasePopulator(this.dropSchemaScript, this.createSchemaScript));
 			return dataSourceInitializer;
 		}
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/postgres/PostgresContainerTest.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/postgres/PostgresContainerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 package org.springframework.integration.jdbc.postgres;
 
+import javax.sql.DataSource;
+
+import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -58,6 +61,15 @@ public interface PostgresContainerTest {
 
 	static String getPassword() {
 		return POSTGRES_CONTAINER.getPassword();
+	}
+
+	static DataSource dataSource() {
+		BasicDataSource dataSource = new BasicDataSource();
+		dataSource.setDriverClassName(POSTGRES_CONTAINER.getDriverClassName());
+		dataSource.setUrl(POSTGRES_CONTAINER.getJdbcUrl());
+		dataSource.setUsername(POSTGRES_CONTAINER.getUsername());
+		dataSource.setPassword(POSTGRES_CONTAINER.getPassword());
+		return dataSource;
 	}
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/AbstractTxTimeoutMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/AbstractTxTimeoutMessageStoreTests.java
@@ -63,7 +63,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DirtiesContext // close at the end after class
 public abstract class AbstractTxTimeoutMessageStoreTests {
 
-	private static final Log log = LogFactory.getLog(AbstractTxTimeoutMessageStoreTests.class);
+	protected final Log log = LogFactory.getLog(this.getClass());
 
 	@Autowired
 	protected DataSource dataSource;

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-oracle-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-oracle-context.xml
@@ -1,25 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<import resource="classpath:org/springframework/integration/jdbc/store/channel/DataSource-common-context.xml" />
 
-	<bean id="dataSource" class="oracle.jdbc.pool.OracleDataSource" destroy-method="close">
-		<property name="connectionCachingEnabled" value="true" />
-		<property name="URL" value="jdbc:oracle:thin:@//[HOST]:1521/XE" />
-		<property name="user"     value="[USER]" />
-		<property name="password" value="[PASSWORD]" />
-		<property name="connectionCacheProperties">
-			<props merge="default">
-				 <prop key="MinLimit">3</prop>
-				 <prop key="MaxLimit">20</prop>
-			</props>
-		 </property>
-	</bean>
+	<bean id="dataSource" class="org.springframework.integration.jdbc.oracle.OracleContainerTest"
+		  factory-method="dataSource"/>
 
 	<bean id="queryProvider" class="org.springframework.integration.jdbc.store.channel.OracleChannelMessageStoreQueryProvider"/>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-postgres-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/DataSource-postgres-context.xml
@@ -2,21 +2,18 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
-	xsi:schemaLocation="
-		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd
-		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc.xsd">
 
 	<import resource="classpath:org/springframework/integration/jdbc/store/channel/DataSource-common-context.xml" />
 
-	<bean id="dataSource" class="org.apache.commons.dbcp2.BasicDataSource"
-		destroy-method="close">
-		<property name="driverClassName" value="org.postgresql.Driver" />
-		<property name="initialSize" value="10"/>
-		<property name="url"
-			value="jdbc:postgresql:integration" />
-		<property name="username" value="postgres" />
-		<property name="password" value="postgres" />
-	</bean>
+	<bean id="dataSource" class="org.springframework.integration.jdbc.postgres.PostgresContainerTest"
+		  factory-method="dataSource" />
+
+	<jdbc:initialize-database>
+		<jdbc:script location="classpath:org/springframework/integration/jdbc/schema-drop-postgresql.sql" />
+		<jdbc:script location="classpath:org/springframework/integration/jdbc/schema-postgresql.sql" />
+	</jdbc:initialize-database>
 
 	<bean id="queryProvider" class="org.springframework.integration.jdbc.store.channel.PostgresChannelMessageStoreQueryProvider"/>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/HsqlTxTimeoutMessageStoreTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/HsqlTxTimeoutMessageStoreTests-context.xml
@@ -1,7 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
+
+	<util:properties id="props">
+		<prop key="concurrentPoll.fixedRate">2000</prop>
+		<prop key="concurrentPoll.fixedDelay">1000</prop>
+	</util:properties>
 
 	<import resource="classpath:org/springframework/integration/jdbc/store/channel/DataSource-hsql-context.xml"/>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/HsqlTxTimeoutMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/HsqlTxTimeoutMessageStoreTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,9 +16,7 @@
 
 package org.springframework.integration.jdbc.store.channel;
 
-import org.junit.Rule;
-
-import org.springframework.integration.test.support.LongRunningIntegrationTest;
+import org.springframework.integration.test.condition.LongRunningTest;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -27,10 +25,8 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Artem Bilan
  *
  */
+@LongRunningTest
 @ContextConfiguration
 public class HsqlTxTimeoutMessageStoreTests extends AbstractTxTimeoutMessageStoreTests {
-
-	@Rule
-	public LongRunningIntegrationTest longTests = new LongRunningIntegrationTest();
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/MySqlTxTimeoutMessageStoreTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/MySqlTxTimeoutMessageStoreTests-context.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<import resource="classpath:org/springframework/integration/jdbc/store/channel/DataSource-mysql-context.xml"/>
 
 	<import resource="classpath:org/springframework/integration/jdbc/store/channel/TxTimeoutMessageStoreTests-context.xml"/>
+
+	<util:properties id="props">
+		<prop key="concurrentPoll.fixedRate">2000</prop>
+		<prop key="concurrentPoll.fixedDelay">1000</prop>
+	</util:properties>
 
 </beans>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/MySqlTxTimeoutMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/MySqlTxTimeoutMessageStoreTests.java
@@ -16,8 +16,7 @@
 
 package org.springframework.integration.jdbc.store.channel;
 
-import org.junit.jupiter.api.Disabled;
-
+import org.springframework.integration.jdbc.mysql.MySqlContainerTest;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -26,8 +25,7 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Artem Bilan
  *
  */
-@Disabled
 @ContextConfiguration
-public class MySqlTxTimeoutMessageStoreTests extends AbstractTxTimeoutMessageStoreTests {
+public class MySqlTxTimeoutMessageStoreTests extends AbstractTxTimeoutMessageStoreTests implements MySqlContainerTest {
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/OracleTxTimeoutMessageStoreTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/OracleTxTimeoutMessageStoreTests-context.xml
@@ -1,11 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:util="http://www.springframework.org/schema/util"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
 
 	<import resource="classpath:org/springframework/integration/jdbc/store/channel/DataSource-oracle-context.xml"/>
 
 	<import resource="classpath:org/springframework/integration/jdbc/store/channel/TxTimeoutMessageStoreTests-context.xml"/>
+
+	<util:properties id="props">
+		<prop key="concurrentPoll.fixedRate">2000</prop>
+		<prop key="concurrentPoll.fixedDelay">1000</prop>
+	</util:properties>
 
 </beans>
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/OracleTxTimeoutMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/OracleTxTimeoutMessageStoreTests.java
@@ -16,9 +16,12 @@
 
 package org.springframework.integration.jdbc.store.channel;
 
-import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.AfterEach;
 
+import org.springframework.integration.jdbc.oracle.OracleContainerTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  *
@@ -26,8 +29,18 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Artem Bilan
  *
  */
-@Disabled
 @ContextConfiguration
-public class OracleTxTimeoutMessageStoreTests extends AbstractTxTimeoutMessageStoreTests {
+public class OracleTxTimeoutMessageStoreTests extends AbstractTxTimeoutMessageStoreTests implements OracleContainerTest {
+
+	@AfterEach
+	public void cleanTable() {
+		final JdbcTemplate jdbcTemplate = new JdbcTemplate(this.dataSource);
+		new TransactionTemplate(this.transactionManager).execute(status -> {
+			final int deletedChannelMessageRows = jdbcTemplate.update("delete from INT_CHANNEL_MESSAGE");
+			log.info(String.format("Cleaning Database - Deleted Channel Messages: %s ",
+					deletedChannelMessageRows));
+			return null;
+		});
+	}
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/PostgresTxTimeoutMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/PostgresTxTimeoutMessageStoreTests.java
@@ -16,8 +16,7 @@
 
 package org.springframework.integration.jdbc.store.channel;
 
-import org.junit.jupiter.api.Disabled;
-
+import org.springframework.integration.jdbc.postgres.PostgresContainerTest;
 import org.springframework.test.context.ContextConfiguration;
 
 /**
@@ -26,8 +25,7 @@ import org.springframework.test.context.ContextConfiguration;
  * @author Artem Bilan
  *
  */
-@Disabled
 @ContextConfiguration
-public class PostgresTxTimeoutMessageStoreTests extends AbstractTxTimeoutMessageStoreTests {
+public class PostgresTxTimeoutMessageStoreTests extends AbstractTxTimeoutMessageStoreTests implements PostgresContainerTest {
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/TxTimeoutMessageStoreTests-context.xml
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/TxTimeoutMessageStoreTests-context.xml
@@ -3,9 +3,16 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:task="http://www.springframework.org/schema/task"
 	xmlns:int="http://www.springframework.org/schema/integration"
+    xmlns:util="http://www.springframework.org/schema/util"
 	xsi:schemaLocation="http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/task https://www.springframework.org/schema/task/spring-task.xsd
-		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util.xsd">
+
+	<util:properties id="props">
+		<prop key="concurrentPoll.fixedRate">200</prop>
+		<prop key="concurrentPoll.fixedDelay">100</prop>
+	</util:properties>
 
 	<int:transaction-synchronization-factory id="syncFactory">
 		<int:before-commit expression="@store.removeFromIdCache(headers.id.toString())"/>
@@ -69,7 +76,7 @@
 	</int:channel>
 
 	<int:bridge input-channel="first" output-channel="second">
-		<int:poller fixed-rate="200" task-executor="threadPoolTaskExecutor" max-messages-per-poll="3">
+		<int:poller fixed-rate="#{props['concurrentPoll.fixedRate']}" task-executor="threadPoolTaskExecutor" max-messages-per-poll="3">
 			<int:transactional transaction-manager="transactionManager"/>
 		</int:poller>
 	</int:bridge>
@@ -79,7 +86,7 @@
 	</bean>
 
 	<int:outbound-channel-adapter channel="second" expression="@successfulLatch.countDown()">
-		<int:poller fixed-delay="100">
+		<int:poller fixed-delay="#{props['concurrentPoll.fixedDelay']}">
 			<int:transactional transaction-manager="transactionManager"/>
 		</int:poller>
 	</int:outbound-channel-adapter>


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
I really don't have any better ways to enable those JDBC concurrent test cases back :(

for `AbstractTxTimeoutMessageStoreTests`, there are two pollers impact the performance, first poller using custom task-executor with 100 threads run with fixed-rate 200, second poller with default executor run with fixed-delay 100.

for Mysql/Oracle, I increase the fixed-rate from 200 to 2000, and fixed-delay from 100 to 1000.

