### PR TITLE
GH-10083: Apply Nullability to test-support module

### DIFF
--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/condition/package-info.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/condition/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * JUnit Jupiter conditions.
+ */
+@org.jspecify.annotations.NullMarked
+package org.springframework.integration.test.condition;

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/context/TestApplicationContextAware.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/context/TestApplicationContextAware.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.test.context;
 
+import java.util.Objects;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
@@ -54,7 +56,7 @@ public interface TestApplicationContextAware {
 			TEST_INTEGRATION_CONTEXT.refresh();
 		}
 		catch (IllegalStateException ex) {
-			if (!ex.getMessage().contains("just call 'refresh' once")) {
+			if (!Objects.requireNonNull(ex.getMessage()).contains("just call 'refresh' once")) {
 				throw ex;
 			}
 		}

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/context/package-info.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/context/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Test context support classes.
+ */
+@org.jspecify.annotations.NullMarked
+package org.springframework.integration.test.context;

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/mail/package-info.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/mail/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Provides testing utils for mail support.
- */
-package org.springframework.integration.test.mail;

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/PayloadAndHeaderMatcher.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/PayloadAndHeaderMatcher.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
@@ -56,13 +57,13 @@ public final class PayloadAndHeaderMatcher<T> extends BaseMatcher<Message<?>> {
 
 	private final Map<String, Object> headers;
 
-	private final String[] ignoreKeys;
+	private final String @Nullable [] ignoreKeys;
 
 	public static <P> PayloadAndHeaderMatcher<P> sameExceptIgnorableHeaders(Message<P> expected, String... ignoreKeys) {
 		return new PayloadAndHeaderMatcher<>(expected, ignoreKeys);
 	}
 
-	private PayloadAndHeaderMatcher(Message<T> expected, String... ignoreKeys) {
+	private PayloadAndHeaderMatcher(Message<T> expected, String @Nullable ... ignoreKeys) {
 		this.ignoreKeys = ignoreKeys != null ? Arrays.copyOf(ignoreKeys, ignoreKeys.length) : null;
 		this.payload = expected.getPayload();
 		this.headers = extractHeadersToAssert(expected);

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/package-info.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides several {@link org.hamcrest.BaseMatcher} implementations.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.test.matcher;

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/predicate/package-info.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/predicate/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * AssertJ predicates.
+ */
+@org.jspecify.annotations.NullMarked
+package org.springframework.integration.test.predicate;

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/AbstractRequestResponseScenarioTests.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/AbstractRequestResponseScenarioTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.test.support;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -56,14 +57,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Deprecated(since = "7.0", forRemoval = true)
 public abstract class AbstractRequestResponseScenarioTests {
 
-	private List<RequestResponseScenario> scenarios = null;
+	@SuppressWarnings("NullAway.Init")
+	private List<RequestResponseScenario> scenarios;
 
 	@Autowired
 	private ApplicationContext applicationContext;
 
 	@Before
 	public void setUp() {
-		scenarios = defineRequestResponseScenarios();
+		this.scenarios = defineRequestResponseScenarios();
 	}
 
 	/**
@@ -91,7 +93,7 @@ public abstract class AbstractRequestResponseScenarioTests {
 			if (outputChannel instanceof PollableChannel) {
 				Message<?> response = ((PollableChannel) outputChannel).receive(10000); // NOSONAR magic number
 				assertThat(response).as(name + ": receive timeout on " + scenario.getOutputChannelName()).isNotNull();
-				scenario.getResponseValidator().handleMessage(response);
+				scenario.getResponseValidator().handleMessage(Objects.requireNonNull(response));
 			}
 
 			assertThat(scenario.getResponseValidator().getLastMessage())

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/AbstractResponseValidator.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/AbstractResponseValidator.java
@@ -16,18 +16,22 @@
 
 package org.springframework.integration.test.support;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 
 /**
  * The base class for response validators used for {@link RequestResponseScenario}s
+ *
  * @author David Turanski
+ * @author Artem Bilan
  *
  */
 public abstract class AbstractResponseValidator<T> implements MessageHandler {
 
-	private Message<?> lastMessage;
+	private @Nullable Message<?> lastMessage;
 
 	/**
 	 * handle the message
@@ -37,6 +41,13 @@ public abstract class AbstractResponseValidator<T> implements MessageHandler {
 	public void handleMessage(Message<?> message) throws MessagingException {
 		this.lastMessage = message;
 		validateResponse((T) (extractPayload() ? message.getPayload() : message));
+	}
+
+	/**
+	 * @return the lastMessage
+	 */
+	public @Nullable Message<?> getLastMessage() {
+		return this.lastMessage;
 	}
 
 	/**
@@ -50,12 +61,5 @@ public abstract class AbstractResponseValidator<T> implements MessageHandler {
 	 * @return true to extract the payload; false to process the message.
 	 */
 	protected abstract boolean extractPayload();
-
-	/**
-	 * @return the lastMessage
-	 */
-	public Message<?> getLastMessage() {
-		return lastMessage;
-	}
 
 }

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/RequestResponseScenario.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/RequestResponseScenario.java
@@ -16,6 +16,10 @@
 
 package org.springframework.integration.test.support;
 
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
@@ -23,7 +27,9 @@ import org.springframework.util.Assert;
 /**
  * Defines a Spring Integration request response test scenario. All setter methods may
  * be chained.
+ *
  * @author David Turanski
+ * @author Artem Bilan
  *
  */
 public class RequestResponseScenario {
@@ -32,20 +38,21 @@ public class RequestResponseScenario {
 
 	private final String outputChannelName;
 
-	private Object payload;
+	private @Nullable Object payload;
 
-	private Message<?> message;
+	private @Nullable Message<?> message;
 
+	@SuppressWarnings("NullAway.Init")
 	private AbstractResponseValidator<?> responseValidator;
 
-	private String name;
+	private @Nullable String name;
 
-	protected Message<? extends Object> getMessage() {
-		if (message == null) {
-			return new GenericMessage<Object>(this.payload);
+	protected Message<?> getMessage() {
+		if (this.message == null) {
+			return new GenericMessage<>(Objects.requireNonNull(this.payload));
 		}
 		else {
-			return message;
+			return this.message;
 		}
 	}
 
@@ -64,7 +71,7 @@ public class RequestResponseScenario {
 	 * @return the input channel name
 	 */
 	public String getInputChannelName() {
-		return inputChannelName;
+		return this.inputChannelName;
 	}
 
 	/**
@@ -72,15 +79,15 @@ public class RequestResponseScenario {
 	 * @return the output channel name
 	 */
 	public String getOutputChannelName() {
-		return outputChannelName;
+		return this.outputChannelName;
 	}
 
 	/**
 	 *
 	 * @return the request message payload
 	 */
-	public Object getPayload() {
-		return payload;
+	public @Nullable Object getPayload() {
+		return this.payload;
 	}
 
 	/**
@@ -97,8 +104,8 @@ public class RequestResponseScenario {
 	 *
 	 * @return the scenario name
 	 */
-	public String getName() {
-		return name;
+	public @Nullable String getName() {
+		return this.name;
 	}
 
 	/**
@@ -117,7 +124,7 @@ public class RequestResponseScenario {
 	 * @see AbstractResponseValidator
 	 */
 	public AbstractResponseValidator<?> getResponseValidator() {
-		return responseValidator;
+		return this.responseValidator;
 	}
 
 	/**
@@ -142,7 +149,10 @@ public class RequestResponseScenario {
 	}
 
 	protected void init() {
-		Assert.state(message == null || payload == null, "cannot set both message and payload");
+		Assert.state(this.message == null || this.payload == null, "cannot set both message and payload");
+		Assert.state(this.responseValidator != null,
+				"A 'responseValidator' must be provided for the 'SubscribableChannel' scenario.");
+
 	}
 
 }

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/package-info.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/package-info.java
@@ -2,4 +2,5 @@
  * Provides several test support classes including for testing Spring Integration
  * request-response message scenarios.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.test.support;

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/OnlyOnceTrigger.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/OnlyOnceTrigger.java
@@ -21,6 +21,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.TriggerContext;
 
@@ -52,13 +54,30 @@ public class OnlyOnceTrigger implements Trigger {
 	}
 
 	@Override
-	public Instant nextExecution(TriggerContext triggerContext) {
+	public @Nullable Instant nextExecution(TriggerContext triggerContext) {
 		if (this.hasRun.getAndSet(true)) {
 			this.latch.countDown();
 			return null;
 		}
 
 		return this.executionTime;
+	}
+
+	public void reset() {
+		this.latch = new CountDownLatch(1);
+		this.hasRun.set(false);
+	}
+
+	public void await() {
+		try {
+			if (!this.latch.await(10000, TimeUnit.MILLISECONDS)) { // NOSONAR magic number
+				throw new IllegalStateException("test latch.await() did not count down");
+			}
+		}
+		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("test latch.await() interrupted", ex);
+		}
 	}
 
 	@Override
@@ -82,23 +101,6 @@ public class OnlyOnceTrigger implements Trigger {
 		}
 		OnlyOnceTrigger other = (OnlyOnceTrigger) obj;
 		return this.executionTime.equals(other.executionTime);
-	}
-
-	public void reset() {
-		this.latch = new CountDownLatch(1);
-		this.hasRun.set(false);
-	}
-
-	public void await() {
-		try {
-			if (!this.latch.await(10000, TimeUnit.MILLISECONDS)) { // NOSONAR magic number
-				throw new IllegalStateException("test latch.await() did not count down");
-			}
-		}
-		catch (InterruptedException ex) {
-			Thread.currentThread().interrupt();
-			throw new IllegalStateException("test latch.await() interrupted", ex);
-		}
 	}
 
 }

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/OnlyOnceTrigger.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/OnlyOnceTrigger.java
@@ -70,7 +70,7 @@ public class OnlyOnceTrigger implements Trigger {
 
 	public void await() {
 		try {
-			if (!this.latch.await(10000, TimeUnit.MILLISECONDS)) { // NOSONAR magic number
+			if (!this.latch.await(10000, TimeUnit.MILLISECONDS)) {
 				throw new IllegalStateException("test latch.await() did not count down");
 			}
 		}

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/TestUtils.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/TestUtils.java
@@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
@@ -41,7 +42,6 @@ import org.springframework.context.expression.MapAccessor;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.format.support.DefaultFormattingConversionService;
-import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
@@ -77,7 +77,7 @@ public abstract class TestUtils {
 	 * @see DirectFieldAccessor
 	 */
 	@SuppressWarnings("unchecked")
-	public static <T> T getPropertyValue(Object root, String propertyPath, Class<T> type) {
+	public static <T>  @Nullable T getPropertyValue(Object root, String propertyPath, Class<T> type) {
 		Object value = getPropertyValue(root, propertyPath);
 		if (value != null) {
 			Assert.isAssignable(type, value.getClass());
@@ -94,7 +94,7 @@ public abstract class TestUtils {
 	 * @return the value of the property or null
 	 * @see DirectFieldAccessor
 	 */
-	public static Object getPropertyValue(Object root, String propertyPath) {
+	public static @Nullable Object getPropertyValue(Object root, String propertyPath) {
 		Object value = null;
 		DirectFieldAccessor accessor = new DirectFieldAccessor(root);
 		String[] tokens = propertyPath.split("\\.");
@@ -170,7 +170,7 @@ public abstract class TestUtils {
 		TestApplicationContext() {
 		}
 
-		public void registerChannel(@Nullable String channelNameArg, final MessageChannel channel) {
+		public void registerChannel(@Nullable String channelNameArg, MessageChannel channel) {
 			String channelName = channelNameArg;
 			String componentName = getComponentNameIfNamed(channel);
 			if (componentName != null) {
@@ -182,6 +182,7 @@ public abstract class TestUtils {
 							"channel name has already been set with a conflicting value");
 				}
 			}
+			Assert.notNull(channelName, "The 'channelName' must be provided, or 'MessageChannel' must be named already");
 			TestUtils.registerBean(channelName, channel, this);
 		}
 
@@ -193,9 +194,9 @@ public abstract class TestUtils {
 			TestUtils.registerBean(beanName, bean, this);
 		}
 
-		private String getComponentNameIfNamed(final MessageChannel channel) {
+		private @Nullable String getComponentNameIfNamed(MessageChannel channel) {
 			Set<Class<?>> interfaces = ClassUtils.getAllInterfacesAsSet(channel);
-			final AtomicReference<String> componentName = new AtomicReference<>();
+			final AtomicReference<@Nullable String> componentName = new AtomicReference<>();
 			for (Class<?> intface : interfaces) {
 				if ("org.springframework.integration.support.context.NamedComponent".equals(intface.getName())) {
 					ReflectionUtils.doWithMethods(channel.getClass(), method -> {
@@ -220,7 +221,7 @@ public abstract class TestUtils {
 	 * @param startingIndex the index to start scanning
 	 * @return the properties provided by the named component or null if none available
 	 */
-	public static Properties locateComponentInHistory(List<Properties> history, String componentName,
+	public static @Nullable Properties locateComponentInHistory(List<Properties> history, String componentName,
 			int startingIndex) {
 
 		Assert.notNull(history, "'history' must not be null");
@@ -288,7 +289,7 @@ public abstract class TestUtils {
 
 		}
 
-		private MessageChannel resolveErrorChannel(Throwable t) {
+		private @Nullable MessageChannel resolveErrorChannel(Throwable t) {
 			if (t instanceof MessagingException) {
 				Message<?> failedMessage = ((MessagingException) t).getFailedMessage();
 				if (failedMessage == null) {

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/package-info.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/package-info.java
@@ -3,4 +3,5 @@
  * {@link org.springframework.integration.test.util.TestUtils} provides convenience
  * helpers to easily retrieve private bean properties.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.test.util;


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10083

* Add missed `package-info.java` to packages of the `test-support` module
* Add `@NullMarked` and fix all the reported nullability failures
* Move `hashCode()` and `equals()` in the `OnlyOnceTrigger` to the end of class for more logical class structure.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
