### PR TITLE
Add JSpecify nullify to channel/interceptor, code, and codec/kryo packages

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/WireTap.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/WireTap.java
@@ -18,6 +18,7 @@ package org.springframework.integration.channel.interceptor;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
@@ -50,16 +51,19 @@ public class WireTap implements ChannelInterceptor, ManageableLifecycle, VetoCap
 
 	private static final Log LOGGER = LogFactory.getLog(WireTap.class);
 
-	private final MessageSelector selector;
+	private final @Nullable MessageSelector selector;
 
+	@SuppressWarnings("NullAway.Init")
 	private MessageChannel channel;
 
-	private String channelName;
+	private @Nullable String channelName;
 
 	private long timeout = 0;
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
+	@SuppressWarnings("NullAway.Init")
 	private MessageBuilderFactory messageBuilderFactory;
 
 	private volatile boolean running = true;
@@ -78,7 +82,7 @@ public class WireTap implements ChannelInterceptor, ManageableLifecycle, VetoCap
 	 * @param selector the selector that must accept a message for it to be
 	 * sent to the intercepting channel
 	 */
-	public WireTap(MessageChannel channel, MessageSelector selector) {
+	public WireTap(MessageChannel channel, @Nullable MessageSelector selector) {
 		Assert.notNull(channel, "channel must not be null");
 		this.channel = channel;
 		this.selector = selector;
@@ -103,7 +107,7 @@ public class WireTap implements ChannelInterceptor, ManageableLifecycle, VetoCap
 	 * sent to the intercepting channel
 	 * @since 4.3
 	 */
-	public WireTap(String channelName, MessageSelector selector) {
+	public WireTap(String channelName, @Nullable MessageSelector selector) {
 		Assert.hasText(channelName, "channelName must not be empty");
 		this.channelName = channelName;
 		this.selector = selector;

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes related to channel interception.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.channel.interceptor;

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CodecMessageConverter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CodecMessageConverter.java
@@ -18,6 +18,8 @@ package org.springframework.integration.codec;
 
 import java.io.IOException;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.messaging.Message;
@@ -57,7 +59,7 @@ public class CodecMessageConverter extends IntegrationObjectSupport implements M
 	}
 
 	@Override
-	public Message<?> toMessage(Object payload, MessageHeaders headers) {
+	public Message<?> toMessage(Object payload, @Nullable MessageHeaders headers) {
 		Assert.isInstanceOf(byte[].class, payload);
 		try {
 			Message<?> decoded = (Message<?>) this.codec.decode((byte[]) payload, this.messageClass);

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -37,7 +37,7 @@ public class CompositeCodec implements Codec {
 
 	private final Codec defaultCodec;
 
-	private final @Nullable Map<Class<?>, Codec> delegates;
+	private final Map<Class<?>, Codec> delegates;
 
 	public CompositeCodec(@Nullable Map<Class<?>, Codec> delegates, Codec defaultCodec) {
 		Assert.notNull(defaultCodec, "'defaultCodec' cannot be null");
@@ -96,7 +96,7 @@ public class CompositeCodec implements Codec {
 	}
 
 	private @Nullable Codec findDelegate(Class<?> type) {
-		if (this.delegates == null) {
+		if (this.delegates.isEmpty()) {
 			return null;
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -39,14 +39,17 @@ public class CompositeCodec implements Codec {
 
 	private final @Nullable Map<Class<?>, Codec> delegates;
 
-	public CompositeCodec(Map<Class<?>, Codec> delegates, Codec defaultCodec) {
+	public CompositeCodec(@Nullable Map<Class<?>, Codec> delegates, Codec defaultCodec) {
 		Assert.notNull(defaultCodec, "'defaultCodec' cannot be null");
 		this.defaultCodec = defaultCodec;
+		if (delegates == null) {
+			delegates = Map.of();
+		}
 		this.delegates = new HashMap<Class<?>, Codec>(delegates);
 	}
 
 	public CompositeCodec(Codec defaultCodec) {
-		this(Map.of(), defaultCodec);
+		this(null, defaultCodec);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -45,6 +45,10 @@ public class CompositeCodec implements Codec {
 		this.delegates = new HashMap<Class<?>, Codec>(delegates);
 	}
 
+	public CompositeCodec(Codec defaultCodec) {
+		this(Map.of(), defaultCodec);
+	}
+
 	@Override
 	public void encode(Object object, OutputStream outputStream) throws IOException {
 		Assert.notNull(object, "cannot encode a null object");

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -23,6 +23,8 @@ import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.util.ClassUtils;
 import org.springframework.util.Assert;
 
@@ -35,16 +37,12 @@ public class CompositeCodec implements Codec {
 
 	private final Codec defaultCodec;
 
-	private final Map<Class<?>, Codec> delegates;
+	private final @Nullable Map<Class<?>, Codec> delegates;
 
 	public CompositeCodec(Map<Class<?>, Codec> delegates, Codec defaultCodec) {
 		Assert.notNull(defaultCodec, "'defaultCodec' cannot be null");
 		this.defaultCodec = defaultCodec;
 		this.delegates = new HashMap<Class<?>, Codec>(delegates);
-	}
-
-	public CompositeCodec(Codec defaultCodec) {
-		this(null, defaultCodec);
 	}
 
 	@Override
@@ -90,7 +88,7 @@ public class CompositeCodec implements Codec {
 		return decode(new ByteArrayInputStream(bytes), type);
 	}
 
-	private Codec findDelegate(Class<?> type) {
+	private @Nullable Codec findDelegate(Class<?> type) {
 		if (this.delegates == null) {
 			return null;
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -39,17 +39,13 @@ public class CompositeCodec implements Codec {
 
 	private final Map<Class<?>, Codec> delegates;
 
-	public CompositeCodec(@Nullable Map<Class<?>, Codec> delegates, Codec defaultCodec) {
-		Assert.notNull(defaultCodec, "'defaultCodec' cannot be null");
+	public CompositeCodec(Map<Class<?>, Codec> delegates, Codec defaultCodec) {
 		this.defaultCodec = defaultCodec;
-		if (delegates == null) {
-			delegates = Map.of();
-		}
 		this.delegates = new HashMap<Class<?>, Codec>(delegates);
 	}
 
 	public CompositeCodec(Codec defaultCodec) {
-		this(null, defaultCodec);
+		this(Map.of(), defaultCodec);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/PojoCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/PojoCodec.java
@@ -23,6 +23,7 @@ import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.util.DefaultInstantiatorStrategy;
+import org.jspecify.annotations.Nullable;
 import org.objenesis.strategy.StdInstantiatorStrategy;
 
 import org.springframework.util.CollectionUtils;
@@ -39,7 +40,7 @@ import org.springframework.util.CollectionUtils;
  */
 public class PojoCodec extends AbstractKryoCodec {
 
-	private final CompositeKryoRegistrar kryoRegistrar;
+	private final @Nullable CompositeKryoRegistrar kryoRegistrar;
 
 	private final boolean useReferences;
 
@@ -52,7 +53,7 @@ public class PojoCodec extends AbstractKryoCodec {
 	 * Create an instance with a single KryoRegistrar.
 	 * @param kryoRegistrar the registrar.
 	 */
-	public PojoCodec(KryoRegistrar kryoRegistrar) {
+	public PojoCodec(@Nullable KryoRegistrar kryoRegistrar) {
 		this(kryoRegistrar != null ? Collections.singletonList(kryoRegistrar) : null, true);
 	}
 
@@ -72,7 +73,7 @@ public class PojoCodec extends AbstractKryoCodec {
 	 * @param useReferences set to false if references are not required (if the object graph is known to be acyclical).
 	 * The default is 'true' which is less performant but more flexible.
 	 */
-	public PojoCodec(KryoRegistrar kryoRegistrar, boolean useReferences) {
+	public PojoCodec(@Nullable KryoRegistrar kryoRegistrar, boolean useReferences) {
 		this(kryoRegistrar != null ? Collections.singletonList(kryoRegistrar) : null, useReferences);
 	}
 
@@ -82,7 +83,7 @@ public class PojoCodec extends AbstractKryoCodec {
 	 * @param useReferences set to false if references are not required (if the object graph is known to be acyclical).
 	 * The default is 'true' which is less performant but more flexible.
 	 */
-	public PojoCodec(List<KryoRegistrar> kryoRegistrars, boolean useReferences) {
+	public PojoCodec(@Nullable List<KryoRegistrar> kryoRegistrars, boolean useReferences) {
 		this.kryoRegistrar = CollectionUtils.isEmpty(kryoRegistrars) ? null :
 				new CompositeKryoRegistrar(kryoRegistrars);
 		this.useReferences = useReferences;

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/package-info.java
@@ -1,4 +1,5 @@
 /**
  * The <a href="https://code.google.com/p/kryo/">Kryo</a> specific {@code Codec} classes.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.codec.kryo;

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides base classes for the {@code Codec} abstraction.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.codec;


### PR DESCRIPTION
* Missed the channel/interceptor on the last PR.
* Removed CompositeCodec(Codec defaultCodec)  because null can never be pass to the Codec.    In the past it would have thrown a NPE.

Continued effort or issue: https://github.com/spring-projects/spring-integration/issues/10083

