### PR TITLE
GH-10083: Replace springframework Nullable with jspecify Nullable in spring-integration-camel

### DIFF
--- a/spring-integration-camel/src/main/java/org/springframework/integration/camel/dsl/Camel.java
+++ b/spring-integration-camel/src/main/java/org/springframework/integration/camel/dsl/Camel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,7 @@ package org.springframework.integration.camel.dsl;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.LambdaRouteBuilder;
-
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Factory class for Apache Camel components DSL.

--- a/spring-integration-camel/src/main/java/org/springframework/integration/camel/dsl/CamelMessageHandlerSpec.java
+++ b/spring-integration-camel/src/main/java/org/springframework/integration/camel/dsl/CamelMessageHandlerSpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import java.util.function.Function;
 import org.apache.camel.ExchangePattern;
 import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.LambdaRouteBuilder;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.expression.Expression;
 import org.springframework.integration.camel.outbound.CamelMessageHandler;
@@ -30,7 +31,6 @@ import org.springframework.integration.camel.support.CamelHeaderMapper;
 import org.springframework.integration.dsl.MessageHandlerSpec;
 import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.mapping.HeaderMapper;
-import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 

--- a/spring-integration-camel/src/main/java/org/springframework/integration/camel/dsl/package-info.java
+++ b/spring-integration-camel/src/main/java/org/springframework/integration/camel/dsl/package-info.java
@@ -2,6 +2,5 @@
  * Provides supporting classes for JavaDSL with Apache Camel components.
  */
 
-@org.springframework.lang.NonNullApi
-@org.springframework.lang.NonNullFields
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.camel.dsl;

--- a/spring-integration-camel/src/main/java/org/springframework/integration/camel/outbound/CamelMessageHandler.java
+++ b/spring-integration-camel/src/main/java/org/springframework/integration/camel/outbound/CamelMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import org.apache.camel.ProducerTemplate;
 import org.apache.camel.builder.LambdaRouteBuilder;
 import org.apache.camel.builder.RouteBuilder;
 import org.apache.camel.model.RouteDefinition;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanInitializationException;
@@ -40,7 +41,6 @@ import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
-import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;

--- a/spring-integration-camel/src/main/java/org/springframework/integration/camel/outbound/package-info.java
+++ b/spring-integration-camel/src/main/java/org/springframework/integration/camel/outbound/package-info.java
@@ -2,6 +2,5 @@
  * Provides classes for Apache Camel outbound channel adapters.
  */
 
-@org.springframework.lang.NonNullApi
-@org.springframework.lang.NonNullFields
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.camel.outbound;

--- a/spring-integration-camel/src/main/java/org/springframework/integration/camel/support/package-info.java
+++ b/spring-integration-camel/src/main/java/org/springframework/integration/camel/support/package-info.java
@@ -2,6 +2,5 @@
  * Provides supporting classes for Apache Camel channel adapters.
  */
 
-@org.springframework.lang.NonNullApi
-@org.springframework.lang.NonNullFields
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.camel.support;


### PR DESCRIPTION
This change is applicable only to `spring-integration-camel`. 
Replaced `org.springframework.lang.Nullable` with `org.jspecify.annotations.Nullable`.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
