### PR TITLE
GH-10163: Fix async mode dropping errors

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandler.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandler.java
@@ -175,26 +175,18 @@ public class RabbitStreamMessageHandler extends AbstractMessageHandler {
 	}
 
 	protected @Nullable MessageChannel getSendFailureChannel() {
-		if (this.sendFailureChannel != null) {
-			return this.sendFailureChannel;
-		}
-		if (this.sync) {
-			if (this.sendFailureChannelName != null) {
-				this.sendFailureChannel = getChannelResolver()
-						.resolveDestination(sendFailureChannelName);
+		if (sendFailureChannel == null) {
+			if (sync && sendFailureChannelName != null) {
+				this.sendFailureChannel = getChannelResolver().resolveDestination(this.sendFailureChannelName);
+			}
+			else if (!sync) {
+				String sendFailureChannelNameToUse = sendFailureChannelName == null
+						? IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME
+						: sendFailureChannelName;
+				this.sendFailureChannel = getChannelResolver().resolveDestination(sendFailureChannelNameToUse);
 			}
 		}
-		else {
-			this.sendFailureChannel = getChannelResolver()
-					.resolveDestination(getSendFailureChannelNameOrDefault());
-		}
-		return this.sendFailureChannel;
-	}
-
-	protected String getSendFailureChannelNameOrDefault() {
-		return this.sendFailureChannelName == null ?
-				IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME :
-				sendFailureChannelName;
+		return sendFailureChannel;
 	}
 
 	protected @Nullable MessageChannel getSendSuccessChannel() {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandler.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandler.java
@@ -29,6 +29,7 @@ import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
 import org.springframework.integration.amqp.support.MappingUtils;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.MessagingTemplate;
 import org.springframework.integration.handler.AbstractMessageHandler;
 import org.springframework.messaging.Message;
@@ -176,11 +177,23 @@ public class RabbitStreamMessageHandler extends AbstractMessageHandler {
 		if (this.sendFailureChannel != null) {
 			return this.sendFailureChannel;
 		}
-		else if (this.sendFailureChannelName != null) {
-			this.sendFailureChannel = getChannelResolver().resolveDestination(this.sendFailureChannelName);
-			return this.sendFailureChannel;
+		if (this.sync) {
+			if (this.sendFailureChannelName != null) {
+				this.sendFailureChannel = getChannelResolver()
+						.resolveDestination(sendFailureChannelName);
+			}
 		}
-		return null;
+		else {
+			this.sendFailureChannel = getChannelResolver()
+					.resolveDestination(getSendFailureChannelNameOrDefault());
+		}
+		return this.sendFailureChannel;
+	}
+
+	protected String getSendFailureChannelNameOrDefault() {
+		return this.sendFailureChannelName == null ?
+				IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME :
+				sendFailureChannelName;
 	}
 
 	protected @Nullable MessageChannel getSendSuccessChannel() {

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandler.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandler.java
@@ -46,6 +46,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Chris Bono
+ * @author Ryan Riley
  * @since 6.0
  *
  */

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandler.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandler.java
@@ -175,18 +175,14 @@ public class RabbitStreamMessageHandler extends AbstractMessageHandler {
 	}
 
 	protected @Nullable MessageChannel getSendFailureChannel() {
-		if (sendFailureChannel == null) {
-			if (sync && sendFailureChannelName != null) {
-				this.sendFailureChannel = getChannelResolver().resolveDestination(this.sendFailureChannelName);
+		if (this.sendFailureChannel == null && (this.sendFailureChannelName != null || !this.sync)) {
+			String sendFailureChannelNameToUse = this.sendFailureChannelName;
+			if (sendFailureChannelNameToUse == null) {
+				sendFailureChannelNameToUse = IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME;
 			}
-			else if (!sync) {
-				String sendFailureChannelNameToUse = sendFailureChannelName == null
-						? IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME
-						: sendFailureChannelName;
-				this.sendFailureChannel = getChannelResolver().resolveDestination(sendFailureChannelNameToUse);
-			}
+			this.sendFailureChannel = getChannelResolver().resolveDestination(sendFailureChannelNameToUse);
 		}
-		return sendFailureChannel;
+		return this.sendFailureChannel;
 	}
 
 	protected @Nullable MessageChannel getSendSuccessChannel() {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandlerTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandlerTests.java
@@ -27,7 +27,6 @@ import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.OffsetSpecification;
 import com.rabbitmq.stream.codec.SimpleCodec;
 import org.junit.jupiter.api.Test;
-
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 
@@ -41,7 +40,7 @@ import org.springframework.rabbit.stream.producer.RabbitStreamTemplate;
 import org.springframework.rabbit.stream.producer.StreamSendException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 
 /**
  * @author Gary Russell
@@ -151,10 +150,7 @@ public class RabbitStreamMessageHandlerTests implements RabbitTestContainer {
 		StreamSendException streamException = new StreamSendException("Test Error Code", 99);
 		errorFuture.completeExceptionally(streamException);
 		ErrorMessage errorMessage = (ErrorMessage) errorChannel.receive(1000);
-		assertThat(errorMessage).isNotNull();
-		Throwable caughtException = errorMessage.getPayload();
-		assertThat(caughtException).isInstanceOf(StreamSendException.class);
-		assertThat(caughtException).isEqualTo(streamException);
+		assertThat(errorMessage).extracting(org.springframework.messaging.Message::getPayload).isEqualTo(streamException);
 	}
 
 	@Test
@@ -176,7 +172,8 @@ public class RabbitStreamMessageHandlerTests implements RabbitTestContainer {
 						.addData(new byte[1])
 						.build())
 				.build();
-		assertThatThrownBy(() -> handler.handleMessage(testMessage))
-				.isInstanceOf(MessageHandlingException.class);
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> handler.handleMessage(testMessage));
 	}
+
 }

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandlerTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandlerTests.java
@@ -47,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Gary Russell
  * @author Chris Bono
  * @author Artem Bilan
+ * @author Ryan Riley
  *
  * @since 6.0
  */

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandlerTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/RabbitStreamMessageHandlerTests.java
@@ -179,29 +179,4 @@ public class RabbitStreamMessageHandlerTests implements RabbitTestContainer {
 		assertThatThrownBy(() -> handler.handleMessage(testMessage))
 				.isInstanceOf(MessageHandlingException.class);
 	}
-
-	@Test
-	void defaultFailureChannel() {
-		Environment env = Mockito.mock(Environment.class);
-		RabbitStreamTemplate streamTemplate = new RabbitStreamTemplate(env, "stream.stream");
-
-		RabbitStreamMessageHandler handler = RabbitStream.outboundStreamAdapter(streamTemplate)
-				.getObject();
-
-		String failureChannelName = handler.getSendFailureChannelNameOrDefault();
-		assertThat(failureChannelName).isEqualTo("errorChannel");
-	}
-
-	@Test
-	void setFailureChannelName() {
-		Environment env = Mockito.mock(Environment.class);
-		RabbitStreamTemplate streamTemplate = new RabbitStreamTemplate(env, "stream.stream");
-
-		RabbitStreamMessageHandler handler = RabbitStream.outboundStreamAdapter(streamTemplate)
-				.getObject();
-		handler.setSendFailureChannelName("SomethingElse");
-
-		String failureChannelName = handler.getSendFailureChannelNameOrDefault();
-		assertThat(failureChannelName).isEqualTo("SomethingElse");
-	}
 }


### PR DESCRIPTION
closes #10163 

A clean branch fixing several issues from my "corrupt" previous PR #10164

This PR has the `RabbitStreamMessageHandler` fallback to a `sendFailureChannelName` of `"errorChannel"` when a channel name is not set and when it is operating in `async` mode.