### PR TITLE
GH-10083: Apply Nullability to `spring-integration-event` module

### DIFF
--- a/spring-integration-event/src/main/java/org/springframework/integration/event/config/package-info.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/config/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes for configuration - parsers, namespace handlers.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.event.config;

--- a/spring-integration-event/src/main/java/org/springframework/integration/event/core/package-info.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/core/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides Event core classes.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.event.core;

--- a/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducer.java
@@ -19,6 +19,8 @@ package org.springframework.integration.event.inbound;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.PayloadApplicationEvent;
 import org.springframework.context.event.ApplicationEventMulticaster;
@@ -49,9 +51,9 @@ import org.springframework.util.Assert;
 public class ApplicationEventListeningMessageProducer extends ExpressionMessageProducerSupport
 		implements GenericApplicationListener {
 
-	private ApplicationEventMulticaster applicationEventMulticaster;
+	private @Nullable ApplicationEventMulticaster applicationEventMulticaster;
 
-	private volatile Set<ResolvableType> eventTypes;
+	private volatile @Nullable Set<ResolvableType> eventTypes;
 
 	private volatile long stoppedAt;
 
@@ -74,7 +76,7 @@ public class ApplicationEventListeningMessageProducer extends ExpressionMessageP
 	 * @see ApplicationEventMulticaster#addApplicationListener
 	 * @see #supportsEventType
 	 */
-	public final void setEventTypes(Class<?>... eventTypes) {
+	public final void setEventTypes(@Nullable Class<?>... eventTypes) {
 		Assert.notNull(eventTypes, "'eventTypes' must not be null");
 		Set<ResolvableType> eventSet = new HashSet<>(eventTypes.length);
 		for (Class<?> eventType : eventTypes) {
@@ -146,11 +148,12 @@ public class ApplicationEventListeningMessageProducer extends ExpressionMessageP
 
 	@Override
 	public boolean supportsEventType(ResolvableType eventType) {
-		if (this.eventTypes == null) {
+		Set<ResolvableType> eventTypesToCheck = this.eventTypes;
+		if (eventTypesToCheck == null) {
 			return true;
 		}
 
-		for (ResolvableType type : this.eventTypes) {
+		for (ResolvableType type : eventTypesToCheck) {
 			if (type.isAssignableFrom(eventType)) {
 				return true;
 			}
@@ -163,7 +166,7 @@ public class ApplicationEventListeningMessageProducer extends ExpressionMessageP
 			}
 
 			ResolvableType payloadType = eventType.as(PayloadApplicationEvent.class).getGeneric();
-			for (ResolvableType type : this.eventTypes) {
+			for (ResolvableType type : eventTypesToCheck) {
 				if (type.isAssignableFrom(payloadType)) {
 					return true;
 				}

--- a/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/package-info.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/inbound/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes supporting inbound endpoints.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.event.inbound;

--- a/spring-integration-event/src/main/java/org/springframework/integration/event/outbound/ApplicationEventPublishingMessageHandler.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/outbound/ApplicationEventPublishingMessageHandler.java
@@ -40,6 +40,7 @@ import org.springframework.util.Assert;
 public class ApplicationEventPublishingMessageHandler extends AbstractMessageHandler
 		implements ApplicationEventPublisherAware {
 
+	@SuppressWarnings("NullAway.Init")
 	private ApplicationEventPublisher applicationEventPublisher;
 
 	private boolean publishPayload;

--- a/spring-integration-event/src/main/java/org/springframework/integration/event/outbound/package-info.java
+++ b/spring-integration-event/src/main/java/org/springframework/integration/event/outbound/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes supporting outbound endpoints.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.event.outbound;


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10083

* Add `@NullMarked` to all the `event` packages
* Add `@Nullable` or `@SuppressWarnings("NullAway.Init")` whenever it is requested
* Fix `ApplicationEventListeningMessageProducer` logic to handle `eventTypes == null`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
