### PR TITLE
Issue 10070: Fix JavaDoc warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -263,7 +263,7 @@ configure(javaProjects) { subproject ->
 
     tasks.withType(Javadoc) {
         options.addBooleanOption('Xdoclint:syntax', true) // only check syntax with doclint
-//  TODO until all fixed      options.addBooleanOption('Werror', true) // fail build on Javadoc warnings
+        options.addBooleanOption('Werror', true) // fail build on Javadoc warnings
     }
 
     tasks.withType(JavaForkOptions) {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/MappingUtils.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/MappingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ public final class MappingUtils {
 	 * {@link ContentTypeDelegatingMessageConverter}, {@link AmqpHeaders#CONTENT_TYPE} and
 	 * {@link MessageHeaders#CONTENT_TYPE} will be used for the selection, with the AMQP
 	 * header taking precedence.
-	 * @param replyMessage the reply message.
+	 * @param message the reply message.
 	 * @param converter the message converter to use.
 	 * @param headerMapper the header mapper to use.
 	 * @param headersMappedLast true if headers are mapped after conversion.

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -95,7 +95,7 @@ public class KafkaInboundGatewaySpec<K, V, R, S extends KafkaInboundGatewaySpec<
 
 	/**
 	 * Specify a {@link BiConsumer} for seeks management during
-	 * {@link ConsumerSeekAware.ConsumerSeekCallback#onPartitionsAssigned(Map, ConsumerSeekAware.ConsumerSeekCallback)}
+	 * {@link ConsumerSeekAware#onPartitionsAssigned(Map, ConsumerSeekAware.ConsumerSeekCallback)}
 	 * call from the {@link org.springframework.kafka.listener.KafkaMessageListenerContainer}.
 	 * @param onPartitionsAssignedCallback the {@link BiConsumer} to use
 	 * @return the spec

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ public class KafkaMessageDrivenChannelAdapterSpec<K, V, S extends KafkaMessageDr
 
 	/**
 	 * Specify a {@link BiConsumer} for seeks management during
-	 * {@link ConsumerSeekAware.ConsumerSeekCallback#onPartitionsAssigned(Map, ConsumerSeekAware.ConsumerSeekCallback)}
+	 * {@link ConsumerSeekAware#onPartitionsAssigned(Map, ConsumerSeekAware.ConsumerSeekCallback)}
 	 * call from the {@link org.springframework.kafka.listener.KafkaMessageListenerContainer}.
 	 * @param onPartitionsAssignedCallback the {@link BiConsumer} to use
 	 * @return the spec

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 
 	/**
 	 * Specify a {@link BiConsumer} for seeks management during
-	 * {@link ConsumerSeekAware.ConsumerSeekCallback#onPartitionsAssigned(Map, ConsumerSeekAware.ConsumerSeekCallback)}
+	 * {@link ConsumerSeekAware#onPartitionsAssigned(Map, ConsumerSeekAware.ConsumerSeekCallback)}
 	 * call from the {@link org.springframework.kafka.listener.KafkaMessageListenerContainer}.
 	 * This is called from the internal
 	 * {@link org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter} implementation.

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -252,7 +252,7 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 
 	/**
 	 * Specify a {@link BiConsumer} for seeks management during
-	 * {@link ConsumerSeekAware.ConsumerSeekCallback#onPartitionsAssigned(Map, ConsumerSeekAware.ConsumerSeekCallback)}
+	 * {@link ConsumerSeekAware#onPartitionsAssigned(Map, ConsumerSeekAware.ConsumerSeekCallback)}
 	 * call from the {@link org.springframework.kafka.listener.KafkaMessageListenerContainer}.
 	 * This is called from the internal
 	 * {@link org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter} implementation.


### PR DESCRIPTION
Fixed incorrect arguments and class names in JavaDoc comments

Fixed: https://github.com/spring-projects/spring-integration/issues/10070
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
