### PR TITLE
GH-10261: Don't use Jackson 3 API in places with Jackson 2

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/SubscribableKafkaChannel.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/SubscribableKafkaChannel.java
@@ -25,7 +25,6 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.integration.dispatcher.MessageDispatcher;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
 import org.springframework.integration.dispatcher.UnicastingDispatcher;
-import org.springframework.integration.support.json.JacksonMessagingUtils;
 import org.springframework.integration.support.management.ManageableSmartLifecycle;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.KafkaOperations;
@@ -77,6 +76,7 @@ public class SubscribableKafkaChannel extends AbstractKafkaChannel implements Su
 	 * @param factory factory for creating a container for receiving.
 	 * @param channelTopic the topic.
 	 */
+	@SuppressWarnings({"this-escape", "removal"})
 	public SubscribableKafkaChannel(KafkaOperations<?, ?> template, KafkaListenerContainerFactory<?> factory,
 			String channelTopic) {
 
@@ -87,7 +87,9 @@ public class SubscribableKafkaChannel extends AbstractKafkaChannel implements Su
 		if (JacksonPresent.isJackson2Present()) {
 			var messageConverter = new MessagingMessageConverter();
 			var headerMapper = new DefaultKafkaHeaderMapper();
-			headerMapper.addTrustedPackages(JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES.toArray(new String[0]));
+			headerMapper.addTrustedPackages(
+					org.springframework.integration.support.json.JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
 			this.recordListener.setMessageConverter(messageConverter);
 		}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -37,7 +37,6 @@ import org.springframework.integration.kafka.support.RawRecordHeaderErrorMessage
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.support.json.JacksonMessagingUtils;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.ConsumerSeekAware;
@@ -97,7 +96,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 	 * @param messageListenerContainer the container.
 	 * @param kafkaTemplate the kafka template.
 	 */
-	@SuppressWarnings("this-escape")
+	@SuppressWarnings({"this-escape", "removal"})
 	public KafkaInboundGateway(AbstractMessageListenerContainer<K, V> messageListenerContainer,
 			KafkaTemplate<K, R> kafkaTemplate) {
 
@@ -112,7 +111,9 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 		if (JacksonPresent.isJackson2Present()) {
 			MessagingMessageConverter messageConverter = new MessagingMessageConverter();
 			DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper();
-			headerMapper.addTrustedPackages(JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES.toArray(new String[0]));
+			headerMapper.addTrustedPackages(
+					org.springframework.integration.support.json.JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
 			this.listener.setMessageConverter(messageConverter);
 		}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -39,7 +39,6 @@ import org.springframework.integration.handler.advice.ErrorMessageSendingRecover
 import org.springframework.integration.kafka.support.RawRecordHeaderErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.integration.support.MessageBuilder;
-import org.springframework.integration.support.json.JacksonMessagingUtils;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.BatchMessageListener;
 import org.springframework.kafka.listener.ConsumerSeekAware;
@@ -120,7 +119,7 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 	 * @param messageListenerContainer the container.
 	 * @param mode the mode.
 	 */
-	@SuppressWarnings("this-escape")
+	@SuppressWarnings({"this-escape", "removal"})
 	public KafkaMessageDrivenChannelAdapter(AbstractMessageListenerContainer<K, V> messageListenerContainer,
 			ListenerMode mode) {
 
@@ -138,7 +137,9 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 			messageConverter.setGenerateMessageId(true);
 			messageConverter.setGenerateTimestamp(true);
 			DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper();
-			headerMapper.addTrustedPackages(JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES.toArray(new String[0]));
+			headerMapper.addTrustedPackages(
+					org.springframework.integration.support.json.JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
 			this.recordListener.setMessageConverter(messageConverter);
 			this.batchListener.setMessageConverter(messageConverter);

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
@@ -58,7 +58,6 @@ import org.springframework.integration.acks.AcknowledgmentCallbackFactory;
 import org.springframework.integration.core.Pausable;
 import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
-import org.springframework.integration.support.json.JacksonMessagingUtils;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ConsumerAwareRebalanceListener;
@@ -235,6 +234,7 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object>
 	 * @param ackCallbackFactory the ack callback factory.
 	 * @param allowMultiFetch true to allow {@code max.poll.records > 1}.
 	 */
+	@SuppressWarnings("removal")
 	public KafkaMessageSource(ConsumerFactory<K, V> consumerFactory,
 			ConsumerProperties consumerProperties,
 			KafkaAckCallbackFactory<K, V> ackCallbackFactory,
@@ -264,7 +264,9 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object>
 
 		if (JacksonPresent.isJackson2Present()) {
 			DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper();
-			headerMapper.addTrustedPackages(JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES.toArray(new String[0]));
+			headerMapper.addTrustedPackages(
+					org.springframework.integration.support.json.JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
 			messagingMessageConverter.setHeaderMapper(headerMapper);
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10261

The problem is like this:
```
Caused by: java.lang.NoClassDefFoundError: tools/jackson/databind/ValueSerializer
    at org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter.<init>(KafkaMessageDrivenChannelAdapter.java:141)
```

Not clear why accessing static constant without any references to Jackson API causes imports of that class to be accessed, but that is what we have so far.

* Use already deprecated `JacksonJsonUtils` in those places when `JacksonPresent.isJackson2Present()`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
