### PR TITLE
GH-10083: Fix Nullability in some missed packages

### DIFF
--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/EntryEventMessagePayload.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/EntryEventMessagePayload.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.hazelcast.message;
 
-import org.springframework.util.Assert;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Hazelcast Message Payload for Entry Events.
@@ -28,59 +28,11 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  *
  * @since 6.0
+ *
+ * @param key The entry key.
+ * @param value The entry value.
+ * @param oldValue The entry old value if any.
  */
-public class EntryEventMessagePayload<K, V> {
-
-	/**
-	 * The entry key.
-	 */
-	public final K key;
-
-	/**
-	 * The entry value.
-	 */
-	public final V value;
-
-	/**
-	 * The entry old value if any.
-	 */
-	public final V oldValue;
-
-	public EntryEventMessagePayload(final K key, final V value, final V oldValue) {
-		Assert.notNull(key, "'key' must not be null");
-		this.key = key;
-		this.value = value;
-		this.oldValue = oldValue;
-	}
-
-	@Override
-	public String toString() {
-		return "EntryEventMessagePayload [key=" + this.key + ", value=" + this.value + ", oldValue=" + this.oldValue + "]";
-	}
-
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-
-		EntryEventMessagePayload<?, ?> that = (EntryEventMessagePayload<?, ?>) o;
-
-		return this.key.equals(that.key) && !(this.value != null ? !this.value.equals(that.value)
-				: that.value != null) && !(this.oldValue != null
-				? !this.oldValue.equals(that.oldValue) : that.oldValue != null);
-
-	}
-
-	@Override
-	public int hashCode() {
-		int result = this.key.hashCode();
-		result = 31 * result + (this.value != null ? this.value.hashCode() : 0);
-		result = 31 * result + (this.oldValue != null ? this.oldValue.hashCode() : 0);
-		return result;
-	}
+public record EntryEventMessagePayload<K, V>(K key, @Nullable V value, @Nullable V oldValue) {
 
 }

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/package-info.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/message/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes supporting Hazelcast message headers and payload.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.hazelcast.message;

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastCQDistributedMapInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastCQDistributedMapInboundChannelAdapterTests.java
@@ -97,13 +97,13 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo("cqDistributedMap2");
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(2));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(2));
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getId()).isEqualTo(2);
+				.getPayload()).oldValue()).getId()).isEqualTo(2);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getName()).isEqualTo("TestName2");
+				.getPayload()).oldValue()).getName()).isEqualTo("TestName2");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getSurname()).isEqualTo("TestSurname2");
+				.getPayload()).oldValue()).getSurname()).isEqualTo("TestSurname2");
 	}
 
 	@Test
@@ -129,19 +129,19 @@ public class HazelcastCQDistributedMapInboundChannelAdapterTests {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo("cqDistributedMap4");
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(1));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(1));
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getId()).isEqualTo(1);
+				.getPayload()).oldValue()).getId()).isEqualTo(1);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getName()).isEqualTo("TestName1");
+				.getPayload()).oldValue()).getName()).isEqualTo("TestName1");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getSurname()).isEqualTo("TestSurname1");
+				.getPayload()).oldValue()).getSurname()).isEqualTo("TestSurname1");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getId()).isEqualTo(2);
+				.getPayload()).value()).getId()).isEqualTo(2);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getName()).isEqualTo("TestName2");
+				.getPayload()).value()).getName()).isEqualTo("TestName2");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getSurname()).isEqualTo("TestSurname2");
+				.getPayload()).value()).getSurname()).isEqualTo("TestSurname2");
 	}
 
 	@Test

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedMapEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastDistributedMapEventDrivenInboundChannelAdapterTests.java
@@ -92,19 +92,19 @@ public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo("edDistributedMap2");
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(2));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(2));
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getId()).isEqualTo(1);
+				.getPayload()).oldValue()).getId()).isEqualTo(1);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getName()).isEqualTo("TestName1");
+				.getPayload()).oldValue()).getName()).isEqualTo("TestName1");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getSurname()).isEqualTo("TestSurname1");
+				.getPayload()).oldValue()).getSurname()).isEqualTo("TestSurname1");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getId()).isEqualTo(2);
+				.getPayload()).value()).getId()).isEqualTo(2);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getName()).isEqualTo("TestName2");
+				.getPayload()).value()).getName()).isEqualTo("TestName2");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getSurname()).isEqualTo("TestSurname2");
+				.getPayload()).value()).getSurname()).isEqualTo("TestSurname2");
 	}
 
 	@Test
@@ -124,13 +124,13 @@ public class HazelcastDistributedMapEventDrivenInboundChannelAdapterTests {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo("edDistributedMap3");
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(2));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(2));
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getId()).isEqualTo(2);
+				.getPayload()).oldValue()).getId()).isEqualTo(2);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getName()).isEqualTo("TestName2");
+				.getPayload()).oldValue()).getName()).isEqualTo("TestName2");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getSurname()).isEqualTo("TestSurname2");
+				.getPayload()).oldValue()).getSurname()).isEqualTo("TestSurname2");
 	}
 
 	@Test

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastMultiMapEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastMultiMapEventDrivenInboundChannelAdapterTests.java
@@ -77,13 +77,13 @@ public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo("edMultiMap1");
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(1));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(1));
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getId()).isEqualTo(1);
+				.getPayload()).value()).getId()).isEqualTo(1);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getName()).isEqualTo("TestName1");
+				.getPayload()).value()).getName()).isEqualTo("TestName1");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getSurname()).isEqualTo("TestSurname1");
+				.getPayload()).value()).getSurname()).isEqualTo("TestSurname1");
 	}
 
 	@Test
@@ -103,14 +103,14 @@ public class HazelcastMultiMapEventDrivenInboundChannelAdapterTests {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo("edMultiMap2");
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(2));
-		assertThat(((EntryEventMessagePayload<?, ?>) msg.getPayload()).value).isNull();
+				.getPayload()).key()).isEqualTo(Integer.valueOf(2));
+		assertThat(((EntryEventMessagePayload<?, ?>) msg.getPayload()).value()).isNull();
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getId()).isEqualTo(2);
+				.getPayload()).oldValue()).getId()).isEqualTo(2);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getName()).isEqualTo("TestName2");
+				.getPayload()).oldValue()).getName()).isEqualTo("TestName2");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getSurname()).isEqualTo("TestSurname2");
+				.getPayload()).oldValue()).getSurname()).isEqualTo("TestSurname2");
 	}
 
 	@Test

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests.java
@@ -83,13 +83,13 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo("edReplicatedMap1");
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(1));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(1));
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getId()).isEqualTo(1);
+				.getPayload()).value()).getId()).isEqualTo(1);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getName()).isEqualTo("TestName1");
+				.getPayload()).value()).getName()).isEqualTo("TestName1");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getSurname()).isEqualTo("TestSurname1");
+				.getPayload()).value()).getSurname()).isEqualTo("TestSurname1");
 	}
 
 	@Test
@@ -109,19 +109,19 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo("edReplicatedMap2");
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(2));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(2));
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getId()).isEqualTo(1);
+				.getPayload()).oldValue()).getId()).isEqualTo(1);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getName()).isEqualTo("TestName1");
+				.getPayload()).oldValue()).getName()).isEqualTo("TestName1");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getSurname()).isEqualTo("TestSurname1");
+				.getPayload()).oldValue()).getSurname()).isEqualTo("TestSurname1");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getId()).isEqualTo(2);
+				.getPayload()).value()).getId()).isEqualTo(2);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getName()).isEqualTo("TestName2");
+				.getPayload()).value()).getName()).isEqualTo("TestName2");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getSurname()).isEqualTo("TestSurname2");
+				.getPayload()).value()).getSurname()).isEqualTo("TestSurname2");
 	}
 
 	@Test
@@ -141,13 +141,13 @@ public class HazelcastReplicatedMapEventDrivenInboundChannelAdapterTests {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo("edReplicatedMap3");
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(2));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(2));
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getId()).isEqualTo(2);
+				.getPayload()).oldValue()).getId()).isEqualTo(2);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getName()).isEqualTo("TestName2");
+				.getPayload()).oldValue()).getName()).isEqualTo("TestName2");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).getSurname()).isEqualTo("TestSurname2");
+				.getPayload()).oldValue()).getSurname()).isEqualTo("TestSurname2");
 	}
 
 	@Test

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/util/HazelcastInboundChannelAdapterTestUtils.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/inbound/util/HazelcastInboundChannelAdapterTestUtils.java
@@ -88,13 +88,13 @@ public final class HazelcastInboundChannelAdapterTestUtils {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo(cacheName);
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(1));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(1));
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getId()).isEqualTo(1);
+				.getPayload()).value()).getId()).isEqualTo(1);
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getName()).isEqualTo("TestName1");
+				.getPayload()).value()).getName()).isEqualTo("TestName1");
 		assertThat((((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).getSurname()).isEqualTo("TestSurname1");
+				.getPayload()).value()).getSurname()).isEqualTo("TestSurname1");
 	}
 
 	public static void testEventDrivenForDistributedMapEntryEvents(
@@ -223,11 +223,11 @@ public final class HazelcastInboundChannelAdapterTestUtils {
 		assertThat(msg.getHeaders().get(HazelcastHeaders.CACHE_NAME)).isEqualTo(cacheName);
 
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).key).isEqualTo(Integer.valueOf(1));
+				.getPayload()).key()).isEqualTo(Integer.valueOf(1));
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).oldValue).isNull();
+				.getPayload()).oldValue()).isNull();
 		assertThat(((EntryEventMessagePayload<Integer, HazelcastIntegrationTestUser>) msg
-				.getPayload()).value).isNull();
+				.getPayload()).value()).isNull();
 	}
 
 	public static void testDistributedSQLForENTRYIterationType(

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/BeanPropertyParameterSource.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/BeanPropertyParameterSource.java
@@ -18,7 +18,10 @@ package org.springframework.integration.jpa.support.parametersource;
 
 import java.beans.PropertyDescriptor;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.NotReadablePropertyException;
@@ -29,6 +32,7 @@ import org.springframework.beans.PropertyAccessorFactory;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Ngoc Nhan
+ * @author Artem Bilan
  *
  * @since 2.2
  *
@@ -37,7 +41,7 @@ public class BeanPropertyParameterSource implements ParameterSource {
 
 	private final BeanWrapper beanWrapper;
 
-	private String[] propertyNames;
+	private String @Nullable [] propertyNames;
 
 	/**
 	 * Create a new BeanPropertySqlParameterSource for the given bean.
@@ -53,19 +57,18 @@ public class BeanPropertyParameterSource implements ParameterSource {
 	}
 
 	@Override
-	public Object getValue(String paramName) {
+	public @Nullable Object getValue(String paramName) {
 		try {
 			return this.beanWrapper.getPropertyValue(paramName);
 		}
 		catch (NotReadablePropertyException ex) {
-			throw new IllegalArgumentException(ex.getMessage()); // NOSONAR - lost stack trace
+			throw new IllegalArgumentException(ex.getMessage());
 		}
 	}
 
 	/**
 	 * Provide access to the property names of the wrapped bean.
-	 * Uses support provided in the {@link org.springframework.beans.PropertyAccessor}
-	 * interface.
+	 * Uses support provided in the {@link org.springframework.beans.PropertyAccessor} interface.
 	 * @return an array containing all the known property names
 	 */
 	public String[] getReadablePropertyNames() {
@@ -77,9 +80,9 @@ public class BeanPropertyParameterSource implements ParameterSource {
 					names.add(pd.getName());
 				}
 			}
-			this.propertyNames = names.toArray(new String[names.size()]);
+			this.propertyNames = names.toArray(new String[0]);
 		}
-		return this.propertyNames; // NOSONAR - expose internals
+		return Arrays.copyOf(this.propertyNames, this.propertyNames.length);
 	}
 
 }

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/BeanPropertyParameterSourceFactory.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/BeanPropertyParameterSourceFactory.java
@@ -20,10 +20,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  *
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.2
  *
  */
@@ -32,13 +36,12 @@ public class BeanPropertyParameterSourceFactory implements ParameterSourceFactor
 	private volatile Map<String, Object> staticParameters;
 
 	public BeanPropertyParameterSourceFactory() {
-		this.staticParameters = Collections.unmodifiableMap(new HashMap<String, Object>());
+		this.staticParameters = Collections.unmodifiableMap(new HashMap<>());
 	}
 
 	/**
 	 * If the input is a List or a Map, the output is a map parameter source, and in that case some static parameters
 	 * can be added (default is empty). If the input is not a List or a Map then this value is ignored.
-	 *
 	 * @param staticParameters the static parameters to set
 	 */
 	public void setStaticParameters(Map<String, Object> staticParameters) {
@@ -50,8 +53,7 @@ public class BeanPropertyParameterSourceFactory implements ParameterSourceFactor
 		return new StaticBeanPropertyParameterSource(input, this.staticParameters);
 	}
 
-	private static final class StaticBeanPropertyParameterSource implements
-			ParameterSource {
+	private static final class StaticBeanPropertyParameterSource implements ParameterSource {
 
 		private final BeanPropertyParameterSource input;
 
@@ -63,9 +65,10 @@ public class BeanPropertyParameterSourceFactory implements ParameterSourceFactor
 		}
 
 		@Override
-		public Object getValue(String paramName) {
-			return this.staticParameters.containsKey(paramName) ? this.staticParameters.get(paramName) : this.input
-					.getValue(paramName);
+		public @Nullable Object getValue(String paramName) {
+			return this.staticParameters.containsKey(paramName)
+					? this.staticParameters.get(paramName)
+					: this.input.getValue(paramName);
 		}
 
 		@Override

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ExpressionEvaluatingParameterSourceFactory.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ExpressionEvaluatingParameterSourceFactory.java
@@ -141,7 +141,9 @@ public class ExpressionEvaluatingParameterSourceFactory implements ParameterSour
 
 		private @Nullable Object obtainParameterValue(JpaParameter jpaParameter) {
 			Object value = jpaParameter.getValue();
-			if (value == null && jpaParameter.getExpression() != null) {
+			if (value == null) {
+				Assert.notNull(jpaParameter.getExpression(),
+						() -> "One of the 'value' or 'expression' must be provided for 'JpaParameter': " + jpaParameter);
 				Expression expression;
 				if (this.input instanceof Collection<?>) {
 					expression = jpaParameter.getProjectionExpression();

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ExpressionEvaluatingParameterSourceFactory.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ExpressionEvaluatingParameterSourceFactory.java
@@ -30,7 +30,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.expression.Expression;
 import org.springframework.expression.ExpressionException;
 import org.springframework.integration.jpa.support.JpaParameter;
-import org.springframework.integration.jpa.support.parametersource.ExpressionEvaluatingParameterSourceUtils.ParameterExpressionEvaluator;
 import org.springframework.util.Assert;
 
 /**
@@ -101,14 +100,16 @@ public class ExpressionEvaluatingParameterSourceFactory implements ParameterSour
 			this.parameters = parameters;
 			this.parametersMap = new HashMap<>(parameters.size());
 			for (JpaParameter parameter : parameters) {
-				this.parametersMap.put(parameter.getName(), parameter);
+				String name = parameter.getName();
+				if (name != null) {
+					this.parametersMap.put(name, parameter);
+				}
 			}
 			this.values.putAll(ExpressionEvaluatingParameterSourceUtils.convertStaticParameters(parameters));
 		}
 
 		@Override
-		@Nullable
-		public Object getValueByPosition(int position) {
+		public @Nullable Object getValueByPosition(int position) {
 			Assert.isTrue(position > 0, "The position must be non-negative.");
 			if (position <= this.parameters.size()) {
 				JpaParameter parameter = this.parameters.get(position - 1);
@@ -124,8 +125,7 @@ public class ExpressionEvaluatingParameterSourceFactory implements ParameterSour
 		}
 
 		@Override
-		@Nullable
-		public Object getValue(String paramName) {
+		public @Nullable Object getValue(String paramName) {
 			return this.values.computeIfAbsent(paramName,
 					(key) -> {
 						JpaParameter jpaParameter =
@@ -139,13 +139,9 @@ public class ExpressionEvaluatingParameterSourceFactory implements ParameterSour
 					});
 		}
 
-		@Nullable
-		private Object obtainParameterValue(JpaParameter jpaParameter) {
-			Object value = null;
-			if (jpaParameter.getValue() != null) {
-				value = jpaParameter.getValue();
-			}
-			if (jpaParameter.getExpression() != null) {
+		private @Nullable Object obtainParameterValue(JpaParameter jpaParameter) {
+			Object value = jpaParameter.getValue();
+			if (value == null && jpaParameter.getExpression() != null) {
 				Expression expression;
 				if (this.input instanceof Collection<?>) {
 					expression = jpaParameter.getProjectionExpression();
@@ -153,9 +149,11 @@ public class ExpressionEvaluatingParameterSourceFactory implements ParameterSour
 				else {
 					expression = jpaParameter.getSpelExpression();
 				}
-				value = this.expressionEvaluator.evaluateExpression(expression, this.input); // NOSONAR
-				if (LOGGER.isDebugEnabled()) {
-					LOGGER.debug("Resolved expression " + expression + " to " + value);
+				if (expression != null) {
+					value = this.expressionEvaluator.evaluateExpression(expression, this.input);
+					if (LOGGER.isDebugEnabled()) {
+						LOGGER.debug("Resolved expression " + expression + " to " + value);
+					}
 				}
 			}
 			return value;

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ExpressionEvaluatingParameterSourceUtils.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ExpressionEvaluatingParameterSourceUtils.java
@@ -20,12 +20,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.jspecify.annotations.Nullable;
-
-import org.springframework.expression.EvaluationContext;
-import org.springframework.expression.Expression;
 import org.springframework.integration.jpa.support.JpaParameter;
-import org.springframework.integration.util.AbstractExpressionEvaluator;
 import org.springframework.util.Assert;
 
 /**
@@ -58,31 +53,14 @@ final class ExpressionEvaluatingParameterSourceUtils {
 		final Map<String, Object> staticParameters = new HashMap<>();
 
 		for (JpaParameter parameter : jpaParameters) {
-			if (parameter.getValue() != null) {
-				staticParameters.put(parameter.getName(), parameter.getValue());
+			String name = parameter.getName();
+			Object value = parameter.getValue();
+			if (name != null && value != null) {
+				staticParameters.put(name, value);
 			}
 		}
 
 		return staticParameters;
-	}
-
-	/**
-	 * Simple {@link AbstractExpressionEvaluator} implementation
-	 * to increase the visibility of protected methods.
-	 */
-	public static class ParameterExpressionEvaluator extends AbstractExpressionEvaluator {
-
-		@Override
-		public EvaluationContext getEvaluationContext() { // NOSONAR - not useless, increases visibility
-			return super.getEvaluationContext();
-		}
-
-		@Override
-		@Nullable
-		public Object evaluateExpression(Expression expression, Object input) { // NOSONAR - not useless, increases vis.
-			return super.evaluateExpression(expression, input);
-		}
-
 	}
 
 }

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ParameterExpressionEvaluator.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ParameterExpressionEvaluator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-present the original author or authors.
+ * Copyright 2025-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,17 +18,28 @@ package org.springframework.integration.jpa.support.parametersource;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.integration.util.AbstractExpressionEvaluator;
+
 /**
+ * Simple {@link AbstractExpressionEvaluator} implementation
+ * to increase the visibility of protected methods.
  *
- * @author Gunnar Hillert
  * @author Artem Bilan
  *
- * @since 2.2
- *
+ * @since 7.0
  */
-public interface PositionSupportingParameterSource extends ParameterSource {
+public class ParameterExpressionEvaluator extends AbstractExpressionEvaluator {
 
-	@Nullable
-	Object getValueByPosition(int position);
+	@Override
+	public EvaluationContext getEvaluationContext() {
+		return super.getEvaluationContext();
+	}
+
+	@Override
+	public @Nullable Object evaluateExpression(Expression expression, Object input) {
+		return super.evaluateExpression(expression, input);
+	}
 
 }

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ParameterSource.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/ParameterSource.java
@@ -16,9 +16,13 @@
 
 package org.springframework.integration.jpa.support.parametersource;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  *
  * @author Gunnar Hillert
+ * @author Artem Bilan
+ *
  * @since 2.2
  *
  */
@@ -36,6 +40,7 @@ public interface ParameterSource {
 	 * @param paramName the name of the parameter
 	 * @return the value of the specified parameter
 	 */
+	@Nullable
 	Object getValue(String paramName);
 
 }

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/package-info.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/package-info.java
@@ -1,6 +1,7 @@
 /**
  * Provides generic support for ParameterSources and ParameterSource Factories.
- * This classes are modeled after the equivalent classes in the JDBC Module. However,
+ * These classes are modeled after the equivalent classes in the JDBC Module. However,
  * the provided classes here do not have any SQL or JPA specific dependencies.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.jpa.support.parametersource;

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/rule/Log4j2LevelAdjuster.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/rule/Log4j2LevelAdjuster.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.Level;
+import org.jspecify.annotations.Nullable;
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
@@ -57,7 +58,7 @@ public final class Log4j2LevelAdjuster implements MethodRule {
 		this(level, null, new String[] {"org.springframework.integration"});
 	}
 
-	private Log4j2LevelAdjuster(Level level, Class<?>[] classes, String[] categories) {
+	private Log4j2LevelAdjuster(Level level, Class<?> @Nullable [] classes, String[] categories) {
 		Assert.notNull(level, "'level' must be null");
 		this.level = level;
 		this.classes = classes != null ? classes : new Class<?>[0];

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/rule/package-info.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/rule/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides various test rules.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.test.rule;


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10083

* Turn `EntryEventMessagePayload` into `record`. Fix access from tests, respectively
* Extract `ParameterExpressionEvaluator` into a top-level class as it is expected by the `ExpressionEvaluatingParameterSource`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
