### PR TITLE
Fix `EventInboundChannelAdapterParserTests` failure

### DIFF
--- a/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests-context.xml
@@ -12,7 +12,10 @@
 	<int:message-history/>
 
 	<int-event:inbound-channel-adapter id="eventAdapterSimple" channel="input"
-									   error-channel="errorChannel"/>
+									   error-channel="errorChannel"
+									   event-types="org.springframework.integration.event.config.EventInboundChannelAdapterParserTests$SampleEvent,
+                                           			org.springframework.integration.event.config.EventInboundChannelAdapterParserTests$AnotherSampleEvent,
+                                           			org.springframework.context.event.ContextRefreshedEvent"/>
 
 	<int:channel id="input">
 		<int:queue/>
@@ -34,13 +37,19 @@
 		<int:queue/>
 	</int:channel>
 
-	<int-event:inbound-channel-adapter id="eventAdapterSpel" channel="inputSpel" payload-expression="source + '-test'"/>
+	<int-event:inbound-channel-adapter id="eventAdapterSpel" channel="inputSpel"
+									   payload-expression="source + '-test'"
+									   event-types="org.springframework.integration.event.config.EventInboundChannelAdapterParserTests$SampleEvent,
+                                           			org.springframework.integration.event.config.EventInboundChannelAdapterParserTests$AnotherSampleEvent"/>
 
 	<int:channel id="inputSpel">
 		<int:queue/>
 	</int:channel>
 
-	<int-event:inbound-channel-adapter id="autoChannel" payload-expression="source + '-test'"/>
+	<int-event:inbound-channel-adapter id="autoChannel"
+									   payload-expression="source + '-test'"
+									   event-types="org.springframework.integration.event.config.EventInboundChannelAdapterParserTests$SampleEvent,
+                                           			org.springframework.integration.event.config.EventInboundChannelAdapterParserTests$AnotherSampleEvent"/>
 
 	<int:bridge input-channel="autoChannel" output-channel="nullChannel"/>
 


### PR DESCRIPTION
`EventInboundChannelAdapterParserTests` was failing with `MessageDispatchingException` during test cleanup:
```
The application context is not ready to dispatch messages. It has to be refreshed or started first. Also, messages must not be emitted from initialization phase, like 'afterPropertiesSet()', '@PostConstruct' or bean definition methods. Consider to use 'SmartLifecycle.start()' instead.
org.springframework.integration.MessageDispatchingException: The application context is not ready to dispatch messages. It has to be refreshed or started first. Also, messages must not be emitted from initialization phase, like 'afterPropertiesSet()', '@PostConstruct' or bean definition methods. Consider to use 'SmartLifecycle.start()' instead., failedMessage=ErrorMessage [payload=org.springframework.integration.MessageDispatchingException: The application context is not ready to dispatch messages. It has to be refreshed or started first. Also, messages must not be emitted from initialization phase, like 'afterPropertiesSet()', '@PostConstruct' or bean definition methods. Consider to use 'SmartLifecycle.start()' instead., failedMessage=GenericMessage [payload=org.springframework.context.event.ContextStoppedEvent[source=org.springframework.context.support.GenericApplicationContext@3e2fc448, started on Wed Jul 16 01:48:44 KST 2025], headers={id=fc8c1837-c740-e7dd-2be1-cd615ea0af8e, timestamp=1752598124657}], headers={id=26ddd289-3c22-a4f7-f5fb-53250e7cbf25, timestamp=1752598124657}] for original GenericMessage [payload=org.springframework.context.event.ContextStoppedEvent[source=org.springframework.context.support.GenericApplicationContext@3e2fc448, started on Wed Jul 16 01:48:44 KST 2025], headers={id=fc8c1837-c740-e7dd-2be1-cd615ea0af8e, timestamp=1752598124657}]
	at org.springframework.integration.channel.AbstractMessageChannel.assertApplicationRunning(AbstractMessageChannel.java:372)
	at org.springframework.integration.channel.AbstractMessageChannel.send(AbstractMessageChannel.java:328)
	at org.springframework.integration.channel.AbstractMessageChannel.send(AbstractMessageChannel.java:310)
	at org.springframework.messaging.core.GenericMessagingTemplate.doSend(GenericMessagingTemplate.java:187)
	at org.springframework.messaging.core.GenericMessagingTemplate.doSend(GenericMessagingTemplate.java:166)
	at org.springframework.messaging.core.GenericMessagingTemplate.doSend(GenericMessagingTemplate.java:47)
	at org.springframework.messaging.core.AbstractMessageSendingTemplate.send(AbstractMessageSendingTemplate.java:108)
	at org.springframework.integration.endpoint.MessageProducerSupport.sendErrorMessageIfNecessary(MessageProducerSupport.java:308)
```

When the test context was shutting down, lifecycle events were being processed but the application context was already in a stopped state, causing the dispatch to fail.

So, I added explicit `event-types` filtering to all event adapters.