### PR TITLE
Disable multicast tests when buiding on MacOS

### DIFF
--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketMulticastSendingHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketMulticastSendingHandlerTests.java
@@ -29,6 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
@@ -47,6 +49,7 @@ import static org.mockito.Mockito.mock;
  * @since 2.0
  */
 @Multicast
+@DisabledOnOs(value = OS.MAC, disabledReason = "Multicast tests don't work on MacOS")
 public class DatagramPacketMulticastSendingHandlerTests {
 
 	@Test

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/UdpChannelAdapterTests.java
@@ -32,6 +32,8 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -292,6 +294,7 @@ public class UdpChannelAdapterTests {
 
 	@SuppressWarnings("unchecked")
 	@Test
+	@DisabledOnOs(value = OS.MAC, disabledReason = "Multicast tests don't work on MacOS")
 	public void testMulticastSender(MulticastCondition multicastCondition) {
 		QueueChannel channel = new QueueChannel(2);
 		UnicastReceivingChannelAdapter adapter =


### PR DESCRIPTION
Multicast tests fail when running on MacOS.  So these tests will be disabled when building on macOS based machines.

I did not include the Oracle tests because M4 processors do support the oracle testcontainer based tests.  
