### PR TITLE
CompositeCodec constructors require at least one delegate

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -41,7 +41,7 @@ public class CompositeCodec implements Codec {
 	public CompositeCodec(Map<Class<?>, Codec> delegates, Codec defaultCodec) {
 		this.defaultCodec = defaultCodec;
 		Assert.notEmpty(delegates, "delegates must not be empty");
-		this.delegates = new HashMap<Class<?>, Codec>(delegates);
+		this.delegates = new HashMap<>(delegates);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -49,7 +49,8 @@ public class CompositeCodec implements Codec {
 	 */
 	@Deprecated(since = "7.0", forRemoval = true)
 	public CompositeCodec(Codec defaultCodec) {
-		this(Map.of(), defaultCodec);
+		this.defaultCodec = defaultCodec;
+		this.delegates = Map.of();
 	}
 
 	@Override
@@ -79,11 +80,7 @@ public class CompositeCodec implements Codec {
 
 	private Codec findDelegate(Class<?> type) {
 		Class<?> clazz = ClassUtils.findClosestMatch(type, this.delegates.keySet(), false);
-		Codec codec = this.delegates.get(clazz);
-		if (codec == null) {
-			codec = this.defaultCodec;
-		}
-		return codec;
+		return clazz == null ? this.defaultCodec : this.delegates.getOrDefault(clazz, this.defaultCodec);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
 /**
  * A Codec that can delegate to one out of many Codecs, each mapped to a class.
  * @author David Turanski
+ * @author Glenn Renfro
  * @since 4.2
  */
 public class CompositeCodec implements Codec {

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -44,15 +44,9 @@ public class CompositeCodec implements Codec {
 	}
 
 	/**
-	 * @since 7.0
-	 *
-	 * @deprecated This constructor is deprecated because the delegates map must contain at least one entry.
-	 * Creating a {@code CompositeCodec} without any delegates is not a valid use case, as there would be
-	 * no codecs to delegate to for encoding or decoding operations. Please use the constructor that accepts
-	 * a non-empty delegates map to ensure proper delegation behavior.
-	 *
+	 * @deprecated since 7.0 in favor of {@link #CompositeCodec(Map, Codec)}.
 	 */
-	@Deprecated
+	@Deprecated(since = "7.0", forRemoval = true)
 	public CompositeCodec(Codec defaultCodec) {
 		this(Map.of(), defaultCodec);
 	}
@@ -83,7 +77,6 @@ public class CompositeCodec implements Codec {
 	}
 
 	private Codec findDelegate(Class<?> type) {
-		Assert.state(!this.delegates.isEmpty(), "Delegates must not be empty");
 		Class<?> clazz = ClassUtils.findClosestMatch(type, this.delegates.keySet(), false);
 		Codec codec = this.delegates.get(clazz);
 		if (codec == null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -22,7 +22,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
 
 import org.springframework.integration.util.ClassUtils;
 import org.springframework.util.Assert;
@@ -43,7 +42,6 @@ import org.springframework.util.Assert;
  * @author Glenn Renfro
  *
  * @since 4.2
- * @see ClassUtils#findClosestMatch(Class, Set, boolean)
  */
 public class CompositeCodec implements Codec {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -22,6 +22,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.integration.util.ClassUtils;
 import org.springframework.util.Assert;
@@ -31,9 +32,18 @@ import org.springframework.util.Assert;
  * delegating encoding and decoding operations to the appropriate type-specific codec.
  * This implementation associates object types with their appropriate codecs while providing a fallback default codec
  * for unregistered types.
+ * This class uses {@code ClassUtils.findClosestMatch} to select the appropriate codec for a given object type.
+ * When multiple codecs match an object type, {@code ClassUtils.findClosestMatch} offers the
+ * {@code failOnTie} option. If {@code failOnTie} is {@code false}, it will return any one of the matching codecs.
+ * If {@code failOnTie} is {@code true} and multiple codecs match, it will throw an {@code IllegalStateException}.
+ * {@link CompositeCodec} sets {@code failOnTie} to {@code true}, so if multiple codecs match, an
+ * {@code IllegalStateException} is thrown.
+ *
  * @author David Turanski
  * @author Glenn Renfro
+ *
  * @since 4.2
+ * @see ClassUtils#findClosestMatch(Class, Set, boolean)
  */
 public class CompositeCodec implements Codec {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -27,7 +27,10 @@ import org.springframework.integration.util.ClassUtils;
 import org.springframework.util.Assert;
 
 /**
- * A Codec that can delegate to one out of many Codecs, each mapped to a class.
+ * An implementation of {@link Codec} that combines multiple codecs into a single codec,
+ * delegating encoding and decoding operations to the appropriate type-specific codec.
+ * This implementation associates object types with their appropriate codecs while providing a fallback default codec
+ * for unregistered types.
  * @author David Turanski
  * @author Glenn Renfro
  * @since 4.2
@@ -42,15 +45,6 @@ public class CompositeCodec implements Codec {
 		this.defaultCodec = defaultCodec;
 		Assert.notEmpty(delegates, "delegates must not be empty");
 		this.delegates = new HashMap<>(delegates);
-	}
-
-	/**
-	 * @deprecated since 7.0 in favor of {@link #CompositeCodec(Map, Codec)}.
-	 */
-	@Deprecated(since = "7.0", forRemoval = true)
-	public CompositeCodec(Codec defaultCodec) {
-		this.defaultCodec = defaultCodec;
-		this.delegates = Map.of();
 	}
 
 	@Override
@@ -79,7 +73,7 @@ public class CompositeCodec implements Codec {
 	}
 
 	private Codec findDelegate(Class<?> type) {
-		Class<?> clazz = ClassUtils.findClosestMatch(type, this.delegates.keySet(), false);
+		Class<?> clazz = ClassUtils.findClosestMatch(type, this.delegates.keySet(), true);
 		return clazz == null ? this.defaultCodec : this.delegates.getOrDefault(clazz, this.defaultCodec);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/codec/kryo/CompositeCodecTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/codec/kryo/CompositeCodecTests.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author David Turanski
+ * @author Glenn Renfro
  * @since 4.2
  */
 public class CompositeCodecTests {

--- a/spring-integration-core/src/test/java/org/springframework/integration/codec/kryo/CompositeCodecTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/codec/kryo/CompositeCodecTests.java
@@ -19,13 +19,13 @@ package org.springframework.integration.codec.kryo;
 import java.io.IOException;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.codec.Codec;
 import org.springframework.integration.codec.CompositeCodec;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  * @author David Turanski
@@ -34,23 +34,54 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class CompositeCodecTests {
 
-	private Codec codec;
-
-	@BeforeEach
-	public void setup() {
-		PojoCodec pojoCodec = new PojoCodec();
-		Map<Class<?>, Codec> codecs = Map.of(pojoCodec.getClass(), pojoCodec);
-		this.codec = new CompositeCodec(codecs, new PojoCodec(
-				new KryoClassListRegistrar(SomeClassWithNoDefaultConstructors.class)));
+	@Test
+	void testWithCodecDelegates() throws IOException {
+		Codec codec = getFullyQualifiedCodec();
+		SomeClassWithNoDefaultConstructors foo = new SomeClassWithNoDefaultConstructors("hello", 123);
+		SomeClassWithNoDefaultConstructors foo2 = codec.decode(
+				codec.encode(foo),
+				SomeClassWithNoDefaultConstructors.class);
+		assertThat(foo2).isEqualTo(foo);
 	}
 
 	@Test
-	public void testPojoSerialization() throws IOException {
+	void testWithCodecDefault() throws IOException {
+		Codec codec = getFullyQualifiedCodec();
+		AnotherClassWithNoDefaultConstructors foo = new AnotherClassWithNoDefaultConstructors("hello", 123);
+		AnotherClassWithNoDefaultConstructors foo2 = codec.decode(
+				codec.encode(foo),
+				AnotherClassWithNoDefaultConstructors.class);
+		assertThat(foo2).isEqualTo(foo);
+	}
+
+	@Test
+	void testWithUnRegisteredClass() throws IOException {
+		// Verify that the default encodes and decodes properly
+		Codec codec = onlyDefaultCodec();
 		SomeClassWithNoDefaultConstructors foo = new SomeClassWithNoDefaultConstructors("hello", 123);
-		SomeClassWithNoDefaultConstructors foo2 = this.codec.decode(
-				this.codec.encode(foo),
+		SomeClassWithNoDefaultConstructors foo2 = codec.decode(
+				codec.encode(foo),
 				SomeClassWithNoDefaultConstructors.class);
 		assertThat(foo2).isEqualTo(foo);
+
+		// Verify that an exception is thrown if an unknown type is to be encoded.
+		assertThatIllegalArgumentException().isThrownBy(() -> codec.decode(
+				codec.encode(foo),
+				AnotherClassWithNoDefaultConstructors.class));
+	}
+
+	private static Codec getFullyQualifiedCodec() {
+		Map<Class<?>, Codec> codecs = Map.of(SomeClassWithNoDefaultConstructors.class, new PojoCodec(
+				new KryoClassListRegistrar(SomeClassWithNoDefaultConstructors.class)));
+		return new CompositeCodec(codecs, new PojoCodec(
+				new KryoClassListRegistrar(AnotherClassWithNoDefaultConstructors.class)));
+	}
+
+	private static Codec onlyDefaultCodec() {
+		PojoCodec pojoCodec = new PojoCodec();
+		Map<Class<?>, Codec> codecs = Map.of(pojoCodec.getClass(), pojoCodec);
+		return new CompositeCodec(codecs, new PojoCodec(
+				new KryoClassListRegistrar(SomeClassWithNoDefaultConstructors.class)));
 	}
 
 	static class SomeClassWithNoDefaultConstructors {
@@ -70,6 +101,35 @@ public class CompositeCodecTests {
 				return false;
 			}
 			SomeClassWithNoDefaultConstructors that = (SomeClassWithNoDefaultConstructors) other;
+			return (this.val1.equals(that.val1) && this.val2 == that.val2);
+		}
+
+		@Override
+		public int hashCode() {
+			int result = this.val1.hashCode();
+			result = 31 * result + this.val2;
+			return result;
+		}
+
+	}
+
+	static class AnotherClassWithNoDefaultConstructors {
+
+		private String val1;
+
+		private int val2;
+
+		AnotherClassWithNoDefaultConstructors(String val1, int val2) {
+			this.val1 = val1;
+			this.val2 = val2;
+		}
+
+		@Override
+		public boolean equals(Object other) {
+			if (!(other instanceof AnotherClassWithNoDefaultConstructors)) {
+				return false;
+			}
+			AnotherClassWithNoDefaultConstructors that = (AnotherClassWithNoDefaultConstructors) other;
 			return (this.val1.equals(that.val1) && this.val2 == that.val2);
 		}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/codec/kryo/CompositeCodecTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/codec/kryo/CompositeCodecTests.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.codec.kryo;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +37,8 @@ public class CompositeCodecTests {
 
 	@BeforeEach
 	public void setup() {
-		Map<Class<?>, Codec> codecs = new HashMap<>();
+		PojoCodec pojoCodec = new PojoCodec();
+		Map<Class<?>, Codec> codecs = Map.of(pojoCodec.getClass(), pojoCodec);
 		this.codec = new CompositeCodec(codecs, new PojoCodec(
 				new KryoClassListRegistrar(SomeClassWithNoDefaultConstructors.class)));
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/codec/kryo/CompositeCodecTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/codec/kryo/CompositeCodecTests.java
@@ -37,36 +37,36 @@ public class CompositeCodecTests {
 	@Test
 	void testWithCodecDelegates() throws IOException {
 		Codec codec = getFullyQualifiedCodec();
-		SomeClassWithNoDefaultConstructors foo = new SomeClassWithNoDefaultConstructors("hello", 123);
-		SomeClassWithNoDefaultConstructors foo2 = codec.decode(
-				codec.encode(foo),
+		SomeClassWithNoDefaultConstructors inputInstance = new SomeClassWithNoDefaultConstructors("hello", 123);
+		SomeClassWithNoDefaultConstructors outputInstance = codec.decode(
+				codec.encode(inputInstance),
 				SomeClassWithNoDefaultConstructors.class);
-		assertThat(foo2).isEqualTo(foo);
+		assertThat(outputInstance).isEqualTo(inputInstance);
 	}
 
 	@Test
 	void testWithCodecDefault() throws IOException {
 		Codec codec = getFullyQualifiedCodec();
-		AnotherClassWithNoDefaultConstructors foo = new AnotherClassWithNoDefaultConstructors("hello", 123);
-		AnotherClassWithNoDefaultConstructors foo2 = codec.decode(
-				codec.encode(foo),
+		AnotherClassWithNoDefaultConstructors inputInstance = new AnotherClassWithNoDefaultConstructors("hello", 123);
+		AnotherClassWithNoDefaultConstructors outputInstance = codec.decode(
+				codec.encode(inputInstance),
 				AnotherClassWithNoDefaultConstructors.class);
-		assertThat(foo2).isEqualTo(foo);
+		assertThat(outputInstance).isEqualTo(inputInstance);
 	}
 
 	@Test
 	void testWithUnRegisteredClass() throws IOException {
 		// Verify that the default encodes and decodes properly
 		Codec codec = onlyDefaultCodec();
-		SomeClassWithNoDefaultConstructors foo = new SomeClassWithNoDefaultConstructors("hello", 123);
-		SomeClassWithNoDefaultConstructors foo2 = codec.decode(
-				codec.encode(foo),
+		SomeClassWithNoDefaultConstructors inputInstance = new SomeClassWithNoDefaultConstructors("hello", 123);
+		SomeClassWithNoDefaultConstructors outputInstance = codec.decode(
+				codec.encode(inputInstance),
 				SomeClassWithNoDefaultConstructors.class);
-		assertThat(foo2).isEqualTo(foo);
+		assertThat(outputInstance).isEqualTo(inputInstance);
 
 		// Verify that an exception is thrown if an unknown type is to be encoded.
 		assertThatIllegalArgumentException().isThrownBy(() -> codec.decode(
-				codec.encode(foo),
+				codec.encode(inputInstance),
 				AnotherClassWithNoDefaultConstructors.class));
 	}
 
@@ -79,67 +79,13 @@ public class CompositeCodecTests {
 
 	private static Codec onlyDefaultCodec() {
 		PojoCodec pojoCodec = new PojoCodec();
-		Map<Class<?>, Codec> codecs = Map.of(pojoCodec.getClass(), pojoCodec);
+		Map<Class<?>, Codec> codecs = Map.of(java.util.Date.class, pojoCodec);
 		return new CompositeCodec(codecs, new PojoCodec(
 				new KryoClassListRegistrar(SomeClassWithNoDefaultConstructors.class)));
 	}
 
-	static class SomeClassWithNoDefaultConstructors {
+	private record SomeClassWithNoDefaultConstructors(String val1, int val2) { }
 
-		private String val1;
-
-		private int val2;
-
-		SomeClassWithNoDefaultConstructors(String val1, int val2) {
-			this.val1 = val1;
-			this.val2 = val2;
-		}
-
-		@Override
-		public boolean equals(Object other) {
-			if (!(other instanceof SomeClassWithNoDefaultConstructors)) {
-				return false;
-			}
-			SomeClassWithNoDefaultConstructors that = (SomeClassWithNoDefaultConstructors) other;
-			return (this.val1.equals(that.val1) && this.val2 == that.val2);
-		}
-
-		@Override
-		public int hashCode() {
-			int result = this.val1.hashCode();
-			result = 31 * result + this.val2;
-			return result;
-		}
-
-	}
-
-	static class AnotherClassWithNoDefaultConstructors {
-
-		private String val1;
-
-		private int val2;
-
-		AnotherClassWithNoDefaultConstructors(String val1, int val2) {
-			this.val1 = val1;
-			this.val2 = val2;
-		}
-
-		@Override
-		public boolean equals(Object other) {
-			if (!(other instanceof AnotherClassWithNoDefaultConstructors)) {
-				return false;
-			}
-			AnotherClassWithNoDefaultConstructors that = (AnotherClassWithNoDefaultConstructors) other;
-			return (this.val1.equals(that.val1) && this.val2 == that.val2);
-		}
-
-		@Override
-		public int hashCode() {
-			int result = this.val1.hashCode();
-			result = 31 * result + this.val2;
-			return result;
-		}
-
-	}
+	private record AnotherClassWithNoDefaultConstructors(String val1, int val2) { }
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
@@ -20,6 +20,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 
@@ -34,7 +35,6 @@ import org.springframework.core.serializer.DefaultSerializer;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.codec.Codec;
 import org.springframework.integration.codec.CodecMessageConverter;
-import org.springframework.integration.codec.CompositeCodec;
 import org.springframework.integration.codec.kryo.MessageCodec;
 import org.springframework.integration.ip.IpHeaders;
 import org.springframework.integration.ip.tcp.serializer.MapJsonSerializer;
@@ -67,12 +67,11 @@ public class TcpMessageMapperTests {
 
 	@BeforeEach
 	public void setup() {
-		MessageCodec messageCodec = new MessageCodec();
-		Map<Class<?>, Codec> codecs = Map.of(messageCodec.getClass(), messageCodec);
-		this.codec = new CompositeCodec(codecs, new MessageCodec());
+		this.codec = new MessageCodec();
 	}
 
 	@Test
+	@SuppressWarnings("NullAway")
 	public void testToMessage() {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		TcpConnection connection = creatMockTcpConcnection(TEST_PAYLOAD.getBytes(), "MyHost", "1.1.1.1", 1234);
@@ -90,6 +89,7 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
+	@SuppressWarnings("NullAway")
 	public void testToMessageWithContentType() {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		mapper.setAddContentTypeHeader(true);
@@ -111,6 +111,7 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
+	@SuppressWarnings("NullAway")
 	public void testToMessageWithCustomContentType() {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		mapper.setAddContentTypeHeader(true);
@@ -142,6 +143,7 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
+	@SuppressWarnings("NullAway")
 	public void testToMessageSequence() throws Exception {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		Socket socket = SocketFactory.getDefault().createSocket();
@@ -217,6 +219,7 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
+	@SuppressWarnings("NullAway")
 	public void testToMessageSequenceNewWithCustomHeader() throws Exception {
 		TcpMessageMapper mapper = new TcpMessageMapper() {
 
@@ -340,11 +343,12 @@ public class TcpMessageMapperTests {
 		MapJsonSerializer serializer = new MapJsonSerializer();
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		serializer.serialize(map, baos);
-		assertThat(new String(baos.toByteArray(), "UTF-8"))
+		assertThat(baos.toString(StandardCharsets.UTF_8))
 				.isEqualTo("{\"headers\":{\"bar\":\"baz\"},\"payload\":\"foo\"}\n");
 	}
 
 	@Test
+	@SuppressWarnings("NullAway")
 	public void testMapMessageConvertingInboundJson() throws Exception {
 		String json = "{\"headers\":{\"bar\":\"baz\"},\"payload\":\"foo\"}\n";
 		MapMessageConverter converter = new MapMessageConverter();
@@ -364,6 +368,7 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
+	@SuppressWarnings("NullAway")
 	public void testMapMessageConvertingBothWaysJava() throws Exception {
 		Message<String> outMessage = MessageBuilder.withPayload("foo")
 				.setHeader("bar", "baz")
@@ -390,6 +395,7 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
+	@SuppressWarnings("NullAway")
 	public void testCodecMessageConvertingBothWaysJava() {
 		Message<String> outMessage = MessageBuilder.withPayload("foo")
 				.setHeader("bar", "baz")
@@ -410,6 +416,7 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
+	@SuppressWarnings("NullAway")
 	public void testWithBytesMapper() {
 		Message<String> outMessage = MessageBuilder.withPayload("foo")
 				.setHeader("bar", "baz")

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gengwu Zhao
+ * @author Glenn Renfro
  * @since 2.0
  *
  */

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
@@ -21,7 +21,6 @@ import java.io.ByteArrayOutputStream;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.net.SocketFactory;
@@ -67,7 +66,8 @@ public class TcpMessageMapperTests {
 
 	@BeforeEach
 	public void setup() {
-		Map<Class<?>, Codec> codecs = new HashMap<>();
+		MessageCodec messageCodec = new MessageCodec();
+		Map<Class<?>, Codec> codecs = Map.of(messageCodec.getClass(), messageCodec);
 		this.codec = new CompositeCodec(codecs, new MessageCodec());
 	}
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpMessageMapperTests.java
@@ -71,7 +71,6 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway")
 	public void testToMessage() {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		TcpConnection connection = creatMockTcpConcnection(TEST_PAYLOAD.getBytes(), "MyHost", "1.1.1.1", 1234);
@@ -89,7 +88,6 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway")
 	public void testToMessageWithContentType() {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		mapper.setAddContentTypeHeader(true);
@@ -111,7 +109,6 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway")
 	public void testToMessageWithCustomContentType() {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		mapper.setAddContentTypeHeader(true);
@@ -143,7 +140,6 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway")
 	public void testToMessageSequence() throws Exception {
 		TcpMessageMapper mapper = new TcpMessageMapper();
 		Socket socket = SocketFactory.getDefault().createSocket();
@@ -219,7 +215,6 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway")
 	public void testToMessageSequenceNewWithCustomHeader() throws Exception {
 		TcpMessageMapper mapper = new TcpMessageMapper() {
 
@@ -348,7 +343,6 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway")
 	public void testMapMessageConvertingInboundJson() throws Exception {
 		String json = "{\"headers\":{\"bar\":\"baz\"},\"payload\":\"foo\"}\n";
 		MapMessageConverter converter = new MapMessageConverter();
@@ -368,7 +362,6 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway")
 	public void testMapMessageConvertingBothWaysJava() throws Exception {
 		Message<String> outMessage = MessageBuilder.withPayload("foo")
 				.setHeader("bar", "baz")
@@ -395,7 +388,6 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway")
 	public void testCodecMessageConvertingBothWaysJava() {
 		Message<String> outMessage = MessageBuilder.withPayload("foo")
 				.setHeader("bar", "baz")
@@ -416,7 +408,6 @@ public class TcpMessageMapperTests {
 	}
 
 	@Test
-	@SuppressWarnings("NullAway")
 	public void testWithBytesMapper() {
 		Message<String> outMessage = MessageBuilder.withPayload("foo")
 				.setHeader("bar", "baz")

--- a/src/reference/antora/modules/ROOT/pages/codec.adoc
+++ b/src/reference/antora/modules/ROOT/pages/codec.adoc
@@ -56,7 +56,8 @@ The second and third are used with the `MessageCodec`, which is initialized with
 
 [[composite-codec]]
 === CompositeCodec
-The CompositeCodec is a codec that combines multiple codecs into a single codec, delegating encoding and decoding operations to the appropriate type-specific codec.
+
+The `CompositeCodec` is a codec that combines multiple codecs into a single codec, delegating encoding and decoding operations to the appropriate type-specific codec.
 This implementation associates object types with their appropriate codecs while providing a fallback default codec for unregistered types.
 
 An example implementation can be seen below:
@@ -108,14 +109,14 @@ record Cat(String name, int age, int lives) {}
 record Animal(String name, int age){}
 ```
 
-In some cases a single type of object may return multiple codecs. In these cases an `IllegalStateException` is thrown.
+In some cases a single type of object may return multiple codecs.
+In these cases an `IllegalStateException` is thrown.
 
 NOTE: This class uses `ClassUtils.findClosestMatch` to select the appropriate codec for a given object type.
 When multiple codecs match an object type, `ClassUtils.findClosestMatch` offers the `failOnTie` option.
 If `failOnTie` is `false`, it will return any one of the matching codecs.
 If `failOnTie` is `true` and multiple codecs match, it will throw an `IllegalStateException`.
-CompositeCodec` sets `failOnTie` to `true`, so if multiple codecs match, an
-`IllegalStateException` is thrown.
+CompositeCodec` sets `failOnTie` to `true`, so if multiple codecs match, an `IllegalStateException` is thrown.
 
 [[customizing-kryo]]
 === Customizing Kryo

--- a/src/reference/antora/modules/ROOT/pages/codec.adoc
+++ b/src/reference/antora/modules/ROOT/pages/codec.adoc
@@ -39,10 +39,11 @@ See the https://docs.spring.io/spring-integration/api/org/springframework/integr
 [[kryo]]
 == Kryo
 
-Currently, this is the only implementation of `Codec`, and it provides two kinds of `Codec`:
+Currently, this is the only implementation of `Codec`, and it provides three kinds of `Codec`:
 
 * `PojoCodec`: Used in the transformers
 * `MessageCodec`: Used in the `CodecMessageConverter`
+* `CompositeCodec`: Used in transformers
 
 The framework provides several custom serializers:
 
@@ -52,6 +53,69 @@ The framework provides several custom serializers:
 
 The first can be used with the `PojoCodec` by initializing it with the `FileKryoRegistrar`.
 The second and third are used with the `MessageCodec`, which is initialized with the `MessageKryoRegistrar`.
+
+[[composite-codec]]
+=== CompositeCodec
+The CompositeCodec is a codec that combines multiple codecs into a single codec, delegating encoding and decoding operations to the appropriate type-specific codec.
+This implementation associates object types with their appropriate codecs while providing a fallback default codec for unregistered types.
+
+An example implementation can be seen below:
+```java
+void encodeDecodeSample() {
+        Codec codec = getFullyQualifiedCodec();
+
+        //Encode and Decode a Dog Object
+        Dog dog = new Dog("Wolfy", 3, "woofwoof");
+        dog = codec.decode(
+                codec.encode(dog),
+                Dog.class);
+        System.out.println(dog);
+
+        //Encode and Decode a Cat Object
+        Cat cat = new Cat("Kitty", 2, 8);
+        cat = codec.decode(
+                codec.encode(cat),
+                Cat.class);
+        System.out.println(cat);
+
+        //Use the default code if the type being decoded and encoded is not Cat or dog.
+        Animal animal = new Animal("Badger", 5);
+        Animal animalOut = codec.decode(
+                codec.encode(animal),
+                Animal.class);
+        System.out.println(animalOut);
+}
+
+/**
+ * Create and return a {@link CompositeCodec} that associates {@code Dog} and {@code Cat}
+ * classes with their respective {@link PojoCodec} instances, while providing a default
+ * codec for {@code Animal} types.
+ * <p>
+ * @return a fully qualified {@link CompositeCodec} for {@code Dog}, {@code Cat},
+ *     and fallback for {@code Animal}
+ */
+static Codec getFullyQualifiedCodec() {
+    Map<Class<?>, Codec> codecs = new HashMap<Class<?>, Codec>();
+    codecs.put(Dog.class, new PojoCodec(new KryoClassListRegistrar(Dog.class)));
+    codecs.put(Cat.class, new PojoCodec(new KryoClassListRegistrar(Cat.class)));
+    return new CompositeCodec(codecs, new PojoCodec(
+            new KryoClassListRegistrar(Animal.class)));
+}
+
+// Records that will be encoded and decoded in this sample
+record Dog(String name, int age, String tag) {}
+record Cat(String name, int age, int lives) {}
+record Animal(String name, int age){}
+```
+
+In some cases a single type of object may return multiple codecs. In these cases an `IllegalStateException` is thrown.
+
+NOTE: This class uses `ClassUtils.findClosestMatch` to select the appropriate codec for a given object type.
+When multiple codecs match an object type, `ClassUtils.findClosestMatch` offers the `failOnTie` option.
+If `failOnTie` is `false`, it will return any one of the matching codecs.
+If `failOnTie` is `true` and multiple codecs match, it will throw an `IllegalStateException`.
+CompositeCodec` sets `failOnTie` to `true`, so if multiple codecs match, an
+`IllegalStateException` is thrown.
 
 [[customizing-kryo]]
 === Customizing Kryo


### PR DESCRIPTION
* In the current implementation, users could pass in an empty list to the composite codec.
* This is an CompositeCodec and if we had no codecs, then why have the class.
* All `Nullable's` were removed from the delegate attribute.
* Null returns from the findDelegate have been removed.   The default delegate will be returned in the stead.
* Update the tests to require at least one codec in the delegates

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
