### PR TITLE
polish `receive()` aop advice and its triggers

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/CompoundTriggerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/CompoundTriggerAdvice.java
@@ -39,8 +39,7 @@ import org.springframework.util.Assert;
  * @since 4.3
  *
  */
-public class CompoundTriggerAdvice
-		implements MessageSourceMutator, ReceiveMessageAdvice {
+public class CompoundTriggerAdvice implements MessageSourceMutator {
 
 	private final CompoundTrigger compoundTrigger;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/aop/SimpleActiveIdleReceiveMessageAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aop/SimpleActiveIdleReceiveMessageAdvice.java
@@ -25,7 +25,7 @@ import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
 /**
- A simple advice that polls at one rate when messages exist and another when
+ * A simple advice that polls at one rate when messages exist and another when
  * there are no messages.
  *
  * @author Gary Russell

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CompoundTrigger.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CompoundTrigger.java
@@ -23,7 +23,7 @@ import org.springframework.scheduling.TriggerContext;
 import org.springframework.util.Assert;
 
 /**
- * A {@link Trigger} that delegates the {@link #nextExecutionTime(TriggerContext)}
+ * A {@link Trigger} that delegates the {@link #nextExecution(TriggerContext)}
  * to one of two Triggers. If the {@link #setOverride(Trigger) override} trigger is
  * {@code null}, the primary trigger is invoked; otherwise the override trigger is
  * invoked.

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/DynamicPeriodicTrigger.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/DynamicPeriodicTrigger.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.util;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
@@ -130,14 +131,15 @@ public class DynamicPeriodicTrigger implements Trigger {
 	@Override
 	public Instant nextExecution(TriggerContext triggerContext) {
 		Instant lastScheduled = triggerContext.lastScheduledExecution();
+		Clock clock = triggerContext.getClock();
 		if (lastScheduled == null) {
-			return Instant.now().plus(this.initialDuration);
+			return clock.instant().plus(this.initialDuration);
 		}
 		else if (this.fixedRate) {
 			return lastScheduled.plus(this.duration);
 		}
-		return
-				triggerContext.lastCompletion().plus(this.duration); // NOSONAR never null here
+		Instant lastCompletion = triggerContext.lastCompletion();
+		return Objects.requireNonNullElse(lastCompletion, clock.instant()).plus(this.duration);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/DynamicPeriodicTrigger.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/DynamicPeriodicTrigger.java
@@ -139,7 +139,10 @@ public class DynamicPeriodicTrigger implements Trigger {
 			return lastScheduled.plus(this.duration);
 		}
 		Instant lastCompletion = triggerContext.lastCompletion();
-		return Objects.requireNonNullElse(lastCompletion, clock.instant()).plus(this.duration);
+		if (lastCompletion == null) {
+			return clock.instant().plus(this.duration);
+		}
+		return lastCompletion.plus(this.duration);
 	}
 
 	@Override


### PR DESCRIPTION
* remove redundant interface for class `CompoundTriggerAdvice`
* fix potential NPE in `DynamicPeriodicTrigger#nextExecution`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
