### PR TITLE
GH-10100: Fix NPE in `AbstractMailReceiver.obtainFolderInstance()`.

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/AbstractMailReceiver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,7 @@ import org.springframework.util.ObjectUtils;
  * @author Yuxin Wang
  * @author Ngoc Nhan
  * @author Filip Hrisafov
+ * @author Jiandong Ma
  */
 public abstract class AbstractMailReceiver extends IntegrationObjectSupport implements MailReceiver, DisposableBean {
 
@@ -370,6 +371,9 @@ public abstract class AbstractMailReceiver extends IntegrationObjectSupport impl
 	}
 
 	private Folder obtainFolderInstance() throws MessagingException {
+		if (this.url == null) {
+			return this.store.getDefaultFolder();
+		}
 		return this.store.getFolder(this.url);
 	}
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/MailReceiverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import jakarta.mail.Folder;
 import jakarta.mail.Message;
 import jakarta.mail.Session;
 import jakarta.mail.Store;
-import jakarta.mail.URLName;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.DirectFieldAccessor;
@@ -68,7 +67,7 @@ public class MailReceiverTests {
 		Folder folder = mock(Folder.class);
 		when(folder.exists()).thenReturn(true);
 		when(folder.isOpen()).thenReturn(false, true);
-		doReturn(folder).when(store).getFolder((URLName) null);
+		doReturn(folder).when(store).getDefaultFolder();
 		doNothing().when(store).connect();
 		receiver.openFolder();
 		receiver.openFolder();


### PR DESCRIPTION
Fixes: #10100

if `url` is not provided, use `store.getDefaultFolder()` instead.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
