### PR TITLE
Introduce NullMarked to some packages in spring-integration-core module

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/acks/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/acks/package-info.java
@@ -1,5 +1,5 @@
 /**
  * Provides classes related to message acknowledgment.
  */
-@org.springframework.lang.NonNullApi
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.acks;

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -56,6 +57,7 @@ public abstract class AbstractAggregatingMessageGroupProcessor implements Messag
 
 	private boolean messageBuilderFactorySet;
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
 	@Override
@@ -117,6 +119,7 @@ public abstract class AbstractAggregatingMessageGroupProcessor implements Messag
 		return getHeadersFunction().apply(group);
 	}
 
+	@Nullable
 	protected abstract Object aggregatePayloads(MessageGroup group, Map<String, Object> defaultHeaders);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractAggregatingMessageGroupProcessor.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -119,7 +118,6 @@ public abstract class AbstractAggregatingMessageGroupProcessor implements Messag
 		return getHeadersFunction().apply(group);
 	}
 
-	@Nullable
 	protected abstract Object aggregatePayloads(MessageGroup group, Map<String, Object> defaultHeaders);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -937,7 +937,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 			this.logger.debug(() -> "Completing group with correlationKey [" + correlationKey + "]");
 
 			result = this.outputProcessor.processMessageGroup(group);
-			Assert.notNull(result, "the group returned a null result");
+			Assert.state(result != null, "The processorMessageGroup returned a null result. Null result is not expected.");
 			if (isResultCollectionOfMessages(result)) {
 				partialSequence = (Collection<Message<?>>) result;
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -65,6 +65,7 @@ import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
@@ -125,8 +126,10 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 	private boolean releaseStrategySet;
 
+	@SuppressWarnings("NullAway.Init")
 	private MessageChannel discardChannel;
 
+	@Nullable
 	private String discardChannelName;
 
 	private boolean sendPartialResultOnExpiry;
@@ -143,18 +146,23 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 	private boolean releasePartialSequences;
 
+	@Nullable
 	private Expression groupTimeoutExpression;
 
+	@Nullable
 	private List<Advice> forceReleaseAdviceChain;
 
 	private long expireTimeout;
 
+	@Nullable
 	private Duration expireDuration;
 
 	private MessageGroupProcessor forceReleaseProcessor = new ForceReleaseMessageGroupProcessor();
 
+	@SuppressWarnings("NullAway.Init")
 	private EvaluationContext evaluationContext;
 
+	@Nullable
 	private ApplicationEventPublisher applicationEventPublisher;
 
 	private boolean expireGroupsUponTimeout = true;
@@ -165,10 +173,11 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 	private volatile boolean running;
 
+	@Nullable
 	private BiFunction<Message<?>, String, String> groupConditionSupplier;
 
 	public AbstractCorrelatingMessageHandler(MessageGroupProcessor processor, MessageGroupStore store,
-			CorrelationStrategy correlationStrategy, ReleaseStrategy releaseStrategy) {
+			@Nullable CorrelationStrategy correlationStrategy, @Nullable ReleaseStrategy releaseStrategy) {
 
 		Assert.notNull(processor, "'processor' must not be null");
 		Assert.notNull(store, "'store' must not be null");
@@ -504,6 +513,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		return this.discardChannel;
 	}
 
+	@Nullable
 	protected String getDiscardChannelName() {
 		return this.discardChannelName;
 	}
@@ -532,6 +542,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		return this.releasePartialSequences;
 	}
 
+	@Nullable
 	protected Expression getGroupTimeoutExpression() {
 		return this.groupTimeoutExpression;
 	}
@@ -641,8 +652,10 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	}
 
 	private void removeEmptyGroupAfterTimeout(UUID groupId, long timeout) {
+		TaskScheduler taskScheduler = getTaskScheduler();
+		Assert.notNull(taskScheduler, "'taskScheduler' must not be null");
 		ScheduledFuture<?> scheduledFuture =
-				getTaskScheduler()
+				taskScheduler
 						.schedule(() -> {
 							Lock lock = this.lockRegistry.obtain(groupId.toString());
 
@@ -699,8 +712,10 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 				Object groupId = messageGroup.getGroupId();
 				long timestamp = messageGroup.getTimestamp();
 				long lastModified = messageGroup.getLastModified();
+				TaskScheduler taskScheduler = getTaskScheduler();
+				Assert.notNull(taskScheduler, "'taskScheduler' must not be null");
 				ScheduledFuture<?> scheduledFuture =
-						getTaskScheduler()
+						taskScheduler
 								.schedule(() -> {
 									try {
 										processForceRelease(groupId, timestamp, lastModified);
@@ -753,7 +768,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	 * @param group The group.
 	 * @param completedMessages The completed messages.
 	 */
-	protected abstract void afterRelease(MessageGroup group, Collection<Message<?>> completedMessages);
+	protected abstract void afterRelease(MessageGroup group, @Nullable Collection<Message<?>> completedMessages);
 
 	/**
 	 * Subclasses may override if special action is needed because the group was released or discarded
@@ -912,14 +927,12 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	}
 
 	protected void completeGroup(Object correlationKey, MessageGroup group, Lock lock) {
-		Message<?> first = null;
-		if (group != null) {
-			first = group.getOne();
-		}
+		Message<?> first = group.getOne();
 		completeGroup(first, correlationKey, group, lock);
 	}
 
 	@SuppressWarnings("unchecked")
+	@Nullable
 	protected Collection<Message<?>> completeGroup(Message<?> message, Object correlationKey, MessageGroup group,
 			Lock lock) {
 
@@ -929,6 +942,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 			this.logger.debug(() -> "Completing group with correlationKey [" + correlationKey + "]");
 
 			result = this.outputProcessor.processMessageGroup(group);
+			Assert.notNull(result, "the group returned a null result");
 			if (isResultCollectionOfMessages(result)) {
 				partialSequence = (Collection<Message<?>>) result;
 			}
@@ -988,6 +1002,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		return false;
 	}
 
+	@Nullable
 	protected Object obtainGroupTimeout(MessageGroup group) {
 		if (this.groupTimeoutExpression != null) {
 			Object timeout = this.groupTimeoutExpression.getValue(this.evaluationContext, group);
@@ -1024,7 +1039,9 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 			if (this.expireTimeout > 0) {
 				purgeOrphanedGroups();
 				if (this.expireDuration != null) {
-					getTaskScheduler()
+					TaskScheduler taskScheduler = getTaskScheduler();
+					Assert.notNull(taskScheduler, "'taskScheduler' must not be null");
+					taskScheduler
 							.scheduleWithFixedDelay(this::purgeOrphanedGroups, this.expireDuration);
 				}
 			}
@@ -1062,6 +1079,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 	protected static class SequenceAwareMessageGroup extends SimpleMessageGroup {
 
+		@Nullable
 		private final SimpleMessageGroup sourceGroup;
 
 		public SequenceAwareMessageGroup(MessageGroup messageGroup) {
@@ -1124,6 +1142,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		}
 
 		@Override
+		@Nullable
 		public Object processMessageGroup(MessageGroup group) {
 			forceComplete(group);
 			return null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -65,7 +65,6 @@ import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
@@ -652,10 +651,8 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	}
 
 	private void removeEmptyGroupAfterTimeout(UUID groupId, long timeout) {
-		TaskScheduler taskScheduler = getTaskScheduler();
-		Assert.notNull(taskScheduler, "'taskScheduler' must not be null");
 		ScheduledFuture<?> scheduledFuture =
-				taskScheduler
+				getTaskScheduler()
 						.schedule(() -> {
 							Lock lock = this.lockRegistry.obtain(groupId.toString());
 
@@ -712,10 +709,8 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 				Object groupId = messageGroup.getGroupId();
 				long timestamp = messageGroup.getTimestamp();
 				long lastModified = messageGroup.getLastModified();
-				TaskScheduler taskScheduler = getTaskScheduler();
-				Assert.notNull(taskScheduler, "'taskScheduler' must not be null");
 				ScheduledFuture<?> scheduledFuture =
-						taskScheduler
+						getTaskScheduler()
 								.schedule(() -> {
 									try {
 										processForceRelease(groupId, timestamp, lastModified);
@@ -1039,9 +1034,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 			if (this.expireTimeout > 0) {
 				purgeOrphanedGroups();
 				if (this.expireDuration != null) {
-					TaskScheduler taskScheduler = getTaskScheduler();
-					Assert.notNull(taskScheduler, "'taskScheduler' must not be null");
-					taskScheduler
+					getTaskScheduler()
 							.scheduleWithFixedDelay(this::purgeOrphanedGroups, this.expireDuration);
 				}
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AggregatingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.integration.aggregator;
 
 import java.util.Collection;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.IntegrationPatternType;
 import org.springframework.integration.store.MessageGroup;
@@ -95,7 +97,7 @@ public class AggregatingMessageHandler extends AbstractCorrelatingMessageHandler
 	 * @param completedMessages The completed messages. Ignored in this implementation.
 	 */
 	@Override
-	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages) {
+	protected void afterRelease(MessageGroup messageGroup, @Nullable Collection<Message<?>> completedMessages) {
 		Object groupId = messageGroup.getGroupId();
 		MessageGroupStore messageStore = getMessageStore();
 		messageStore.completeGroup(groupId);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/BarrierMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/BarrierMessageHandler.java
@@ -68,8 +68,10 @@ public class BarrierMessageHandler extends AbstractReplyProducingMessageHandler
 
 	private final MessageGroupProcessor messageGroupProcessor;
 
+	@Nullable
 	private String discardChannelName;
 
+	@Nullable
 	private MessageChannel discardChannel;
 
 	/**
@@ -159,7 +161,7 @@ public class BarrierMessageHandler extends AbstractReplyProducingMessageHandler
 	 * @since 5.4
 	 */
 	public BarrierMessageHandler(long requestTimeout, long triggerTimeout, MessageGroupProcessor outputProcessor,
-			CorrelationStrategy correlationStrategy) {
+			@Nullable CorrelationStrategy correlationStrategy) {
 
 		Assert.notNull(outputProcessor, "'messageGroupProcessor' cannot be null");
 		this.messageGroupProcessor = outputProcessor;
@@ -218,6 +220,7 @@ public class BarrierMessageHandler extends AbstractReplyProducingMessageHandler
 	}
 
 	@Override
+	@Nullable
 	protected Object handleRequestMessage(Message<?> requestMessage) {
 		Object key = this.correlationStrategy.getCorrelationKey(requestMessage);
 		if (key == null) {
@@ -247,6 +250,7 @@ public class BarrierMessageHandler extends AbstractReplyProducingMessageHandler
 		return null;
 	}
 
+	@Nullable
 	private Object processRelease(Object key, Message<?> requestMessage, Message<?> releaseMessage) {
 		this.suspensions.remove(key);
 		if (releaseMessage.getPayload() instanceof Throwable) {
@@ -266,6 +270,7 @@ public class BarrierMessageHandler extends AbstractReplyProducingMessageHandler
 	 * @param releaseMessage the release message.
 	 * @return the result.
 	 */
+	@Nullable
 	protected Object buildResult(Object key, Message<?> requestMessage, Message<?> releaseMessage) {
 		SimpleMessageGroup group = new SimpleMessageGroup(key);
 		group.add(requestMessage);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelationStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/CorrelationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.aggregator;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.messaging.Message;
 
@@ -35,6 +37,7 @@ public interface CorrelationStrategy {
 	 * @param message The message.
 	 * @return The correlation key.
 	 */
+	@Nullable
 	Object getCorrelationKey(Message<?> message);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/DelegatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/DelegatingMessageGroupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,6 +61,7 @@ public class DelegatingMessageGroupProcessor implements MessageGroupProcessor, B
 
 	private volatile boolean messageBuilderFactorySet;
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
 	public DelegatingMessageGroupProcessor(MessageGroupProcessor delegate,

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageGroupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.integration.aggregator;
 
 import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.ConversionService;
@@ -58,6 +60,7 @@ public class ExpressionEvaluatingMessageGroupProcessor extends AbstractAggregati
 	 * {@link org.springframework.integration.core.MessagingTemplate} to send downstream.
 	 */
 	@Override
+	@Nullable
 	protected Object aggregatePayloads(MessageGroup group, Map<String, Object> headers) {
 		return this.processor.process(group.getMessages());
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageGroupProcessor.java
@@ -61,7 +61,7 @@ public class ExpressionEvaluatingMessageGroupProcessor extends AbstractAggregati
 	@Override
 	protected Object aggregatePayloads(MessageGroup group, Map<String, Object> headers) {
 		Object object = this.processor.process(group.getMessages());
-		Assert.notNull(object, "Result from processor must not be null");
+		Assert.state(object != null, "The process returned a null result. Null result is not expected.");
 		return object;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageGroupProcessor.java
@@ -18,11 +18,10 @@ package org.springframework.integration.aggregator;
 
 import java.util.Map;
 
-import org.jspecify.annotations.Nullable;
-
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.store.MessageGroup;
+import org.springframework.util.Assert;
 
 /**
  * A {@link MessageGroupProcessor} implementation that evaluates a SpEL expression. The SpEL context root is the list of
@@ -60,9 +59,10 @@ public class ExpressionEvaluatingMessageGroupProcessor extends AbstractAggregati
 	 * {@link org.springframework.integration.core.MessagingTemplate} to send downstream.
 	 */
 	@Override
-	@Nullable
 	protected Object aggregatePayloads(MessageGroup group, Map<String, Object> headers) {
-		return this.processor.process(group.getMessages());
+		Object object = this.processor.process(group.getMessages());
+		Assert.notNull(object, "Result from processor must not be null");
+		return object;
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageListProcessor.java
@@ -104,9 +104,10 @@ public class ExpressionEvaluatingMessageListProcessor extends AbstractExpression
 	 * evaluation result Object will be returned.
 	 */
 	@Override
-	@Nullable
 	public Object process(Collection<? extends Message<?>> messages) {
-		return this.evaluateExpression(this.expression, messages, this.expectedType);
+		Object object = this.evaluateExpression(this.expression, messages, this.expectedType);
+		Assert.state(object != null, "Failed to evaluate expression: " + this.expression);
+		return object;
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageListProcessor.java
@@ -106,7 +106,7 @@ public class ExpressionEvaluatingMessageListProcessor extends AbstractExpression
 	@Override
 	public Object process(Collection<? extends Message<?>> messages) {
 		Object object = this.evaluateExpression(this.expression, messages, this.expectedType);
-		Assert.state(object != null, "Failed to evaluate expression: " + this.expression);
+		Assert.state(object != null, "The evaluation of the expression returned a null. Null result is not expected." + this.expression);
 		return object;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ExpressionEvaluatingMessageListProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.integration.aggregator;
 
 import java.util.Collection;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.expression.Expression;
 import org.springframework.expression.ParseException;
@@ -37,6 +39,7 @@ public class ExpressionEvaluatingMessageListProcessor extends AbstractExpression
 
 	private final Expression expression;
 
+	@Nullable
 	private volatile Class<?> expectedType = null;
 
 	/**
@@ -101,6 +104,7 @@ public class ExpressionEvaluatingMessageListProcessor extends AbstractExpression
 	 * evaluation result Object will be returned.
 	 */
 	@Override
+	@Nullable
 	public Object process(Collection<? extends Message<?>> messages) {
 		return this.evaluateExpression(this.expression, messages, this.expectedType);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.aggregator;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -67,8 +68,7 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 	@Nullable
 	private Predicate<Message<?>> boundaryTrigger;
 
-	@Nullable
-	public Function<Message<?>, Integer> windowSizeFunction = FluxAggregatorMessageHandler::sequenceSizeHeader;
+	private Function<Message<?>, @Nullable Integer> windowSizeFunction = FluxAggregatorMessageHandler::sequenceSizeHeader;
 
 	@Nullable
 	private Function<Flux<Message<?>>, Flux<Flux<Message<?>>>> windowConfigurer;
@@ -203,7 +203,7 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 	 * @see Flux#window(int)
 	 * @see Flux#windowTimeout(int, Duration)
 	 */
-	public void setWindowSizeFunction(Function<Message<?>, Integer> windowSizeFunction) {
+	public void setWindowSizeFunction(Function<Message<?>, @Nullable  Integer> windowSizeFunction) {
 		Assert.notNull(windowSizeFunction, "'windowSizeFunction' must not be null");
 		this.windowSizeFunction = windowSizeFunction;
 	}
@@ -289,9 +289,9 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 								.build());
 	}
 
-	@NullUnmarked
+
 	private static Integer sequenceSizeHeader(Message<?> message) {
-		return message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, Integer.class);
+		return Objects.requireNonNull(message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, Integer.class));
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.aggregator;
 
 import java.time.Duration;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -203,7 +202,7 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 	 * @see Flux#window(int)
 	 * @see Flux#windowTimeout(int, Duration)
 	 */
-	public void setWindowSizeFunction(Function<Message<?>, @Nullable  Integer> windowSizeFunction) {
+	public void setWindowSizeFunction(Function<Message<?>, @Nullable Integer> windowSizeFunction) {
 		Assert.notNull(windowSizeFunction, "'windowSizeFunction' must not be null");
 		this.windowSizeFunction = windowSizeFunction;
 	}
@@ -255,8 +254,9 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 
 	@Override
 	public void stop() {
-		if (this.subscribed.compareAndSet(true, false) && this.subscription != null) {
-			this.subscription.dispose();
+		Disposable subscriptionToDispose = this.subscription;
+		if (this.subscribed.compareAndSet(true, false) && subscriptionToDispose != null) {
+			subscriptionToDispose.dispose();
 		}
 	}
 
@@ -289,9 +289,7 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 								.build());
 	}
 
-
-	private static Integer sequenceSizeHeader(Message<?> message) {
-		return Objects.requireNonNull(message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, Integer.class));
+	private static @Nullable Integer sequenceSizeHeader(Message<?> message) {
+		return message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, Integer.class);
 	}
-
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.FluxSink;
@@ -62,18 +64,24 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 	private CorrelationStrategy correlationStrategy =
 			new HeaderAttributeCorrelationStrategy(IntegrationMessageHeaderAccessor.CORRELATION_ID);
 
+	@Nullable
 	private Predicate<Message<?>> boundaryTrigger;
 
-	private Function<Message<?>, Integer> windowSizeFunction = FluxAggregatorMessageHandler::sequenceSizeHeader;
+	@Nullable
+	public Function<Message<?>, Integer> windowSizeFunction = FluxAggregatorMessageHandler::sequenceSizeHeader;
 
+	@Nullable
 	private Function<Flux<Message<?>>, Flux<Flux<Message<?>>>> windowConfigurer;
 
+	@Nullable
 	private Duration windowTimespan;
 
 	private Function<Flux<Message<?>>, Mono<Message<?>>> combineFunction = this::messageForWindowFlux;
 
+	@SuppressWarnings("NullAway.Init")
 	private FluxSink<Message<?>> sink;
 
+	@Nullable
 	private volatile Disposable subscription;
 
 	/**
@@ -90,7 +98,9 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 	}
 
 	private Object groupBy(Message<?> message) {
-		return this.correlationStrategy.getCorrelationKey(message);
+		Object result = this.correlationStrategy.getCorrelationKey(message);
+		Assert.notNull(result, "Correlation key cannot be null");
+		return result;
 	}
 
 	private Flux<Message<?>> releaseBy(Flux<Message<?>> groupFlux) {
@@ -99,6 +109,7 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 				.flatMap((windowFlux) -> windowFlux.transform(this.combineFunction));
 	}
 
+	@NullUnmarked
 	private Flux<Flux<Message<?>>> applyWindowOptions(Flux<Message<?>> groupFlux) {
 		if (this.boundaryTrigger != null) {
 			return groupFlux.windowUntil(this.boundaryTrigger);
@@ -106,6 +117,7 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 		return groupFlux
 				.switchOnFirst((signal, group) -> {
 					if (signal.hasValue()) {
+						Assert.notNull(this.windowSizeFunction, "'windowSizeFunction' must not be null");
 						Integer maxSize = this.windowSizeFunction.apply(signal.get());
 						if (maxSize != null) {
 							if (this.windowTimespan != null) {
@@ -277,6 +289,7 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 								.build());
 	}
 
+	@NullUnmarked
 	private static Integer sequenceSizeHeader(Message<?> message) {
 		return message.getHeaders().get(IntegrationMessageHeaderAccessor.SEQUENCE_SIZE, Integer.class);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandler.java
@@ -17,11 +17,11 @@
 package org.springframework.integration.aggregator;
 
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import org.jspecify.annotations.NullUnmarked;
 import org.jspecify.annotations.Nullable;
 import reactor.core.Disposable;
 import reactor.core.publisher.Flux;
@@ -108,7 +108,6 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 				.flatMap((windowFlux) -> windowFlux.transform(this.combineFunction));
 	}
 
-	@NullUnmarked
 	private Flux<Flux<Message<?>>> applyWindowOptions(Flux<Message<?>> groupFlux) {
 		if (this.boundaryTrigger != null) {
 			return groupFlux.windowUntil(this.boundaryTrigger);
@@ -117,7 +116,7 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 				.switchOnFirst((signal, group) -> {
 					if (signal.hasValue()) {
 						Assert.notNull(this.windowSizeFunction, "'windowSizeFunction' must not be null");
-						Integer maxSize = this.windowSizeFunction.apply(signal.get());
+						Integer maxSize = this.windowSizeFunction.apply(Objects.requireNonNull(signal.get()));
 						if (maxSize != null) {
 							if (this.windowTimespan != null) {
 								return group.windowTimeout(maxSize, this.windowTimespan);
@@ -196,7 +195,7 @@ public class FluxAggregatorMessageHandler extends AbstractMessageProducingHandle
 	/**
 	 * Specify a {@link Function} to determine a size for windows to close against the first message in group.
 	 * Tne result of the function can be combined with the {@link #setWindowTimespan(Duration)}.
-	 * By default an {@link IntegrationMessageHeaderAccessor#SEQUENCE_SIZE} header is consulted.
+	 * By default, an {@link IntegrationMessageHeaderAccessor#SEQUENCE_SIZE} header is consulted.
 	 * @param windowSizeFunction the {@link Function} to use to determine a window size
 	 * against a first message in the group.
 	 * @see Flux#window(int)

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/HeaderAttributeCorrelationStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/HeaderAttributeCorrelationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.aggregator;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -35,6 +37,7 @@ public class HeaderAttributeCorrelationStrategy implements CorrelationStrategy {
 		this.attributeName = attributeName;
 	}
 
+	@Nullable
 	public Object getCorrelationKey(Message<?> message) {
 		return message.getHeaders().get(this.attributeName);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageGroupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.integration.aggregator;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.store.MessageGroup;
 
@@ -37,6 +39,7 @@ public interface MessageGroupProcessor {
 	 * @param group The message group.
 	 * @return The result of processing the group.
 	 */
+	@Nullable
 	Object processMessageGroup(MessageGroup group);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageListProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.integration.aggregator;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 
 /**
@@ -27,6 +29,7 @@ import org.springframework.messaging.Message;
 @FunctionalInterface
 public interface MessageListProcessor {
 
+	@Nullable
 	Object process(Collection<? extends Message<?>> messages);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageListProcessor.java
@@ -29,7 +29,6 @@ import org.springframework.messaging.Message;
 @FunctionalInterface
 public interface MessageListProcessor {
 
-	@Nullable
 	Object process(Collection<? extends Message<?>> messages);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MessageListProcessor.java
@@ -18,8 +18,6 @@ package org.springframework.integration.aggregator;
 
 import java.util.Collection;
 
-import org.jspecify.annotations.Nullable;
-
 import org.springframework.messaging.Message;
 
 /**

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingCorrelationStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingCorrelationStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.integration.aggregator;
 
 import java.lang.reflect.Method;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -57,6 +59,7 @@ public class MethodInvokingCorrelationStrategy implements CorrelationStrategy, B
 	}
 
 	@Override
+	@Nullable
 	public Object getCorrelationKey(Message<?> message) {
 		return this.processor.processMessage(message);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
@@ -20,14 +20,13 @@ import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
 
-import org.jspecify.annotations.Nullable;
-
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.integration.annotation.Aggregator;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.integration.support.management.ManageableLifecycle;
 import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
 
 /**
  * MessageGroupProcessor that serves as an adapter for the invocation of a POJO method.
@@ -87,10 +86,11 @@ public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMess
 	}
 
 	@Override
-	@Nullable
 	protected final Object aggregatePayloads(MessageGroup group, Map<String, Object> headers) {
 		final Collection<Message<?>> messagesUpForProcessing = group.getMessages();
-		return this.processor.process(messagesUpForProcessing, headers);
+		Object object = this.processor.process(messagesUpForProcessing, headers);
+		Assert.notNull(object, "Result from processor must not be null");
+		return object;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,8 @@ package org.springframework.integration.aggregator;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Map;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.convert.ConversionService;
@@ -85,6 +87,7 @@ public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMess
 	}
 
 	@Override
+	@Nullable
 	protected final Object aggregatePayloads(MessageGroup group, Map<String, Object> headers) {
 		final Collection<Message<?>> messagesUpForProcessing = group.getMessages();
 		return this.processor.process(messagesUpForProcessing, headers);

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageGroupProcessor.java
@@ -89,7 +89,7 @@ public class MethodInvokingMessageGroupProcessor extends AbstractAggregatingMess
 	protected final Object aggregatePayloads(MessageGroup group, Map<String, Object> headers) {
 		final Collection<Message<?>> messagesUpForProcessing = group.getMessages();
 		Object object = this.processor.process(messagesUpForProcessing, headers);
-		Assert.notNull(object, "Result from processor must not be null");
+		Assert.state(object != null, "The process returned a null result. Null result is not expected.");
 		return object;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingMessageListProcessor.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.Map;
 
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.handler.support.MessagingMethodInvokerHelper;
@@ -89,7 +90,7 @@ public class MethodInvokingMessageListProcessor<T> extends AbstractExpressionEva
 	}
 
 	@SuppressWarnings("unchecked")
-	public T process(Collection<Message<?>> messages, Map<String, Object> aggregateHeaders) {
+	public @Nullable T process(Collection<Message<?>> messages, @Nullable Map<String, Object> aggregateHeaders) {
 		return (T) this.delegate.process(messages, aggregateHeaders);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/MethodInvokingReleaseStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,7 @@ public class MethodInvokingReleaseStrategy implements ReleaseStrategy, BeanFacto
 
 	@Override
 	public boolean canRelease(MessageGroup messages) {
-		return this.adapter.process(messages.getMessages(), null);
+		return Boolean.TRUE.equals(this.adapter.process(messages.getMessages(), null));
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageGroupProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,8 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.store.MessageGroup;
 import org.springframework.messaging.Message;
@@ -40,6 +42,7 @@ public class ResequencingMessageGroupProcessor implements MessageGroupProcessor 
 
 	private final Comparator<Message<?>> comparator = new MessageSequenceComparator();
 
+	@Nullable
 	public Object processMessageGroup(MessageGroup group) {
 		Collection<Message<?>> messages = group.getMessages();
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@
 package org.springframework.integration.aggregator;
 
 import java.util.Collection;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.IntegrationPatternType;
 import org.springframework.integration.store.MessageGroup;
@@ -78,7 +80,7 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 	}
 
 	@Override
-	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages) {
+	protected void afterRelease(MessageGroup messageGroup, @Nullable Collection<Message<?>> completedMessages) {
 		afterRelease(messageGroup, completedMessages, false);
 	}
 
@@ -90,7 +92,7 @@ public class ResequencingMessageHandler extends AbstractCorrelatingMessageHandle
 	 * @param timeout True if the release/discard was due to a timeout.
 	 */
 	@Override
-	protected void afterRelease(MessageGroup messageGroup, Collection<Message<?>> completedMessages, boolean timeout) {
+	protected void afterRelease(MessageGroup messageGroup, @Nullable Collection<Message<?>> completedMessages, boolean timeout) {
 		int size = messageGroup.size();
 		int sequenceSize = messageGroup.getSequenceSize();
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes related to message aggregation.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.aggregator;

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/ExpressionCapable.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/ExpressionCapable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 
 package org.springframework.integration.context;
+
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.expression.Expression;
 
@@ -32,6 +35,7 @@ public interface ExpressionCapable {
 	 * Return the primary SpEL expression if this component is expression-based.
 	 * @return the expression as a String.
 	 */
+	@Nullable
 	Expression getExpression();
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/ExpressionCapable.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/ExpressionCapable.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.context;
 
-
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.expression.Expression;

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -140,9 +140,10 @@ public abstract class IntegrationContextUtils {
 	 * @param beanFactory BeanFactory for lookup, must not be null.
 	 * @return The {@link TaskScheduler} bean whose name is "taskScheduler" if available.
 	 */
-	@Nullable
 	public static TaskScheduler getTaskScheduler(BeanFactory beanFactory) {
-		return getBeanOfType(beanFactory, TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class);
+		TaskScheduler taskScheduler  = getBeanOfType(beanFactory, TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class);
+		Assert.state(taskScheduler != null, "No such bean '" + TASK_SCHEDULER_BEAN_NAME + "'");
+		return taskScheduler;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -131,9 +131,10 @@ public abstract class IntegrationContextUtils {
 	 * @param beanFactory BeanFactory for lookup, must not be null.
 	 * @return The {@link MessageChannel} bean whose name is "errorChannel".
 	 */
-	@Nullable
 	public static MessageChannel getErrorChannel(BeanFactory beanFactory) {
-		return getBeanOfType(beanFactory, ERROR_CHANNEL_BEAN_NAME, MessageChannel.class);
+		MessageChannel channel = getBeanOfType(beanFactory, ERROR_CHANNEL_BEAN_NAME, MessageChannel.class);
+		Assert.state(channel != null, "Error Channel was not found");
+		return channel;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationContextUtils.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.context;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -120,6 +122,7 @@ public abstract class IntegrationContextUtils {
 	 * @param beanFactory BeanFactory for lookup, must not be null.
 	 * @return The {@link MetadataStore} bean whose name is "metadataStore".
 	 */
+	@Nullable
 	public static MetadataStore getMetadataStore(BeanFactory beanFactory) {
 		return getBeanOfType(beanFactory, METADATA_STORE_BEAN_NAME, MetadataStore.class);
 	}
@@ -128,6 +131,7 @@ public abstract class IntegrationContextUtils {
 	 * @param beanFactory BeanFactory for lookup, must not be null.
 	 * @return The {@link MessageChannel} bean whose name is "errorChannel".
 	 */
+	@Nullable
 	public static MessageChannel getErrorChannel(BeanFactory beanFactory) {
 		return getBeanOfType(beanFactory, ERROR_CHANNEL_BEAN_NAME, MessageChannel.class);
 	}
@@ -136,6 +140,7 @@ public abstract class IntegrationContextUtils {
 	 * @param beanFactory BeanFactory for lookup, must not be null.
 	 * @return The {@link TaskScheduler} bean whose name is "taskScheduler" if available.
 	 */
+	@Nullable
 	public static TaskScheduler getTaskScheduler(BeanFactory beanFactory) {
 		return getBeanOfType(beanFactory, TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class);
 	}
@@ -156,6 +161,7 @@ public abstract class IntegrationContextUtils {
 	 * @return the instance of {@link StandardEvaluationContext} bean whose name is
 	 * {@value #INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME}.
 	 */
+	@Nullable
 	public static StandardEvaluationContext getEvaluationContext(BeanFactory beanFactory) {
 		return getBeanOfType(beanFactory, INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME, StandardEvaluationContext.class);
 	}
@@ -166,11 +172,13 @@ public abstract class IntegrationContextUtils {
 	 * {@value #INTEGRATION_SIMPLE_EVALUATION_CONTEXT_BEAN_NAME}.
 	 * @since 4.3.15
 	 */
+	@Nullable
 	public static SimpleEvaluationContext getSimpleEvaluationContext(BeanFactory beanFactory) {
 		return getBeanOfType(beanFactory, INTEGRATION_SIMPLE_EVALUATION_CONTEXT_BEAN_NAME,
 				SimpleEvaluationContext.class);
 	}
 
+	@Nullable
 	private static <T> T getBeanOfType(BeanFactory beanFactory, String beanName, Class<T> type) {
 		Assert.notNull(beanFactory, "BeanFactory must not be null");
 		if (!beanFactory.containsBean(beanName)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -72,38 +72,50 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 
 	protected final LogAccessor logger = new LogAccessor(getClass()); // NOSONAR protected
 
+	@SuppressWarnings("NullAway.Init")
 	private DestinationResolver<MessageChannel> channelResolver;
 
+	@SuppressWarnings("NullAway.Init")
 	private String beanName;
 
+	@Nullable
 	private String componentName;
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
+	@Nullable
 	private TaskScheduler taskScheduler;
 
 	private IntegrationProperties integrationProperties = new IntegrationProperties();
 
+	@Nullable
 	private ConversionService conversionService;
 
+	@SuppressWarnings("NullAway.Init")
 	private ApplicationContext applicationContext;
 
+	@SuppressWarnings("NullAway.Init")
 	private MessageBuilderFactory messageBuilderFactory;
 
+	@Nullable
 	private Expression expression;
 
+	@Nullable
 	private Object beanSource;
 
+	@Nullable
 	private String beanDescription;
 
 	private boolean initialized;
 
 	@Override
-	public final void setBeanName(@Nullable String beanName) {
+	public final void setBeanName(String beanName) {
 		this.beanName = beanName;
 	}
 
 	@Override
+	@Nullable
 	public String getBeanName() {
 		return this.beanName;
 	}
@@ -113,6 +125,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	 * If {@link #componentName} was not set this method will default to the 'beanName' of this component;
 	 */
 	@Override
+	@Nullable
 	public String getComponentName() {
 		return StringUtils.hasText(this.componentName) ? this.componentName : this.beanName;
 	}
@@ -128,6 +141,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	/**
 	 * Subclasses may implement this method to provide component type information.
 	 */
+	@Nullable
 	@Override
 	public String getComponentType() {
 		return null;
@@ -195,6 +209,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	}
 
 	@Override
+	@Nullable
 	public Expression getExpression() {
 		return this.expression;
 	}
@@ -208,6 +223,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 		this.expression = expression;
 	}
 
+	@SuppressWarnings("NullAway.Init")
 	@Override
 	public final void afterPropertiesSet() {
 		this.integrationProperties = IntegrationContextUtils.getIntegrationProperties(this.beanFactory);
@@ -264,6 +280,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 		this.taskScheduler = taskScheduler;
 	}
 
+	@Nullable
 	protected TaskScheduler getTaskScheduler() {
 		if (this.taskScheduler == null && this.beanFactory != null) {
 			this.taskScheduler = IntegrationContextUtils.getTaskScheduler(this.beanFactory);
@@ -278,6 +295,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 		return this.channelResolver;
 	}
 
+	@Nullable
 	public ConversionService getConversionService() {
 		if (this.conversionService == null && this.beanFactory != null) {
 			this.conversionService = IntegrationUtils.getConversionService(this.beanFactory);
@@ -299,6 +317,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	 * {@link ApplicationContext} is available.
 	 * @return The id, or null if there is no application context.
 	 */
+	@Nullable
 	public String getApplicationContextId() {
 		return this.applicationContext == null ? null : this.applicationContext.getId();
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -280,11 +280,11 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 		this.taskScheduler = taskScheduler;
 	}
 
-	@Nullable
 	protected TaskScheduler getTaskScheduler() {
 		if (this.taskScheduler == null && this.beanFactory != null) {
 			this.taskScheduler = IntegrationContextUtils.getTaskScheduler(this.beanFactory);
 		}
+		Assert.notNull(this.taskScheduler, "'taskScheduler' must not be null");
 		return this.taskScheduler;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -141,8 +141,8 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	/**
 	 * Subclasses may implement this method to provide component type information.
 	 */
-	@Nullable
 	@Override
+	@Nullable
 	public String getComponentType() {
 		return null;
 	}
@@ -152,8 +152,8 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 		this.beanSource = source;
 	}
 
-	@Nullable
 	@Override
+	@Nullable
 	public Object getComponentSource() {
 		return this.beanSource;
 	}
@@ -163,8 +163,8 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 		this.beanDescription = description;
 	}
 
-	@Nullable
 	@Override
+	@Nullable
 	public String getComponentDescription() {
 		return this.beanDescription;
 	}
@@ -223,8 +223,8 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 		this.expression = expression;
 	}
 
-	@SuppressWarnings("NullAway.Init")
 	@Override
+	@SuppressWarnings("NullAway.Init")
 	public final void afterPropertiesSet() {
 		this.integrationProperties = IntegrationContextUtils.getIntegrationProperties(this.beanFactory);
 		if (this.messageBuilderFactory == null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -224,7 +224,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	}
 
 	@Override
-	@SuppressWarnings("NullAway.Init")
+	@SuppressWarnings("NullAway")
 	public final void afterPropertiesSet() {
 		this.integrationProperties = IntegrationContextUtils.getIntegrationProperties(this.beanFactory);
 		if (this.messageBuilderFactory == null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2024 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.integration.context;
 
 import java.util.Arrays;
 import java.util.Properties;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.JavaUtils;
 import org.springframework.util.Assert;
@@ -139,6 +141,7 @@ public final class IntegrationProperties {
 
 	private long endpointsDefaultTimeout = IntegrationContextUtils.DEFAULT_TIMEOUT;
 
+	@Nullable
 	private volatile Properties properties;
 
 	static {

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes relating to application context configuration.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.context;

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
@@ -54,10 +54,13 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 
 	protected final MessagingTemplate messagingTemplate = new MessagingTemplate(); // NOSONAR final
 
+	@SuppressWarnings("NullAway.Init")
 	private DestinationResolver<MessageChannel> channelResolver;
 
+	@Nullable
 	private MessageChannel channel;
 
+	@Nullable
 	private String channelName;
 
 	private ErrorMessageStrategy errorMessageStrategy = new DefaultErrorMessageStrategy();
@@ -79,6 +82,7 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 		return this.errorMessageStrategy;
 	}
 
+	@Nullable
 	public MessageChannel getChannel() {
 		populateChannel();
 		return this.channel;
@@ -146,7 +150,7 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 	 * @param failedMessage the message.
 	 * @param throwable the throwable.
 	 */
-	public void publish(@Nullable Message<?> inputMessage, Message<?> failedMessage, Throwable throwable) {
+	public void publish(@Nullable Message<?> inputMessage, @Nullable Message<?> failedMessage, Throwable throwable) {
 		publish(throwable, ErrorMessageUtils.getAttributeAccessor(inputMessage, failedMessage));
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
@@ -120,6 +120,7 @@ public class MessagingTemplate extends GenericMessagingTemplate {
 			return null;
 		}
 	}
+
 	@Nullable
 	public Message<?> receive(MessageChannel destination, long timeout) {
 		return doReceive(destination, timeout);

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/MessagingTemplate.java
@@ -44,6 +44,7 @@ public class MessagingTemplate extends GenericMessagingTemplate {
 
 	private final Lock lock = new ReentrantLock();
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
 	private volatile boolean throwExceptionOnLateReplySet;
@@ -84,7 +85,7 @@ public class MessagingTemplate extends GenericMessagingTemplate {
 	 * backward compatibility.
 	 * @param channel the channel to set.
 	 */
-	public void setDefaultChannel(MessageChannel channel) {
+	public void setDefaultChannel(@Nullable MessageChannel channel) {
 		super.setDefaultDestination(channel);
 	}
 
@@ -109,6 +110,7 @@ public class MessagingTemplate extends GenericMessagingTemplate {
 		return super.sendAndReceive(destination, requestMessage);
 	}
 
+	@Nullable
 	public Object receiveAndConvert(MessageChannel destination, long timeout) {
 		Message<?> message = doReceive(destination, timeout);
 		if (message != null) {
@@ -118,7 +120,7 @@ public class MessagingTemplate extends GenericMessagingTemplate {
 			return null;
 		}
 	}
-
+	@Nullable
 	public Message<?> receive(MessageChannel destination, long timeout) {
 		return doReceive(destination, timeout);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides core classes.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.core;

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2024 the original author or authors.
+ * Copyright 2019-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,13 +29,19 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.TaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Artem Bilan
@@ -159,6 +165,7 @@ class FluxAggregatorMessageHandlerTests {
 	void testWindowTimespan() {
 		QueueChannel resultChannel = new QueueChannel();
 		FluxAggregatorMessageHandler fluxAggregatorMessageHandler = new FluxAggregatorMessageHandler();
+		fluxAggregatorMessageHandler.setBeanFactory(getBeanFactory());
 		fluxAggregatorMessageHandler.setOutputChannel(resultChannel);
 		fluxAggregatorMessageHandler.setWindowTimespan(Duration.ofMillis(100));
 		fluxAggregatorMessageHandler.start();
@@ -211,6 +218,15 @@ class FluxAggregatorMessageHandlerTests {
 		fluxAggregatorMessageHandler.stop();
 
 		executorService.shutdown();
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/FluxAggregatorMessageHandlerTests.java
@@ -29,19 +29,14 @@ import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Artem Bilan
@@ -165,7 +160,7 @@ class FluxAggregatorMessageHandlerTests {
 	void testWindowTimespan() {
 		QueueChannel resultChannel = new QueueChannel();
 		FluxAggregatorMessageHandler fluxAggregatorMessageHandler = new FluxAggregatorMessageHandler();
-		fluxAggregatorMessageHandler.setBeanFactory(getBeanFactory());
+		fluxAggregatorMessageHandler.setTaskScheduler(mock());
 		fluxAggregatorMessageHandler.setOutputChannel(resultChannel);
 		fluxAggregatorMessageHandler.setWindowTimespan(Duration.ofMillis(100));
 		fluxAggregatorMessageHandler.start();
@@ -218,15 +213,6 @@ class FluxAggregatorMessageHandlerTests {
 		fluxAggregatorMessageHandler.stop();
 
 		executorService.shutdown();
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
@@ -41,13 +41,12 @@ import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -240,7 +239,7 @@ public class HeaderChannelRegistryTests {
 	@Test
 	public void testRemoveOnGet() {
 		DefaultHeaderChannelRegistry registry = new DefaultHeaderChannelRegistry();
-		registry.setBeanFactory(getBeanFactory());
+		registry.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		MessageChannel channel = new DirectChannel();
 		String foo = (String) registry.channelToChannelName(channel);
 		Map<?, ?> map = TestUtils.getPropertyValue(registry, "channels", Map.class);
@@ -250,15 +249,6 @@ public class HeaderChannelRegistryTests {
 		registry.setRemoveOnGet(true);
 		assertThat(registry.channelNameToChannel(foo)).isSameAs(channel);
 		assertThat(map.size()).isEqualTo(0);
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 
 	public static class Foo extends AbstractReplyProducingMessageHandler {

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2024 the original author or authors.
+ * Copyright 2013-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,8 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -238,6 +240,7 @@ public class HeaderChannelRegistryTests {
 	@Test
 	public void testRemoveOnGet() {
 		DefaultHeaderChannelRegistry registry = new DefaultHeaderChannelRegistry();
+		registry.setBeanFactory(getBeanFactory());
 		MessageChannel channel = new DirectChannel();
 		String foo = (String) registry.channelToChannelName(channel);
 		Map<?, ?> map = TestUtils.getPropertyValue(registry, "channels", Map.class);
@@ -247,6 +250,15 @@ public class HeaderChannelRegistryTests {
 		registry.setRemoveOnGet(true);
 		assertThat(registry.channelNameToChannel(foo)).isSameAs(channel);
 		assertThat(map.size()).isEqualTo(0);
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 	public static class Foo extends AbstractReplyProducingMessageHandler {

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
@@ -36,6 +36,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -57,10 +58,15 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Artem Bilan
@@ -130,6 +136,7 @@ public class ReactiveStreamsTests {
 	@Test
 	void testPollableReactiveFlow() throws Exception {
 		assertThat(this.reactiveTransformer).isInstanceOf(ReactiveStreamsConsumer.class);
+		this.reactiveTransformer.setBeanFactory(getBeanFactory());
 		this.inputChannel.send(new GenericMessage<>("1,2,3,4,5"));
 
 		CountDownLatch latch = new CountDownLatch(6);
@@ -163,6 +170,15 @@ public class ReactiveStreamsTests {
 		assertThat(integers).isNotNull();
 		assertThat(integers.size()).isEqualTo(7);
 		exec.shutdownNow();
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
@@ -36,7 +36,6 @@ import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -58,15 +57,11 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Artem Bilan
@@ -136,7 +131,7 @@ public class ReactiveStreamsTests {
 	@Test
 	void testPollableReactiveFlow() throws Exception {
 		assertThat(this.reactiveTransformer).isInstanceOf(ReactiveStreamsConsumer.class);
-		this.reactiveTransformer.setBeanFactory(getBeanFactory());
+		this.reactiveTransformer.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		this.inputChannel.send(new GenericMessage<>("1,2,3,4,5"));
 
 		CountDownLatch latch = new CountDownLatch(6);
@@ -170,15 +165,6 @@ public class ReactiveStreamsTests {
 		assertThat(integers).isNotNull();
 		assertThat(integers.size()).isEqualTo(7);
 		exec.shutdownNow();
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/AsyncGatewayTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,11 +42,15 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Mark Fisher
@@ -65,7 +69,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
 		Future<Message<?>> f = service.returnMessage("foo");
@@ -88,7 +92,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(channel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
 		Future<Message<?>> f = service.returnMessage("foo");
@@ -106,7 +110,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
 		CompletableFuture<Message<?>> f = service.returnMessageListenable("foo");
@@ -132,7 +136,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
 		CustomFuture f = service.returnCustomFuture("foo");
@@ -149,7 +153,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 
 		proxyFactory.setAsyncExecutor(null);    // Not async - user flow returns Future<?>
 
@@ -181,7 +185,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
 		Future<String> f = service.returnString("foo");
@@ -197,7 +201,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
 		Future<?> f = service.returnSomething("foo");
@@ -211,7 +215,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(new NullChannel());
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
 		Future<Void> f = service.asyncSendAndForget("test1");
@@ -251,7 +255,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.setAsyncExecutor(null);
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
@@ -267,7 +271,7 @@ public class AsyncGatewayTests {
 		startResponder(requestChannel);
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
@@ -282,7 +286,7 @@ public class AsyncGatewayTests {
 		startResponder(requestChannel);
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
@@ -297,7 +301,7 @@ public class AsyncGatewayTests {
 		startResponder(requestChannel);
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
@@ -313,7 +317,7 @@ public class AsyncGatewayTests {
 		startResponder(requestChannel);
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
@@ -329,7 +333,7 @@ public class AsyncGatewayTests {
 		GatewayProxyFactoryBean<TestEchoService> proxyFactory = new GatewayProxyFactoryBean<>(TestEchoService.class);
 		proxyFactory.setDefaultRequestChannel(new NullChannel());
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestEchoService service = proxyFactory.getObject();
 		Mono<Void> mono = service.monoVoid("test1");
@@ -370,6 +374,15 @@ public class AsyncGatewayTests {
 			}
 			((MessageChannel) input.getHeaders().getReplyChannel()).send(reply);
 		}).start();
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 	private interface TestEchoService {

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -89,6 +89,7 @@ import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
@@ -340,6 +341,7 @@ public class GatewayInterfaceTests {
 		bf.registerSingleton("requestChannelBar", channel);
 		bf.registerSingleton("requestChannelBaz", channel);
 		bf.registerSingleton("requestChannelFoo", channel);
+		bf.registerSingleton("taskScheduler", mock(TaskScheduler.class));
 		fb.setBeanFactory(bf);
 		fb.afterPropertiesSet();
 		assertThat(fb.getObject()).isNotSameAs(bar);

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,15 +59,19 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Mark Fisher
@@ -85,7 +89,7 @@ public class GatewayProxyFactoryBeanTests {
 		startResponder(requestChannel);
 		GatewayProxyFactoryBean<TestService> proxyFactory = new GatewayProxyFactoryBean<>(TestService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.setBeanName("testGateway");
 		proxyFactory.afterPropertiesSet();
 		TestService service = proxyFactory.getObject();
@@ -113,7 +117,7 @@ public class GatewayProxyFactoryBeanTests {
 		GatewayProxyFactoryBean<TestService> proxyFactory = new GatewayProxyFactoryBean<>(TestService.class);
 		DefaultListableBeanFactory bf = new DefaultListableBeanFactory();
 		bf.registerSingleton(IntegrationUtils.INTEGRATION_CONVERSION_SERVICE_BEAN_NAME, cs);
-
+		bf.registerSingleton("taskScheduler", mock(TaskScheduler.class));
 		proxyFactory.setBeanFactory(bf);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
@@ -121,7 +125,7 @@ public class GatewayProxyFactoryBeanTests {
 		TestService service = proxyFactory.getObject();
 		byte[] result = service.requestReplyInBytes("foo");
 		assertThat(result.length).isEqualTo(6);
-		Mockito.verify(stringToByteConverter, Mockito.times(1)).convert(Mockito.any(String.class));
+		Mockito.verify(stringToByteConverter, Mockito.times(1)).convert(any(String.class));
 	}
 
 	@Test
@@ -130,7 +134,7 @@ public class GatewayProxyFactoryBeanTests {
 		GatewayProxyFactoryBean<TestService> proxyFactory = new GatewayProxyFactoryBean<>(TestService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestService service = proxyFactory.getObject();
 		service.oneWay("test");
@@ -142,7 +146,7 @@ public class GatewayProxyFactoryBeanTests {
 	@Test
 	public void testOneWayIgnoreReply() {
 		DirectChannel requestChannel = new DirectChannel();
-		BeanFactory beanFactory = mock(BeanFactory.class);
+		BeanFactory beanFactory = getBeanFactory();
 		QueueChannel nullChannel = new QueueChannel();
 		willReturn(nullChannel)
 				.given(beanFactory)
@@ -173,7 +177,7 @@ public class GatewayProxyFactoryBeanTests {
 		proxyFactory.setDefaultRequestChannel(new DirectChannel());
 		proxyFactory.setDefaultReplyChannel(replyChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestService service = proxyFactory.getObject();
 		String result = service.solicitResponse();
@@ -188,7 +192,7 @@ public class GatewayProxyFactoryBeanTests {
 		GatewayProxyFactoryBean<TestService> proxyFactory = new GatewayProxyFactoryBean<>(TestService.class);
 		proxyFactory.setDefaultReplyChannel(replyChannel);
 
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestService service = proxyFactory.getObject();
 		Message<String> message = service.getMessage();
@@ -210,7 +214,7 @@ public class GatewayProxyFactoryBeanTests {
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setDefaultReplyChannel(replyChannel);
 
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestService service = proxyFactory.getObject();
 
@@ -229,7 +233,7 @@ public class GatewayProxyFactoryBeanTests {
 		GatewayProxyFactoryBean<TestService> proxyFactory = new GatewayProxyFactoryBean<>(TestService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestService service = proxyFactory.getObject();
 		Integer result = service.requestReplyWithIntegers(123);
@@ -300,7 +304,7 @@ public class GatewayProxyFactoryBeanTests {
 		GatewayProxyFactoryBean<TestService> proxyFactory = new GatewayProxyFactoryBean<>(TestService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestService service = proxyFactory.getObject();
 		String result = service.requestReplyWithMessageParameter(new GenericMessage<>("foo"));
@@ -314,7 +318,7 @@ public class GatewayProxyFactoryBeanTests {
 		GatewayProxyFactoryBean<TestService> proxyFactory = new GatewayProxyFactoryBean<>(TestService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestService service = proxyFactory.getObject();
 		String result = service.requestReplyWithPayloadAnnotation();
@@ -338,7 +342,7 @@ public class GatewayProxyFactoryBeanTests {
 		GatewayProxyFactoryBean<TestService> proxyFactory = new GatewayProxyFactoryBean<>(TestService.class);
 		proxyFactory.setDefaultRequestChannel(requestChannel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestService service = proxyFactory.getObject();
 		Message<?> result = service.requestReplyWithMessageReturnValue("foo");
@@ -356,7 +360,7 @@ public class GatewayProxyFactoryBeanTests {
 		GatewayProxyFactoryBean<TestService> proxyFactory = new GatewayProxyFactoryBean<>(TestService.class);
 		proxyFactory.setDefaultRequestChannel(new DirectChannel());
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		Object proxy = proxyFactory.getObject();
 		String expected = "gateway proxy for";
@@ -380,7 +384,7 @@ public class GatewayProxyFactoryBeanTests {
 		consumer.start();
 		proxyFactory.setDefaultRequestChannel(channel);
 		proxyFactory.setBeanName("testGateway");
-		proxyFactory.setBeanFactory(mock(BeanFactory.class));
+		proxyFactory.setBeanFactory(getBeanFactory());
 		proxyFactory.afterPropertiesSet();
 		TestExceptionThrowingInterface proxy = proxyFactory.getObject();
 		assertThatExceptionOfType(TestException.class)
@@ -398,7 +402,7 @@ public class GatewayProxyFactoryBeanTests {
 	@Test
 	public void testProgrammaticWiring() {
 		GatewayProxyFactoryBean<TestEchoService> gpfb = new GatewayProxyFactoryBean<>(TestEchoService.class);
-		gpfb.setBeanFactory(mock(BeanFactory.class));
+		gpfb.setBeanFactory(getBeanFactory());
 		QueueChannel drc = new QueueChannel();
 		gpfb.setDefaultRequestChannel(drc);
 		gpfb.setDefaultReplyTimeout(0L);
@@ -412,6 +416,15 @@ public class GatewayProxyFactoryBeanTests {
 		String bar = (String) message.getHeaders().get("foo");
 		assertThat(bar).isNotNull();
 		assertThat(bar).isEqualTo("bar");
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 	@Test
@@ -495,7 +508,7 @@ public class GatewayProxyFactoryBeanTests {
 	@Test
 	public void testOverriddenMethod() {
 		GatewayProxyFactoryBean<InheritChild> gpfb = new GatewayProxyFactoryBean<>(InheritChild.class);
-		gpfb.setBeanFactory(mock(BeanFactory.class));
+		gpfb.setBeanFactory(getBeanFactory());
 		gpfb.afterPropertiesSet();
 		Map<Method, MessagingGatewaySupport> gateways = gpfb.getGateways();
 		assertThat(gateways.size()).isEqualTo(2);
@@ -508,6 +521,7 @@ public class GatewayProxyFactoryBeanTests {
 		beanFactory.registerSingleton("requestChannel", requestChannel);
 		GatewayProxyFactoryBean<CompositedGatewayService> gpfb = new GatewayProxyFactoryBean<>(
 				CompositedGatewayService.class);
+		beanFactory.registerSingleton("taskScheduler", mock(TaskScheduler.class));
 		gpfb.setBeanFactory(beanFactory);
 		gpfb.afterPropertiesSet();
 		Map<Method, MessagingGatewaySupport> gateways = gpfb.getGateways();

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyMessageMappingTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayProxyMessageMappingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,9 +32,11 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Headers;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.scheduling.TaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Mark Fisher
@@ -58,6 +60,8 @@ public class GatewayProxyMessageMappingTests {
 		context.registerBeanDefinition(IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME,
 				new RootBeanDefinition(IntegrationEvaluationContextFactoryBean.class));
 		context.refresh();
+		context.getBeanFactory().registerSingleton("taskScheduler", mock(TaskScheduler.class));
+
 		factoryBean.setBeanFactory(context);
 		factoryBean.afterPropertiesSet();
 		this.gateway = factoryBean.getObject();
@@ -144,6 +148,7 @@ public class GatewayProxyMessageMappingTests {
 		context.registerBeanDefinition("testBean", new RootBeanDefinition(TestBean.class));
 		context.registerBeanDefinition(IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME,
 				new RootBeanDefinition(IntegrationEvaluationContextFactoryBean.class));
+		context.getBeanFactory().registerSingleton("taskScheduler", mock(TaskScheduler.class));
 		context.refresh();
 		TestGateway gateway = context.getBean("testGateway", TestGateway.class);
 		gateway.payloadAnnotationAtMethodLevelUsingBeanResolver("foo");
@@ -171,6 +176,7 @@ public class GatewayProxyMessageMappingTests {
 		context.registerBeanDefinition("testBean", new RootBeanDefinition(TestBean.class));
 		context.registerBeanDefinition(IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME,
 				new RootBeanDefinition(IntegrationEvaluationContextFactoryBean.class));
+		context.getBeanFactory().registerSingleton("taskScheduler", mock(TaskScheduler.class));
 		context.refresh();
 		TestGateway gateway = context.getBean("testGateway", TestGateway.class);
 		gateway.payloadAnnotationWithExpressionUsingBeanResolver("foo");

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/AsyncHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/AsyncHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,12 +41,15 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.TaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -218,7 +221,7 @@ public class AsyncHandlerTests {
 	public void testGateway() {
 		this.whichTest = 0;
 		GatewayProxyFactoryBean<Foo> gpfb = new GatewayProxyFactoryBean<>(Foo.class);
-		gpfb.setBeanFactory(mock(BeanFactory.class));
+		gpfb.setBeanFactory(getBeanFactory());
 		DirectChannel input = new DirectChannel();
 		gpfb.setDefaultRequestChannel(input);
 		gpfb.setDefaultReplyTimeout(10000L);
@@ -233,11 +236,20 @@ public class AsyncHandlerTests {
 		assertThat(result).isEqualTo("reply");
 	}
 
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
+	}
+
 	@Test
 	public void testGatewayWithException() {
 		this.whichTest = 0;
 		GatewayProxyFactoryBean<Foo> gpfb = new GatewayProxyFactoryBean<>(Foo.class);
-		gpfb.setBeanFactory(mock(BeanFactory.class));
+		gpfb.setBeanFactory(getBeanFactory());
 		DirectChannel input = new DirectChannel();
 		gpfb.setDefaultRequestChannel(input);
 		gpfb.setDefaultReplyTimeout(10000L);

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/AsyncHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/AsyncHandlerTests.java
@@ -41,15 +41,13 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.core.DestinationResolutionException;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -221,7 +219,8 @@ public class AsyncHandlerTests {
 	public void testGateway() {
 		this.whichTest = 0;
 		GatewayProxyFactoryBean<Foo> gpfb = new GatewayProxyFactoryBean<>(Foo.class);
-		gpfb.setBeanFactory(getBeanFactory());
+		gpfb.setBeanFactory(mock());
+		gpfb.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		DirectChannel input = new DirectChannel();
 		gpfb.setDefaultRequestChannel(input);
 		gpfb.setDefaultReplyTimeout(10000L);
@@ -236,20 +235,12 @@ public class AsyncHandlerTests {
 		assertThat(result).isEqualTo("reply");
 	}
 
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
-	}
-
 	@Test
 	public void testGatewayWithException() {
 		this.whichTest = 0;
 		GatewayProxyFactoryBean<Foo> gpfb = new GatewayProxyFactoryBean<>(Foo.class);
-		gpfb.setBeanFactory(getBeanFactory());
+		gpfb.setBeanFactory(mock());
+		gpfb.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		DirectChannel input = new DirectChannel();
 		gpfb.setDefaultRequestChannel(input);
 		gpfb.setDefaultReplyTimeout(10000L);

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -79,7 +79,7 @@ import org.springframework.messaging.handler.annotation.support.DefaultMessageHa
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.util.StopWatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -88,12 +88,9 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Mark Fisher
@@ -609,7 +606,8 @@ public class MethodInvokingMessageProcessorTests {
 	@Test
 	public void gatewayTest() throws Exception {
 		GatewayProxyFactoryBean<?> gwFactoryBean = new GatewayProxyFactoryBean<>();
-		gwFactoryBean.setBeanFactory(getBeanFactory());
+		gwFactoryBean.setTaskScheduler(new SimpleAsyncTaskScheduler());
+		gwFactoryBean.setBeanFactory(mock());
 		gwFactoryBean.afterPropertiesSet();
 		Object target = gwFactoryBean.getObject();
 		// just instantiate a helper with a simple target; we're going to invoke getTargetClass with reflection
@@ -619,15 +617,6 @@ public class MethodInvokingMessageProcessorTests {
 		method.setAccessible(true);
 		Object result = method.invoke(helper, target);
 		assertThat(result).isSameAs(RequestReplyExchanger.class);
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ import org.springframework.messaging.handler.annotation.support.DefaultMessageHa
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.StopWatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -87,9 +88,12 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Mark Fisher
@@ -605,7 +609,7 @@ public class MethodInvokingMessageProcessorTests {
 	@Test
 	public void gatewayTest() throws Exception {
 		GatewayProxyFactoryBean<?> gwFactoryBean = new GatewayProxyFactoryBean<>();
-		gwFactoryBean.setBeanFactory(mock(BeanFactory.class));
+		gwFactoryBean.setBeanFactory(getBeanFactory());
 		gwFactoryBean.afterPropertiesSet();
 		Object target = gwFactoryBean.getObject();
 		// just instantiate a helper with a simple target; we're going to invoke getTargetClass with reflection
@@ -615,6 +619,15 @@ public class MethodInvokingMessageProcessorTests {
 		method.setAccessible(true);
 		Object result = method.invoke(helper, target);
 		assertThat(result).isSameAs(RequestReplyExchanger.class);
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 	@Test

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFactoryTests.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.integration.ip.tcp.connection.AbstractClientConnectionFactory;
 import org.springframework.integration.ip.tcp.connection.AbstractServerConnectionFactory;
@@ -39,13 +38,10 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.transformer.ObjectToStringTransformer;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -62,7 +58,7 @@ public class ConnectionFactoryTests {
 		ApplicationEventPublisher publisher = e -> {
 		};
 		AbstractServerConnectionFactory server = Tcp.netServer(0).backlog(2).soTimeout(5000).getObject();
-		server.setBeanFactory(getBeanFactory());
+		server.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		final AtomicReference<Message<?>> received = new AtomicReference<>();
 		final CountDownLatch latch = new CountDownLatch(1);
 		server.registerListener(m -> {
@@ -83,15 +79,6 @@ public class ConnectionFactoryTests {
 		assertThat(received.get().getPayload()).isEqualTo("foo");
 		client.stop();
 		server.stop();
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 
 	@Test

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
@@ -69,6 +69,7 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.ReflectionUtils;
@@ -185,6 +186,7 @@ public class IpIntegrationTests {
 				.setHeader("udp_dest", "udp://localhost:" + this.udpInbound.getPort())
 				.build();
 		this.udpOut.send(outMessage);
+		this.udpIn.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		Message<?> received = this.udpIn.receive(10000);
 		assertThat(received).isNotNull();
 		assertThat(Transformers.objectToString().transform(received).getPayload()).isEqualTo("foo");

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,11 +68,13 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Gary Russell
@@ -134,6 +136,7 @@ public class IpIntegrationTests {
 		AbstractServerConnectionFactory server = Tcp.netServer(0).backlog(2).soTimeout(5000).id("server").getObject();
 		assertThat(server.getComponentName()).isEqualTo("server");
 		server.setApplicationEventPublisher(publisher);
+		server.setTaskScheduler(mock(TaskScheduler.class));
 		server.afterPropertiesSet();
 		TcpReceivingChannelAdapter inbound = Tcp.inboundAdapter(server).getObject();
 		QueueChannel received = new QueueChannel();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
@@ -56,13 +56,11 @@ import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -452,18 +450,9 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		scf.stop();
 	}
 
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
-	}
-
 	private AbstractServerConnectionFactory getDefaultServerConnectionFactory() {
 		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
-		scf.setBeanFactory(getBeanFactory());
+		scf.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		return scf;
 	}
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
@@ -451,12 +451,6 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		scf.stop();
 	}
 
-	private AbstractServerConnectionFactory getDefaultServerConnectionFactory() {
-		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
-		scf.setTaskScheduler(new SimpleAsyncTaskScheduler());
-		return scf;
-	}
-
 	@Test
 	public void testNetSingleNoOutboundInterceptors() throws Exception {
 		AbstractServerConnectionFactory scf = getDefaultServerConnectionFactory();
@@ -658,6 +652,12 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		assertThat(message).isNotNull();
 		assertThat(((Exception) message.getPayload()).getCause().getMessage()).isEqualTo("Failed");
 		scf.stop();
+	}
+
+	private static AbstractServerConnectionFactory getDefaultServerConnectionFactory() {
+		AbstractServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
+		scf.setTaskScheduler(new SimpleAsyncTaskScheduler());
+		return scf;
 	}
 
 	private class FailingService {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapterTests.java
@@ -82,7 +82,8 @@ public class TcpReceivingChannelAdapterTests extends AbstractTcpChannelAdapterTe
 		int port = scf.getPort();
 		QueueChannel channel = new QueueChannel();
 		adapter.setOutputChannel(channel);
-		adapter.setBeanFactory(mock(BeanFactory.class));
+		adapter.setBeanFactory(mock());
+		adapter.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		adapter.afterPropertiesSet();
 		Socket socket = SocketFactory.getDefault().createSocket("localhost", port);
 		socket.getOutputStream().write("Test1\r\n".getBytes());

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
@@ -73,16 +73,13 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -1207,7 +1204,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 	public void testInterceptedConnection() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
 		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
-		scf.setBeanFactory(getBeanFactory());
+		scf.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
 		scf.setDeserializer(serializer);
@@ -1241,7 +1238,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 	public void testInterceptedCleanup() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
 		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
-		scf.setBeanFactory(getBeanFactory());
+		scf.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
 		scf.setDeserializer(serializer);
@@ -1266,14 +1263,4 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		await().untilAsserted(() -> assertThat(handler.getConnections()).isEmpty());
 		scf.stop();
 	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
-	}
-
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpSendingMessageHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -73,12 +73,16 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -1203,6 +1207,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 	public void testInterceptedConnection() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
 		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
+		scf.setBeanFactory(getBeanFactory());
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
 		scf.setDeserializer(serializer);
@@ -1236,6 +1241,7 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 	public void testInterceptedCleanup() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
 		AbstractServerConnectionFactory scf = new TcpNetServerConnectionFactory(0);
+		scf.setBeanFactory(getBeanFactory());
 		ByteArrayCrLfSerializer serializer = new ByteArrayCrLfSerializer();
 		scf.setSerializer(serializer);
 		scf.setDeserializer(serializer);
@@ -1259,6 +1265,15 @@ public class TcpSendingMessageHandlerTests extends AbstractTcpChannelAdapterTest
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		await().untilAsserted(() -> assertThat(handler.getConnections()).isEmpty());
 		scf.stop();
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -68,7 +68,7 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -78,7 +78,6 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -700,7 +699,7 @@ public class CachingClientConnectionFactoryTests {
 	@Test //INT-3722
 	public void testGatewayRelease() {
 		TcpNetServerConnectionFactory in = new TcpNetServerConnectionFactory(0);
-		in.setBeanFactory(getBeanFactory());
+		in.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		in.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
 		final TcpSendingMessageHandler handler = new TcpSendingMessageHandler();
 		handler.setConnectionFactory(in);
@@ -823,14 +822,4 @@ public class CachingClientConnectionFactoryTests {
 		when(factory.isActive()).thenReturn(true);
 		return factory;
 	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
-	}
-
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,6 +68,7 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -77,6 +78,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -698,6 +700,7 @@ public class CachingClientConnectionFactoryTests {
 	@Test //INT-3722
 	public void testGatewayRelease() {
 		TcpNetServerConnectionFactory in = new TcpNetServerConnectionFactory(0);
+		in.setBeanFactory(getBeanFactory());
 		in.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
 		final TcpSendingMessageHandler handler = new TcpSendingMessageHandler();
 		handler.setConnectionFactory(in);
@@ -819,6 +822,15 @@ public class CachingClientConnectionFactoryTests {
 		when(factory.getConnection()).thenReturn(mockConn);
 		when(factory.isActive()).thenReturn(true);
 		return factory;
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -84,7 +85,7 @@ public class ConnectionFactoryTests {
 
 	@Test
 	void netOpenEventOnReadThread() throws InterruptedException, IOException {
-		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
+		TcpNetServerConnectionFactory server = getTcpNetServerConnectionFactory(0);
 		AtomicReference<Thread> readThread = new AtomicReference<>();
 		AtomicReference<Thread> openEventThread = new AtomicReference<>();
 		CountDownLatch latch1 = new CountDownLatch(1);
@@ -162,7 +163,7 @@ public class ConnectionFactoryTests {
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.setPoolSize(10);
 		scheduler.afterPropertiesSet();
-		BeanFactory bf = mock(BeanFactory.class);
+		BeanFactory bf = getBeanFactory();
 		when(bf.containsBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME)).thenReturn(true);
 		when(bf.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME, TaskScheduler.class)).thenReturn(scheduler);
 		serverFactory.setBeanFactory(bf);
@@ -273,22 +274,22 @@ public class ConnectionFactoryTests {
 
 	@Test
 	void healthCheckSuccessNet() throws InterruptedException {
-		healthCheckSuccess(new TcpNetServerConnectionFactory(0), false);
+		healthCheckSuccess(getTcpNetServerConnectionFactory(0), false);
 	}
 
 	@Test
 	void healthCheckSuccessNio() throws InterruptedException {
-		healthCheckSuccess(new TcpNioServerConnectionFactory(0), false);
+		healthCheckSuccess(getTcpNetServerConnectionFactory(0), false);
 	}
 
 	@Test
 	void healthCheckFailureNet() throws InterruptedException {
-		healthCheckSuccess(new TcpNetServerConnectionFactory(0), true);
+		healthCheckSuccess(getTcpNetServerConnectionFactory(0), true);
 	}
 
 	@Test
 	void healthCheckFailureNio() throws InterruptedException {
-		healthCheckSuccess(new TcpNioServerConnectionFactory(0), true);
+		healthCheckSuccess(getTcpNetServerConnectionFactory(0), true);
 	}
 
 	private void healthCheckSuccess(AbstractServerConnectionFactory server, boolean fail) throws InterruptedException {
@@ -298,7 +299,7 @@ public class ConnectionFactoryTests {
 				serverUp.countDown();
 			}
 		});
-		server.setBeanFactory(mock(BeanFactory.class));
+		server.setBeanFactory(getBeanFactory());
 		AtomicReference<TcpConnection> connection = new AtomicReference<>();
 		server.registerSender(conn -> {
 			connection.set(conn);
@@ -367,6 +368,21 @@ public class ConnectionFactoryTests {
 		server.stop();
 	}
 
+	private TcpNetServerConnectionFactory getTcpNetServerConnectionFactory(int port) {
+		TcpNetServerConnectionFactory result = new TcpNetServerConnectionFactory(port);
+		result.setBeanFactory(getBeanFactory());
+		return result;
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
+	}
+
 	@SuppressWarnings("serial")
 	private class FooEvent extends TcpConnectionOpenEvent {
 
@@ -375,5 +391,4 @@ public class ConnectionFactoryTests {
 		}
 
 	}
-
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -706,11 +706,12 @@ public class FailoverClientConnectionFactoryTests {
 		return result;
 	}
 
-	private TcpNetClientConnectionFactory getTcpNetServerConnectionFactory(String host, int port) {
+	private static TcpNetClientConnectionFactory getTcpNetServerConnectionFactory(String host, int port) {
 		TcpNetClientConnectionFactory result = new TcpNetClientConnectionFactory(host, port);
 		result.setTaskScheduler(new SimpleAsyncTaskScheduler());
 
 		return result;
 	}
+
 }
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -54,13 +54,12 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.SubscribableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -702,25 +701,16 @@ public class FailoverClientConnectionFactoryTests {
 
 	private TcpNetServerConnectionFactory getTcpNetServerConnectionFactory(int port) {
 		TcpNetServerConnectionFactory result = new TcpNetServerConnectionFactory(port);
-		result.setBeanFactory(getBeanFactory());
+		result.setTaskScheduler(new SimpleAsyncTaskScheduler());
 
 		return result;
 	}
 
 	private TcpNetClientConnectionFactory getTcpNetServerConnectionFactory(String host, int port) {
 		TcpNetClientConnectionFactory result = new TcpNetClientConnectionFactory(host, port);
-		result.setBeanFactory(getBeanFactory());
+		result.setTaskScheduler(new SimpleAsyncTaskScheduler());
 
 		return result;
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 }
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import javax.net.ssl.SSLServerSocket;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
 import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.integration.test.util.TestUtils;
@@ -48,6 +49,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.scheduling.TaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -470,6 +472,7 @@ public class SocketSupportTests {
 	public void testNioClientAndServerSSL() throws Exception {
 		System.setProperty("javax.net.debug", "all"); // SSL activity in the console
 		TcpNioServerConnectionFactory server = new TcpNioServerConnectionFactory(0);
+		server.setBeanFactory(getBeanFactory());
 		server.setSslHandshakeTimeout(43);
 		DefaultTcpSSLContextSupport sslContextSupport = new DefaultTcpSSLContextSupport("test.ks",
 				"test.truststore.ks", "secret", "secret");
@@ -576,6 +579,7 @@ public class SocketSupportTests {
 	public void testNioClientAndServerSSLDifferentContextsLargeDataWithReply() throws Exception {
 		System.setProperty("javax.net.debug", "all"); // SSL activity in the console
 		TcpNioServerConnectionFactory server = new TcpNioServerConnectionFactory(0);
+		server.setBeanFactory(getBeanFactory());
 		TcpSSLContextSupport serverSslContextSupport = new DefaultTcpSSLContextSupport("server.ks",
 				"server.truststore.ks", "secret", "secret");
 		DefaultTcpNioSSLConnectionSupport serverTcpNioConnectionSupport =
@@ -643,6 +647,15 @@ public class SocketSupportTests {
 
 		client.stop();
 		server.stop();
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 	private static class Replier implements TcpSender {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
@@ -41,7 +41,6 @@ import javax.net.ssl.SSLServerSocket;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
 import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.integration.test.util.TestUtils;
@@ -49,7 +48,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -472,7 +471,7 @@ public class SocketSupportTests {
 	public void testNioClientAndServerSSL() throws Exception {
 		System.setProperty("javax.net.debug", "all"); // SSL activity in the console
 		TcpNioServerConnectionFactory server = new TcpNioServerConnectionFactory(0);
-		server.setBeanFactory(getBeanFactory());
+		server.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		server.setSslHandshakeTimeout(43);
 		DefaultTcpSSLContextSupport sslContextSupport = new DefaultTcpSSLContextSupport("test.ks",
 				"test.truststore.ks", "secret", "secret");
@@ -579,7 +578,7 @@ public class SocketSupportTests {
 	public void testNioClientAndServerSSLDifferentContextsLargeDataWithReply() throws Exception {
 		System.setProperty("javax.net.debug", "all"); // SSL activity in the console
 		TcpNioServerConnectionFactory server = new TcpNioServerConnectionFactory(0);
-		server.setBeanFactory(getBeanFactory());
+		server.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		TcpSSLContextSupport serverSslContextSupport = new DefaultTcpSSLContextSupport("server.ks",
 				"server.truststore.ks", "secret", "secret");
 		DefaultTcpNioSSLConnectionSupport serverTcpNioConnectionSupport =
@@ -647,15 +646,6 @@ public class SocketSupportTests {
 
 		client.stop();
 		server.stop();
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 
 	private static class Replier implements TcpSender {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionSupportTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionSupportTests.java
@@ -26,10 +26,16 @@ import javax.net.SocketFactory;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
+import org.springframework.scheduling.TaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -41,6 +47,7 @@ public class TcpNetConnectionSupportTests {
 	@Test
 	public void testBadCode() throws Exception {
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
+		server.setBeanFactory(getBeanFactory());
 		AtomicReference<Message<?>> message = new AtomicReference<>();
 		CountDownLatch latch1 = new CountDownLatch(1);
 		server.registerListener(m -> {
@@ -81,4 +88,12 @@ public class TcpNetConnectionSupportTests {
 		server.stop();
 	}
 
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
+	}
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionSupportTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionSupportTests.java
@@ -26,16 +26,11 @@ import javax.net.SocketFactory;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.messaging.Message;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -47,7 +42,7 @@ public class TcpNetConnectionSupportTests {
 	@Test
 	public void testBadCode() throws Exception {
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
-		server.setBeanFactory(getBeanFactory());
+		server.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		AtomicReference<Message<?>> message = new AtomicReference<>();
 		CountDownLatch latch1 = new CountDownLatch(1);
 		server.registerListener(m -> {
@@ -86,14 +81,5 @@ public class TcpNetConnectionSupportTests {
 		assertThat(latch1.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(message.get()).isNotNull();
 		server.stop();
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionTests.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.beans.DirectFieldAccessor;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.integration.ip.tcp.connection.TcpNioConnection.ChannelInputStream;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayStxEtxSerializer;
@@ -47,12 +46,10 @@ import org.springframework.integration.support.converter.MapMessageConverter;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -157,7 +154,7 @@ public class TcpNetConnectionTests {
 	@Test
 	public void socketClosedNextRead() throws InterruptedException, IOException {
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
-		server.setBeanFactory(getBeanFactory());
+		server.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		AtomicInteger port = new AtomicInteger();
 		CountDownLatch latch = new CountDownLatch(1);
 		ApplicationEventPublisher publisher = ev -> {
@@ -177,15 +174,6 @@ public class TcpNetConnectionTests {
 		assertThatThrownBy(() -> connection.getPayload())
 				.isInstanceOf(SoftEndOfStreamException.class);
 		server.stop();
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
@@ -30,7 +30,6 @@ import javax.net.SocketFactory;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.ip.tcp.serializer.AbstractByteArraySerializer;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayLengthHeaderSerializer;
@@ -39,14 +38,10 @@ import org.springframework.integration.ip.util.SocketTestUtils;
 import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.with;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -68,7 +63,7 @@ public class TcpNioConnectionReadTests {
 			AbstractByteArraySerializer serializer, TcpListener listener, TcpSender sender) {
 
 		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
-		scf.setBeanFactory(getBeanFactory());
+		scf.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		scf.setUsingDirectBuffers(true);
 		scf.setApplicationEventPublisher(e -> {
 		});
@@ -538,14 +533,4 @@ public class TcpNioConnectionReadTests {
 				.atMost(Duration.ofSeconds(20))
 				.until(() -> !added.get(0).isOpen());
 	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
-	}
-
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import javax.net.SocketFactory;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.integration.ip.tcp.serializer.AbstractByteArraySerializer;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayCrLfSerializer;
 import org.springframework.integration.ip.tcp.serializer.ByteArrayLengthHeaderSerializer;
@@ -38,9 +39,14 @@ import org.springframework.integration.ip.util.SocketTestUtils;
 import org.springframework.integration.ip.util.TestingUtilities;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.ErrorMessage;
+import org.springframework.scheduling.TaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.with;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -62,6 +68,7 @@ public class TcpNioConnectionReadTests {
 			AbstractByteArraySerializer serializer, TcpListener listener, TcpSender sender) {
 
 		TcpNioServerConnectionFactory scf = new TcpNioServerConnectionFactory(0);
+		scf.setBeanFactory(getBeanFactory());
 		scf.setUsingDirectBuffers(true);
 		scf.setApplicationEventPublisher(e -> {
 		});
@@ -119,7 +126,6 @@ public class TcpNioConnectionReadTests {
 			semaphore.release();
 			return false;
 		});
-
 		int howMany = 2;
 		scf.setBacklog(howMany + 5);
 		// Fire up the sender.
@@ -144,7 +150,6 @@ public class TcpNioConnectionReadTests {
 			semaphore.release();
 			return false;
 		});
-
 		// Fire up the sender.
 
 		CountDownLatch done = SocketTestUtils.testSendStxEtx(scf.getPort(), latch);
@@ -532,6 +537,15 @@ public class TcpNioConnectionReadTests {
 		with().pollInterval(Duration.ofMillis(50)).await("Failed to close socket")
 				.atMost(Duration.ofSeconds(20))
 				.until(() -> !added.get(0).isOpen());
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpSenderTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpSenderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 the original author or authors.
+ * Copyright 2022-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.scheduling.TaskScheduler;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -43,6 +50,7 @@ public class TcpSenderTests {
 	void senderCalledForDeadConnectionClientNet() throws InterruptedException {
 		CountDownLatch latch = new CountDownLatch(1);
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
+		server.setBeanFactory(getBeanFactory());
 		server.registerListener(msg -> false);
 		server.afterPropertiesSet();
 		server.setApplicationEventPublisher(event -> {
@@ -61,6 +69,7 @@ public class TcpSenderTests {
 	void senderCalledForDeadConnectionClientNio() throws InterruptedException {
 		CountDownLatch latch = new CountDownLatch(1);
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
+		server.setBeanFactory(getBeanFactory());
 		server.registerListener(msg -> false);
 		server.afterPropertiesSet();
 		server.setApplicationEventPublisher(event -> {
@@ -161,4 +170,12 @@ public class TcpSenderTests {
 		assertThat(passedConnectionsToSenderViaAddNewConnection.get(1)).isSameAs(interceptorsPerInstance.get(6));
 	}
 
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
+	}
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpSenderTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpSenderTests.java
@@ -27,14 +27,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -50,7 +45,7 @@ public class TcpSenderTests {
 	void senderCalledForDeadConnectionClientNet() throws InterruptedException {
 		CountDownLatch latch = new CountDownLatch(1);
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
-		server.setBeanFactory(getBeanFactory());
+		server.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		server.registerListener(msg -> false);
 		server.afterPropertiesSet();
 		server.setApplicationEventPublisher(event -> {
@@ -69,7 +64,7 @@ public class TcpSenderTests {
 	void senderCalledForDeadConnectionClientNio() throws InterruptedException {
 		CountDownLatch latch = new CountDownLatch(1);
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
-		server.setBeanFactory(getBeanFactory());
+		server.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		server.registerListener(msg -> false);
 		server.afterPropertiesSet();
 		server.setApplicationEventPublisher(event -> {
@@ -168,14 +163,5 @@ public class TcpSenderTests {
 		// should be passed the last interceptor to the real sender via addNewConnection method
 		assertThat(passedConnectionsToSenderViaAddNewConnection.get(0)).isSameAs(interceptorsPerInstance.get(3));
 		assertThat(passedConnectionsToSenderViaAddNewConnection.get(1)).isSameAs(interceptorsPerInstance.get(6));
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/DeserializationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/DeserializationTests.java
@@ -44,16 +44,13 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatException;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIOException;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -314,17 +311,8 @@ public class DeserializationTests {
 
 	private TcpNioServerConnectionFactory getTcpNioServerConnectionFactory(int port) {
 		TcpNioServerConnectionFactory result = new TcpNioServerConnectionFactory(port);
-		result.setBeanFactory(getBeanFactory());
+		result.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		return result;
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 
 	private void testTimeoutWhileDecoding(AbstractByteArraySerializer deserializer, String reply) {

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailSearchTermsTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailSearchTermsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,12 @@ import jakarta.mail.search.SearchTerm;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -62,7 +65,7 @@ public class ImapMailSearchTermsTests {
 	public void validateSearchTermsWhenShouldMarkAsReadNoExistingFlagsGuts(String userFlag, ImapMailReceiver receiver)
 			throws NoSuchFieldException, IllegalAccessException, InvocationTargetException {
 		receiver.setShouldMarkMessagesAsRead(true);
-		receiver.setBeanFactory(mock(BeanFactory.class));
+		receiver.setBeanFactory(getBeanFactory());
 
 		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
 		folderField.setAccessible(true);
@@ -85,7 +88,7 @@ public class ImapMailSearchTermsTests {
 	public void validateSearchTermsWhenShouldMarkAsReadWithExistingFlags() throws Exception {
 		ImapMailReceiver receiver = new ImapMailReceiver();
 		receiver.setShouldMarkMessagesAsRead(true);
-		receiver.setBeanFactory(mock(BeanFactory.class));
+		receiver.setBeanFactory(getBeanFactory());
 
 		receiver.afterPropertiesSet();
 		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
@@ -115,7 +118,7 @@ public class ImapMailSearchTermsTests {
 	public void validateSearchTermsWhenShouldNotMarkAsReadNoExistingFlags() throws Exception {
 		ImapMailReceiver receiver = new ImapMailReceiver();
 		receiver.setShouldMarkMessagesAsRead(false);
-		receiver.setBeanFactory(mock(BeanFactory.class));
+		receiver.setBeanFactory(getBeanFactory());
 		receiver.afterPropertiesSet();
 
 		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
@@ -129,6 +132,15 @@ public class ImapMailSearchTermsTests {
 		Flags flags = new Flags();
 		SearchTerm searchTerms = (SearchTerm) compileSearchTerms.invoke(receiver, flags);
 		assertThat(searchTerms instanceof NotTerm).isTrue();
+	}
+
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
 	}
 
 }

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailSearchTermsTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/ImapMailSearchTermsTests.java
@@ -29,13 +29,10 @@ import jakarta.mail.search.NotTerm;
 import jakarta.mail.search.SearchTerm;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,7 +62,7 @@ public class ImapMailSearchTermsTests {
 	public void validateSearchTermsWhenShouldMarkAsReadNoExistingFlagsGuts(String userFlag, ImapMailReceiver receiver)
 			throws NoSuchFieldException, IllegalAccessException, InvocationTargetException {
 		receiver.setShouldMarkMessagesAsRead(true);
-		receiver.setBeanFactory(getBeanFactory());
+		receiver.setTaskScheduler(new SimpleAsyncTaskScheduler());
 
 		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
 		folderField.setAccessible(true);
@@ -88,7 +85,7 @@ public class ImapMailSearchTermsTests {
 	public void validateSearchTermsWhenShouldMarkAsReadWithExistingFlags() throws Exception {
 		ImapMailReceiver receiver = new ImapMailReceiver();
 		receiver.setShouldMarkMessagesAsRead(true);
-		receiver.setBeanFactory(getBeanFactory());
+		receiver.setTaskScheduler(new SimpleAsyncTaskScheduler());
 
 		receiver.afterPropertiesSet();
 		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
@@ -118,7 +115,7 @@ public class ImapMailSearchTermsTests {
 	public void validateSearchTermsWhenShouldNotMarkAsReadNoExistingFlags() throws Exception {
 		ImapMailReceiver receiver = new ImapMailReceiver();
 		receiver.setShouldMarkMessagesAsRead(false);
-		receiver.setBeanFactory(getBeanFactory());
+		receiver.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		receiver.afterPropertiesSet();
 
 		Field folderField = AbstractMailReceiver.class.getDeclaredField("folder");
@@ -132,15 +129,6 @@ public class ImapMailSearchTermsTests {
 		Flags flags = new Flags();
 		SearchTerm searchTerms = (SearchTerm) compileSearchTerms.invoke(receiver, flags);
 		assertThat(searchTerms instanceof NotTerm).isTrue();
-	}
-
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
 	}
 
 }

--- a/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterTests.java
+++ b/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterTests.java
@@ -75,14 +75,14 @@ public class SyslogReceivingChannelAdapterTests {
 		PollableChannel outputChannel = new QueueChannel();
 		factory.setPort(0);
 		factory.setOutputChannel(outputChannel);
-		factory.setBeanFactory(getBeanFactory());
+		factory.setBeanFactory(mock());
 		factory.afterPropertiesSet();
 		factory.start();
 		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter",
 				UnicastReceivingChannelAdapter.class);
 		TestingUtilities.waitListening(server, null);
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
-		adapter.setBeanFactory(getBeanFactory());
+		adapter.setBeanFactory(mock());
 		byte[] buf = "<157>JUL 26 22:08:35 WEBERN TESTING[70729]: TEST SYSLOG MESSAGE".getBytes(StandardCharsets.UTF_8);
 		DatagramPacket packet = new DatagramPacket(buf, buf.length, new InetSocketAddress("localhost",
 				server.getPort()));
@@ -141,15 +141,6 @@ public class SyslogReceivingChannelAdapterTests {
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
-	private BeanFactory getBeanFactory() {
-		BeanFactory beanFactory = mock(BeanFactory.class);
-		TaskScheduler taskScheduler = mock(TaskScheduler.class);
-		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
-				.thenReturn(taskScheduler);
-		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
-		return beanFactory;
-	}
-
 	@Test
 	public void testAsMapFalse() throws Exception {
 		SyslogReceivingChannelAdapterFactoryBean factory = new SyslogReceivingChannelAdapterFactoryBean(
@@ -157,18 +148,18 @@ public class SyslogReceivingChannelAdapterTests {
 		factory.setPort(0);
 		PollableChannel outputChannel = new QueueChannel();
 		factory.setOutputChannel(outputChannel);
-		factory.setBeanFactory(getBeanFactory());
+		factory.setBeanFactory(mock());
 		factory.afterPropertiesSet();
 		factory.start();
 		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter",
 				UnicastReceivingChannelAdapter.class);
-		server.setBeanFactory(getBeanFactory());
+		server.setBeanFactory(mock());
 		TestingUtilities.waitListening(server, null);
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
-		adapter.setBeanFactory(getBeanFactory());
+		adapter.setBeanFactory(mock());
 		DefaultMessageConverter defaultMessageConverter = new DefaultMessageConverter();
 		defaultMessageConverter.setAsMap(false);
-		defaultMessageConverter.setBeanFactory(getBeanFactory());
+		defaultMessageConverter.setBeanFactory(mock());
 		adapter.setConverter(defaultMessageConverter);
 		byte[] buf = "<157>JUL 26 22:08:35 WEBERN TESTING[70729]: TEST SYSLOG MESSAGE".getBytes(StandardCharsets.UTF_8);
 		DatagramPacket packet = new DatagramPacket(buf, buf.length, new InetSocketAddress("localhost",
@@ -242,7 +233,7 @@ public class SyslogReceivingChannelAdapterTests {
 	public void testUdpRFC5424() throws Exception {
 		SyslogReceivingChannelAdapterFactoryBean factory = new SyslogReceivingChannelAdapterFactoryBean(
 				SyslogReceivingChannelAdapterFactoryBean.Protocol.udp);
-		factory.setBeanFactory(getBeanFactory());
+		factory.setBeanFactory(mock());
 		factory.setPort(0);
 		PollableChannel outputChannel = new QueueChannel();
 		factory.setOutputChannel(outputChannel);
@@ -251,14 +242,14 @@ public class SyslogReceivingChannelAdapterTests {
 		factory.start();
 		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter",
 				UnicastReceivingChannelAdapter.class);
-		server.setBeanFactory(getBeanFactory());
+		server.setBeanFactory(mock());
 		TestingUtilities.waitListening(server, null);
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
 		byte[] buf = ("<14>1 2014-06-20T09:14:07+00:00 loggregator d0602076-b14a-4c55-852a-981e7afeed38 DEA - " +
 				"[exampleSDID@32473 iut=\\\"3\\\" eventSource=\\\"Application\\\" eventID=\\\"1011\\\"]" +
 				"[exampleSDID@32473 iut=\\\"3\\\" eventSource=\\\"Application\\\" eventID=\\\"1011\\\"] Removing instance")
 				.getBytes(StandardCharsets.UTF_8);
-		adapter.setBeanFactory(getBeanFactory());
+		adapter.setBeanFactory(mock());
 		DatagramPacket packet = new DatagramPacket(buf, buf.length, new InetSocketAddress("localhost",
 				adapter.getPort()));
 		DatagramSocket socket = new DatagramSocket();
@@ -272,4 +263,12 @@ public class SyslogReceivingChannelAdapterTests {
 		adapter.stop();
 	}
 
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
+	}
 }

--- a/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterTests.java
+++ b/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,14 +46,17 @@ import org.springframework.integration.syslog.config.SyslogReceivingChannelAdapt
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
+import org.springframework.scheduling.TaskScheduler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Gary Russell
@@ -72,13 +75,14 @@ public class SyslogReceivingChannelAdapterTests {
 		PollableChannel outputChannel = new QueueChannel();
 		factory.setPort(0);
 		factory.setOutputChannel(outputChannel);
-		factory.setBeanFactory(mock(BeanFactory.class));
+		factory.setBeanFactory(getBeanFactory());
 		factory.afterPropertiesSet();
 		factory.start();
 		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter",
 				UnicastReceivingChannelAdapter.class);
 		TestingUtilities.waitListening(server, null);
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
+		adapter.setBeanFactory(getBeanFactory());
 		byte[] buf = "<157>JUL 26 22:08:35 WEBERN TESTING[70729]: TEST SYSLOG MESSAGE".getBytes(StandardCharsets.UTF_8);
 		DatagramPacket packet = new DatagramPacket(buf, buf.length, new InetSocketAddress("localhost",
 				server.getPort()));
@@ -106,7 +110,7 @@ public class SyslogReceivingChannelAdapterTests {
 			return null;
 		}).when(publisher).publishEvent(any(ApplicationEvent.class));
 		factory.setApplicationEventPublisher(publisher);
-		factory.setBeanFactory(mock(BeanFactory.class));
+		factory.setBeanFactory(getBeanFactory());
 		factory.afterPropertiesSet();
 		factory.start();
 		AbstractServerConnectionFactory server = TestUtils.getPropertyValue(factory, "syslogAdapter.connectionFactory",
@@ -137,6 +141,15 @@ public class SyslogReceivingChannelAdapterTests {
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
+	private BeanFactory getBeanFactory() {
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		TaskScheduler taskScheduler = mock(TaskScheduler.class);
+		when(beanFactory.getBean(eq("taskScheduler"), any(Class.class)))
+				.thenReturn(taskScheduler);
+		when(beanFactory.containsBean("taskScheduler")).thenReturn(true);
+		return beanFactory;
+	}
+
 	@Test
 	public void testAsMapFalse() throws Exception {
 		SyslogReceivingChannelAdapterFactoryBean factory = new SyslogReceivingChannelAdapterFactoryBean(
@@ -144,15 +157,18 @@ public class SyslogReceivingChannelAdapterTests {
 		factory.setPort(0);
 		PollableChannel outputChannel = new QueueChannel();
 		factory.setOutputChannel(outputChannel);
-		factory.setBeanFactory(mock(BeanFactory.class));
+		factory.setBeanFactory(getBeanFactory());
 		factory.afterPropertiesSet();
 		factory.start();
 		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter",
 				UnicastReceivingChannelAdapter.class);
+		server.setBeanFactory(getBeanFactory());
 		TestingUtilities.waitListening(server, null);
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
+		adapter.setBeanFactory(getBeanFactory());
 		DefaultMessageConverter defaultMessageConverter = new DefaultMessageConverter();
 		defaultMessageConverter.setAsMap(false);
+		defaultMessageConverter.setBeanFactory(getBeanFactory());
 		adapter.setConverter(defaultMessageConverter);
 		byte[] buf = "<157>JUL 26 22:08:35 WEBERN TESTING[70729]: TEST SYSLOG MESSAGE".getBytes(StandardCharsets.UTF_8);
 		DatagramPacket packet = new DatagramPacket(buf, buf.length, new InetSocketAddress("localhost",
@@ -173,6 +189,7 @@ public class SyslogReceivingChannelAdapterTests {
 	public void testTcpRFC5424() throws Exception {
 		SyslogReceivingChannelAdapterFactoryBean factory = new SyslogReceivingChannelAdapterFactoryBean(
 				SyslogReceivingChannelAdapterFactoryBean.Protocol.tcp);
+		factory.setBeanFactory(getBeanFactory());
 		PollableChannel outputChannel = new QueueChannel();
 		factory.setOutputChannel(outputChannel);
 		ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
@@ -181,8 +198,9 @@ public class SyslogReceivingChannelAdapterTests {
 			latch.countDown();
 			return null;
 		}).when(publisher).publishEvent(any(ApplicationEvent.class));
-		factory.setBeanFactory(mock(BeanFactory.class));
+		factory.setBeanFactory(getBeanFactory());
 		AbstractServerConnectionFactory connectionFactory = new TcpNioServerConnectionFactory(0);
+		connectionFactory.setBeanFactory(getBeanFactory());
 		connectionFactory.setDeserializer(new RFC6587SyslogDeserializer());
 		connectionFactory.setApplicationEventPublisher(publisher);
 		factory.setConnectionFactory(connectionFactory);
@@ -191,6 +209,7 @@ public class SyslogReceivingChannelAdapterTests {
 		factory.start();
 		TestingUtilities.waitListening(connectionFactory, null);
 		TcpSyslogReceivingChannelAdapter adapter = (TcpSyslogReceivingChannelAdapter) factory.getObject();
+		adapter.setBeanFactory(getBeanFactory());
 		LogAccessor logger = spy(TestUtils.getPropertyValue(adapter, "logger", LogAccessor.class));
 		doReturn(true).when(logger).isDebugEnabled();
 		final CountDownLatch sawLog = new CountDownLatch(1);
@@ -223,21 +242,23 @@ public class SyslogReceivingChannelAdapterTests {
 	public void testUdpRFC5424() throws Exception {
 		SyslogReceivingChannelAdapterFactoryBean factory = new SyslogReceivingChannelAdapterFactoryBean(
 				SyslogReceivingChannelAdapterFactoryBean.Protocol.udp);
+		factory.setBeanFactory(getBeanFactory());
 		factory.setPort(0);
 		PollableChannel outputChannel = new QueueChannel();
 		factory.setOutputChannel(outputChannel);
-		factory.setBeanFactory(mock(BeanFactory.class));
 		factory.setConverter(new RFC5424MessageConverter());
 		factory.afterPropertiesSet();
 		factory.start();
 		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter",
 				UnicastReceivingChannelAdapter.class);
+		server.setBeanFactory(getBeanFactory());
 		TestingUtilities.waitListening(server, null);
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
 		byte[] buf = ("<14>1 2014-06-20T09:14:07+00:00 loggregator d0602076-b14a-4c55-852a-981e7afeed38 DEA - " +
 				"[exampleSDID@32473 iut=\\\"3\\\" eventSource=\\\"Application\\\" eventID=\\\"1011\\\"]" +
 				"[exampleSDID@32473 iut=\\\"3\\\" eventSource=\\\"Application\\\" eventID=\\\"1011\\\"] Removing instance")
 				.getBytes(StandardCharsets.UTF_8);
+		adapter.setBeanFactory(getBeanFactory());
 		DatagramPacket packet = new DatagramPacket(buf, buf.length, new InetSocketAddress("localhost",
 				adapter.getPort()));
 		DatagramSocket socket = new DatagramSocket();


### PR DESCRIPTION

This is a first pass at the module to make sure it is being converted properly.

There are 3 commits that comprise this PR.  Each commit handles a specific series of package(s) on the model.  
This was done to simplify the review process so each package could be reviewed indepently.
* Commit 1 - org.springframework.integration.container
* Commit 2 - org.springframework.integration.messaging.core
* Commit 3 - org.springframework.integration.aggregator & org.springframework.integration.acks

> [!NOTE]  
> Highlights information that users should take into account, even when skimming. in this commit that there cases where  methods are called where the parameters passed in may contain a null.
> In those cases the attribute that contains the potential null is tested with an `Assert.notNull`.  This may not be the best approach, let's discuss.

> [!NOTE]  
> Also note that in FluxAggregatorMessageHandler line 112 `@NullUnmarked` is used on the the applyWindowOptions method.
> This is because the consumer.apply on line 121 can not be null according to JSpecify.   But we can't make that assumption for how the user implemented the fuction.
>There maybe a better way of handling this besides marking the method as `NullUnmarked`.   Let's discuss.
> Similarly in FluxAggregatorMessageHandler the way in which sequenceSizeHeader is utilized it had to be `@NullUnmarked`.   Let's discuss

Related to https://github.com/spring-projects/spring-integration/issues/10083