### PR TITLE
GH-10083: Migrate `spring-integration-ws` module to Jspecify

### DIFF
--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import javax.xml.transform.TransformerException;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -68,13 +70,14 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 
 	private final String uri;
 
-	private final DestinationProvider destinationProvider;
+	private final @Nullable DestinationProvider destinationProvider;
 
 	private final Map<String, Expression> uriVariableExpressions = new HashMap<>();
 
+	@SuppressWarnings("NullAway.Init")
 	private StandardEvaluationContext evaluationContext;
 
-	private WebServiceMessageCallback requestCallback;
+	private @Nullable WebServiceMessageCallback requestCallback;
 
 	private WebServiceTemplate webServiceTemplate;
 
@@ -84,15 +87,17 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 
 	private boolean webServiceTemplateExplicitlySet;
 
-	public AbstractWebServiceOutboundGateway(final String uri, WebServiceMessageFactory messageFactory) {
+	@SuppressWarnings("NullAway")
+	public AbstractWebServiceOutboundGateway(final String uri, @Nullable WebServiceMessageFactory messageFactory) {
 		Assert.hasText(uri, "URI must not be empty");
 		this.webServiceTemplate = new WebServiceTemplate(messageFactory);
 		this.destinationProvider = null;
 		this.uri = uri;
 	}
 
+	@SuppressWarnings("NullAway")
 	public AbstractWebServiceOutboundGateway(DestinationProvider destinationProvider,
-			WebServiceMessageFactory messageFactory) {
+			@Nullable WebServiceMessageFactory messageFactory) {
 
 		Assert.notNull(destinationProvider, "DestinationProvider must not be null");
 		this.webServiceTemplate = new WebServiceTemplate(messageFactory);
@@ -165,7 +170,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 		this.webServiceTemplate.setMessageFactory(messageFactory);
 	}
 
-	public void setRequestCallback(WebServiceMessageCallback requestCallback) {
+	public void setRequestCallback(@Nullable WebServiceMessageCallback requestCallback) {
 		this.requestCallback = requestCallback;
 	}
 
@@ -199,7 +204,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 	}
 
 	@Override
-	public final Object handleRequestMessage(Message<?> requestMessage) {
+	public final @Nullable Object handleRequestMessage(Message<?> requestMessage) {
 		URI uriWithVariables = prepareUri(requestMessage);
 		if (uriWithVariables == null) {
 			throw new MessageDeliveryException(requestMessage, "Failed to determine URI for " +
@@ -215,7 +220,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 		return null;
 	}
 
-	private URI prepareUri(Message<?> requestMessage) {
+	private @Nullable URI prepareUri(Message<?> requestMessage) {
 		if (this.destinationProvider != null) {
 			return this.destinationProvider.getDestination();
 		}
@@ -229,17 +234,17 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 		return this.uriFactory.expand(this.uri, uriVariables);
 	}
 
-	protected abstract Object doHandle(String theUri, Message<?> requestMessage,
-			WebServiceMessageCallback reqCallback);
+	protected abstract @Nullable Object doHandle(String theUri, Message<?> requestMessage,
+			@Nullable WebServiceMessageCallback reqCallback);
 
 	protected abstract class RequestMessageCallback extends TransformerObjectSupport
 			implements WebServiceMessageCallback {
 
-		private final WebServiceMessageCallback reqCallback;
+		private final @Nullable WebServiceMessageCallback reqCallback;
 
 		private final Message<?> requestMessage;
 
-		public RequestMessageCallback(WebServiceMessageCallback requestCallback, Message<?> requestMessage) {
+		public RequestMessageCallback(@Nullable WebServiceMessageCallback requestCallback, Message<?> requestMessage) {
 			this.reqCallback = requestCallback;
 			this.requestMessage = requestMessage;
 		}
@@ -266,7 +271,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 			implements WebServiceMessageExtractor<Object> {
 
 		@Override
-		public Object extractData(WebServiceMessage message)
+		public @Nullable Object extractData(WebServiceMessage message)
 				throws IOException, TransformerException {
 
 			Object resultObject = this.doExtractData(message);
@@ -284,7 +289,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 			}
 		}
 
-		public abstract Object doExtractData(WebServiceMessage message) throws IOException, TransformerException;
+		public abstract @Nullable Object doExtractData(WebServiceMessage message) throws IOException, TransformerException;
 
 	}
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -69,7 +69,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 
 	protected final DefaultUriBuilderFactory uriFactory = new DefaultUriBuilderFactory(); // NOSONAR - final
 
-	private final String uri;
+	private final @Nullable String uri;
 
 	private final @Nullable DestinationProvider destinationProvider;
 
@@ -88,56 +88,25 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 
 	private boolean webServiceTemplateExplicitlySet;
 
-	public AbstractWebServiceOutboundGateway(final String uri) {
+	public AbstractWebServiceOutboundGateway(@Nullable final String uri, @Nullable WebServiceMessageFactory messageFactory) {
 		Assert.hasText(uri, "URI must not be empty");
-		this.webServiceTemplate = new WebServiceTemplate();
+		this.webServiceTemplate = messageFactory != null ?
+				new WebServiceTemplate(messageFactory) : new WebServiceTemplate();
 		this.destinationProvider = null;
 		this.uri = uri;
-	}
-
-	public AbstractWebServiceOutboundGateway(final String uri, WebServiceMessageFactory messageFactory) {
-		Assert.hasText(uri, "URI must not be empty");
-		this.webServiceTemplate = new WebServiceTemplate(messageFactory);
-		this.destinationProvider = null;
-		this.uri = uri;
-	}
-
-	public AbstractWebServiceOutboundGateway(final String uri, WebServiceTemplate webServiceTemplate) {
-		Assert.hasText(uri, "URI must not be empty");
-		doSetWebServiceTemplate(webServiceTemplate);
-		this.destinationProvider = null;
-		this.uri = uri;
-	}
-
-	protected AbstractWebServiceOutboundGateway(DestinationProvider destinationProvider,
-												WebServiceTemplate webServiceTemplate) {
-
-		Assert.notNull(destinationProvider, "DestinationProvider must not be null");
-		doSetWebServiceTemplate(webServiceTemplate);
-		this.destinationProvider = destinationProvider;
-		this.uri = "";
-	}
-
-	public AbstractWebServiceOutboundGateway(DestinationProvider destinationProvider) {
-		Assert.notNull(destinationProvider, "DestinationProvider must not be null");
-		this.webServiceTemplate = new WebServiceTemplate();
-		this.destinationProvider = destinationProvider;
-		// we always call WebServiceTemplate methods with an explicit URI argument,
-		// but in case the WebServiceTemplate is accessed directly we'll set this:
-		this.webServiceTemplate.setDestinationProvider(destinationProvider);
-		this.uri = "";
 	}
 
 	public AbstractWebServiceOutboundGateway(DestinationProvider destinationProvider,
-			WebServiceMessageFactory messageFactory) {
+			@Nullable WebServiceMessageFactory messageFactory) {
 
 		Assert.notNull(destinationProvider, "DestinationProvider must not be null");
-		this.webServiceTemplate = new WebServiceTemplate(messageFactory);
+		this.webServiceTemplate = messageFactory != null ?
+				new WebServiceTemplate(messageFactory) : new WebServiceTemplate();
 		this.destinationProvider = destinationProvider;
 		// we always call WebServiceTemplate methods with an explicit URI argument,
 		// but in case the WebServiceTemplate is accessed directly we'll set this:
 		this.webServiceTemplate.setDestinationProvider(destinationProvider);
-		this.uri = "";
+		this.uri = null;
 	}
 
 	public void setHeaderMapper(SoapHeaderMapper headerMapper) {
@@ -263,6 +232,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 						.withRoot(requestMessage)
 						.build();
 
+		Assert.notNull(this.uri, "'uri' must not be null");
 		return this.uriFactory.expand(this.uri, uriVariables);
 	}
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -61,6 +61,7 @@ import org.springframework.xml.transform.TransformerObjectSupport;
  * @author Artem Bilan
  * @author Christian Tzolov
  * @author Ngoc Nhan
+ * @author Jooyoung Pyoung
  */
 public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyProducingMessageHandler {
 
@@ -87,17 +88,48 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 
 	private boolean webServiceTemplateExplicitlySet;
 
-	@SuppressWarnings("NullAway")
-	public AbstractWebServiceOutboundGateway(final String uri, @Nullable WebServiceMessageFactory messageFactory) {
+	public AbstractWebServiceOutboundGateway(final String uri) {
+		Assert.hasText(uri, "URI must not be empty");
+		this.webServiceTemplate = new WebServiceTemplate();
+		this.destinationProvider = null;
+		this.uri = uri;
+	}
+
+	public AbstractWebServiceOutboundGateway(final String uri, WebServiceMessageFactory messageFactory) {
 		Assert.hasText(uri, "URI must not be empty");
 		this.webServiceTemplate = new WebServiceTemplate(messageFactory);
 		this.destinationProvider = null;
 		this.uri = uri;
 	}
 
-	@SuppressWarnings("NullAway")
+	public AbstractWebServiceOutboundGateway(final String uri, WebServiceTemplate webServiceTemplate) {
+		Assert.hasText(uri, "URI must not be empty");
+		doSetWebServiceTemplate(webServiceTemplate);
+		this.destinationProvider = null;
+		this.uri = uri;
+	}
+
+	protected AbstractWebServiceOutboundGateway(DestinationProvider destinationProvider,
+												WebServiceTemplate webServiceTemplate) {
+
+		Assert.notNull(destinationProvider, "DestinationProvider must not be null");
+		doSetWebServiceTemplate(webServiceTemplate);
+		this.destinationProvider = destinationProvider;
+		this.uri = "";
+	}
+
+	public AbstractWebServiceOutboundGateway(DestinationProvider destinationProvider) {
+		Assert.notNull(destinationProvider, "DestinationProvider must not be null");
+		this.webServiceTemplate = new WebServiceTemplate();
+		this.destinationProvider = destinationProvider;
+		// we always call WebServiceTemplate methods with an explicit URI argument,
+		// but in case the WebServiceTemplate is accessed directly we'll set this:
+		this.webServiceTemplate.setDestinationProvider(destinationProvider);
+		this.uri = "";
+	}
+
 	public AbstractWebServiceOutboundGateway(DestinationProvider destinationProvider,
-			@Nullable WebServiceMessageFactory messageFactory) {
+			WebServiceMessageFactory messageFactory) {
 
 		Assert.notNull(destinationProvider, "DestinationProvider must not be null");
 		this.webServiceTemplate = new WebServiceTemplate(messageFactory);
@@ -105,7 +137,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 		// we always call WebServiceTemplate methods with an explicit URI argument,
 		// but in case the WebServiceTemplate is accessed directly we'll set this:
 		this.webServiceTemplate.setDestinationProvider(destinationProvider);
-		this.uri = null;
+		this.uri = "";
 	}
 
 	public void setHeaderMapper(SoapHeaderMapper headerMapper) {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.springframework.xml.transform.TransformerHelper;
  * @author Mauro Molinari
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Jooyoung Pyoung
  *
  * @since 2.0
  */
@@ -126,6 +127,10 @@ public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapMessage> i
 	@Override
 	protected void populateUserDefinedHeader(String headerName, Object headerValue, SoapMessage target) {
 		SoapHeader soapHeader = target.getSoapHeader();
+		if (soapHeader == null) {
+			return;
+		}
+
 		if (headerValue instanceof String) {
 			QName qname = QNameUtils.parseQNameString(headerName);
 			soapHeader.addAttribute(qname, (String) headerValue);

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceInboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceInboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,10 @@ import org.springframework.ws.support.MarshallingUtils;
  */
 public class MarshallingWebServiceInboundGateway extends AbstractWebServiceInboundGateway {
 
+	@SuppressWarnings("NullAway.Init")
 	private Marshaller marshaller;
 
+	@SuppressWarnings("NullAway.Init")
 	private Unmarshaller unmarshaller;
 
 	/**

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
@@ -46,45 +46,41 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 
 	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider, Marshaller marshaller,
-			@Nullable Unmarshaller unmarshaller, WebServiceMessageFactory messageFactory) {
+			@Nullable Unmarshaller unmarshaller, @Nullable WebServiceMessageFactory messageFactory) {
 		super(destinationProvider, messageFactory);
 		configureMarshallers(marshaller, unmarshaller);
 	}
 
-	@SuppressWarnings("NullAway")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider, Marshaller marshaller,
 			Unmarshaller unmarshaller) {
 		this(destinationProvider, marshaller, unmarshaller, null);
 	}
 
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider, Marshaller marshaller,
-			WebServiceMessageFactory messageFactory) {
+			@Nullable WebServiceMessageFactory messageFactory) {
 		this(destinationProvider, marshaller, null, messageFactory);
 	}
 
-	@SuppressWarnings("NullAway")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider, Marshaller marshaller) {
 		this(destinationProvider, marshaller, (WebServiceMessageFactory) null);
 	}
 
 	@SuppressWarnings("this-escape")
-	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller, @Nullable Unmarshaller unmarshaller,
-			WebServiceMessageFactory messageFactory) {
+	public MarshallingWebServiceOutboundGateway(@Nullable String uri, Marshaller marshaller, @Nullable Unmarshaller unmarshaller,
+			@Nullable WebServiceMessageFactory messageFactory) {
 		super(uri, messageFactory);
 		configureMarshallers(marshaller, unmarshaller);
 	}
 
-	@SuppressWarnings("NullAway")
 	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller, Unmarshaller unmarshaller) {
 		this(uri, marshaller, unmarshaller, null);
 	}
 
 	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller,
-			WebServiceMessageFactory messageFactory) {
+			@Nullable WebServiceMessageFactory messageFactory) {
 		this(uri, marshaller, null, messageFactory);
 	}
 
-	@SuppressWarnings("NullAway")
 	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller) {
 		this(uri, marshaller, (WebServiceMessageFactory) null);
 	}
@@ -96,8 +92,9 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	 * @since 5.0
 	 */
 	@SuppressWarnings("this-escape")
-	public MarshallingWebServiceOutboundGateway(String uri, WebServiceTemplate webServiceTemplate) {
-		super(uri, webServiceTemplate);
+	public MarshallingWebServiceOutboundGateway(@Nullable String uri, WebServiceTemplate webServiceTemplate) {
+		super(uri, null);
+		doSetWebServiceTemplate(webServiceTemplate);
 	}
 
 	/**
@@ -109,7 +106,8 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider,
 			WebServiceTemplate webServiceTemplate) {
-		super(destinationProvider, webServiceTemplate);
+		super(destinationProvider, null);
+		doSetWebServiceTemplate(webServiceTemplate);
 	}
 
 	/**

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
@@ -46,7 +46,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 
 	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider, Marshaller marshaller,
-			@Nullable Unmarshaller unmarshaller, @Nullable WebServiceMessageFactory messageFactory) {
+			@Nullable Unmarshaller unmarshaller, WebServiceMessageFactory messageFactory) {
 		super(destinationProvider, messageFactory);
 		configureMarshallers(marshaller, unmarshaller);
 	}
@@ -69,7 +69,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 
 	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller, @Nullable Unmarshaller unmarshaller,
-			@Nullable WebServiceMessageFactory messageFactory) {
+			WebServiceMessageFactory messageFactory) {
 		super(uri, messageFactory);
 		configureMarshallers(marshaller, unmarshaller);
 	}
@@ -95,10 +95,9 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	 * @param webServiceTemplate the WebServiceTemplate
 	 * @since 5.0
 	 */
-	@SuppressWarnings({"this-escape", "NullAway"})
+	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(String uri, WebServiceTemplate webServiceTemplate) {
-		super(uri, null);
-		doSetWebServiceTemplate(webServiceTemplate);
+		super(uri, webServiceTemplate);
 	}
 
 	/**
@@ -107,11 +106,10 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	 * @param webServiceTemplate the WebServiceTemplate
 	 * @since 5.0
 	 */
-	@SuppressWarnings({"this-escape", "NullAway"})
+	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider,
 			WebServiceTemplate webServiceTemplate) {
-		super(destinationProvider, null);
-		doSetWebServiceTemplate(webServiceTemplate);
+		super(destinationProvider, webServiceTemplate);
 	}
 
 	/**

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
@@ -46,11 +46,12 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 
 	@SuppressWarnings("this-escape")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider, Marshaller marshaller,
-			Unmarshaller unmarshaller, WebServiceMessageFactory messageFactory) {
+			@Nullable Unmarshaller unmarshaller, @Nullable WebServiceMessageFactory messageFactory) {
 		super(destinationProvider, messageFactory);
 		configureMarshallers(marshaller, unmarshaller);
 	}
 
+	@SuppressWarnings("NullAway")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider, Marshaller marshaller,
 			Unmarshaller unmarshaller) {
 		this(destinationProvider, marshaller, unmarshaller, null);
@@ -61,17 +62,19 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 		this(destinationProvider, marshaller, null, messageFactory);
 	}
 
+	@SuppressWarnings("NullAway")
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider, Marshaller marshaller) {
 		this(destinationProvider, marshaller, (WebServiceMessageFactory) null);
 	}
 
 	@SuppressWarnings("this-escape")
-	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller, Unmarshaller unmarshaller,
-			WebServiceMessageFactory messageFactory) {
+	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller, @Nullable Unmarshaller unmarshaller,
+			@Nullable WebServiceMessageFactory messageFactory) {
 		super(uri, messageFactory);
 		configureMarshallers(marshaller, unmarshaller);
 	}
 
+	@SuppressWarnings("NullAway")
 	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller, Unmarshaller unmarshaller) {
 		this(uri, marshaller, unmarshaller, null);
 	}
@@ -81,6 +84,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 		this(uri, marshaller, null, messageFactory);
 	}
 
+	@SuppressWarnings("NullAway")
 	public MarshallingWebServiceOutboundGateway(String uri, Marshaller marshaller) {
 		this(uri, marshaller, (WebServiceMessageFactory) null);
 	}
@@ -91,7 +95,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	 * @param webServiceTemplate the WebServiceTemplate
 	 * @since 5.0
 	 */
-	@SuppressWarnings("this-escape")
+	@SuppressWarnings({"this-escape", "NullAway"})
 	public MarshallingWebServiceOutboundGateway(String uri, WebServiceTemplate webServiceTemplate) {
 		super(uri, null);
 		doSetWebServiceTemplate(webServiceTemplate);
@@ -103,7 +107,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	 * @param webServiceTemplate the WebServiceTemplate
 	 * @since 5.0
 	 */
-	@SuppressWarnings("this-escape")
+	@SuppressWarnings({"this-escape", "NullAway"})
 	public MarshallingWebServiceOutboundGateway(DestinationProvider destinationProvider,
 			WebServiceTemplate webServiceTemplate) {
 		super(destinationProvider, null);
@@ -140,7 +144,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 	}
 
 	@Override
-	protected Object doHandle(String uri, Message<?> requestMessage, WebServiceMessageCallback requestCallback) {
+	protected @Nullable Object doHandle(String uri, Message<?> requestMessage, @Nullable WebServiceMessageCallback requestCallback) {
 		return getWebServiceTemplate()
 				.marshalSendAndReceive(uri, requestMessage.getPayload(),
 						new PassThroughRequestMessageCallback(requestCallback, requestMessage));
@@ -148,7 +152,7 @@ public class MarshallingWebServiceOutboundGateway extends AbstractWebServiceOutb
 
 	private final class PassThroughRequestMessageCallback extends RequestMessageCallback {
 
-		PassThroughRequestMessageCallback(WebServiceMessageCallback requestCallback, Message<?> requestMessage) {
+		PassThroughRequestMessageCallback(@Nullable WebServiceMessageCallback requestCallback, Message<?> requestMessage) {
 			super(requestCallback, requestMessage);
 		}
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/MarshallingWebServiceOutboundGateway.java
@@ -18,7 +18,8 @@ package org.springframework.integration.ws;
 
 import java.io.IOException;
 
-import org.springframework.lang.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 import org.springframework.oxm.Marshaller;
 import org.springframework.oxm.Unmarshaller;

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -58,33 +58,32 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 	private boolean extractPayload = true;
 
 	public SimpleWebServiceOutboundGateway(DestinationProvider destinationProvider) {
-		this(destinationProvider, null);
+		this(destinationProvider, null, null);
 	}
 
 	public SimpleWebServiceOutboundGateway(DestinationProvider destinationProvider,
-			@Nullable SourceExtractor<?> sourceExtractor) {
-		super(destinationProvider);
-		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();
+			SourceExtractor<?> sourceExtractor) {
+
+		this(destinationProvider, sourceExtractor, null);
 	}
 
 	public SimpleWebServiceOutboundGateway(DestinationProvider destinationProvider,
 			@Nullable SourceExtractor<?> sourceExtractor,
-			WebServiceMessageFactory messageFactory) {
+			@Nullable WebServiceMessageFactory messageFactory) {
 		super(destinationProvider, messageFactory);
 		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();
 	}
 
 	public SimpleWebServiceOutboundGateway(String uri) {
-		this(uri, null);
+		this(uri, null, null);
 	}
 
-	public SimpleWebServiceOutboundGateway(String uri, @Nullable SourceExtractor<?> sourceExtractor) {
-		super(uri);
-		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();
+	public SimpleWebServiceOutboundGateway(String uri, SourceExtractor<?> sourceExtractor) {
+		this(uri, sourceExtractor, null);
 	}
 
-	public SimpleWebServiceOutboundGateway(String uri, @Nullable SourceExtractor<?> sourceExtractor,
-			WebServiceMessageFactory messageFactory) {
+	public SimpleWebServiceOutboundGateway(@Nullable String uri, @Nullable SourceExtractor<?> sourceExtractor,
+			@Nullable WebServiceMessageFactory messageFactory) {
 
 		super(uri, messageFactory);
 		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -58,33 +58,33 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 	private boolean extractPayload = true;
 
 	public SimpleWebServiceOutboundGateway(DestinationProvider destinationProvider) {
-		this(destinationProvider, null, null);
+		this(destinationProvider, null);
 	}
 
 	public SimpleWebServiceOutboundGateway(DestinationProvider destinationProvider,
-			SourceExtractor<?> sourceExtractor) {
-
-		this(destinationProvider, sourceExtractor, null);
+			@Nullable SourceExtractor<?> sourceExtractor) {
+		super(destinationProvider);
+		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();
 	}
 
 	public SimpleWebServiceOutboundGateway(DestinationProvider destinationProvider,
 			@Nullable SourceExtractor<?> sourceExtractor,
-			@Nullable WebServiceMessageFactory messageFactory) {
-
+			WebServiceMessageFactory messageFactory) {
 		super(destinationProvider, messageFactory);
 		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();
 	}
 
 	public SimpleWebServiceOutboundGateway(String uri) {
-		this(uri, null, null);
+		this(uri, null);
 	}
 
-	public SimpleWebServiceOutboundGateway(String uri, SourceExtractor<?> sourceExtractor) {
-		this(uri, sourceExtractor, null);
+	public SimpleWebServiceOutboundGateway(String uri, @Nullable SourceExtractor<?> sourceExtractor) {
+		super(uri);
+		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();
 	}
 
 	public SimpleWebServiceOutboundGateway(String uri, @Nullable SourceExtractor<?> sourceExtractor,
-			@Nullable WebServiceMessageFactory messageFactory) {
+			WebServiceMessageFactory messageFactory) {
 
 		super(uri, messageFactory);
 		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/SimpleWebServiceOutboundGateway.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,9 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
 
+import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Document;
 
-import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/package-info.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Contains parser classes for the Web Services namespace support.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.ws.config;

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
@@ -53,11 +53,13 @@ public abstract class BaseWsOutboundGatewaySpec<
 
 	private final Map<String, Expression> uriVariableExpressions = new HashMap<>();
 
-	protected @Nullable WebServiceTemplate template; // NOSONAR
+	@SuppressWarnings("NullAway.Init")
+	protected WebServiceTemplate template; // NOSONAR
 
 	protected @Nullable DestinationProvider destinationProvider; // NOSONAR
 
-	protected @Nullable String uri; // NOSONAR
+	@SuppressWarnings("NullAway.Init")
+	protected String uri; // NOSONAR
 
 	protected @Nullable WebServiceMessageFactory webServiceMessageFactory; // NOSONAR
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,12 +19,14 @@ package org.springframework.integration.ws.dsl;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.expression.Expression;
 import org.springframework.integration.JavaUtils;
 import org.springframework.integration.dsl.MessageHandlerSpec;
 import org.springframework.integration.ws.AbstractWebServiceOutboundGateway;
 import org.springframework.integration.ws.SoapHeaderMapper;
-import org.springframework.web.util.DefaultUriBuilderFactory;
+import org.springframework.web.util.DefaultUriBuilderFactory.EncodingMode;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
@@ -51,26 +53,36 @@ public abstract class BaseWsOutboundGatewaySpec<
 
 	private final Map<String, Expression> uriVariableExpressions = new HashMap<>();
 
+	@Nullable
 	protected WebServiceTemplate template; // NOSONAR
 
+	@Nullable
 	protected DestinationProvider destinationProvider; // NOSONAR
 
+	@Nullable
 	protected String uri; // NOSONAR
 
+	@Nullable
 	protected WebServiceMessageFactory webServiceMessageFactory; // NOSONAR
 
+	@Nullable
 	private SoapHeaderMapper headerMapper;
 
-	private DefaultUriBuilderFactory.EncodingMode encodingMode;
+	@Nullable
+	private EncodingMode encodingMode;
 
 	private boolean ignoreEmptyResponses = true;
 
+	@Nullable
 	private WebServiceMessageCallback requestCallback;
 
+	@Nullable
 	protected FaultMessageResolver faultMessageResolver; // NOSONAR
 
+	@SuppressWarnings("NullAway.Init")
 	protected WebServiceMessageSender[] messageSenders; // NOSONAR
 
+	@SuppressWarnings("NullAway.Init")
 	protected ClientInterceptor[] gatewayInterceptors; // NOSONAR
 
 	protected boolean extractPayload = true; // NOSONAR
@@ -117,11 +129,11 @@ public abstract class BaseWsOutboundGatewaySpec<
 	}
 
 	/**
-	 * Specify a {@link DefaultUriBuilderFactory.EncodingMode} for uri construction.
+	 * Specify a {@link EncodingMode} for uri construction.
 	 * @param encodingMode to use for uri construction.
 	 * @return the spec
 	 */
-	public S encodingMode(DefaultUriBuilderFactory.EncodingMode encodingMode) {
+	public S encodingMode(EncodingMode encodingMode) {
 		this.encodingMode = encodingMode;
 		return _this();
 	}

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
@@ -26,7 +26,7 @@ import org.springframework.integration.JavaUtils;
 import org.springframework.integration.dsl.MessageHandlerSpec;
 import org.springframework.integration.ws.AbstractWebServiceOutboundGateway;
 import org.springframework.integration.ws.SoapHeaderMapper;
-import org.springframework.web.util.DefaultUriBuilderFactory.EncodingMode;
+import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
@@ -53,37 +53,27 @@ public abstract class BaseWsOutboundGatewaySpec<
 
 	private final Map<String, Expression> uriVariableExpressions = new HashMap<>();
 
-	@Nullable
-	protected WebServiceTemplate template; // NOSONAR
+	protected @Nullable WebServiceTemplate template; // NOSONAR
 
-	@Nullable
-	protected DestinationProvider destinationProvider; // NOSONAR
+	protected @Nullable DestinationProvider destinationProvider; // NOSONAR
 
-	@Nullable
-	protected String uri; // NOSONAR
+	protected @Nullable String uri; // NOSONAR
 
-	@Nullable
-	protected WebServiceMessageFactory webServiceMessageFactory; // NOSONAR
+	protected @Nullable WebServiceMessageFactory webServiceMessageFactory; // NOSONAR
 
-	@Nullable
-	private SoapHeaderMapper headerMapper;
+	private @Nullable SoapHeaderMapper headerMapper;
 
-	@Nullable
-	private EncodingMode encodingMode;
+	private DefaultUriBuilderFactory.@Nullable EncodingMode encodingMode;
 
 	private boolean ignoreEmptyResponses = true;
 
-	@Nullable
-	private WebServiceMessageCallback requestCallback;
+	private @Nullable WebServiceMessageCallback requestCallback;
 
-	@Nullable
-	protected FaultMessageResolver faultMessageResolver; // NOSONAR
+	protected @Nullable FaultMessageResolver faultMessageResolver; // NOSONAR
 
-	@SuppressWarnings("NullAway.Init")
-	protected WebServiceMessageSender[] messageSenders; // NOSONAR
+	protected WebServiceMessageSender @Nullable [] messageSenders; // NOSONAR
 
-	@SuppressWarnings("NullAway.Init")
-	protected ClientInterceptor[] gatewayInterceptors; // NOSONAR
+	protected ClientInterceptor @Nullable [] gatewayInterceptors; // NOSONAR
 
 	protected boolean extractPayload = true; // NOSONAR
 
@@ -129,11 +119,11 @@ public abstract class BaseWsOutboundGatewaySpec<
 	}
 
 	/**
-	 * Specify a {@link EncodingMode} for uri construction.
+	 * Specify a {@link DefaultUriBuilderFactory.EncodingMode} for uri construction.
 	 * @param encodingMode to use for uri construction.
 	 * @return the spec
 	 */
-	public S encodingMode(EncodingMode encodingMode) {
+	public S encodingMode(DefaultUriBuilderFactory.EncodingMode encodingMode) {
 		this.encodingMode = encodingMode;
 		return _this();
 	}

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
@@ -58,11 +58,9 @@ public abstract class BaseWsOutboundGatewaySpec<
 
 	protected @Nullable DestinationProvider destinationProvider; // NOSONAR
 
-	@SuppressWarnings("NullAway.Init")
-	protected String uri; // NOSONAR
+	protected @Nullable String uri; // NOSONAR
 
-	@SuppressWarnings("NullAway.Init")
-	protected WebServiceMessageFactory webServiceMessageFactory; // NOSONAR
+	protected @Nullable WebServiceMessageFactory webServiceMessageFactory; // NOSONAR
 
 	private @Nullable SoapHeaderMapper headerMapper;
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/BaseWsOutboundGatewaySpec.java
@@ -61,7 +61,8 @@ public abstract class BaseWsOutboundGatewaySpec<
 	@SuppressWarnings("NullAway.Init")
 	protected String uri; // NOSONAR
 
-	protected @Nullable WebServiceMessageFactory webServiceMessageFactory; // NOSONAR
+	@SuppressWarnings("NullAway.Init")
+	protected WebServiceMessageFactory webServiceMessageFactory; // NOSONAR
 
 	private @Nullable SoapHeaderMapper headerMapper;
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/MarshallingWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/MarshallingWsOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,8 +63,10 @@ public class MarshallingWsOutboundGatewaySpec extends
 			extends BaseWsOutboundGatewaySpec<MarshallingWsOutboundGatewayNoTemplateSpec,
 			MarshallingWebServiceOutboundGateway> {
 
+		@SuppressWarnings("NullAway.Init")
 		protected Marshaller gatewayMarshaller; // NOSONAR
 
+		@SuppressWarnings("NullAway.Init")
 		protected Unmarshaller gatewayUnmarshaller; // NOSONAR
 
 		/**

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/MarshallingWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/MarshallingWsOutboundGatewaySpec.java
@@ -18,10 +18,13 @@ package org.springframework.integration.ws.dsl;
 
 import java.util.Arrays;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.JavaUtils;
 import org.springframework.integration.ws.MarshallingWebServiceOutboundGateway;
 import org.springframework.oxm.Marshaller;
 import org.springframework.oxm.Unmarshaller;
+import org.springframework.oxm.jaxb.Jaxb2Marshaller;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
 import org.springframework.ws.client.core.WebServiceTemplate;
@@ -63,11 +66,9 @@ public class MarshallingWsOutboundGatewaySpec extends
 			extends BaseWsOutboundGatewaySpec<MarshallingWsOutboundGatewayNoTemplateSpec,
 			MarshallingWebServiceOutboundGateway> {
 
-		@SuppressWarnings("NullAway.Init")
-		protected Marshaller gatewayMarshaller; // NOSONAR
+		protected Marshaller gatewayMarshaller = new Jaxb2Marshaller(); // NOSONAR
 
-		@SuppressWarnings("NullAway.Init")
-		protected Unmarshaller gatewayUnmarshaller; // NOSONAR
+		protected @Nullable Unmarshaller gatewayUnmarshaller; // NOSONAR
 
 		/**
 		 * Configure the marshaller to use.

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/MarshallingWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/MarshallingWsOutboundGatewaySpec.java
@@ -66,7 +66,7 @@ public class MarshallingWsOutboundGatewaySpec extends
 			extends BaseWsOutboundGatewaySpec<MarshallingWsOutboundGatewayNoTemplateSpec,
 			MarshallingWebServiceOutboundGateway> {
 
-		protected Marshaller gatewayMarshaller = new Jaxb2Marshaller(); // NOSONAR
+		protected Marshaller gatewayMarshaller = new Jaxb2Marshaller();
 
 		protected @Nullable Unmarshaller gatewayUnmarshaller; // NOSONAR
 

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/SimpleWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/SimpleWsOutboundGatewaySpec.java
@@ -41,8 +41,7 @@ import org.springframework.ws.transport.WebServiceMessageSender;
 public class SimpleWsOutboundGatewaySpec
 		extends BaseWsOutboundGatewaySpec<SimpleWsOutboundGatewaySpec, SimpleWebServiceOutboundGateway> {
 
-	@Nullable
-	protected SourceExtractor<?> sourceExtractor; // NOSONAR
+	protected @Nullable SourceExtractor<?> sourceExtractor; // NOSONAR
 
 	protected SimpleWsOutboundGatewaySpec(WebServiceTemplate template) {
 		this.template = template;

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/SimpleWsOutboundGatewaySpec.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/SimpleWsOutboundGatewaySpec.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2024 the original author or authors.
+ * Copyright 2020-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,10 @@ package org.springframework.integration.ws.dsl;
 
 import java.util.Arrays;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.JavaUtils;
 import org.springframework.integration.ws.SimpleWebServiceOutboundGateway;
-import org.springframework.lang.Nullable;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.FaultMessageResolver;
 import org.springframework.ws.client.core.SourceExtractor;
@@ -100,6 +101,7 @@ public class SimpleWsOutboundGatewaySpec
 	public static class SimpleWsOutboundGatewayNoTemplateSpec
 			extends BaseWsOutboundGatewaySpec<SimpleWsOutboundGatewayNoTemplateSpec, SimpleWebServiceOutboundGateway> {
 
+		@Nullable
 		protected SourceExtractor<?> sourceExtractor; // NOSONAR
 
 		private boolean extractPayload = true;

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/package-info.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/dsl/package-info.java
@@ -1,5 +1,5 @@
 /**
  * Contains classes for DSL support.
  */
-@org.springframework.lang.NonNullApi
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.ws.dsl;

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/package-info.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/package-info.java
@@ -2,4 +2,5 @@
  * Provides several inbound and outbound Web Service components. Also contains
  * support classes (e.g. Header Mapper)
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.ws;

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -382,7 +382,7 @@ public class WebServiceOutboundGatewayParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
 		assertThat(accessor.getPropertyValue("destinationProvider")).as("Wrong DestinationProvider")
 				.isEqualTo(stubProvider);
-		assertThat(accessor.getPropertyValue("uri")).isNull();
+		assertThat(accessor.getPropertyValue("uri")).isEqualTo("");
 		Object destinationProviderObject = new DirectFieldAccessor(
 				accessor.getPropertyValue("webServiceTemplate")).getPropertyValue("destinationProvider");
 		assertThat(destinationProviderObject).as("Wrong DestinationProvider").isEqualTo(stubProvider);

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -382,7 +382,7 @@ public class WebServiceOutboundGatewayParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
 		assertThat(accessor.getPropertyValue("destinationProvider")).as("Wrong DestinationProvider")
 				.isEqualTo(stubProvider);
-		assertThat(accessor.getPropertyValue("uri")).isEqualTo("");
+		assertThat(accessor.getPropertyValue("uri")).isNull();
 		Object destinationProviderObject = new DirectFieldAccessor(
 				accessor.getPropertyValue("webServiceTemplate")).getPropertyValue("destinationProvider");
 		assertThat(destinationProviderObject).as("Wrong DestinationProvider").isEqualTo(stubProvider);


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10083
- Replace `org.springframework.lang.Nullable` with `org.jspecify.annotations.Nullable`
- Migrate `package-info.java` files to use `@NullMarked` annotation
- Add `@SuppressWarnings("NullAway.Init")` for fields initialized in lifecycle methods

For the array fields `BaseWsOutboundGatewaySpec.messageSenders` and `BaseWsOutboundGatewaySpec.gatewayInterceptors`, I applied `@SuppressWarnings("NullAway.Init")` instead of `@Nullable` because adding `@Nullable` still produces the same NullAway warnings.