### PR TITLE
Fix Kotlin DSL according to IDEA errors and suggestions

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -1008,7 +1008,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 * @see LambdaMessageProcessor
 	 */
-	public <P> B handle(@Nullable Class<P> expectedType, GenericHandler<P> handler) {
+	public <P> B handle(Class<P> expectedType, GenericHandler<P> handler) {
 		return handle(expectedType, handler, null);
 	}
 
@@ -1032,7 +1032,13 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 * @see LambdaMessageProcessor
 	 */
-	public <P> B handle(@Nullable Class<P> expectedType, GenericHandler<P> handler,
+	public <P> B handle(Class<P> expectedType, GenericHandler<P> handler,
+			@Nullable Consumer<GenericEndpointSpec<ServiceActivatingHandler>> endpointConfigurer) {
+
+		return doHandle(expectedType, handler, endpointConfigurer);
+	}
+
+	protected  <P> B doHandle(@Nullable Class<P> expectedType, GenericHandler<P> handler,
 			@Nullable Consumer<GenericEndpointSpec<ServiceActivatingHandler>> endpointConfigurer) {
 
 		ServiceActivatingHandler serviceActivatingHandler;
@@ -1799,7 +1805,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 */
 	public B route(MessageProcessorSpec<?> messageProcessorSpec) {
-		return route(messageProcessorSpec, (Consumer<RouterSpec<Object, MethodInvokingRouter>>) null);
+		return route(messageProcessorSpec, (Consumer<RouterSpec<@Nullable Object, MethodInvokingRouter>>) null);
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -1723,7 +1723,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @param <T> the target result type.
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 */
-	public <@Nullable T> B route(String expression,
+	public <T extends @Nullable Object> B route(String expression,
 			@Nullable Consumer<RouterSpec<T, ExpressionEvaluatingRouter>> routerConfigurer) {
 
 		return route(new RouterSpec<>(new ExpressionEvaluatingRouter(PARSER.parseExpression(expression))),
@@ -1748,7 +1748,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 * @see LambdaMessageProcessor
 	 */
-	public <S, @Nullable T> B route(Class<S> expectedType, Function<S, T> router) {
+	public <S, T extends @Nullable Object> B route(Class<S> expectedType, Function<S, T> router) {
 		return route(expectedType, router, null);
 	}
 
@@ -1776,13 +1776,13 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 * @see LambdaMessageProcessor
 	 */
-	public <P, @Nullable T> B route(Class<P> expectedType, Function<P, T> router,
+	public <P, T extends @Nullable Object> B route(Class<P> expectedType, Function<P, T> router,
 			@Nullable Consumer<RouterSpec<T, MethodInvokingRouter>> routerConfigurer) {
 
 		return doRoute(expectedType, router, routerConfigurer);
 	}
 
-	protected <P, @Nullable T> B doRoute(@Nullable Class<P> expectedType, Function<P, T> router,
+	protected <P, T extends @Nullable Object> B doRoute(@Nullable Class<P> expectedType, Function<P, T> router,
 			@Nullable Consumer<RouterSpec<T, MethodInvokingRouter>> routerConfigurer) {
 
 		MethodInvokingRouter methodInvokingRouter =

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -129,7 +129,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @see org.springframework.integration.handler.LambdaMessageProcessor
 	 */
 	public <P> B handle(GenericHandler<P> handler) {
-		return handle(null, handler);
+		return doHandle(null, handler, null);
 	}
 
 	/**
@@ -155,7 +155,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	public <P> B handle(GenericHandler<P> handler,
 			Consumer<GenericEndpointSpec<ServiceActivatingHandler>> endpointConfigurer) {
 
-		return handle(null, handler, endpointConfigurer);
+		return doHandle(null, handler, endpointConfigurer);
 	}
 
 	/**
@@ -173,7 +173,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @param <T> the target result type.
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 */
-	public <S, @Nullable T> B route(Function<S, T> router) {
+	public <S, T extends @Nullable Object> B route(Function<S, T> router) {
 		return doRoute(null, router,  null);
 	}
 
@@ -198,7 +198,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @param <T> the target result type.
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 */
-	public <S, @Nullable T> B route(Function<S, T> router,
+	public <S, T extends @Nullable Object> B route(Function<S, T> router,
 			Consumer<RouterSpec<T, MethodInvokingRouter>> routerConfigurer) {
 
 		return doRoute(null, router, routerConfigurer);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowDefinition.java
@@ -19,6 +19,8 @@ package org.springframework.integration.dsl;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.core.GenericHandler;
 import org.springframework.integration.core.GenericSelector;
 import org.springframework.integration.core.GenericTransformer;
@@ -83,7 +85,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 */
 	public <P> B filter(GenericSelector<P> genericSelector) {
-		return filter(null, genericSelector);
+		return doFilter(null, genericSelector, null);
 	}
 
 	/**
@@ -106,7 +108,7 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @see FilterEndpointSpec
 	 */
 	public <P> B filter(GenericSelector<P> genericSelector, Consumer<FilterEndpointSpec> endpointConfigurer) {
-		return filter(null, genericSelector, endpointConfigurer);
+		return doFilter(null, genericSelector, endpointConfigurer);
 	}
 
 	/**
@@ -171,8 +173,8 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @param <T> the target result type.
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 */
-	public <S, T> B route(Function<S, T> router) {
-		return route(null, router);
+	public <S, @Nullable T> B route(Function<S, T> router) {
+		return doRoute(null, router,  null);
 	}
 
 	/**
@@ -196,8 +198,10 @@ public abstract class IntegrationFlowDefinition<B extends IntegrationFlowDefinit
 	 * @param <T> the target result type.
 	 * @return the current {@link IntegrationFlowDefinition}.
 	 */
-	public <S, T> B route(Function<S, T> router, Consumer<RouterSpec<T, MethodInvokingRouter>> routerConfigurer) {
-		return route(null, router, routerConfigurer);
+	public <S, @Nullable T> B route(Function<S, T> router,
+			Consumer<RouterSpec<T, MethodInvokingRouter>> routerConfigurer) {
+
+		return doRoute(null, router, routerConfigurer);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
@@ -43,7 +43,8 @@ import org.springframework.util.StringUtils;
  *
  * @since 5.0
  */
-public class RouterSpec<K, R extends AbstractMappingMessageRouter> extends AbstractRouterSpec<RouterSpec<K, R>, R> {
+public class RouterSpec<@Nullable K, R extends AbstractMappingMessageRouter>
+		extends AbstractRouterSpec<RouterSpec<K, R>, R> {
 
 	private final RouterMappingProvider mappingProvider;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
@@ -43,7 +43,7 @@ import org.springframework.util.StringUtils;
  *
  * @since 5.0
  */
-public class RouterSpec<@Nullable K, R extends AbstractMappingMessageRouter>
+public class RouterSpec<K extends @Nullable Object, R extends AbstractMappingMessageRouter>
 		extends AbstractRouterSpec<RouterSpec<K, R>, R> {
 
 	private final RouterMappingProvider mappingProvider;

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/SplitterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/SplitterSpec.java
@@ -161,7 +161,7 @@ public class SplitterSpec extends ConsumerEndpointSpec<SplitterSpec, AbstractMes
 	 * @param expectedType the {@link Function} input argument type.
 	 * @return the spec.
 	 */
-	public SplitterSpec expectedType(@Nullable Class<?> expectedType) {
+	public SplitterSpec expectedType(Class<?> expectedType) {
 		this.expectedType = expectedType;
 		return this;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/TransformerEndpointSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/TransformerEndpointSpec.java
@@ -140,7 +140,7 @@ public class TransformerEndpointSpec extends ConsumerEndpointSpec<TransformerEnd
 	 * @param <P> the type ot expect.
 	 * @return the spec.
 	 */
-	public <P> TransformerEndpointSpec expectedType(@Nullable Class<P> expectedType) {
+	public <P> TransformerEndpointSpec expectedType(Class<P> expectedType) {
 		this.expectedType = expectedType;
 		return this;
 	}

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinConsumerEndpointSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinConsumerEndpointSpec.kt
@@ -67,11 +67,11 @@ abstract class KotlinConsumerEndpointSpec<S : ConsumerEndpointSpec<S, H>, H : Me
 		this.delegate.taskScheduler(taskScheduler)
 	}
 
-	fun handleMessageAdvice(vararg interceptors: MethodInterceptor?) {
+	fun handleMessageAdvice(vararg interceptors: MethodInterceptor) {
 		this.delegate.handleMessageAdvice(*interceptors)
 	}
 
-	fun advice(vararg advice: Advice?) {
+	fun advice(vararg advice: Advice) {
 		this.delegate.advice(*advice)
 	}
 
@@ -95,11 +95,11 @@ abstract class KotlinConsumerEndpointSpec<S : ConsumerEndpointSpec<S, H>, H : Me
 		this.delegate.transactional(handleMessageAdvice)
 	}
 
-	fun <T : Any?, V : Any?> customizeMonoReply(replyCustomizer: (Message<*>, Mono<T>) -> Publisher<V>) {
+	fun <T : Any, V : Any> customizeMonoReply(replyCustomizer: (Message<*>, Mono<T>) -> Publisher<V>) {
 		this.delegate.customizeMonoReply(replyCustomizer)
 	}
 
-	fun id(id: String?) {
+	fun id(id: String) {
 		this.delegate.id(id)
 	}
 

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
@@ -74,7 +74,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Inline function for [IntegrationFlowDefinition.convert] providing a `convert<MyType>()` variant
 	 * with reified generic type.
 	 */
-	inline fun <reified T> convert(
+	inline fun <reified T: Any> convert(
 			crossinline configurer: GenericEndpointSpec<MessageTransformingHandler>.() -> Unit = {}
 	) {
 
@@ -85,7 +85,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Inline function for [IntegrationFlowDefinition.transform] providing a `transform<MyTypeIn, MyTypeOut>()` variant
 	 * with reified generic type.
 	 */
-	inline fun <reified P> transform(crossinline function: (P) -> Any) {
+	inline fun <reified P : Any> transform(crossinline function: (P) -> Any) {
 		this.delegate.transform(P::class.java) { function(it) }
 	}
 
@@ -101,7 +101,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Inline function for [IntegrationFlowDefinition.split] providing a `split<MyTypeIn>()` variant
 	 * with reified generic type.
 	 */
-	inline fun <reified P> split(crossinline function: (P) -> Any) {
+	inline fun <reified P : Any> split(crossinline function: (P) -> Any) {
 		this.delegate.split(P::class.java) { function(it) }
 	}
 
@@ -117,7 +117,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Inline function for [IntegrationFlowDefinition.filter] providing a `filter<MyTypeIn>()` variant
 	 * with reified generic type.
 	 */
-	inline fun <reified P> filter(crossinline function: (P) -> Boolean) {
+	inline fun <reified P : Any> filter(crossinline function: (P) -> Boolean) {
 		this.delegate.filter(P::class.java) { function(it) }
 	}
 
@@ -125,7 +125,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Inline function for [IntegrationFlowDefinition.filter] providing a `filter<MyTypeIn>()` variant
 	 * with reified generic type.
 	 */
-	inline fun <reified P> filter(
+	inline fun <reified P: Any> filter(
 			crossinline function: (P) -> Boolean,
 			crossinline filterConfigurer: KotlinFilterEndpointSpec.() -> Unit
 	) {
@@ -138,7 +138,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Inline function for [IntegrationFlowDefinition.route] providing a `route<MyTypeIn>()` variant
 	 * with reified generic type.
 	 */
-	inline fun <reified P> route(crossinline function: (P) -> Any?) {
+	inline fun <reified P : Any> route(crossinline function: (P) -> Any?) {
 		route(function) { }
 	}
 
@@ -146,7 +146,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Inline function for [IntegrationFlowDefinition.route] providing a `route<MyTypeIn>()` variant
 	 * with reified generic type.
 	 */
-	inline fun <reified P, T> route(
+	inline fun <reified P : Any, T : Any?> route(
 			crossinline function: (P) -> T,
 			crossinline configurer: KotlinRouterSpec<T, MethodInvokingRouter>.() -> Unit
 	) {
@@ -379,7 +379,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Populate a [ServiceActivatingHandler] for the selected protocol specific
 	 * [MessageHandler] implementation from `Namespace Factory`:
 	 */
-	fun <H : MessageHandler?> handle(messageHandlerSpec: MessageHandlerSpec<*, H>) {
+	fun <H : MessageHandler> handle(messageHandlerSpec: MessageHandlerSpec<*, H>) {
 		this.delegate.handle(messageHandlerSpec)
 	}
 
@@ -443,7 +443,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * [org.springframework.integration.handler.MethodInvokingMessageProcessor]
 	 * to invoke the provided [GenericHandler] at runtime.
 	 */
-	inline fun <reified P> handle(crossinline handler: (P, MessageHeaders) -> Any) {
+	inline fun <reified P : Any> handle(crossinline handler: (P, MessageHeaders) -> Any) {
 		this.delegate.handle(P::class.java) { p, h -> handler(p, h) }
 	}
 
@@ -453,7 +453,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * to invoke the provided [GenericHandler] at runtime.
 	 * In addition, accept options for the integration endpoint using [GenericEndpointSpec].
 	 */
-	inline fun <reified P> handle(
+	inline fun <reified P : Any> handle(
 			crossinline handler: (P, MessageHeaders) -> Any,
 			crossinline endpointConfigurer: GenericEndpointSpec<ServiceActivatingHandler>.() -> Unit
 	) {
@@ -712,7 +712,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 */
 	fun route(
 			beanName: String, method: String?,
-			routerConfigurer: KotlinRouterSpec<Any, MethodInvokingRouter>.() -> Unit
+			routerConfigurer: KotlinRouterSpec<Any?, MethodInvokingRouter>.() -> Unit
 	) {
 
 		this.delegate.route(beanName, method) { routerConfigurer(KotlinRouterSpec(it)) }
@@ -732,7 +732,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 */
 	fun route(
 			service: Any, methodName: String?,
-			routerConfigurer: KotlinRouterSpec<Any, MethodInvokingRouter>.() -> Unit
+			routerConfigurer: KotlinRouterSpec<Any?, MethodInvokingRouter>.() -> Unit
 	) {
 
 		this.delegate.route(service, methodName) { routerConfigurer(KotlinRouterSpec(it)) }
@@ -742,7 +742,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Populate the [ExpressionEvaluatingRouter] for provided SpEL expression
 	 * with provided options from [KotlinRouterSpec].
 	 */
-	fun <T> route(
+	fun <T: Any?> route(
 			expression: String,
 			routerConfigurer: KotlinRouterSpec<T, ExpressionEvaluatingRouter>.() -> Unit = {}
 	) {
@@ -756,7 +756,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 */
 	fun route(
 			messageProcessorSpec: MessageProcessorSpec<*>,
-			routerConfigurer: KotlinRouterSpec<Any, MethodInvokingRouter>.() -> Unit = {}
+			routerConfigurer: KotlinRouterSpec<Any?, MethodInvokingRouter>.() -> Unit = {}
 	) {
 
 		this.delegate.route(messageProcessorSpec) { routerConfigurer(KotlinRouterSpec(it)) }
@@ -1065,7 +1065,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * wrap it to a [Flux], apply provided function via [Flux.transform]
 	 * and emit the result to one more [FluxMessageChannel], subscribed in the downstream flow.
 	 */
-	fun <I: Any, O> fluxTransform(fluxFunction: (Flux<Message<I>>) -> Publisher<O>) {
+	fun <I : Any, O : Any> fluxTransform(fluxFunction: (Flux<Message<I>>) -> Publisher<O>) {
 		this.delegate.fluxTransform(fluxFunction)
 	}
 

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRecipientListRouterSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRecipientListRouterSpec.kt
@@ -41,7 +41,7 @@ class KotlinRecipientListRouterSpec(override val delegate: RecipientListRouterSp
 		this.delegate.recipient(channelName, expression)
 	}
 
-	inline fun <reified P> recipient(channelName: String, crossinline selector: (P) -> Boolean) {
+	inline fun <reified P : Any> recipient(channelName: String, crossinline selector: (P) -> Boolean) {
 		if (Message::class.java.isAssignableFrom(P::class.java))
 			this.delegate.recipientMessageSelector(channelName) { selector(it as P) }
 		else
@@ -56,14 +56,14 @@ class KotlinRecipientListRouterSpec(override val delegate: RecipientListRouterSp
 		this.delegate.recipient(channel, expression)
 	}
 
-	inline fun <reified P> recipient(channel: MessageChannel, crossinline selector: (P) -> Boolean) {
+	inline fun <reified P : Any> recipient(channel: MessageChannel, crossinline selector: (P) -> Boolean) {
 		if (Message::class.java.isAssignableFrom(P::class.java))
 			this.delegate.recipientMessageSelector(channel) { selector(it as P) }
 		else
 			this.delegate.recipient<P>(channel) { selector(it) }
 	}
 
-	inline fun <reified P> recipientFlow(crossinline selector: (P) -> Boolean,
+	inline fun <reified P : Any> recipientFlow(crossinline selector: (P) -> Boolean,
 										 crossinline subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
 
 		if (Message::class.java.isAssignableFrom(P::class.java))

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRouterSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRouterSpec.kt
@@ -28,8 +28,8 @@ import org.springframework.messaging.MessageChannel
  *
  * @since 5.3
  */
-class KotlinRouterSpec<K, R : AbstractMappingMessageRouter>(override val delegate: RouterSpec<K, R>)
-	: AbstractKotlinRouterSpec<RouterSpec<K, R>, R>(delegate) {
+class KotlinRouterSpec<K : Any?, R : AbstractMappingMessageRouter>(override val delegate: RouterSpec<K, R>) :
+	AbstractKotlinRouterSpec<RouterSpec<K, R>, R>(delegate) {
 
 	fun resolutionRequired(resolutionRequired: Boolean) {
 		this.delegate.resolutionRequired(resolutionRequired)
@@ -51,19 +51,19 @@ class KotlinRouterSpec<K, R : AbstractMappingMessageRouter>(override val delegat
 		this.delegate.channelKeyFallback(channelKeyFallback)
 	}
 
-	fun channelMapping(key: K & Any, channelName: String) {
+	fun channelMapping(key: K, channelName: String) {
 		this.delegate.channelMapping(key, channelName)
 	}
 
-	fun channelMapping(key: K & Any, channel: MessageChannel) {
+	fun channelMapping(key: K, channel: MessageChannel) {
 		this.delegate.channelMapping(key, channel)
 	}
 
-	fun subFlowMapping(key: K & Any, subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
+	fun subFlowMapping(key: K, subFlow: KotlinIntegrationFlowDefinition.() -> Unit) {
 		subFlowMapping(key) { definition -> subFlow(KotlinIntegrationFlowDefinition(definition)) }
 	}
 
-	fun subFlowMapping(key: K & Any, subFlow: IntegrationFlow) {
+	fun subFlowMapping(key: K, subFlow: IntegrationFlow) {
 		this.delegate.subFlowMapping(key, subFlow)
 	}
 

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinSplitterSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinSplitterSpec.kt
@@ -40,7 +40,7 @@ class KotlinSplitterSpec(override val delegate: SplitterSpec)
 	 * @param function the function instance to use.
 	 * @param <P> the input type.
 	 */
-	inline fun <reified P> function(crossinline function: (P) -> Any) {
+	inline fun <reified P : Any> function(crossinline function: (P) -> Any) {
 		this.delegate.expectedType(P::class.java)
 		this.delegate.function<P> { function(it) }
 	}

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinTransformerEndpointSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinTransformerEndpointSpec.kt
@@ -40,7 +40,7 @@ class KotlinTransformerEndpointSpec(override val delegate: TransformerEndpointSp
 	 * @param function the function instance to use.
 	 * @param <P> the input type.
 	 */
-	inline fun <reified P> transformer(crossinline function: (P) -> Any) {
+	inline fun <reified P : Any> transformer(crossinline function: (P) -> Any) {
 		this.delegate.expectedType(P::class.java)
 		this.delegate.transformer<P, Any> { function(it) }
 	}


### PR DESCRIPTION
It is not clear why it does not fail with Gradle, but right now it is not possible to build the project using IDEA compiler.

Some of the suggestions are good and have led to the Nullability fixes in related Java DSL classes. The `Any` extension requirement for the generic argument of reified types is not clear, but works. The requirement to refine nullable Kotlin types is good.

Somewhat related to: https://github.com/spring-projects/spring-integration/issues/10083

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
