### PR TITLE
Make pathFor protected to allow overriding

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -151,7 +151,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 		}
 	}
 
-	private String pathFor(String input) {
+	protected String pathFor(String input) {
 		return UUIDConverter.getUUID(input).toString();
 	}
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
@@ -613,6 +613,26 @@ class JdbcLockRegistryTests {
 				.isThrownBy(lock::unlock);
 	}
 
+	@Test
+	void testPathForCanBeOverridden() {
+		DefaultLockRepository client = new DefaultLockRepository(dataSource);
+		client.setApplicationContext(this.context);
+		client.afterPropertiesSet();
+		client.afterSingletonsInstantiated();
+		JdbcLockRegistry registry = new JdbcLockRegistry(client) {
+			@Override
+			protected String pathFor(String input) {
+				return input;
+			}
+		};
+
+		final String lockKey = "foo";
+		Lock lock = registry.obtain(lockKey);
+		String lockPath = TestUtils.getPropertyValue(lock, "path", String.class);
+
+		assertThat(lockPath).isEqualTo(lockKey);
+	}
+
 	@SuppressWarnings("unchecked")
 	private static Map<String, Lock> getRegistryLocks(JdbcLockRegistry registry) {
 		return TestUtils.getPropertyValue(registry, "locks", Map.class);


### PR DESCRIPTION
This PR changes the visibility of the `pathFor` method to `protected`.

Intention:
While developing and debugging an application, it can be very helpful to know which locks are currently locked. The UUIDs cannot be reversed to the original lock keys and therefore it can get hard to check which locks are currently obtained.

When overriding the `pathFor` method for this, one can write the lock key directly to the db and view human-readable strings in the db table.