### PR TITLE
Apply JSpecify Nullify to the Channel and AOT packages

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
@@ -20,6 +20,7 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jspecify.annotations.Nullable;
@@ -322,12 +323,12 @@ public class PollableAmqpChannel extends AbstractAmqpChannel
 	}
 
 	@Override
-	public @Nullable ChannelInterceptor removeInterceptor(int index) {
+	public ChannelInterceptor removeInterceptor(int index) {
 		ChannelInterceptor interceptor = super.removeInterceptor(index);
 		if (interceptor instanceof ExecutorChannelInterceptor) {
 			this.executorInterceptorsSize--;
 		}
-		return interceptor;
+		return Objects.requireNonNull(interceptor);
 	}
 
 	@Override

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/channel/PollableAmqpChannel.java
@@ -20,7 +20,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.jspecify.annotations.Nullable;
@@ -328,7 +327,7 @@ public class PollableAmqpChannel extends AbstractAmqpChannel
 		if (interceptor instanceof ExecutorChannelInterceptor) {
 			this.executorInterceptorsSize--;
 		}
-		return Objects.requireNonNull(interceptor);
+		return interceptor;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/aot/CoreRuntimeHints.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aot/CoreRuntimeHints.java
@@ -26,6 +26,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.aot.hint.ExecutableMode;
 import org.springframework.aot.hint.MemberCategory;
@@ -79,7 +81,7 @@ import org.springframework.util.ReflectionUtils;
 class CoreRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override
-	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 		ReflectionHints reflectionHints = hints.reflection();
 		Stream.of(
 						GenericSelector.class,

--- a/spring-integration-core/src/main/java/org/springframework/integration/aot/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aot/package-info.java
@@ -1,6 +1,5 @@
 /**
  * Provides classes to support Spring AOT.
  */
-@org.springframework.lang.NonNullApi
-@org.springframework.lang.NonNullFields
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.aot;

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractExecutorChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractExecutorChannel.java
@@ -61,10 +61,6 @@ public abstract class AbstractExecutorChannel extends AbstractSubscribableChanne
 
 	protected @Nullable Executor executor;
 
-	/**
-	 * {@code @SuppressWarnings} was used the dispatcher is initialized in each of the implementations in the {@link AbstractExecutorChannel}.   And each implementation
-	 * utilizes a unique implementation of the {@link AbstractDispatcher}.
-	 */
 	@SuppressWarnings("NullAway.Init")
 	protected AbstractDispatcher dispatcher;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractExecutorChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractExecutorChannel.java
@@ -59,13 +59,19 @@ import org.springframework.util.CollectionUtils;
 public abstract class AbstractExecutorChannel extends AbstractSubscribableChannel
 		implements ExecutorChannelInterceptorAware {
 
-	protected Executor executor; // NOSONAR
+	protected @Nullable Executor executor;
 
-	protected AbstractDispatcher dispatcher; // NOSONAR
+	/**
+	 * {@code @SuppressWarnings} was used the dispatcher is initialized in each of the implementations in the {@link AbstractExecutorChannel}.   And each implementation
+	 * utilizes a unique implementation of the {@link AbstractDispatcher}.
+	 */
+	@SuppressWarnings("NullAway.Init")
+	protected AbstractDispatcher dispatcher;
 
-	protected Integer maxSubscribers; // NOSONAR
+	@Nullable
+	protected Integer maxSubscribers;
 
-	protected int executorInterceptorsSize; // NOSONAR
+	protected int executorInterceptorsSize;
 
 	public AbstractExecutorChannel(@Nullable Executor executor) {
 		this.executor = executor;
@@ -117,7 +123,6 @@ public abstract class AbstractExecutorChannel extends AbstractSubscribableChanne
 	}
 
 	@Override
-	@Nullable
 	public ChannelInterceptor removeInterceptor(int index) {
 		ChannelInterceptor interceptor = super.removeInterceptor(index);
 		if (interceptor instanceof ExecutorChannelInterceptor) {
@@ -167,7 +172,7 @@ public abstract class AbstractExecutorChannel extends AbstractSubscribableChanne
 				if (!CollectionUtils.isEmpty(interceptorStack)) {
 					triggerAfterMessageHandled(message, ex, interceptorStack);
 				}
-				if (ex instanceof MessagingException) { // NOSONAR
+				if (ex instanceof MessagingException) {
 					throw new MessagingExceptionWrapper(message, (MessagingException) ex);
 				}
 				String description = "Failed to handle " + message + " to " + this + " in " + messageHandler;
@@ -195,7 +200,7 @@ public abstract class AbstractExecutorChannel extends AbstractSubscribableChanne
 							logger.debug(() -> executorInterceptor.getClass().getSimpleName()
 									+ " returned null from beforeHandle, i.e. precluding the send.");
 						}
-						triggerAfterMessageHandled(null, null, interceptorStack);
+						triggerAfterMessageHandled(message, null, interceptorStack);
 						return null;
 					}
 					interceptorStack.add(executorInterceptor);
@@ -204,13 +209,13 @@ public abstract class AbstractExecutorChannel extends AbstractSubscribableChanne
 			return theMessage;
 		}
 
-		private void triggerAfterMessageHandled(@Nullable Message<?> message, @Nullable Exception ex,
+		private void triggerAfterMessageHandled(Message<?> message, @Nullable Exception ex,
 				Deque<ExecutorChannelInterceptor> interceptorStack) {
 			Iterator<ExecutorChannelInterceptor> iterator = interceptorStack.descendingIterator();
 			while (iterator.hasNext()) {
 				ExecutorChannelInterceptor interceptor = iterator.next();
 				try {
-					interceptor.afterMessageHandled(message, AbstractExecutorChannel.this, //NOSONAR
+					interceptor.afterMessageHandled(message, AbstractExecutorChannel.this,
 							this.delegate.getMessageHandler(), ex);
 				}
 				catch (Throwable ex2) { //NOSONAR

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractMessageChannel.java
@@ -389,10 +389,11 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 		Boolean observe = observation.observe(() -> {
 			Message<?> messageToSendInternal = messageToSend;
 			if (message instanceof ErrorMessage errorMessage) {
+				Message<?> originalMessage = errorMessage.getOriginalMessage();
 				messageToSendInternal =
-						(errorMessage.getOriginalMessage() != null) ? new ErrorMessage(errorMessage.getPayload(),
+						(originalMessage != null) ? new ErrorMessage(errorMessage.getPayload(),
 								messageToSend.getHeaders(),
-								errorMessage.getOriginalMessage()) : new ErrorMessage(errorMessage.getPayload(),
+								originalMessage) : new ErrorMessage(errorMessage.getPayload(),
 								messageToSend.getHeaders());
 			}
 			return sendInternal(messageToSendInternal, timeout);
@@ -679,9 +680,7 @@ public abstract class AbstractMessageChannel extends IntegrationObjectSupport
 
 		public ChannelInterceptor remove(int index) {
 			ChannelInterceptor removed = this.interceptors.remove(index);
-			if (removed != null) {
-				this.size--;
-			}
+			this.size--;
 			return removed;
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/AbstractPollableChannel.java
@@ -45,7 +45,7 @@ public abstract class AbstractPollableChannel extends AbstractMessageChannel
 
 	private int executorInterceptorsSize;
 
-	private CounterFacade receiveCounter;
+	private @Nullable CounterFacade receiveCounter;
 
 	@Override
 	public IntegrationPatternType getIntegrationPatternType() {
@@ -186,7 +186,6 @@ public abstract class AbstractPollableChannel extends AbstractMessageChannel
 	}
 
 	@Override
-	@Nullable
 	public ChannelInterceptor removeInterceptor(int index) {
 		ChannelInterceptor interceptor = super.removeInterceptor(index);
 		if (interceptor instanceof ExecutorChannelInterceptor) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ChannelPurger.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ChannelPurger.java
@@ -48,7 +48,7 @@ public class ChannelPurger {
 
 	private final QueueChannel[] channels;
 
-	private final MessageSelector selector;
+	private final @Nullable MessageSelector selector;
 
 	public ChannelPurger(QueueChannel... channels) {
 		this(null, channels);

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DefaultHeaderChannelRegistry.java
@@ -67,7 +67,7 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 
 	private long reaperDelay;
 
-	private volatile ScheduledFuture<?> reaperScheduledFuture;
+	private volatile @Nullable ScheduledFuture<?> reaperScheduledFuture;
 
 	private volatile boolean running;
 
@@ -147,8 +147,9 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 		this.lock.lock();
 		try {
 			this.running = false;
-			if (this.reaperScheduledFuture != null) {
-				this.reaperScheduledFuture.cancel(true);
+			ScheduledFuture<?> reaperScheduledFutureToCancel = this.reaperScheduledFuture;
+			if (reaperScheduledFutureToCancel != null) {
+				reaperScheduledFutureToCancel.cancel(true);
 				this.reaperScheduledFuture = null;
 			}
 			this.explicitlyStopped = true;
@@ -221,8 +222,9 @@ public class DefaultHeaderChannelRegistry extends IntegrationObjectSupport
 	public void runReaper() {
 		this.lock.lock();
 		try {
-			if (this.reaperScheduledFuture != null) {
-				this.reaperScheduledFuture.cancel(true);
+			ScheduledFuture<?> reaperScheduledFutureToCancel = this.reaperScheduledFuture;
+			if (reaperScheduledFutureToCancel != null) {
+				reaperScheduledFutureToCancel.cancel(true);
 				this.reaperScheduledFuture = null;
 			}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
@@ -39,7 +39,7 @@ public class DirectChannel extends AbstractSubscribableChannel {
 
 	private final UnicastingDispatcher dispatcher = new UnicastingDispatcher();
 
-	private volatile Integer maxSubscribers;
+	private volatile @Nullable Integer maxSubscribers;
 
 	/**
 	 * Create a channel with default {@link RoundRobinLoadBalancingStrategy}.

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
@@ -49,7 +49,7 @@ import org.springframework.util.ErrorHandler;
  */
 public class ExecutorChannel extends AbstractExecutorChannel {
 
-	private final LoadBalancingStrategy loadBalancingStrategy;
+	private final @Nullable LoadBalancingStrategy loadBalancingStrategy;
 
 	private Predicate<Exception> failoverStrategy = (exception) -> true;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/FixedSubscriberChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/FixedSubscriberChannel.java
@@ -45,6 +45,7 @@ public final class FixedSubscriberChannel implements SubscribableChannel, BeanNa
 
 	private final MessageHandler handler;
 
+	@SuppressWarnings("NullAway.Init")
 	private String beanName;
 
 	public FixedSubscriberChannel() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
@@ -16,8 +16,6 @@
 
 package org.springframework.integration.channel;
 
-import java.util.Objects;
-
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.context.IntegrationContextUtils;
@@ -47,10 +45,11 @@ public class MessagePublishingErrorHandler extends ErrorMessagePublisher impleme
 
 	private static final int DEFAULT_SEND_TIMEOUT = 1000;
 
+	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	private static final ErrorMessageStrategy DEFAULT_ERROR_MESSAGE_STRATEGY = (ex, attrs) -> {
-		if (ex instanceof MessagingExceptionWrapper) {
-			return new ErrorMessage(Objects.requireNonNull(ex.getCause()),
-					Objects.requireNonNull(((MessagingExceptionWrapper) ex).getFailedMessage()));
+		if (ex instanceof MessagingExceptionWrapper messagingExceptionWrapper) {
+			return new ErrorMessage(messagingExceptionWrapper.getCause(),
+					messagingExceptionWrapper.getFailedMessage());
 		}
 		else {
 			return new ErrorMessage(ex);
@@ -69,7 +68,7 @@ public class MessagePublishingErrorHandler extends ErrorMessagePublisher impleme
 		setChannelResolver(channelResolver);
 	}
 
-	public void setDefaultErrorChannel(@Nullable MessageChannel defaultErrorChannel) {
+	public void setDefaultErrorChannel(MessageChannel defaultErrorChannel) {
 		setChannel(defaultErrorChannel);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/MessagePublishingErrorHandler.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.channel;
 
+import java.util.Objects;
+
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.context.IntegrationContextUtils;
@@ -47,7 +49,8 @@ public class MessagePublishingErrorHandler extends ErrorMessagePublisher impleme
 
 	private static final ErrorMessageStrategy DEFAULT_ERROR_MESSAGE_STRATEGY = (ex, attrs) -> {
 		if (ex instanceof MessagingExceptionWrapper) {
-			return new ErrorMessage(ex.getCause(), ((MessagingExceptionWrapper) ex).getFailedMessage());
+			return new ErrorMessage(Objects.requireNonNull(ex.getCause()),
+					Objects.requireNonNull(((MessagingExceptionWrapper) ex).getFailedMessage()));
 		}
 		else {
 			return new ErrorMessage(ex);

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/NullChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/NullChannel.java
@@ -34,6 +34,7 @@ import org.springframework.integration.support.management.metrics.MetricsCaptor;
 import org.springframework.integration.support.management.metrics.TimerFacade;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
+import org.springframework.util.Assert;
 
 /**
  * A channel implementation that essentially behaves like "/dev/null".
@@ -60,13 +61,14 @@ public class NullChannel implements PollableChannel,
 
 	private boolean loggingEnabled = true;
 
+	@SuppressWarnings("NullAway.Init")
 	private String beanName;
 
-	private MetricsCaptor metricsCaptor;
+	private @Nullable MetricsCaptor metricsCaptor;
 
-	private TimerFacade successTimer;
+	private @Nullable TimerFacade successTimer;
 
-	private CounterFacade receiveCounter;
+	private @Nullable CounterFacade receiveCounter;
 
 	@Override
 	public void setBeanName(String beanName) {
@@ -163,6 +165,7 @@ public class NullChannel implements PollableChannel,
 
 	private TimerFacade sendTimer() {
 		if (this.successTimer == null) {
+			Assert.state(this.metricsCaptor != null, "metricsCaptor not must not be null");
 			this.successTimer =
 					this.metricsCaptor.timerBuilder(SEND_TIMER_NAME)
 							.tag("type", "channel")
@@ -176,7 +179,7 @@ public class NullChannel implements PollableChannel,
 	}
 
 	@Override
-	public Message<?> receive() {
+	public @Nullable Message<?> receive() {
 		if (this.loggingEnabled) {
 			LOG.debug("receive called on null channel");
 		}
@@ -185,7 +188,7 @@ public class NullChannel implements PollableChannel,
 	}
 
 	@Override
-	public Message<?> receive(long timeout) {
+	public @Nullable Message<?> receive(long timeout) {
 		return receive();
 	}
 
@@ -199,6 +202,7 @@ public class NullChannel implements PollableChannel,
 	}
 
 	private CounterFacade buildReceiveCounter() {
+		Assert.state(this.metricsCaptor != null, "metricsCaptor not must not be null");
 		return this.metricsCaptor
 				.counterBuilder(RECEIVE_COUNTER_NAME)
 				.tag("name", getComponentName() == null ? "unknown" : getComponentName())

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/NullChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/NullChannel.java
@@ -34,7 +34,6 @@ import org.springframework.integration.support.management.metrics.MetricsCaptor;
 import org.springframework.integration.support.management.metrics.TimerFacade;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
-import org.springframework.util.Assert;
 
 /**
  * A channel implementation that essentially behaves like "/dev/null".
@@ -163,9 +162,9 @@ public class NullChannel implements PollableChannel,
 		return true;
 	}
 
+	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	private TimerFacade sendTimer() {
 		if (this.successTimer == null) {
-			Assert.state(this.metricsCaptor != null, "metricsCaptor not must not be null");
 			this.successTimer =
 					this.metricsCaptor.timerBuilder(SEND_TIMER_NAME)
 							.tag("type", "channel")
@@ -201,8 +200,8 @@ public class NullChannel implements PollableChannel,
 		}
 	}
 
+	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	private CounterFacade buildReceiveCounter() {
-		Assert.state(this.metricsCaptor != null, "metricsCaptor not must not be null");
 		return this.metricsCaptor
 				.counterBuilder(RECEIVE_COUNTER_NAME)
 				.tag("name", getComponentName() == null ? "unknown" : getComponentName())

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
@@ -66,8 +66,7 @@ public class PartitionedChannel extends AbstractExecutorChannel {
 	 * sent to this channel.
 	 */
 	public PartitionedChannel(int partitionCount) {
-		this(partitionCount, (message) -> Objects.requireNonNull(
-				message.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID)));
+		this(partitionCount, (message) -> Objects.requireNonNull(message.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID)));
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
@@ -66,7 +66,8 @@ public class PartitionedChannel extends AbstractExecutorChannel {
 	 * sent to this channel.
 	 */
 	public PartitionedChannel(int partitionCount) {
-		this(partitionCount, (message) -> Objects.requireNonNull(message.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID)));
+		this(partitionCount, (message) ->
+				Objects.requireNonNull(message.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID)));
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.channel;
 
+import java.util.Objects;
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -65,7 +66,8 @@ public class PartitionedChannel extends AbstractExecutorChannel {
 	 * sent to this channel.
 	 */
 	public PartitionedChannel(int partitionCount) {
-		this(partitionCount, (message) -> message.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID));
+		this(partitionCount, (message) -> Objects.requireNonNull(
+				message.getHeaders().get(IntegrationMessageHeaderAccessor.CORRELATION_ID)));
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PriorityChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PriorityChannel.java
@@ -135,7 +135,7 @@ public class PriorityChannel extends QueueChannel {
 	}
 
 	@Override
-	protected Message<?> doReceive(long timeout) {
+	protected @Nullable Message<?> doReceive(long timeout) {
 		Message<?> message = super.doReceive(timeout);
 		if (message != null) {
 			if (!this.useMessageStore) {
@@ -148,7 +148,7 @@ public class PriorityChannel extends QueueChannel {
 
 	private static final class SequenceFallbackComparator implements Comparator<Message<?>> {
 
-		private final Comparator<Message<?>> targetComparator;
+		private final @Nullable Comparator<Message<?>> targetComparator;
 
 		SequenceFallbackComparator(@Nullable Comparator<Message<?>> targetComparator) {
 			this.targetComparator = targetComparator;

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PublishSubscribeChannel.java
@@ -40,7 +40,7 @@ public class PublishSubscribeChannel extends AbstractExecutorChannel implements 
 
 	private final boolean requireSubscribers;
 
-	private ErrorHandler errorHandler;
+	private @Nullable ErrorHandler errorHandler;
 
 	private boolean ignoreFailures;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/package-info.java
@@ -1,5 +1,5 @@
 /**
  * Provides classes representing various channel types.
  */
-@org.springframework.lang.NonNullApi
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.channel;

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
@@ -70,7 +70,7 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 		this.errorMessageStrategy = errorMessageStrategy;
 	}
 
-	public final void setChannel(MessageChannel channel) {
+	public final void setChannel(@Nullable MessageChannel channel) {
 		this.channel = channel;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
@@ -70,7 +70,7 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 		this.errorMessageStrategy = errorMessageStrategy;
 	}
 
-	public final void setChannel(@Nullable MessageChannel channel) {
+	public final void setChannel(MessageChannel channel) {
 		this.channel = channel;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/PollingConsumer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/PollingConsumer.java
@@ -185,7 +185,7 @@ public class PollingConsumer extends AbstractPollingEndpoint implements Integrat
 				if (theMessage == null) {
 					logger.debug(() -> executorInterceptor.getClass().getSimpleName()
 							+ " returned null from beforeHandle, i.e. precluding the send.");
-					triggerAfterMessageHandled(null, null, interceptorStack);
+					triggerAfterMessageHandled(message, null, interceptorStack);
 					return null;
 				}
 				interceptorStack.add(executorInterceptor);
@@ -203,7 +203,7 @@ public class PollingConsumer extends AbstractPollingEndpoint implements Integrat
 			try {
 				interceptor.afterMessageHandled(message, this.inputChannel, this.handler, ex);
 			}
-			catch (Throwable ex2) { //NOSONAR
+			catch (Throwable ex2) {
 				logger.error(ex2, () -> "Exception from afterMessageHandled in " + interceptor);
 			}
 		}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/PollableKafkaChannel.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/PollableKafkaChannel.java
@@ -183,7 +183,6 @@ public class PollableKafkaChannel extends AbstractKafkaChannel
 	}
 
 	@Override
-	@Nullable
 	public ChannelInterceptor removeInterceptor(int index) {
 		ChannelInterceptor interceptor = super.removeInterceptor(index);
 		if (interceptor instanceof ExecutorChannelInterceptor) {


### PR DESCRIPTION
* Removed `@Nullify` annotations from classes outside the target packages, where the implemented interface or parent class did not mark the method as `Nullable`.
*  Note: One `"NullAway.Init"` was used for beanName.   
*  Removed all `NOSONAR` comments in touched classes for improved code cleanliness.
* Adjusted placement of existing `Nullable` annotations: moved them from above the method declarations to precede the method return type for consistency.