### PR TITLE
GH-10058: Introduce Jackson 3 in the Gradle build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ ext {
     hsqldbVersion = '2.7.4'
     h2Version = '2.3.232'
     jacksonVersion = '2.19.1'
+    jackson3Version = '3.0.0-rc5'
     jaxbVersion = '4.0.5'
     jcifsVersion = '2.1.40'
     jeroMqVersion = '0.6.0'
@@ -165,6 +166,7 @@ allprojects {
 
         imports {
             mavenBom "com.fasterxml.jackson:jackson-bom:$jacksonVersion"
+            mavenBom "tools.jackson:jackson-bom:$jackson3Version"
             mavenBom "io.micrometer:micrometer-bom:$micrometerVersion"
             mavenBom "io.micrometer:micrometer-tracing-bom:$micrometerTracingVersion"
             mavenBom "io.projectreactor:reactor-bom:$reactorVersion"
@@ -453,6 +455,7 @@ project('spring-integration-amqp') {
         testImplementation 'org.springframework:spring-web'
         testImplementation 'org.testcontainers:rabbitmq'
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+        testImplementation 'tools.jackson.core:jackson-databind'
     }
 }
 
@@ -497,6 +500,11 @@ project('spring-integration-core') {
         api 'io.projectreactor:reactor-core'
         api 'io.micrometer:micrometer-observation'
 
+        optionalApi 'tools.jackson.core:jackson-databind'
+        optionalApi 'tools.jackson.datatype:jackson-datatype-joda'
+        optionalApi('tools.jackson.module:jackson-module-kotlin') {
+            exclude group: 'org.jetbrains.kotlin'
+        }
         optionalApi 'com.fasterxml.jackson.core:jackson-databind'
         optionalApi 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
         optionalApi 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
@@ -592,6 +600,7 @@ project('spring-integration-file') {
         testImplementation "io.lettuce:lettuce-core:$lettuceVersion"
         testImplementation "com.jayway.jsonpath:json-path:$jsonpathVersion"
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+        testImplementation 'tools.jackson.core:jackson-databind'
     }
 }
 
@@ -668,6 +677,7 @@ project('spring-integration-http') {
         testImplementation 'org.springframework.security:spring-security-config'
         testImplementation 'org.springframework.security:spring-security-test'
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+        testImplementation 'tools.jackson.core:jackson-databind'
 
         testRuntimeOnly "com.jayway.jsonpath:json-path:$jsonpathVersion"
     }
@@ -681,6 +691,7 @@ project('spring-integration-ip') {
 
         testRuntimeOnly "com.esotericsoftware:kryo:$kryoVersion"
         testRuntimeOnly 'com.fasterxml.jackson.core:jackson-databind'
+        testRuntimeOnly 'tools.jackson.core:jackson-databind'
     }
 
     tasks.withType(JavaForkOptions) {
@@ -709,6 +720,7 @@ project('spring-integration-jdbc') {
         testImplementation 'org.testcontainers:oracle-xe'
 
         testRuntimeOnly 'com.fasterxml.jackson.core:jackson-databind'
+        testRuntimeOnly 'tools.jackson.core:jackson-databind'
         testRuntimeOnly "com.oracle.database.jdbc:ojdbc11:$oracleVersion"
     }
 }
@@ -725,6 +737,7 @@ project('spring-integration-jms') {
         testImplementation "org.apache.activemq:artemis-jakarta-client:$artemisVersion"
         testImplementation 'org.springframework:spring-oxm'
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+        testImplementation 'tools.jackson.core:jackson-databind'
         testImplementation 'io.micrometer:micrometer-observation-test'
     }
 }
@@ -757,6 +770,7 @@ project('spring-integration-kafka') {
             exclude group: 'ch.qos.logback'
         }
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+        testImplementation 'tools.jackson.core:jackson-databind'
     }
 }
 
@@ -802,6 +816,7 @@ project('spring-integration-mqtt') {
 
         testImplementation project(':spring-integration-jmx')
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+        testImplementation 'tools.jackson.core:jackson-databind'
     }
 }
 
@@ -812,6 +827,7 @@ project('spring-integration-redis') {
 
         testImplementation "io.lettuce:lettuce-core:$lettuceVersion"
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+        testImplementation 'tools.jackson.core:jackson-databind'
     }
 }
 
@@ -882,6 +898,7 @@ project('spring-integration-stomp') {
         }
         testImplementation "org.apache.tomcat.embed:tomcat-embed-websocket:$tomcatVersion"
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+        testImplementation 'tools.jackson.core:jackson-databind'
 
         testRuntimeOnly 'org.springframework:spring-webmvc'
         testRuntimeOnly 'io.projectreactor.netty:reactor-netty-http'
@@ -931,6 +948,7 @@ project('spring-integration-webflux') {
         testImplementation 'org.springframework.security:spring-security-config'
         testImplementation 'org.springframework.security:spring-security-test'
         testImplementation 'com.fasterxml.jackson.core:jackson-databind'
+        testImplementation 'tools.jackson.core:jackson-databind'
         testImplementation 'io.micrometer:micrometer-observation-test'
         testImplementation('io.micrometer:micrometer-tracing-integration-test') {
             exclude group: 'io.opentelemetry'
@@ -953,6 +971,7 @@ project('spring-integration-websocket') {
         testImplementation "org.apache.tomcat.embed:tomcat-embed-websocket:$tomcatVersion"
 
         testRuntimeOnly 'com.fasterxml.jackson.core:jackson-databind'
+        testRuntimeOnly 'tools.jackson.core:jackson-databind'
     }
 
     tasks.withType(JavaForkOptions) {
@@ -1024,6 +1043,7 @@ project('spring-integration-zeromq') {
         api "org.zeromq:jeromq:$jeroMqVersion"
 
         optionalApi 'com.fasterxml.jackson.core:jackson-databind'
+        optionalApi 'tools.jackson.core:jackson-databind'
     }
 }
 


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10058

First part of the Jackson 3 support implementation for issue. I've split this work for easier review and management:
- This PR (Work 1): Jackson 3 dependency management
- Work 2: Jackson 3 API implementation
- Work 3: Migration (e.g., from MappingJackson2MessageConverter to JacksonJsonMessageConverter)
- Work 4: Deprecation Jackson2 APIs

Does this approach work for you?