### PR TITLE
GH-10083: Apply Nullability to Core `expression` package

### DIFF
--- a/spring-integration-cassandra/src/main/java/org/springframework/integration/cassandra/outbound/CassandraMessageHandler.java
+++ b/spring-integration-cassandra/src/main/java/org/springframework/integration/cassandra/outbound/CassandraMessageHandler.java
@@ -145,6 +145,7 @@ public class CassandraMessageHandler extends AbstractReplyProducingMessageHandle
 		setStatementProcessor((ExpressionEvaluatingMessageProcessor<Statement<?>>) expressionEvaluatingMessageProcessor);
 	}
 
+	@SuppressWarnings("NullAway") // Cassandra driver uses NullAllowingImmutableMap
 	public void setQuery(String query) {
 		Assert.hasText(query, "'query' must not be empty");
 		this.sessionMessageCallback =

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/MessagePublishingInterceptor.java
@@ -169,7 +169,7 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 			AbstractIntegrationMessageBuilder<?> builder = (result instanceof Message<?>)
 					? getMessageBuilderFactory().fromMessage((Message<?>) result)
 					: getMessageBuilderFactory().withPayload(result);
-			Map<String, Object> headers = evaluateHeaders(method, context);
+			Map<String, @Nullable Object> headers = evaluateHeaders(method, context);
 			if (headers != null) {
 				builder.copyHeaders(headers);
 			}
@@ -190,7 +190,7 @@ public class MessagePublishingInterceptor implements MethodInterceptor, BeanFact
 		}
 	}
 
-	private @Nullable Map<String, Object> evaluateHeaders(Method method, StandardEvaluationContext context) {
+	private @Nullable Map<String, @Nullable Object> evaluateHeaders(Method method, StandardEvaluationContext context) {
 		Map<String, Expression> headerExpressionMap = this.metadataSource.getExpressionsForHeaders(method);
 		if (headerExpressionMap != null) {
 			return ExpressionEvalMap.from(headerExpressionMap)

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/ThreadStatePropagationChannelInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/interceptor/ThreadStatePropagationChannelInterceptor.java
@@ -19,7 +19,7 @@ package org.springframework.integration.channel.interceptor;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-import io.micrometer.common.lang.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.support.MessageDecorator;
 import org.springframework.messaging.Message;
@@ -92,8 +92,7 @@ public abstract class ThreadStatePropagationChannelInterceptor<S> implements Exe
 		return postReceive(message, channel);
 	}
 
-	@Nullable
-	protected abstract S obtainPropagatingContext(Message<?> message, MessageChannel channel);
+	protected abstract @Nullable S obtainPropagatingContext(Message<?> message, MessageChannel channel);
 
 	protected abstract void populatePropagatedContext(@Nullable S state, Message<?> message, MessageChannel channel);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/DynamicExpression.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/DynamicExpression.java
@@ -18,6 +18,8 @@ package org.springframework.integration.expression;
 
 import java.util.Locale;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.expression.EvaluationContext;
@@ -30,6 +32,8 @@ import org.springframework.util.Assert;
  * for resolving the actual Expression instance per-invocation at runtime.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class DynamicExpression implements Expression {
@@ -45,96 +49,110 @@ public class DynamicExpression implements Expression {
 		this.expressionSource = expressionSource;
 	}
 
-	public Object getValue() throws EvaluationException {
-		return this.resolveExpression().getValue();
+	public @Nullable Object getValue() throws EvaluationException {
+		return getValue((Object) null);
 	}
 
-	public Object getValue(Object rootObject) throws EvaluationException {
-		return this.resolveExpression().getValue(rootObject);
+	public @Nullable Object getValue(@Nullable Object rootObject) throws EvaluationException {
+		return getValue(rootObject, null);
 	}
 
-	public <T> T getValue(Class<T> desiredResultType) throws EvaluationException {
-		return this.resolveExpression().getValue(desiredResultType);
+	public <T> @Nullable T getValue(@Nullable Class<T> desiredResultType) throws EvaluationException {
+		return getValue((Object) null, desiredResultType);
 	}
 
-	public <T> T getValue(Object rootObject, Class<T> desiredResultType) throws EvaluationException {
-		return this.resolveExpression().getValue(rootObject, desiredResultType);
+	public <T> @Nullable T getValue(@Nullable Object rootObject, @Nullable Class<T> desiredResultType)
+			throws EvaluationException {
+
+		return resolveExpression().getValue(rootObject, desiredResultType);
 	}
 
-	public Object getValue(EvaluationContext context) throws EvaluationException {
-		return this.resolveExpression().getValue(context);
+	public @Nullable Object getValue(EvaluationContext context) throws EvaluationException {
+		return resolveExpression().getValue(context);
 	}
 
-	public Object getValue(EvaluationContext context, Object rootObject) throws EvaluationException {
-		return this.resolveExpression().getValue(context, rootObject);
+	public @Nullable Object getValue(EvaluationContext context, @Nullable  Object rootObject)
+			throws EvaluationException {
+
+		return getValue(context, rootObject, null);
 	}
 
-	public <T> T getValue(EvaluationContext context, Class<T> desiredResultType) throws EvaluationException {
-		return this.resolveExpression().getValue(context, desiredResultType);
+	public <T> @Nullable T getValue(EvaluationContext context, @Nullable Class<T> desiredResultType)
+			throws EvaluationException {
+
+		return resolveExpression().getValue(context, desiredResultType);
 	}
 
-	public <T> T getValue(EvaluationContext context, Object rootObject, Class<T> desiredResultType) throws EvaluationException {
-		return this.resolveExpression().getValue(context, rootObject, desiredResultType);
+	public <T> @Nullable T getValue(EvaluationContext context, @Nullable Object rootObject,
+			@Nullable Class<T> desiredResultType) throws EvaluationException {
+
+		return resolveExpression().getValue(context, rootObject, desiredResultType);
 	}
 
-	public Class<?> getValueType() throws EvaluationException {
-		return this.resolveExpression().getValueType();
+	public @Nullable Class<?> getValueType() throws EvaluationException {
+		return getValueType((Object) null);
 	}
 
-	public Class<?> getValueType(Object rootObject) throws EvaluationException {
-		return this.resolveExpression().getValueType(rootObject);
+	public @Nullable Class<?> getValueType(@Nullable Object rootObject) throws EvaluationException {
+		return resolveExpression().getValueType(rootObject);
 	}
 
-	public Class<?> getValueType(EvaluationContext context) throws EvaluationException {
-		return this.resolveExpression().getValueType(context);
+	public @Nullable Class<?> getValueType(EvaluationContext context) throws EvaluationException {
+		return resolveExpression().getValueType(context);
 	}
 
-	public Class<?> getValueType(EvaluationContext context, Object rootObject) throws EvaluationException {
-		return this.resolveExpression().getValueType(context, rootObject);
+	public @Nullable Class<?> getValueType(EvaluationContext context, @Nullable Object rootObject)
+			throws EvaluationException {
+
+		return resolveExpression().getValueType(context, rootObject);
 	}
 
-	public TypeDescriptor getValueTypeDescriptor() throws EvaluationException {
-		return this.resolveExpression().getValueTypeDescriptor();
+	public @Nullable TypeDescriptor getValueTypeDescriptor() throws EvaluationException {
+		return getValueTypeDescriptor((Object) null);
 	}
 
-	public TypeDescriptor getValueTypeDescriptor(Object rootObject) throws EvaluationException {
+	public @Nullable TypeDescriptor getValueTypeDescriptor(@Nullable Object rootObject) throws EvaluationException {
 		return this.resolveExpression().getValueTypeDescriptor(rootObject);
 	}
 
-	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context) throws EvaluationException {
-		return this.resolveExpression().getValueTypeDescriptor(context);
+	public @Nullable TypeDescriptor getValueTypeDescriptor(EvaluationContext context) throws EvaluationException {
+		return resolveExpression().getValueTypeDescriptor(context);
 	}
 
-	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context, Object rootObject) throws EvaluationException {
-		return this.resolveExpression().getValueTypeDescriptor(context, rootObject);
+	public @Nullable TypeDescriptor getValueTypeDescriptor(EvaluationContext context, @Nullable Object rootObject)
+			throws EvaluationException {
+
+		return resolveExpression().getValueTypeDescriptor(context, rootObject);
 	}
 
 	public boolean isWritable(EvaluationContext context) throws EvaluationException {
-		return this.resolveExpression().isWritable(context);
+		return resolveExpression().isWritable(context);
 	}
 
-	public boolean isWritable(EvaluationContext context, Object rootObject) throws EvaluationException {
-		return this.resolveExpression().isWritable(context, rootObject);
+	public boolean isWritable(EvaluationContext context, @Nullable Object rootObject) throws EvaluationException {
+		return resolveExpression().isWritable(context, rootObject);
 	}
 
-	public boolean isWritable(Object rootObject) throws EvaluationException {
-		return this.resolveExpression().isWritable(rootObject);
+	public boolean isWritable(@Nullable Object rootObject) throws EvaluationException {
+		return resolveExpression().isWritable(rootObject);
 	}
 
-	public void setValue(EvaluationContext context, Object value) throws EvaluationException {
-		this.resolveExpression().setValue(context, value);
+	public void setValue(EvaluationContext context, @Nullable Object value) throws EvaluationException {
+		resolveExpression().setValue(context, value);
 	}
 
-	public void setValue(Object rootObject, Object value) throws EvaluationException {
-		this.resolveExpression().setValue(rootObject, value);
+	public void setValue(@Nullable Object rootObject, @Nullable Object value) throws EvaluationException {
+		resolveExpression().setValue(rootObject, value);
 	}
 
-	public void setValue(EvaluationContext context, Object rootObject, Object value) throws EvaluationException {
-		this.resolveExpression().setValue(context, rootObject, value);
+	public void setValue(EvaluationContext context, @Nullable Object rootObject, @Nullable Object value)
+			throws EvaluationException {
+
+		resolveExpression().setValue(context, rootObject, value);
 	}
 
 	public String getExpressionString() {
-		return this.resolveExpression().getExpressionString();
+		return resolveExpression().getExpressionString();
 	}
 
 	private Expression resolveExpression() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/ReloadableResourceBundleExpressionSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/ReloadableResourceBundleExpressionSource.java
@@ -102,9 +102,9 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 
 	private String[] basenames = {};
 
-	private String defaultEncoding;
+	private @Nullable String defaultEncoding;
 
-	private Properties fileEncodings;
+	private @Nullable Properties fileEncodings;
 
 	private boolean fallbackToSystemLocale = true;
 
@@ -144,7 +144,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 	 * @see #setBasename
 	 * @see java.util.ResourceBundle
 	 */
-	public void setBasenames(@Nullable String[] basenames) {
+	public void setBasenames(String @Nullable [] basenames) {
 		if (basenames != null) {
 			this.basenames = new String[basenames.length];
 			for (int i = 0; i < basenames.length; i++) {
@@ -218,7 +218,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 	 * @param cacheSeconds The cache seconds.
 	 */
 	public void setCacheSeconds(int cacheSeconds) {
-		this.cacheMillis = (cacheSeconds * 1000); // NOSONAR
+		this.cacheMillis = (cacheSeconds * 1000L);
 	}
 
 	/**
@@ -237,7 +237,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 	 * <p>The default is a DefaultResourceLoader. Will get overridden by the
 	 * ApplicationContext if running in a context, as it implements the
 	 * ResourceLoaderAware interface. Can be manually overridden when
-	 * running outside of an ApplicationContext.
+	 * running outside an ApplicationContext.
 	 * @see org.springframework.core.io.DefaultResourceLoader
 	 * @see org.springframework.context.ResourceLoaderAware
 	 */
@@ -250,7 +250,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 	 * Resolves the given key in the retrieved bundle files to an Expression.
 	 */
 	@Override
-	public Expression getExpression(String key, Locale locale) {
+	public @Nullable Expression getExpression(String key, Locale locale) {
 		String expressionString = getExpressionString(key, locale);
 		if (expressionString != null) {
 			return this.parser.parseExpression(expressionString);
@@ -258,8 +258,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 		return null;
 	}
 
-	@Nullable
-	private String getExpressionString(String key, Locale locale) {
+	private @Nullable String getExpressionString(String key, Locale locale) {
 		if (this.cacheMillis < 0) {
 			PropertiesHolder propHolder = getMergedProperties(locale);
 			return propHolder.getProperty(key);
@@ -379,18 +378,18 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 		StringBuilder temp = new StringBuilder(basename);
 
 		temp.append('_');
-		if (language.length() > 0) {
+		if (!language.isEmpty()) {
 			temp.append(language);
 			result.add(0, temp.toString());
 		}
 
 		temp.append('_');
-		if (country.length() > 0) {
+		if (!country.isEmpty()) {
 			temp.append(country);
 			result.add(0, temp.toString());
 		}
 
-		if (variant.length() > 0 && (language.length() > 0 || country.length() > 0)) {
+		if (!variant.isEmpty() && (!language.isEmpty() || !country.isEmpty())) {
 			temp.append('_').append(variant);
 			result.add(0, temp.toString());
 		}
@@ -454,7 +453,6 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 						LOGGER.debug(resource
 								+ " could not be resolved in the file system - assuming that is hasn't changed", ex);
 					}
-					fileTimestamp = -1;
 				}
 			}
 			propHolder = load(filename, resource, fileTimestamp);
@@ -542,8 +540,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 		}
 		else {
 			if (LOGGER.isDebugEnabled()) {
-				LOGGER.debug("Loading properties [" + (resourceFilename == null ? resource : resourceFilename)
-						+ "]");
+				LOGGER.debug("Loading properties [" + (resourceFilename == null ? resource : resourceFilename) + "]");
 			}
 			this.propertiesPersister.load(props, is);
 		}
@@ -585,7 +582,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 	 */
 	private static final class PropertiesHolder {
 
-		private Properties properties;
+		private @Nullable Properties properties;
 
 		private long fileTimestamp = -1;
 
@@ -599,8 +596,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 			this.fileTimestamp = fileTimestamp;
 		}
 
-		@Nullable
-		public Properties getProperties() {
+		public @Nullable Properties getProperties() {
 			return this.properties;
 		}
 
@@ -616,8 +612,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 			return this.refreshTimestamp;
 		}
 
-		@Nullable
-		public String getProperty(String code) {
+		public @Nullable String getProperty(String code) {
 			if (this.properties == null) {
 				return null;
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/SupplierExpression.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/SupplierExpression.java
@@ -16,7 +16,10 @@
 
 package org.springframework.integration.expression;
 
+import java.util.Objects;
 import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.expression.EvaluationContext;
@@ -67,40 +70,43 @@ public class SupplierExpression<T> implements Expression {
 	}
 
 	@Override
-	public Object getValue(Object rootObject) throws EvaluationException {
+	public Object getValue(@Nullable Object rootObject) throws EvaluationException {
 		return getValue();
 	}
 
 	@Override
-	public <C> C getValue(Class<C> desiredResultType) throws EvaluationException {
+	public <C> C getValue(@Nullable Class<C> desiredResultType) throws EvaluationException {
 		return getValue(this.defaultContext, desiredResultType);
 	}
 
 	@Override
-	public <C> C getValue(Object rootObject, Class<C> desiredResultType) throws EvaluationException {
+	public <C> C getValue(@Nullable Object rootObject, @Nullable Class<C> desiredResultType)
+			throws EvaluationException {
+
 		return getValue(this.defaultContext, rootObject, desiredResultType);
 	}
 
 	@Override
 	public Object getValue(EvaluationContext context) throws EvaluationException {
-		Object root = context.getRootObject().getValue();
-		return root == null ? getValue() : getValue(root);
+		return getValue();
 	}
 
 	@Override
-	public Object getValue(EvaluationContext context, Object rootObject) throws EvaluationException {
-		return getValue(rootObject);
+	public Object getValue(EvaluationContext context, @Nullable Object rootObject) throws EvaluationException {
+		return getValue();
 	}
 
 	@Override
-	public <C> C getValue(EvaluationContext context, Class<C> desiredResultType) throws EvaluationException {
-		return ExpressionUtils.convertTypedValue(context, new TypedValue(getValue(context)), desiredResultType);
+	public <C> C getValue(EvaluationContext context, @Nullable Class<C> desiredResultType) throws EvaluationException {
+		C value = ExpressionUtils.convertTypedValue(context, new TypedValue(getValue()), desiredResultType);
+		return Objects.requireNonNull(value);
 	}
 
 	@Override
-	public <C> C getValue(EvaluationContext context, Object rootObject, Class<C> desiredResultType)
+	public <C> C getValue(EvaluationContext context, @Nullable Object rootObject, @Nullable Class<C> desiredResultType)
 			throws EvaluationException {
-		return ExpressionUtils.convertTypedValue(context, new TypedValue(getValue(rootObject)), desiredResultType);
+
+		return getValue(context, desiredResultType);
 	}
 
 	@Override
@@ -109,7 +115,7 @@ public class SupplierExpression<T> implements Expression {
 	}
 
 	@Override
-	public Class<?> getValueType(Object rootObject) throws EvaluationException {
+	public Class<?> getValueType(@Nullable Object rootObject) throws EvaluationException {
 		throw readOnlyException();
 	}
 
@@ -119,7 +125,7 @@ public class SupplierExpression<T> implements Expression {
 	}
 
 	@Override
-	public Class<?> getValueType(EvaluationContext context, Object rootObject) throws EvaluationException {
+	public Class<?> getValueType(EvaluationContext context, @Nullable Object rootObject) throws EvaluationException {
 		throw readOnlyException();
 	}
 
@@ -129,7 +135,7 @@ public class SupplierExpression<T> implements Expression {
 	}
 
 	@Override
-	public TypeDescriptor getValueTypeDescriptor(Object rootObject) throws EvaluationException {
+	public TypeDescriptor getValueTypeDescriptor(@Nullable Object rootObject) throws EvaluationException {
 		throw readOnlyException();
 	}
 
@@ -139,23 +145,26 @@ public class SupplierExpression<T> implements Expression {
 	}
 
 	@Override
-	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context, Object rootObject)
+	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context, @Nullable Object rootObject)
 			throws EvaluationException {
+
 		throw readOnlyException();
 	}
 
 	@Override
-	public void setValue(EvaluationContext context, Object value) throws EvaluationException {
+	public void setValue(EvaluationContext context, @Nullable Object value) throws EvaluationException {
 		throw readOnlyException();
 	}
 
 	@Override
-	public void setValue(Object rootObject, Object value) throws EvaluationException {
+	public void setValue(@Nullable Object rootObject, @Nullable Object value) throws EvaluationException {
 		throw readOnlyException();
 	}
 
 	@Override
-	public void setValue(EvaluationContext context, Object rootObject, Object value) throws EvaluationException {
+	public void setValue(EvaluationContext context, @Nullable Object rootObject, @Nullable Object value)
+			throws EvaluationException {
+
 		throw readOnlyException();
 	}
 
@@ -170,12 +179,12 @@ public class SupplierExpression<T> implements Expression {
 	}
 
 	@Override
-	public boolean isWritable(EvaluationContext context, Object rootObject) throws EvaluationException {
+	public boolean isWritable(EvaluationContext context, @Nullable Object rootObject) throws EvaluationException {
 		return false;
 	}
 
 	@Override
-	public boolean isWritable(Object rootObject) throws EvaluationException {
+	public boolean isWritable(@Nullable Object rootObject) throws EvaluationException {
 		return false;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/ValueExpression.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/ValueExpression.java
@@ -16,11 +16,16 @@
 
 package org.springframework.integration.expression;
 
+import java.util.Objects;
+
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.EvaluationException;
 import org.springframework.expression.Expression;
 import org.springframework.expression.TypedValue;
+import org.springframework.expression.common.ExpressionUtils;
 import org.springframework.util.Assert;
 
 /**
@@ -47,7 +52,7 @@ public class ValueExpression<V> implements Expression {
 
 	private final TypeDescriptor typeDescriptor;
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked", "NullAway"})
 	public ValueExpression(V value) {
 		Assert.notNull(value, "'value' must not be null");
 		this.value = value;
@@ -62,7 +67,7 @@ public class ValueExpression<V> implements Expression {
 	}
 
 	@Override
-	public V getValue(Object rootObject) throws EvaluationException {
+	public V getValue(@Nullable Object rootObject) throws EvaluationException {
 		return this.value;
 	}
 
@@ -72,30 +77,34 @@ public class ValueExpression<V> implements Expression {
 	}
 
 	@Override
-	public V getValue(EvaluationContext context, Object rootObject) throws EvaluationException {
+	public V getValue(EvaluationContext context, @Nullable Object rootObject) throws EvaluationException {
 		return this.value;
 	}
 
 	@Override
-	public <T> T getValue(Object rootObject, Class<T> desiredResultType) throws EvaluationException {
+	public <T> T getValue(@Nullable Object rootObject, @Nullable Class<T> desiredResultType)
+			throws EvaluationException {
+
 		return getValue(desiredResultType);
 	}
 
 	@Override
-	public <T> T getValue(Class<T> desiredResultType) throws EvaluationException {
-		return org.springframework.expression.common.ExpressionUtils
-				.convertTypedValue(null, this.typedResultValue, desiredResultType);
+	public <T> T getValue(@Nullable Class<T> desiredResultType) throws EvaluationException {
+		T aValue = ExpressionUtils.convertTypedValue(null, this.typedResultValue, desiredResultType);
+		return Objects.requireNonNull(aValue);
 	}
 
 	@Override
-	public <T> T getValue(EvaluationContext context, Object rootObject, Class<T> desiredResultType) throws EvaluationException {
+	public <T> T getValue(EvaluationContext context, @Nullable Object rootObject, @Nullable Class<T> desiredResultType)
+			throws EvaluationException {
+
 		return getValue(context, desiredResultType);
 	}
 
 	@Override
-	public <T> T getValue(EvaluationContext context, Class<T> desiredResultType) throws EvaluationException {
-		return org.springframework.expression.common.ExpressionUtils
-				.convertTypedValue(context, this.typedResultValue, desiredResultType);
+	public <T> T getValue(EvaluationContext context, @Nullable Class<T> desiredResultType) throws EvaluationException {
+		T aValue = ExpressionUtils.convertTypedValue(context, this.typedResultValue, desiredResultType);
+		return Objects.requireNonNull(aValue);
 	}
 
 	@Override
@@ -104,7 +113,7 @@ public class ValueExpression<V> implements Expression {
 	}
 
 	@Override
-	public Class<V> getValueType(Object rootObject) throws EvaluationException {
+	public Class<V> getValueType(@Nullable Object rootObject) throws EvaluationException {
 		return this.aClass;
 	}
 
@@ -114,7 +123,7 @@ public class ValueExpression<V> implements Expression {
 	}
 
 	@Override
-	public Class<V> getValueType(EvaluationContext context, Object rootObject) throws EvaluationException {
+	public Class<V> getValueType(EvaluationContext context, @Nullable Object rootObject) throws EvaluationException {
 		return this.aClass;
 	}
 
@@ -124,7 +133,7 @@ public class ValueExpression<V> implements Expression {
 	}
 
 	@Override
-	public TypeDescriptor getValueTypeDescriptor(Object rootObject) throws EvaluationException {
+	public TypeDescriptor getValueTypeDescriptor(@Nullable Object rootObject) throws EvaluationException {
 		return this.typeDescriptor;
 	}
 
@@ -134,7 +143,9 @@ public class ValueExpression<V> implements Expression {
 	}
 
 	@Override
-	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context, Object rootObject) throws EvaluationException {
+	public TypeDescriptor getValueTypeDescriptor(EvaluationContext context, @Nullable Object rootObject)
+			throws EvaluationException {
+
 		return this.typeDescriptor;
 	}
 
@@ -144,27 +155,29 @@ public class ValueExpression<V> implements Expression {
 	}
 
 	@Override
-	public boolean isWritable(EvaluationContext context, Object rootObject) throws EvaluationException {
+	public boolean isWritable(EvaluationContext context, @Nullable Object rootObject) throws EvaluationException {
 		return false;
 	}
 
 	@Override
-	public boolean isWritable(Object rootObject) throws EvaluationException {
+	public boolean isWritable(@Nullable Object rootObject) throws EvaluationException {
 		return false;
 	}
 
 	@Override
-	public void setValue(EvaluationContext context, Object value) throws EvaluationException {
+	public void setValue(EvaluationContext context, @Nullable Object value) throws EvaluationException {
 		setValue(context, null, value);
 	}
 
 	@Override
-	public void setValue(Object rootObject, Object value) throws EvaluationException {
-		setValue(null, rootObject, value);
+	public void setValue(@Nullable Object rootObject, @Nullable Object value) throws EvaluationException {
+		throw new EvaluationException(this.value.toString(), "Cannot call setValue() on a ValueExpression");
 	}
 
 	@Override
-	public void setValue(EvaluationContext context, Object rootObject, Object value) throws EvaluationException {
+	public void setValue(EvaluationContext context, @Nullable Object rootObject, @Nullable Object value)
+			throws EvaluationException {
+
 		throw new EvaluationException(this.value.toString(), "Cannot call setValue() on a ValueExpression");
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/package-info.java
@@ -1,5 +1,5 @@
 /**
  * Provides classes supporting SpEL expressions.
  */
-@org.springframework.lang.NonNullApi
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.expression;

--- a/spring-integration-graphql/src/main/java/org/springframework/integration/graphql/outbound/GraphQlMessageHandler.java
+++ b/spring-integration-graphql/src/main/java/org/springframework/integration/graphql/outbound/GraphQlMessageHandler.java
@@ -30,7 +30,6 @@ import org.springframework.graphql.ExecutionGraphQlService;
 import org.springframework.graphql.support.DefaultExecutionGraphQlRequest;
 import org.springframework.integration.expression.ExpressionUtils;
 import org.springframework.integration.expression.FunctionExpression;
-import org.springframework.integration.expression.SupplierExpression;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -52,13 +51,13 @@ public class GraphQlMessageHandler extends AbstractReplyProducingMessageHandler 
 
 	private @Nullable Expression operationExpression;
 
-	private Expression operationNameExpression = new SupplierExpression<>(() -> null);
+	private @Nullable Expression operationNameExpression = null;
 
-	private Expression variablesExpression = new SupplierExpression<>(() -> null);
+	private @Nullable Expression variablesExpression = null;
 
 	private @Nullable Locale locale;
 
-	@SuppressWarnings("NullAway") // In most cases the message really comes with an ID
+	@SuppressWarnings("NullAway") // Cannot determine that function result could be null
 	private Expression executionIdExpression =
 			new FunctionExpression<Message<?>>(message -> message.getHeaders().getId());
 
@@ -164,12 +163,20 @@ public class GraphQlMessageHandler extends AbstractReplyProducingMessageHandler 
 	}
 
 	private @Nullable String evaluateOperationNameExpression(Message<?> message) {
-		return this.operationNameExpression.getValue(this.evaluationContext, message, String.class);
+		if (this.operationNameExpression != null) {
+			return this.operationNameExpression.getValue(this.evaluationContext, message, String.class);
+		}
+
+		return null;
 	}
 
 	@SuppressWarnings("unchecked")
 	private @Nullable Map<String, Object> evaluateVariablesExpression(Message<?> message) {
-		return this.variablesExpression.getValue(this.evaluationContext, message, Map.class);
+		if (this.variablesExpression != null) {
+			return this.variablesExpression.getValue(this.evaluationContext, message, Map.class);
+		}
+
+		return null;
 	}
 
 	private @Nullable String evaluateExecutionIdExpression(Message<?> message) {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/AbstractWebServiceOutboundGateway.java
@@ -226,7 +226,7 @@ public abstract class AbstractWebServiceOutboundGateway extends AbstractReplyPro
 			return this.destinationProvider.getDestination();
 		}
 
-		Map<String, Object> uriVariables =
+		Map<String, @Nullable Object> uriVariables =
 				ExpressionEvalMap.from(this.uriVariableExpressions)
 						.usingEvaluationContext(this.evaluationContext)
 						.withRoot(requestMessage)


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10083

* Make `SupplierExpression` as to not return null for result of the provided `Supplier`. And fix Nullability from the super contract
* Make `ValueExpression` compatible with super contract, but still ensure not null for return value
* Make `DynamicExpression` compatible with super contract. Provide usability and code style refactoring
* Make `FunctionExpression` to be compatible with super contract. At the same time ensure that input for the function is not null, but result of function could be null. Some other code style and usability refactoring
* Remove redundant logic in the `ExpressionUtils` which is deliberately not reachable due to Nullability
* Fix Nullability for the `ReloadableResourceBundleExpressionSource` and some simple refactoring according to IDE report.
* Make `ExpressionEvalMap` to be aware of null values after expressions evaluation.
* Fix usage of the `ExpressionEvalMap` in the project.
* Mark `CassandraMessageHandler.setQuery()` with `NullAway` since `ExpressionEvalMap` may produce nulls, and Cassandra driver can deal with nulls, but that is not expressed on the API with Nullability
* Fix `ThreadStatePropagationChannelInterceptor` for wrong import for the `@Nullable`
* Slight change in the `GraphQlMessageHandler` according to the mentioned above `expression` package fixes

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
