### PR TITLE
Fix `SpringIntegrationTestExecutionListener` for restart

### DIFF
--- a/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContext.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContext.java
@@ -16,11 +16,11 @@
 
 package org.springframework.integration.test.context;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import reactor.core.publisher.Mono;
 
@@ -79,7 +79,7 @@ public class MockIntegrationContext implements BeanPostProcessor, SmartInitializ
 
 	private final MultiValueMap<String, Object> beans = new LinkedMultiValueMap<>();
 
-	private final List<AbstractEndpoint> autoStartupCandidates = new ArrayList<>();
+	private final Set<AbstractEndpoint> autoStartupCandidates = new HashSet<>();
 
 	private ConfigurableListableBeanFactory beanFactory;
 
@@ -99,8 +99,9 @@ public class MockIntegrationContext implements BeanPostProcessor, SmartInitializ
 	}
 
 	private void addAutoStartupCandidates(AbstractEndpoint endpoint) {
-		endpoint.setAutoStartup(false);
-		this.autoStartupCandidates.add(endpoint);
+		if (this.autoStartupCandidates.add(endpoint)) {
+			endpoint.setAutoStartup(false);
+		}
 	}
 
 	@Override
@@ -112,8 +113,8 @@ public class MockIntegrationContext implements BeanPostProcessor, SmartInitializ
 				.forEach(this::addAutoStartupCandidates);
 	}
 
-	List<AbstractEndpoint> getAutoStartupCandidates() {
-		return Collections.unmodifiableList(this.autoStartupCandidates);
+	Set<AbstractEndpoint> getAutoStartupCandidates() {
+		return Collections.unmodifiableSet(this.autoStartupCandidates);
 	}
 
 	/**

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/context/SpringIntegrationTestExecutionListener.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/context/SpringIntegrationTestExecutionListener.java
@@ -17,7 +17,7 @@
 package org.springframework.integration.test.context;
 
 import java.util.Arrays;
-import java.util.List;
+import java.util.Set;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.integration.endpoint.AbstractEndpoint;
@@ -37,7 +37,7 @@ import org.springframework.util.PatternMatchUtils;
  */
 class SpringIntegrationTestExecutionListener implements TestExecutionListener {
 
-	private List<AbstractEndpoint> autoStartupCandidates;
+	private Set<AbstractEndpoint> autoStartupCandidates;
 
 	@Override
 	public void prepareTestInstance(TestContext testContext) {
@@ -49,8 +49,7 @@ class SpringIntegrationTestExecutionListener implements TestExecutionListener {
 		ApplicationContext applicationContext = testContext.getApplicationContext();
 		MockIntegrationContext mockIntegrationContext = applicationContext.getBean(MockIntegrationContext.class);
 		this.autoStartupCandidates = mockIntegrationContext.getAutoStartupCandidates();
-		this.autoStartupCandidates
-				.stream()
+		this.autoStartupCandidates.stream()
 				.filter(endpoint -> !match(endpoint.getBeanName(), patterns))
 				.peek(endpoint -> endpoint.setAutoStartup(true))
 				.forEach(AbstractEndpoint::start);
@@ -58,7 +57,9 @@ class SpringIntegrationTestExecutionListener implements TestExecutionListener {
 
 	@Override
 	public void afterTestClass(TestContext testContext) {
-		this.autoStartupCandidates.forEach(AbstractEndpoint::stop);
+		this.autoStartupCandidates.stream()
+				.peek(endpoint -> endpoint.setAutoStartup(false))
+				.forEach(AbstractEndpoint::stop);
 	}
 
 	private static boolean match(String name, String[] patterns) {


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-framework/issues/35168

Spring Framework has introduced recently an optimization for cached contexts. So, if one is not used, it is stopped in the cache. When we pull it next time from there, it is restarted. The `SpringIntegrationTestExecutionListener` ha a flaw to change the state of the endpoints in the application context, but never reset it back to original. The problem has become apparent because of not reset auto-startup status of endpoints and that `AC.restart()`

* Fix `SpringIntegrationTestExecutionListener` to use `setAutoStartup(false)` on `autoStartupCandidates` in the `afterTestClass()`. This is exactly a state the `MockIntegrationContext` has gathered them in its initialization phase.
* Fix `MockIntegrationContext.autoStartupCandidates` to be a `Set` instead. The point is that `postProcessBeforeInitialization()` deals with `AbstractEndpoint` beans. And then `afterSingletonsInstantiated()` also gathers those beans from the `BeanFactory`. So, with a `Set` we aim for no duplications

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
