### PR TITLE
GH-10083: Apply Nullability to core dispatcher package

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AbstractDispatcher.java
@@ -22,6 +22,7 @@ import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.messaging.Message;
@@ -53,7 +54,7 @@ public abstract class AbstractDispatcher implements MessageDispatcher {
 
 	private volatile int maxSubscribers = Integer.MAX_VALUE;
 
-	private volatile MessageHandler theOneHandler;
+	private volatile @Nullable MessageHandler theOneHandler;
 
 	private final Lock lock = new ReentrantLock();
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AggregateMessageDeliveryException.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/AggregateMessageDeliveryException.java
@@ -19,6 +19,8 @@ package org.springframework.integration.dispatcher;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.util.StringUtils;
@@ -30,6 +32,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -69,7 +72,7 @@ public class AggregateMessageDeliveryException extends MessageDeliveryException 
 		return message.toString();
 	}
 
-	private String appendPeriodIfNecessary(String baseMessage) {
+	private String appendPeriodIfNecessary(@Nullable String baseMessage) {
 		if (!StringUtils.hasText(baseMessage)) {
 			return "";
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/BroadcastingDispatcher.java
@@ -20,6 +20,8 @@ import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -56,12 +58,13 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class BroadcastingDispatcher extends AbstractDispatcher implements BeanFactoryAware {
 
 	private final boolean requireSubscribers;
 
-	private final Executor executor;
+	private final @Nullable Executor executor;
 
 	private boolean ignoreFailures;
 
@@ -71,6 +74,7 @@ public class BroadcastingDispatcher extends AbstractDispatcher implements BeanFa
 
 	private MessageHandlingTaskDecorator messageHandlingTaskDecorator = task -> task;
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
 	private volatile MessageBuilderFactory messageBuilderFactory = new DefaultMessageBuilderFactory();
@@ -89,7 +93,7 @@ public class BroadcastingDispatcher extends AbstractDispatcher implements BeanFa
 		this(null, requireSubscribers);
 	}
 
-	public BroadcastingDispatcher(Executor executor, boolean requireSubscribers) {
+	public BroadcastingDispatcher(@Nullable Executor executor, boolean requireSubscribers) {
 		this.requireSubscribers = requireSubscribers;
 		this.executor = executor;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -165,11 +164,12 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 	}
 
 	@Override
+	@SuppressWarnings("NullAway")
 	public boolean dispatch(Message<?> message) {
 		populatedPartitions();
 		int partition = Math.abs(this.partitionKeyFunction.apply(message).hashCode()) % this.partitionCount;
 		UnicastingDispatcher partitionDispatcher = this.partitions.get(partition);
-		return Objects.requireNonNull(partitionDispatcher).dispatch(message);
+		return partitionDispatcher.dispatch(message);
 	}
 
 	private void populatedPartitions() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
@@ -164,7 +164,7 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 	}
 
 	@Override
-	@SuppressWarnings("NullAway")
+	@SuppressWarnings("NullAway") // Dataflow analysis limitation!
 	public boolean dispatch(Message<?> message) {
 		populatedPartitions();
 		int partition = Math.abs(this.partitionKeyFunction.apply(message).hashCode()) % this.partitionCount;

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
@@ -164,7 +164,7 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 	}
 
 	@Override
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation!
+	@SuppressWarnings("NullAway") // The partitions map never returns null according to partition hash
 	public boolean dispatch(Message<?> message) {
 		populatedPartitions();
 		int partition = Math.abs(this.partitionKeyFunction.apply(message).hashCode()) % this.partitionCount;

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -54,6 +55,7 @@ import org.springframework.util.ErrorHandler;
  *
  * @author Artem Bilan
  * @author Christian Tzolov
+ * @author Glenn Renfro
  *
  * @since 6.1
  */
@@ -71,10 +73,9 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 
 	private Predicate<Exception> failoverStrategy = (exception) -> true;
 
-	@Nullable
-	private LoadBalancingStrategy loadBalancingStrategy;
+	private @Nullable LoadBalancingStrategy loadBalancingStrategy;
 
-	private ErrorHandler errorHandler;
+	private @Nullable ErrorHandler errorHandler;
 
 	private MessageHandlingTaskDecorator messageHandlingTaskDecorator = task -> task;
 
@@ -168,7 +169,7 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 		populatedPartitions();
 		int partition = Math.abs(this.partitionKeyFunction.apply(message).hashCode()) % this.partitionCount;
 		UnicastingDispatcher partitionDispatcher = this.partitions.get(partition);
-		return partitionDispatcher.dispatch(message);
+		return Objects.requireNonNull(partitionDispatcher).dispatch(message);
 	}
 
 	private void populatedPartitions() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
@@ -51,6 +51,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 1.0.2
  */
@@ -58,11 +59,11 @@ public class UnicastingDispatcher extends AbstractDispatcher {
 
 	private final MessageHandler dispatchHandler = this::doDispatch;
 
-	private final Executor executor;
+	private final @Nullable Executor executor;
 
 	private Predicate<Exception> failoverStrategy = (exception) -> true;
 
-	private LoadBalancingStrategy loadBalancingStrategy;
+	private @Nullable LoadBalancingStrategy loadBalancingStrategy;
 
 	private MessageHandlingTaskDecorator messageHandlingTaskDecorator = task -> task;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes related to dispatching messages.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.dispatcher;


### PR DESCRIPTION
PartititonDispatcher.partition will always return at least 1 partition. So return value is wrapped with Objects.requireNonNull, for nullaway

Related to: https://github.com/spring-projects/spring-integration/issues/10083

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
