### PR TITLE
Mark CompositeCodec(defaultCodec) ctor for deprecation

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -43,8 +43,10 @@ public class CompositeCodec implements Codec {
 		this.delegates = new HashMap<Class<?>, Codec>(delegates);
 	}
 
+	@Deprecated(since = "6.4", forRemoval = true)
 	public CompositeCodec(Codec defaultCodec) {
-		this(null, defaultCodec);
+		this.defaultCodec = defaultCodec;
+		this.delegates = Map.of();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -42,6 +42,7 @@ public class CompositeCodec implements Codec {
 		this.defaultCodec = defaultCodec;
 		this.delegates = new HashMap<Class<?>, Codec>(delegates);
 	}
+
 	/**
 	 * @param defaultCodec codec for fallback
 	 * @deprecated since 6.4.6 in favor of {@link #CompositeCodec(Map, Codec)} with provided delegates.

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -42,7 +42,10 @@ public class CompositeCodec implements Codec {
 		this.defaultCodec = defaultCodec;
 		this.delegates = new HashMap<Class<?>, Codec>(delegates);
 	}
-
+	/**
+	 * @param defaultCodec codec for fallback
+	 * @deprecated since 6.4.6 in favor of {@link #CompositeCodec(Map, Codec)} with provided delegates.
+	 */
 	@Deprecated(since = "6.4.6", forRemoval = true)
 	public CompositeCodec(Codec defaultCodec) {
 		this.defaultCodec = defaultCodec;

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/CompositeCodec.java
@@ -43,7 +43,7 @@ public class CompositeCodec implements Codec {
 		this.delegates = new HashMap<Class<?>, Codec>(delegates);
 	}
 
-	@Deprecated(since = "6.4", forRemoval = true)
+	@Deprecated(since = "6.4.6", forRemoval = true)
 	public CompositeCodec(Codec defaultCodec) {
 		this.defaultCodec = defaultCodec;
 		this.delegates = Map.of();


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10197

Update deprecated ctor to use an empty map for delegates instead of null.

**Auto-cherry-pick to `6.4.x`**
