### PR TITLE
Close ClientSession in DefaultSftpSessionFactory on auth fail

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/DefaultSftpSessionFactory.java
@@ -79,6 +79,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Adama Sorho
  * @author Darryl Smith
+ * @author Alastair Mailer
  *
  * @since 2.0
  */
@@ -351,7 +352,12 @@ public class DefaultSftpSessionFactory
 						.verify(verifyTimeout)
 						.getSession();
 
-		clientSession.auth().verify(verifyTimeout);
+		try {
+			clientSession.auth().verify(verifyTimeout);
+		} catch (IOException e) {
+			clientSession.close();
+			throw e;
+		}
 
 		return clientSession;
 	}


### PR DESCRIPTION
 * Prevent a connection leak due to ClientSession going out of scope in DefaultSftpSessionFactory.getSession when connecting is successful but authentication fails.

Resolves: spring-projects/spring-integration#10188

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
