### PR TITLE
GH-10069: Mitigate `warning: [this-escape]` in the project

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 	 * Construct an instance using the provided container.
 	 * @param listenerContainer the container.
 	 */
+	@SuppressWarnings("this-escape")
 	public AmqpInboundChannelAdapter(MessageListenerContainer listenerContainer) {
 		Assert.notNull(listenerContainer, "listenerContainer must not be null");
 		Assert.isNull(listenerContainer.getMessageListener(),

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,6 +98,7 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 
 	private boolean replyHeadersMappedLast;
 
+	@SuppressWarnings("this-escape")
 	public AmqpInboundGateway(AbstractMessageListenerContainer listenerContainer) {
 		this(listenerContainer, new RabbitTemplate(listenerContainer.getConnectionFactory()), false);
 	}
@@ -108,10 +109,12 @@ public class AmqpInboundGateway extends MessagingGatewaySupport {
 	 * @param listenerContainer the {@link MessageListenerContainer} to receive AMQP messages.
 	 * @param amqpTemplate the {@link AmqpTemplate} to send reply messages.
 	 */
+	@SuppressWarnings("this-escape")
 	public AmqpInboundGateway(MessageListenerContainer listenerContainer, AmqpTemplate amqpTemplate) {
 		this(listenerContainer, amqpTemplate, true);
 	}
 
+	@SuppressWarnings("this-escape")
 	private AmqpInboundGateway(MessageListenerContainer listenerContainer, AmqpTemplate amqpTemplate,
 			boolean amqpTemplateExplicitlySet) {
 

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ public class AmqpOutboundEndpoint extends AbstractAmqpOutboundEndpoint
 
 	private boolean multiSend;
 
+	@SuppressWarnings("this-escape")
 	public AmqpOutboundEndpoint(AmqpTemplate amqpTemplate) {
 		Assert.notNull(amqpTemplate, "amqpTemplate must not be null");
 		this.amqpTemplate = amqpTemplate;

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AsyncAmqpOutboundGateway.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AsyncAmqpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ public class AsyncAmqpOutboundGateway extends AbstractAmqpOutboundEndpoint {
 
 	private final MessageConverter messageConverter;
 
+	@SuppressWarnings("this-escape")
 	public AsyncAmqpOutboundGateway(AsyncRabbitTemplate template) {
 		Assert.notNull(template, "AsyncRabbitTemplate cannot be null");
 		this.template = template;

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,7 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 		STANDARD_HEADER_NAMES.add(AmqpHeaders.SPRING_REPLY_TO_STACK);
 	}
 
+	@SuppressWarnings("this-escape")
 	protected DefaultAmqpHeaderMapper(String[] requestHeaderNames, String[] replyHeaderNames) {
 		super(AmqpHeaders.PREFIX, STANDARD_HEADER_NAMES, STANDARD_HEADER_NAMES);
 		if (requestHeaderNames != null) {

--- a/spring-integration-cassandra/src/main/java/org/springframework/integration/cassandra/outbound/CassandraMessageHandler.java
+++ b/spring-integration-cassandra/src/main/java/org/springframework/integration/cassandra/outbound/CassandraMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,6 +93,7 @@ public class CassandraMessageHandler extends AbstractReplyProducingMessageHandle
 		this(cassandraOperations, Type.INSERT);
 	}
 
+	@SuppressWarnings("this-escape")
 	public CassandraMessageHandler(ReactiveCassandraOperations cassandraOperations,
 			CassandraMessageHandler.Type queryType) {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationAdvisor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/PublisherAnnotationAdvisor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Jooyoung Pyoung
  *
  * @since 2.0
  */
@@ -51,7 +52,7 @@ public class PublisherAnnotationAdvisor extends AbstractPointcutAdvisor implemen
 
 	private final transient MessagePublishingInterceptor interceptor;
 
-	private final Pointcut pointcut;
+	private final transient Pointcut pointcut;
 
 	public PublisherAnnotationAdvisor() {
 		this(Publisher.class);

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,11 +53,13 @@ public class MessagePublishingErrorHandler extends ErrorMessagePublisher impleme
 		}
 	};
 
+	@SuppressWarnings("this-escape")
 	public MessagePublishingErrorHandler() {
 		setErrorMessageStrategy(DEFAULT_ERROR_MESSAGE_STRATEGY);
 		setSendTimeout(DEFAULT_SEND_TIMEOUT);
 	}
 
+	@SuppressWarnings("this-escape")
 	public MessagePublishingErrorHandler(DestinationResolver<MessageChannel> channelResolver) {
 		this();
 		setChannelResolver(channelResolver);

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/TransformerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/TransformerFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  */
 public class TransformerFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
 
+	@SuppressWarnings("this-escape")
 	public TransformerFactoryBean() {
 		setRequiresReply(true);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/xml/StandardHeaderEnricherParser.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/xml/StandardHeaderEnricherParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import org.springframework.util.StringUtils;
  */
 public class StandardHeaderEnricherParser extends HeaderEnricherParserSupport {
 
+	@SuppressWarnings("this-escape")
 	public StandardHeaderEnricherParser() {
 		addElementToHeaderMapping("reply-channel", MessageHeaders.REPLY_CHANNEL);
 		addElementToHeaderMapping("error-channel", MessageHeaders.ERROR_CHANNEL);

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,7 @@ public class MessagingTemplate extends GenericMessagingTemplate {
 	 * Create a MessagingTemplate with the given default channel.
 	 * @param defaultChannel the default {@link MessageChannel} for {@code send} operations
 	 */
+	@SuppressWarnings("this-escape")
 	public MessagingTemplate(MessageChannel defaultChannel) {
 		super.setDefaultDestination(defaultChannel);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AggregateMessageDeliveryException.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AggregateMessageDeliveryException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ public class AggregateMessageDeliveryException extends MessageDeliveryException 
 
 	private final List<? extends Exception> aggregatedExceptions;
 
+	@SuppressWarnings("this-escape")
 	public AggregateMessageDeliveryException(Message<?> undeliveredMessage,
 			String description, List<? extends Exception> aggregatedExceptions) {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowExtension.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ public abstract class IntegrationFlowExtension<B extends IntegrationFlowExtensio
 
 	private final DirectChannel inputChannel = new DirectChannel();
 
+	@SuppressWarnings("this-escape")
 	protected IntegrationFlowExtension() {
 		channel(this.inputChannel);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/AbstractPollingEndpoint.java
@@ -122,6 +122,7 @@ public abstract class AbstractPollingEndpoint extends AbstractEndpoint implement
 
 	private volatile boolean initialized;
 
+	@SuppressWarnings("this-escape")
 	public AbstractPollingEndpoint() {
 		this.setPhase(Integer.MAX_VALUE / 2);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/EventDrivenConsumer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/EventDrivenConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ public class EventDrivenConsumer extends AbstractEndpoint implements Integration
 
 	private final MessageHandler handler;
 
+	@SuppressWarnings("this-escape")
 	public EventDrivenConsumer(SubscribableChannel inputChannel, MessageHandler handler) {
 		Assert.notNull(inputChannel, "inputChannel must not be null");
 		Assert.notNull(handler, "handler must not be null");

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -80,6 +80,7 @@ public abstract class MessageProducerSupport extends AbstractEndpoint
 
 	private volatile Subscription subscription;
 
+	@SuppressWarnings("this-escape")
 	protected MessageProducerSupport() {
 		setPhase(Integer.MAX_VALUE / 2);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/SimpleExpressionEvaluatingSelector.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/SimpleExpressionEvaluatingSelector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 the original author or authors.
+ * Copyright 2024-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,12 +34,14 @@ public class SimpleExpressionEvaluatingSelector extends AbstractMessageProcessin
 
 	private final String expressionString;
 
+	@SuppressWarnings("this-escape")
 	public SimpleExpressionEvaluatingSelector(String expressionString) {
 		super(new ExpressionEvaluatingMessageProcessor<>(expressionString, Boolean.class));
 		((ExpressionEvaluatingMessageProcessor<?>) getMessageProcessor()).setSimpleEvaluationContext(true);
 		this.expressionString = expressionString;
 	}
 
+	@SuppressWarnings("this-escape")
 	public SimpleExpressionEvaluatingSelector(Expression expression) {
 		super(new ExpressionEvaluatingMessageProcessor<>(expression, Boolean.class));
 		((ExpressionEvaluatingMessageProcessor<?>) getMessageProcessor()).setSimpleEvaluationContext(true);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/DelayHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,6 +170,7 @@ public class DelayHandler extends AbstractReplyProducingMessageHandler implement
 	 * @param messageGroupId The message group identifier.
 	 * @param taskScheduler A task scheduler.
 	 */
+	@SuppressWarnings("this-escape")
 	public DelayHandler(String messageGroupId, TaskScheduler taskScheduler) {
 		this(messageGroupId);
 		setTaskScheduler(taskScheduler);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ public class ExpressionEvaluatingMessageHandler extends AbstractMessageHandler {
 
 	private String componentType;
 
+	@SuppressWarnings("this-escape")
 	public ExpressionEvaluatingMessageHandler(Expression expression) {
 		Assert.notNull(expression, "'expression' must not be null");
 		this.processor = new ExpressionEvaluatingMessageProcessor<>(expression, Void.class);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,6 +70,7 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	 * {@link DefaultErrorMessageStrategy} is used.
 	 * @since 4.3.10
 	 */
+	@SuppressWarnings("this-escape")
 	public ErrorMessageSendingRecoverer(MessageChannel channel, ErrorMessageStrategy errorMessageStrategy) {
 		setChannel(channel);
 		setErrorMessageStrategy(

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	 * @param requestHeaderNames the header names that should be mapped from a request to {@link MessageHeaders}
 	 * @param replyHeaderNames the header names that should be mapped to a response from {@link MessageHeaders}
 	 */
+	@SuppressWarnings("this-escape")
 	protected AbstractHeaderMapper(String standardHeaderPrefix,
 			Collection<String> requestHeaderNames, Collection<String> replyHeaderNames) {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/ExpressionEvaluatingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/ExpressionEvaluatingRouter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ public class ExpressionEvaluatingRouter extends AbstractMessageProcessingRouter 
 	 * Construct an instance with the supplied {@link Expression}.
 	 * @param expression the expression.
 	 */
+	@SuppressWarnings("this-escape")
 	public ExpressionEvaluatingRouter(Expression expression) {
 		super(new ExpressionEvaluatingMessageProcessor<Object>(expression));
 		setPrimaryExpression(expression);

--- a/spring-integration-core/src/main/java/org/springframework/integration/splitter/ExpressionEvaluatingSplitter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/splitter/ExpressionEvaluatingSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import org.springframework.integration.handler.ExpressionEvaluatingMessageProces
  */
 public class ExpressionEvaluatingSplitter extends AbstractMessageProcessingSplitter {
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
+	@SuppressWarnings({"unchecked", "rawtypes", "this-escape"})
 	public ExpressionEvaluatingSplitter(Expression expression) {
 		super(new ExpressionEvaluatingMessageProcessor(expression));
 		setPrimaryExpression(expression);

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/SimpleMessageStore.java
@@ -120,6 +120,7 @@ public class SimpleMessageStore extends AbstractMessageGroupStore
 	 * @param lockRegistry       The lock registry.
 	 * @since 4.3
 	 */
+	@SuppressWarnings("this-escape")
 	public SimpleMessageStore(int individualCapacity, int groupCapacity, long upperBoundTimeout,
 			LockRegistry lockRegistry) {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/ErrorMessageJacksonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/ErrorMessageJacksonDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ public class ErrorMessageJacksonDeserializer extends MessageJacksonDeserializer<
 
 	private static final long serialVersionUID = 1L;
 
+	@SuppressWarnings("this-escape")
 	public ErrorMessageJacksonDeserializer() {
 		super(ErrorMessage.class);
 		setPayloadType(TypeFactory.defaultInstance().constructType(Throwable.class));

--- a/spring-integration-core/src/main/java/org/springframework/integration/transaction/TransactionHandleMessageAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transaction/TransactionHandleMessageAdvice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ public class TransactionHandleMessageAdvice extends TransactionInterceptor imple
 	public TransactionHandleMessageAdvice() {
 	}
 
+	@SuppressWarnings("this-escape")
 	public TransactionHandleMessageAdvice(TransactionManager transactionManager, Properties transactionAttributes) {
 		setTransactionManager(transactionManager);
 		setTransactionAttributes(transactionAttributes);

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 	 * The target delegate {@link Transformer} must be provided then via setter.
 	 * @since 6.2
 	 */
+	@SuppressWarnings("this-escape")
 	public MessageTransformingHandler() {
 		setRequiresReply(true);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/PayloadDeserializingTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/PayloadDeserializingTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ public class PayloadDeserializingTransformer extends PayloadTypeConvertingTransf
 	 * Instantiate based on the {@link AllowListDeserializingConverter} with the
 	 * {@link org.springframework.core.serializer.DefaultDeserializer}.
 	 */
+	@SuppressWarnings("this-escape")
 	public PayloadDeserializingTransformer() {
 		doSetConverter(new AllowListDeserializingConverter());
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/PayloadSerializingTransformer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/PayloadSerializingTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ public class PayloadSerializingTransformer extends PayloadTypeConvertingTransfor
 	 * Instantiate based on the {@link SerializingConverter} with the
 	 * {@link org.springframework.core.serializer.DefaultSerializer}.
 	 */
+	@SuppressWarnings("this-escape")
 	public PayloadSerializingTransformer() {
 		doSetConverter(new SerializingConverter());
 	}

--- a/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
@@ -58,6 +58,7 @@ public class ApplicationEventListeningMessageProducer extends ExpressionMessageP
 	/**
 	 * Construct an instance.
 	 */
+	@SuppressWarnings("this-escape")
 	public ApplicationEventListeningMessageProducer() {
 		setPhase(Integer.MAX_VALUE / 2 - 1000); // NOSONAR magic number
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -219,6 +219,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	 * @param command the command.
 	 * @param expressionArg the remote path.
 	 */
+	@SuppressWarnings("this-escape")
 	public AbstractRemoteFileOutboundGateway(RemoteFileTemplate<F> remoteFileTemplate, Command command,
 			@Nullable String expressionArg) {
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/splitter/FileSplitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,7 @@ public class FileSplitter extends AbstractMessageSplitter {
 	 * @param markersJson when true, markers are represented as JSON.
 	 * @since 4.2.7
 	 */
+	@SuppressWarnings("this-escape")
 	public FileSplitter(boolean iterator, boolean markers, boolean markersJson) {
 		this.returnIterator = iterator;
 		this.markers = markers;

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/ChainElementsTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/ChainElementsTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Jooyoung Pyoung
  *
  * @since 2.2
  */
@@ -49,7 +50,7 @@ public class ChainElementsTests {
 	@BeforeEach
 	public void setUp() {
 		localeBeforeTest = Locale.getDefault();
-		Locale.setDefault(new Locale("en", "US"));
+		Locale.setDefault(Locale.US);
 	}
 
 	@AfterEach

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -269,11 +269,13 @@ public class StreamingInboundTests {
 
 		ConcurrentHashMap<String, String> metadataMap = new ConcurrentHashMap<>();
 
+		@SuppressWarnings("this-escape")
 		protected Streamer(RemoteFileTemplate<String> template) {
 			super(template, null);
 			doSetFilter(null);
 		}
 
+		@SuppressWarnings("this-escape")
 		protected Streamer(RemoteFileTemplate<String> template, Comparator<String> comparator) {
 			super(template, comparator);
 			doSetFilter(new StringPersistentFileListFilter(new SimpleMetadataStore(this.metadataMap), "streamer"));

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/tail/TailCondition.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/tail/TailCondition.java
@@ -45,6 +45,7 @@ import org.springframework.core.annotation.MergedAnnotations;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Jiandong Ma
+ * @author Jooyoung Pyoung
  *
  * @since 6.5
  *
@@ -94,7 +95,8 @@ public class TailCondition implements ExecutionCondition {
 			ExecutorService newSingleThreadExecutor = Executors.newSingleThreadExecutor();
 			Future<Process> future =
 					newSingleThreadExecutor.submit(() -> {
-						final Process process = Runtime.getRuntime().exec(commandToTest + " " + file.getAbsolutePath());
+						ProcessBuilder pb = new ProcessBuilder(commandToTest, file.getAbsolutePath());
+						final Process process = pb.start();
 						ExecutorService executorService = Executors.newSingleThreadExecutor();
 						executorService.execute(() -> {
 							try {

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/gateway/FtpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,6 +64,7 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 	 * @param sessionFactory the session factory.
 	 * @param messageSessionCallback the callback.
 	 */
+	@SuppressWarnings("this-escape")
 	public FtpOutboundGateway(SessionFactory<FTPFile> sessionFactory,
 			MessageSessionCallback<FTPFile, ?> messageSessionCallback) {
 
@@ -91,6 +92,7 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 	 * @param command the command.
 	 * @param expression the remote path expression.
 	 */
+	@SuppressWarnings("this-escape")
 	public FtpOutboundGateway(SessionFactory<FTPFile> sessionFactory, String command, @Nullable String expression) {
 		this(new FtpRemoteFileTemplate(sessionFactory), command, expression);
 		((FtpRemoteFileTemplate) getRemoteFileTemplate()).setExistsMode(FtpRemoteFileTemplate.ExistsMode.NLST);

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpInboundFileSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ public class FtpInboundFileSynchronizer extends AbstractInboundFileSynchronizer<
 	 * {@link org.springframework.integration.file.remote.session.Session} instances.
 	 * @param sessionFactory The session factory.
 	 */
+	@SuppressWarnings("this-escape")
 	public FtpInboundFileSynchronizer(SessionFactory<FTPFile> sessionFactory) {
 		super(sessionFactory);
 		doSetRemoteDirectoryExpression(new LiteralExpression(null)); // NOSONAR - LE can actually handle null ok

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ public class FtpStreamingMessageSource extends AbstractRemoteFileStreamingMessag
 	 * @param template the template.
 	 * @param comparator the comparator.
 	 */
+	@SuppressWarnings("this-escape")
 	public FtpStreamingMessageSource(RemoteFileTemplate<FTPFile> template, Comparator<FTPFile> comparator) {
 		super(template, comparator);
 		doSetFilter(new FtpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "ftpStreamingMessageSource"));

--- a/spring-integration-graphql/src/main/java/org/springframework/integration/graphql/outbound/GraphQlMessageHandler.java
+++ b/spring-integration-graphql/src/main/java/org/springframework/integration/graphql/outbound/GraphQlMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,6 +62,7 @@ public class GraphQlMessageHandler extends AbstractReplyProducingMessageHandler 
 	private Expression executionIdExpression =
 			new FunctionExpression<Message<?>>(message -> message.getHeaders().getId());
 
+	@SuppressWarnings("this-escape")
 	public GraphQlMessageHandler(ExecutionGraphQlService graphQlService) {
 		Assert.notNull(graphQlService, "'graphQlService' must not be null");
 		this.graphQlService = graphQlService;

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/JmsMessageDrivenEndpoint.java
@@ -59,6 +59,7 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 	 * @param listenerContainer the container.
 	 * @param listener the listener.
 	 */
+	@SuppressWarnings("this-escape")
 	public JmsMessageDrivenEndpoint(AbstractMessageListenerContainer listenerContainer,
 			ChannelPublishingJmsMessageListener listener) {
 
@@ -74,6 +75,7 @@ public class JmsMessageDrivenEndpoint extends MessageProducerSupport implements 
 	 * @param externalContainer true if the container is externally configured and should not have its ack mode
 	 * coerced when no sessionAcknowledgeMode was supplied.
 	 */
+	@SuppressWarnings("this-escape")
 	private JmsMessageDrivenEndpoint(AbstractMessageListenerContainer listenerContainer,
 			ChannelPublishingJmsMessageListener listener, boolean externalContainer) {
 

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsHeaderEnricherParser.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsHeaderEnricherParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.jms.support.JmsHeaders;
  */
 public class JmsHeaderEnricherParser extends HeaderEnricherParserSupport {
 
+	@SuppressWarnings("this-escape")
 	public JmsHeaderEnricherParser() {
 		this.addElementToHeaderMapping("correlation-id", JmsHeaders.CORRELATION_ID);
 		this.addElementToHeaderMapping("reply-to", JmsHeaders.REPLY_TO);

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/monitor/IntegrationMBeanExporter.java
@@ -153,6 +153,7 @@ public class IntegrationMBeanExporter extends MBeanExporter
 
 	private volatile boolean singletonsInstantiated;
 
+	@SuppressWarnings("this-escape")
 	public IntegrationMBeanExporter() {
 		// Shouldn't be necessary, but to be on the safe side...
 		setAutodetect(false);

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaErrorSendingMessageRecoverer.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaErrorSendingMessageRecoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ public class KafkaErrorSendingMessageRecoverer extends ErrorMessagePublisher imp
 	 * @param channel the channel.
 	 * @param errorMessageStrategy the strategy.
 	 */
+	@SuppressWarnings("this-escape")
 	public KafkaErrorSendingMessageRecoverer(MessageChannel channel, ErrorMessageStrategy errorMessageStrategy) {
 		setChannel(channel);
 		setErrorMessageStrategy(errorMessageStrategy);

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -97,6 +97,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 	 * @param messageListenerContainer the container.
 	 * @param kafkaTemplate the kafka template.
 	 */
+	@SuppressWarnings("this-escape")
 	public KafkaInboundGateway(AbstractMessageListenerContainer<K, V> messageListenerContainer,
 			KafkaTemplate<K, R> kafkaTemplate) {
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -120,6 +120,7 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 	 * @param messageListenerContainer the container.
 	 * @param mode the mode.
 	 */
+	@SuppressWarnings("this-escape")
 	public KafkaMessageDrivenChannelAdapter(AbstractMessageListenerContainer<K, V> messageListenerContainer,
 			ListenerMode mode) {
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,6 +167,7 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractReplyProducingMes
 
 	private volatile byte[] singleReplyTopic;
 
+	@SuppressWarnings("this-escape")
 	public KafkaProducerMessageHandler(final KafkaTemplate<K, V> kafkaTemplate) {
 		Assert.notNull(kafkaTemplate, "kafkaTemplate cannot be null");
 		this.kafkaTemplate = kafkaTemplate;

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/ImapMailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,10 +73,12 @@ public class ImapMailReceiver extends AbstractMailReceiver {
 
 	private volatile ScheduledFuture<?> pingTask;
 
+	@SuppressWarnings("this-escape")
 	public ImapMailReceiver() {
 		setProtocol(PROTOCOL);
 	}
 
+	@SuppressWarnings("this-escape")
 	public ImapMailReceiver(String url) {
 		super(url);
 		if (url != null) {

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/Pop3MailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/Pop3MailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,10 +35,12 @@ public class Pop3MailReceiver extends AbstractMailReceiver {
 
 	public static final String PROTOCOL = "pop3";
 
+	@SuppressWarnings("this-escape")
 	public Pop3MailReceiver() {
 		setProtocol(PROTOCOL);
 	}
 
+	@SuppressWarnings("this-escape")
 	public Pop3MailReceiver(String url) {
 		super(url);
 		if (url != null) {

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailHeaderEnricherParser.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/config/MailHeaderEnricherParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.springframework.integration.mail.MailHeaders;
  */
 public class MailHeaderEnricherParser extends HeaderEnricherParserSupport {
 
+	@SuppressWarnings("this-escape")
 	public MailHeaderEnricherParser() {
 		this.addElementToHeaderMapping("subject", MailHeaders.SUBJECT);
 		this.addElementToHeaderMapping("to", MailHeaders.TO);

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ public class Mqttv3ClientManager
 		this(buildDefaultConnectionOptions(url), clientId);
 	}
 
+	@SuppressWarnings("this-escape")
 	public Mqttv3ClientManager(MqttConnectOptions connectionOptions, String clientId) {
 		super(clientId);
 		Assert.notNull(connectionOptions, "'connectionOptions' is required");

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ public class Mqttv5ClientManager
 		this(buildDefaultConnectionOptions(url), clientId);
 	}
 
+	@SuppressWarnings("this-escape")
 	public Mqttv5ClientManager(MqttConnectionOptions connectionOptions, String clientId) {
 		super(clientId);
 		Assert.notNull(connectionOptions, "'connectionOptions' is required");

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/ReactiveRedisStreamMessageProducer.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/ReactiveRedisStreamMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,6 +65,7 @@ public class ReactiveRedisStreamMessageProducer extends MessageProducerSupport {
 
 	private final String streamKey;
 
+	@SuppressWarnings("this-escape")
 	private final StreamReceiver.StreamReceiverOptionsBuilder<String, ?> streamReceiverOptionsBuilder =
 			StreamReceiver.StreamReceiverOptions.builder()
 					.pollTimeout(Duration.ZERO)

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGateway.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/outbound/RSocketOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,6 +112,7 @@ public class RSocketOutboundGateway extends AbstractReplyProducingMessageHandler
 	 * in this expression evaluation, for example using some bean with an appropriate logic.
 	 * @param routeExpression the SpEL expression to use.
 	 */
+	@SuppressWarnings("this-escape")
 	public RSocketOutboundGateway(Expression routeExpression) {
 		Assert.notNull(routeExpression, "'routeExpression' must not be null");
 		this.routeExpression = routeExpression;

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/gateway/SftpOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ public class SftpOutboundGateway extends AbstractRemoteFileOutboundGateway<SftpC
 	 * @param sessionFactory the session factory.
 	 * @param messageSessionCallback the callback.
 	 */
+	@SuppressWarnings("this-escape")
 	public SftpOutboundGateway(SessionFactory<SftpClient.DirEntry> sessionFactory,
 			MessageSessionCallback<SftpClient.DirEntry, ?> messageSessionCallback) {
 
@@ -77,6 +78,7 @@ public class SftpOutboundGateway extends AbstractRemoteFileOutboundGateway<SftpC
 	 * @param command the command.
 	 * @param expression the remote path expression.
 	 */
+	@SuppressWarnings("this-escape")
 	public SftpOutboundGateway(SessionFactory<SftpClient.DirEntry> sessionFactory, String command,
 			@Nullable String expression) {
 

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpInboundFileSynchronizer.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpInboundFileSynchronizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ public class SftpInboundFileSynchronizer extends AbstractInboundFileSynchronizer
 	 * Create a synchronizer with the {@code SessionFactory} used to acquire {@code Session} instances.
 	 * @param sessionFactory The session factory.
 	 */
+	@SuppressWarnings("this-escape")
 	public SftpInboundFileSynchronizer(SessionFactory<SftpClient.DirEntry> sessionFactory) {
 		super(sessionFactory);
 		doSetFilter(new SftpPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "sftpMessageSource"));

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,7 @@ public class SftpStreamingMessageSource extends AbstractRemoteFileStreamingMessa
 	 * @param template the template.
 	 * @param comparator the comparator.
 	 */
+	@SuppressWarnings("this-escape")
 	public SftpStreamingMessageSource(RemoteFileTemplate<SftpClient.DirEntry> template,
 			Comparator<SftpClient.DirEntry> comparator) {
 

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/server/DirectoryCreatedEvent.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/server/DirectoryCreatedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.lang.Nullable;
  * An event emitted when a directory is created.
  *
  * @author Gary Russell
+ * @author Jooyoung Pyoung
  * @since 5.2
  *
  */
@@ -34,7 +35,7 @@ public class DirectoryCreatedEvent extends ApacheMinaSftpEvent {
 
 	private transient Path path;
 
-	private final Map<String, ?> attrs;
+	private final transient Map<String, ?> attrs;
 
 	public DirectoryCreatedEvent(Object source, Path path, Map<String, ?> attrs) {
 		super(source);

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbStreamingMessageSource.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbStreamingMessageSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,6 +60,7 @@ public class SmbStreamingMessageSource extends AbstractRemoteFileStreamingMessag
 	 * @param template the template.
 	 * @param comparator the comparator.
 	 */
+	@SuppressWarnings("this-escape")
 	public SmbStreamingMessageSource(RemoteFileTemplate<SmbFile> template, Comparator<SmbFile> comparator) {
 		super(template, comparator);
 		doSetFilter(new SmbPersistentAcceptOnceFileListFilter(new SimpleMetadataStore(), "smbStreamingMessageSource"));

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbOutboundGateway.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,6 +48,7 @@ public class SmbOutboundGateway extends AbstractRemoteFileOutboundGateway<SmbFil
 	 * @param sessionFactory the session factory.
 	 * @param messageSessionCallback the callback.
 	 */
+	@SuppressWarnings("this-escape")
 	public SmbOutboundGateway(SessionFactory<SmbFile> sessionFactory,
 			MessageSessionCallback<SmbFile, ?> messageSessionCallback) {
 
@@ -74,6 +75,7 @@ public class SmbOutboundGateway extends AbstractRemoteFileOutboundGateway<SmbFil
 	 * @param command the command.
 	 * @param expression the remote path expression.
 	 */
+	@SuppressWarnings("this-escape")
 	public SmbOutboundGateway(SessionFactory<SmbFile> sessionFactory, String command, @Nullable String expression) {
 		this(new SmbRemoteFileTemplate(sessionFactory), command, expression);
 		remoteFileTemplateExplicitlySet(false);

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/outbound/WebFluxRequestExecutingMessageHandler.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/outbound/WebFluxRequestExecutingMessageHandler.java
@@ -131,6 +131,7 @@ public class WebFluxRequestExecutingMessageHandler extends AbstractHttpRequestEx
 	 * {@link org.springframework.beans.factory.BeanFactory}.
 	 * @param webClient The WebClient to use.
 	 */
+	@SuppressWarnings("this-escape")
 	public WebFluxRequestExecutingMessageHandler(Expression uriExpression, @Nullable WebClient webClient) {
 		super(uriExpression);
 		this.webClientExplicitlySet = webClient != null;

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,6 +115,7 @@ public class WebSocketInboundChannelAdapter extends MessageProducerSupport
 		this(webSocketContainer, new SubProtocolHandlerRegistry(new PassThruSubProtocolHandler()));
 	}
 
+	@SuppressWarnings("this-escape")
 	public WebSocketInboundChannelAdapter(IntegrationWebSocketContainer webSocketContainer,
 			SubProtocolHandlerRegistry protocolHandlerRegistry) {
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.ws.client.support.destination.DestinationProvider;
  */
 public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutboundGateway {
 
+	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider, Marshaller marshaller,
 			Unmarshaller unmarshaller, WebServiceMessageFactory messageFactory) {
 		super(destinationProvider, messageFactory);
@@ -63,6 +64,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 		this(destinationProvider, marshaller, (WebServiceMessageFactory) null);
 	}
 
+	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller, Unmarshaller unmarshaller,
 			WebServiceMessageFactory messageFactory) {
 		super(uri, messageFactory);
@@ -88,6 +90,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	 * @param webServiceTemplate the WebServiceTemplate
 	 * @since 5.0
 	 */
+	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(String uri, WebServiceTemplate webServiceTemplate) {
 		super(uri, null);
 		doSetWebServiceTemplate(webServiceTemplate);
@@ -99,6 +102,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	 * @param webServiceTemplate the WebServiceTemplate
 	 * @since 5.0
 	 */
+	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider,
 			WebServiceTemplate webServiceTemplate) {
 		super(destinationProvider, null);
@@ -111,6 +115,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	 * @param marshaller The marshaller.
 	 * @param unmarshallerArg The unmarshaller.
 	 */
+	@SuppressWarnings("this-escape")
 	private void configureMarshallers(Marshaller marshaller, @Nullable Unmarshaller unmarshallerArg) {
 		Unmarshaller unmarshaller = unmarshallerArg;
 		Assert.notNull(marshaller, "marshaller must not be null");

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceHeaderEnricherParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceHeaderEnricherParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.integration.ws.WebServiceHeaders;
  */
 public class WebServiceHeaderEnricherParser extends HeaderEnricherParserSupport {
 
+	@SuppressWarnings("this-escape")
 	public WebServiceHeaderEnricherParser() {
 		this.addElementToHeaderMapping("soap-action", WebServiceHeaders.SOAP_ACTION);
 	}

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/TestXmlApplicationContext.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/TestXmlApplicationContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ public class TestXmlApplicationContext extends AbstractXmlApplicationContext {
 
 	private final Resource[] resources;
 
+	@SuppressWarnings("this-escape")
 	public TestXmlApplicationContext(String... xmlStrings) {
 		resources = new Resource[xmlStrings.length];
 		for (int i = 0; i < xmlStrings.length; i++) {

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Jooyoung Pyoung
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -63,7 +64,7 @@ public class XmlPayloadValidatingFilterParserTests {
 	@BeforeEach
 	public void setUp() {
 		localeBeforeTest = Locale.getDefault();
-		Locale.setDefault(new Locale("en", "US"));
+		Locale.setDefault(Locale.US);
 	}
 
 	@AfterEach

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppHeaderEnricherParser.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/config/XmppHeaderEnricherParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.integration.xmpp.XmppHeaders;
  */
 public class XmppHeaderEnricherParser extends HeaderEnricherParserSupport {
 
+	@SuppressWarnings("this-escape")
 	public XmppHeaderEnricherParser() {
 		this.addElementToHeaderMapping("chat-to", XmppHeaders.TO);
 		this.addElementToHeaderMapping("chat-thread-id", XmppHeaders.THREAD);

--- a/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/channel/ZeroMqChannel.java
+++ b/spring-integration-zeromq/src/main/java/org/springframework/integration/zeromq/channel/ZeroMqChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -128,6 +128,7 @@ public class ZeroMqChannel extends AbstractMessageChannel implements Subscribabl
 	 * @param context the {@link ZContext} to use.
 	 * @param pubSub the communication model: push/pull or pub/sub.
 	 */
+	@SuppressWarnings("this-escape")
 	public ZeroMqChannel(ZContext context, boolean pubSub) {
 		Assert.notNull(context, "'context' must not be null");
 		this.context = context;
@@ -141,6 +142,7 @@ public class ZeroMqChannel extends AbstractMessageChannel implements Subscribabl
 		this.subscriberData = prepareSubscriberDataFlux();
 	}
 
+	@SuppressWarnings("this-escape")
 	private Mono<Integer> prepareProxyMono() {
 		return Mono.defer(() -> {
 					if (this.zeroMqProxy != null) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-integration/issues/10069

**Changes:**
- Add `@SuppressWarnings("this-escape")` to 80+ constructor calls across 22 modules
- Fix 4 additional deprecation/serial warnings in file, xml, and core modules