### PR TITLE
GH-10314: Revise `TcpListener.onMessage()` contract for `void`

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/TcpReceivingChannelAdapter.java
@@ -70,20 +70,17 @@ public class TcpReceivingChannelAdapter
 	private final AtomicInteger activeCount = new AtomicInteger();
 
 	@Override
-	public boolean onMessage(Message<?> message) {
+	public void onMessage(Message<?> message) {
 		boolean isErrorMessage = message instanceof ErrorMessage;
 		try {
 			if (this.shuttingDown) {
 				logger.info(() -> "Inbound message ignored; shutting down; " + message);
 			}
-			else {
-				if (isErrorMessage) {
-					/*
-					 * Socket errors are sent here so they can be conveyed to any waiting thread.
-					 * There's not one here; simply ignore.
-					 */
-					return false;
-				}
+			/*
+			 * Socket errors are sent here so they can be conveyed to any waiting thread.
+			 * There's not one here; simply ignore.
+			 */
+			else if (!isErrorMessage) {
 				this.activeCount.incrementAndGet();
 				try {
 					sendMessage(message);
@@ -92,7 +89,6 @@ public class TcpReceivingChannelAdapter
 					this.activeCount.decrementAndGet();
 				}
 			}
-			return false;
 		}
 		finally {
 			String connectionId = (String) message.getHeaders().get(IpHeaders.CONNECTION_ID);

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactory.java
@@ -462,7 +462,7 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 		 * purposes.
 		 */
 		@Override
-		public boolean onMessage(Message<?> message) {
+		public void onMessage(Message<?> message) {
 			Message<?> modifiedMessage;
 			Object connectionId = message.getHeaders().get(IpHeaders.CONNECTION_ID);
 			if (message instanceof ErrorMessage) {
@@ -492,7 +492,6 @@ public class CachingClientConnectionFactory extends AbstractClientConnectionFact
 					logger.debug("Message discarded; no listener: " + message);
 				}
 			}
-			return true;
 		}
 
 		private void physicallyClose() {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactory.java
@@ -461,7 +461,7 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 		 * purposes.
 		 */
 		@Override
-		public boolean onMessage(Message<?> message) {
+		public void onMessage(Message<?> message) {
 			if (this.delegate.getConnectionId().equals(message.getHeaders().get(IpHeaders.CONNECTION_ID))) {
 				AbstractIntegrationMessageBuilder<?> messageBuilder =
 						getMessageBuilderFactory()
@@ -476,17 +476,15 @@ public class FailoverClientConnectionFactory extends AbstractClientConnectionFac
 					if (this.logger.isDebugEnabled()) {
 						logger.debug("No listener for " + message);
 					}
-					return false;
 				}
 				else {
-					return listener.onMessage(messageBuilder.build());
+					listener.onMessage(messageBuilder.build());
 				}
 			}
 			else {
 				if (logger.isDebugEnabled()) {
 					logger.debug("Message from defunct connection ignored " + message);
 				}
-				return false;
 			}
 		}
 

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpConnectionInterceptorSupport.java
@@ -194,16 +194,14 @@ public abstract class TcpConnectionInterceptorSupport extends TcpConnectionSuppo
 	}
 
 	@Override
-	public boolean onMessage(Message<?> message) {
+	public void onMessage(Message<?> message) {
 		if (this.tcpListener == null) {
-			if (message instanceof ErrorMessage) {
-				return false;
-			}
-			else {
+			if (!(message instanceof ErrorMessage)) {
 				throw new NoListenerException("No listener registered for message reception");
 			}
+			return;
 		}
-		return this.tcpListener.onMessage(message);
+		this.tcpListener.onMessage(message);
 	}
 
 	@Override
@@ -250,12 +248,16 @@ public abstract class TcpConnectionInterceptorSupport extends TcpConnectionSuppo
 				return;
 			}
 			this.removed = true;
-			if (this.theConnection instanceof TcpConnectionInterceptorSupport tcpConnectionInterceptorSupport && !this.theConnection.equals(this)) {
+			if (this.theConnection instanceof TcpConnectionInterceptorSupport tcpConnectionInterceptorSupport
+					&& !this.theConnection.equals(this)) {
+
 				tcpConnectionInterceptorSupport.removeDeadConnection(this);
 			}
 			TcpSender sender = getSender();
-			if (sender != null && this.interceptedSenders != null && !(sender instanceof TcpConnectionInterceptorSupport)) {
-				this.interceptedSenders.forEach(snder -> snder.removeDeadConnection(connection));
+			if (sender != null && this.interceptedSenders != null
+					&& !(sender instanceof TcpConnectionInterceptorSupport)) {
+
+				this.interceptedSenders.forEach(intercepted -> intercepted.removeDeadConnection(connection));
 			}
 		}
 		finally {

--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpListener.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpListener.java
@@ -24,6 +24,7 @@ import org.springframework.messaging.Message;
  * {@link TcpConnection}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 2.0
  */
@@ -33,8 +34,7 @@ public interface TcpListener {
 	/**
 	 * Called by a TCPConnection when a new message arrives.
 	 * @param message The message.
-	 * @return true if the message was intercepted
 	 */
-	boolean onMessage(Message<?> message);
+	void onMessage(Message<?> message);
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFactoryTests.java
@@ -65,7 +65,6 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 		server.registerListener(m -> {
 			received.set(new ObjectToStringTransformer().transform(m));
 			latch.countDown();
-			return false;
 		});
 		server.setApplicationEventPublisher(publisher);
 		server.setBeanFactory(TEST_INTEGRATION_CONTEXT);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpInboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/TcpInboundGatewayTests.java
@@ -351,10 +351,7 @@ public class TcpInboundGatewayTests implements TestApplicationContextAware {
 		consumer.start();
 		AbstractClientConnectionFactory client = ccf.apply(port);
 		CountDownLatch latch = new CountDownLatch(1);
-		client.registerListener(message -> {
-			latch.countDown();
-			return false;
-		});
+		client.registerListener(message -> latch.countDown());
 		client.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		client.afterPropertiesSet();
 		client.start();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -533,10 +533,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(0);
 		server1.setBeanName("server1");
 		final CountDownLatch latch1 = new CountDownLatch(3);
-		server1.registerListener(message -> {
-			latch1.countDown();
-			return false;
-		});
+		server1.registerListener(message -> latch1.countDown());
 		server1.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		server1.afterPropertiesSet();
 		server1.start();
@@ -545,10 +542,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(0);
 		server1.setBeanName("server2");
 		final CountDownLatch latch2 = new CountDownLatch(2);
-		server2.registerListener(message -> {
-			latch2.countDown();
-			return false;
-		});
+		server2.registerListener(message -> latch2.countDown());
 		server2.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		server2.afterPropertiesSet();
 		server2.start();
@@ -557,10 +551,12 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		// Failover
 		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("localhost", port1);
 		factory1.setBeanName("client1");
-		factory1.registerListener(message -> false);
+		factory1.registerListener(message -> {
+		});
 		AbstractClientConnectionFactory factory2 = new TcpNetClientConnectionFactory("localhost", port2);
 		factory2.setBeanName("client2");
-		factory2.registerListener(message -> false);
+		factory2.registerListener(message -> {
+		});
 		List<AbstractClientConnectionFactory> factories = new ArrayList<>();
 		factories.add(factory1);
 		factories.add(factory2);
@@ -606,10 +602,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		TcpNetServerConnectionFactory server1 = new TcpNetServerConnectionFactory(0);
 		server1.setBeanName("server1");
 		final CountDownLatch latch1 = new CountDownLatch(3);
-		server1.registerListener(message -> {
-			latch1.countDown();
-			return false;
-		});
+		server1.registerListener(message -> latch1.countDown());
 		server1.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		server1.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		server1.afterPropertiesSet();
@@ -619,10 +612,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		TcpNetServerConnectionFactory server2 = new TcpNetServerConnectionFactory(0);
 		server1.setBeanName("server2");
 		final CountDownLatch latch2 = new CountDownLatch(2);
-		server2.registerListener(message -> {
-			latch2.countDown();
-			return false;
-		});
+		server2.registerListener(message -> latch2.countDown());
 		server2.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		server2.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		server2.afterPropertiesSet();
@@ -632,13 +622,15 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		// Failover
 		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("junkjunk", port1);
 		factory1.setBeanName("client1");
-		factory1.registerListener(message -> false);
+		factory1.registerListener(message -> {
+		});
 		factory1.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		factory1.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		factory1.afterPropertiesSet();
 		AbstractClientConnectionFactory factory2 = new TcpNetClientConnectionFactory("localhost", port2);
 		factory2.setBeanName("client2");
-		factory2.registerListener(message -> false);
+		factory2.registerListener(message -> {
+		});
 		factory2.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		factory2.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		factory2.afterPropertiesSet();
@@ -682,7 +674,6 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 			connectionIds.add((String) message.getHeaders().get(IpHeaders.CONNECTION_ID));
 			latch1.countDown();
 			latch2.countDown();
-			return false;
 		});
 		in.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		in.afterPropertiesSet();
@@ -738,7 +729,6 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 				}
 				handler.handleMessage(message);
 			}
-			return false;
 		});
 		in.afterPropertiesSet();
 		handler.setBeanFactory(mock(BeanFactory.class));
@@ -827,7 +817,6 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 				received.set(message);
 				latch.countDown();
 			}
-			return false;
 		});
 		cachingFactory.start();
 
@@ -844,7 +833,9 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		return connection;
 	}
 
-	private static AbstractClientConnectionFactory createFactoryWithMockConnection(TcpConnectionSupport mockConn) throws Exception {
+	private static AbstractClientConnectionFactory createFactoryWithMockConnection(TcpConnectionSupport mockConn)
+			throws Exception {
+
 		AbstractClientConnectionFactory factory = mock(AbstractClientConnectionFactory.class);
 		when(factory.getConnection()).thenReturn(mockConn);
 		when(factory.isActive()).thenReturn(true);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
@@ -283,7 +283,8 @@ public class ConnectionEventTests implements TestApplicationContextAware {
 
 		});
 		factory.setBeanName("sf");
-		factory.registerListener(message -> false);
+		factory.registerListener(message -> {
+		});
 		LogAccessor logger = spy(TestUtils.getPropertyValue(factory, "logger", LogAccessor.class));
 		doNothing().when(logger).error(any(Throwable.class), anyString());
 		new DirectFieldAccessor(factory).setPropertyValue("logger", logger);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
@@ -91,7 +91,6 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 		server.registerListener(msg -> {
 			readThread.set(Thread.currentThread());
 			latch2.countDown();
-			return false;
 		});
 		server.setApplicationEventPublisher(event -> {
 			if (event instanceof TcpConnectionServerListeningEvent) {
@@ -174,7 +173,8 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 		assertThat(((TcpConnectionServerListeningEvent) events.get(0)).getPort()).isEqualTo(serverFactory.getPort());
 		int port = serverFactory.getPort();
 		TcpNetClientConnectionFactory clientFactory = new TcpNetClientConnectionFactory("localhost", port);
-		clientFactory.registerListener(message -> false);
+		clientFactory.registerListener(message -> {
+		});
 		clientFactory.setBeanName("clientFactory");
 		clientFactory.setApplicationEventPublisher(publisher);
 		clientFactory.start();
@@ -306,7 +306,6 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 					connection.get().send(msg);
 				}
 			}
-			return false;
 		});
 		server.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		server.afterPropertiesSet();
@@ -324,7 +323,6 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 					result.set(true);
 				}
 				latch.countDown();
-				return false;
 			});
 			conn.send(new GenericMessage<>("PING"));
 			try {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionTimeoutTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionTimeoutTests.java
@@ -36,6 +36,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.2
  */
 @LongRunningTest
@@ -66,7 +68,8 @@ public class ConnectionTimeoutTests {
 		server.start();
 		TestingUtilities.waitListening(server, null);
 		TcpNetClientConnectionFactory client = new TcpNetClientConnectionFactory("localhost", server.getPort());
-		client.registerListener(message -> false);
+		client.registerListener(message -> {
+		});
 		client.setSoTimeout(1000);
 		CountDownLatch clientCloseLatch = getCloseLatch(client);
 		setupClientCallback(client);
@@ -81,7 +84,7 @@ public class ConnectionTimeoutTests {
 	}
 
 	/**
-	 * Ensure we don't timeout on the read side (client) if we sent a message within the
+	 * Ensure we don't time out on the read side (client) if we sent a message within the
 	 * current timeout.
 	 * @throws Exception
 	 */
@@ -94,7 +97,7 @@ public class ConnectionTimeoutTests {
 	}
 
 	/**
-	 * Ensure we don't timeout on the read side (client) if we sent a message within the
+	 * Ensure we don't time out on the read side (client) if we sent a message within the
 	 * current timeout.
 	 * @throws Exception
 	 */
@@ -107,15 +110,14 @@ public class ConnectionTimeoutTests {
 	}
 
 	private void notTimeoutGuts(AbstractServerConnectionFactory server, AbstractClientConnectionFactory client)
-			throws Exception, InterruptedException {
-		final AtomicReference<Message<?>> reply = new AtomicReference<Message<?>>();
+			throws Exception {
+		final AtomicReference<Message<?>> reply = new AtomicReference<>();
 		final CountDownLatch replyLatch = new CountDownLatch(1);
 		client.registerListener(message -> {
 			if (!(message instanceof ErrorMessage)) {
 				reply.set(message);
 				replyLatch.countDown();
 			}
-			return false;
 		});
 		client.setSoTimeout(2000);
 		CountDownLatch clientClosedLatch = getCloseLatch(client);
@@ -147,7 +149,7 @@ public class ConnectionTimeoutTests {
 	public void testNetReplyTimeout() throws Exception {
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
 		this.setupServerCallbacks(server, 4500);
-		final AtomicReference<Message<?>> reply = new AtomicReference<Message<?>>();
+		final AtomicReference<Message<?>> reply = new AtomicReference<>();
 		server.start();
 		TestingUtilities.waitListening(server, null);
 		TcpNetClientConnectionFactory client = new TcpNetClientConnectionFactory("localhost", server.getPort());
@@ -155,7 +157,6 @@ public class ConnectionTimeoutTests {
 			if (!(message instanceof ErrorMessage)) {
 				reply.set(message);
 			}
-			return false;
 		});
 		client.setSoTimeout(2000);
 		CountDownLatch clientCloseLatch = getCloseLatch(client);
@@ -184,7 +185,7 @@ public class ConnectionTimeoutTests {
 	public void testNioReplyTimeout() throws Exception {
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
 		this.setupServerCallbacks(server, 2100);
-		final AtomicReference<Message<?>> reply = new AtomicReference<Message<?>>();
+		final AtomicReference<Message<?>> reply = new AtomicReference<>();
 		server.start();
 		TestingUtilities.waitListening(server, null);
 		TcpNioClientConnectionFactory client = new TcpNioClientConnectionFactory("localhost", server.getPort());
@@ -192,7 +193,6 @@ public class ConnectionTimeoutTests {
 			if (!(message instanceof ErrorMessage)) {
 				reply.set(message);
 			}
-			return false;
 		});
 		client.setSoTimeout(1000);
 		CountDownLatch clientCloseLatch = getCloseLatch(client);
@@ -212,7 +212,7 @@ public class ConnectionTimeoutTests {
 
 	private void setupServerCallbacks(AbstractServerConnectionFactory server, final int serverDelay) {
 		server.setComponentName("serverFactory");
-		final AtomicReference<TcpConnection> serverConnection = new AtomicReference<TcpConnection>();
+		final AtomicReference<TcpConnection> serverConnection = new AtomicReference<>();
 		server.registerListener(message -> {
 			try {
 				Thread.sleep(serverDelay);
@@ -221,7 +221,6 @@ public class ConnectionTimeoutTests {
 			catch (Exception e) {
 				e.printStackTrace();
 			}
-			return false;
 		});
 		server.registerSender(new TcpSender() {
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -215,7 +215,7 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 		FailoverClientConnectionFactory fccf = new FailoverClientConnectionFactory(List.of(cf1, cf2));
 
 		CompletableFuture<Message<?>> messageCompletableFuture = new CompletableFuture<>();
-		fccf.registerListener(messageCompletableFuture::complete);
+		fccf.registerListener(value -> messageCompletableFuture.complete(value));
 
 		fccf.start();
 		fccf.getConnection().send(new GenericMessage<>("test"));
@@ -392,10 +392,7 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 		server1.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		server1.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		final CountDownLatch latch1 = new CountDownLatch(3);
-		server1.registerListener(message -> {
-			latch1.countDown();
-			return false;
-		});
+		server1.registerListener(message -> latch1.countDown());
 		server1.afterPropertiesSet();
 		server1.start();
 		TestingUtilities.waitListening(server1, 10000L);
@@ -405,20 +402,19 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 		server2.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		server2.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		final CountDownLatch latch2 = new CountDownLatch(2);
-		server2.registerListener(message -> {
-			latch2.countDown();
-			return false;
-		});
+		server2.registerListener(message -> latch2.countDown());
 		server2.afterPropertiesSet();
 		server2.start();
 		TestingUtilities.waitListening(server2, 10000L);
 		int port2 = server2.getPort();
 		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("localhost", port1);
 		factory1.setBeanName("client1");
-		factory1.registerListener(message -> false);
+		factory1.registerListener(message -> {
+		});
 		AbstractClientConnectionFactory factory2 = new TcpNetClientConnectionFactory("localhost", port2);
 		factory2.setBeanName("client2");
-		factory2.registerListener(message -> false);
+		factory2.registerListener(message -> {
+		});
 		// Cache
 		CachingClientConnectionFactory cachingFactory1 = new CachingClientConnectionFactory(factory1, 2);
 		cachingFactory1.setBeanName("cache1");
@@ -535,10 +531,7 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 		server1.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		server1.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		final CountDownLatch latch1 = new CountDownLatch(3);
-		server1.registerListener(message -> {
-			latch1.countDown();
-			return false;
-		});
+		server1.registerListener(message -> latch1.countDown());
 		server1.afterPropertiesSet();
 		server1.start();
 		TestingUtilities.waitListening(server1, 10000L);
@@ -549,10 +542,7 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 		server2.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		server2.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		final CountDownLatch latch2 = new CountDownLatch(2);
-		server2.registerListener(message -> {
-			latch2.countDown();
-			return false;
-		});
+		server2.registerListener(message -> latch2.countDown());
 		server2.afterPropertiesSet();
 		server2.start();
 		TestingUtilities.waitListening(server2, 10000L);
@@ -560,14 +550,16 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 
 		AbstractClientConnectionFactory factory1 = new TcpNetClientConnectionFactory("junkjunk", port1);
 		factory1.setBeanName("client1");
-		factory1.registerListener(message -> false);
+		factory1.registerListener(message -> {
+		});
 		factory1.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		factory1.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		factory1.afterPropertiesSet();
 
 		AbstractClientConnectionFactory factory2 = new TcpNetClientConnectionFactory("localhost", port2);
 		factory2.setBeanName("client2");
-		factory2.registerListener(message -> false);
+		factory2.registerListener(message -> {
+		});
 		factory2.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		factory2.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		factory2.afterPropertiesSet();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
@@ -181,7 +181,8 @@ public class SocketSupportTests implements TestApplicationContextAware {
 	@Test
 	public void testNioClientAndServer() throws Exception {
 		TcpNioServerConnectionFactory serverConnectionFactory = new TcpNioServerConnectionFactory(0);
-		serverConnectionFactory.registerListener(message -> false);
+		serverConnectionFactory.registerListener(message -> {
+		});
 		final AtomicInteger ppSocketCountServer = new AtomicInteger();
 		final AtomicInteger ppServerSocketCountServer = new AtomicInteger();
 		final CountDownLatch latch = new CountDownLatch(1);
@@ -404,7 +405,6 @@ public class SocketSupportTests implements TestApplicationContextAware {
 		server.registerListener(message -> {
 			messages.add(message);
 			latch.countDown();
-			return false;
 		});
 		SSLMapper mapper = new SSLMapper();
 		mapper.setBeanFactory(TEST_INTEGRATION_CONTEXT);
@@ -455,7 +455,6 @@ public class SocketSupportTests implements TestApplicationContextAware {
 				messages.add(message);
 				latch.countDown();
 			}
-			return false;
 		});
 		server.setTcpSocketSupport(new DefaultTcpSocketSupport(false) {
 
@@ -511,7 +510,6 @@ public class SocketSupportTests implements TestApplicationContextAware {
 		server.registerListener(message -> {
 			messages.add(message);
 			latch.countDown();
-			return false;
 		});
 		SSLMapper mapper = new SSLMapper();
 		mapper.setBeanFactory(TEST_INTEGRATION_CONTEXT);
@@ -530,7 +528,8 @@ public class SocketSupportTests implements TestApplicationContextAware {
 		TcpNioClientConnectionFactory client = new TcpNioClientConnectionFactory("localhost", server.getPort());
 		client.setSslHandshakeTimeout(34);
 		client.setTcpNioConnectionSupport(tcpNioConnectionSupport);
-		client.registerListener(message -> false);
+		client.registerListener(message -> {
+		});
 		client.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		client.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		client.afterPropertiesSet();
@@ -580,7 +579,6 @@ public class SocketSupportTests implements TestApplicationContextAware {
 		server.registerListener(message -> {
 			messages.add(message);
 			latch.countDown();
-			return false;
 		});
 		server.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);
 		server.setBeanFactory(TEST_INTEGRATION_CONTEXT);
@@ -633,7 +631,6 @@ public class SocketSupportTests implements TestApplicationContextAware {
 				throw new RuntimeException(e);
 			}
 			latch.countDown();
-			return false;
 		});
 		ByteArrayCrLfSerializer deserializer = new ByteArrayCrLfSerializer();
 		deserializer.setMaxMessageSize(120000);
@@ -658,7 +655,6 @@ public class SocketSupportTests implements TestApplicationContextAware {
 		client.registerListener(message -> {
 			messages.add(message);
 			latch.countDown();
-			return false;
 		});
 		client.setDeserializer(deserializer);
 		client.setApplicationEventPublisher(TEST_INTEGRATION_CONTEXT);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionSupportTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionSupportTests.java
@@ -49,7 +49,6 @@ public class TcpNetConnectionSupportTests implements TestApplicationContextAware
 		server.registerListener(m -> {
 			message.set(m);
 			latch1.countDown();
-			return false;
 		});
 		AtomicBoolean firstTime = new AtomicBoolean(true);
 		server.setTcpNetConnectionSupport(new DefaultTcpNetConnectionSupport() {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionReadTests.java
@@ -89,7 +89,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 		AbstractServerConnectionFactory scf = getConnectionFactory(serializer, message -> {
 			responses.add(message);
 			semaphore.release();
-			return false;
 		});
 
 		// Fire up the sender.
@@ -122,7 +121,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 				Thread.currentThread().interrupt();
 			}
 			semaphore.release();
-			return false;
 		});
 		int howMany = 2;
 		scf.setBacklog(howMany + 5);
@@ -146,7 +144,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 		AbstractServerConnectionFactory scf = getConnectionFactory(serializer, message -> {
 			responses.add(message);
 			semaphore.release();
-			return false;
 		});
 		// Fire up the sender.
 
@@ -172,7 +169,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 		AbstractServerConnectionFactory scf = getConnectionFactory(serializer, message -> {
 			responses.add(message);
 			semaphore.release();
-			return false;
 		});
 
 		// Fire up the sender.
@@ -205,7 +201,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 				errorMessageRef.set(((ErrorMessage) message).getPayload());
 				errorMessageLetch.countDown();
 			}
-			return false;
 		}, new TcpSender() {
 
 			@Override
@@ -258,7 +253,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 				errorMessageRef.set(((ErrorMessage) message).getPayload());
 				errorMessageLetch.countDown();
 			}
-			return false;
 		}, new TcpSender() {
 
 			@Override
@@ -312,7 +306,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 				errorMessageRef.set(((ErrorMessage) message).getPayload());
 				errorMessageLetch.countDown();
 			}
-			return false;
 		}, new TcpSender() {
 
 			@Override
@@ -367,7 +360,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 				errorMessageRef.set(((ErrorMessage) message).getPayload());
 				errorMessageLetch.countDown();
 			}
-			return false;
 		}, new TcpSender() {
 
 			@Override
@@ -419,7 +411,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 				errorMessageRef.set(((ErrorMessage) message).getPayload());
 				errorMessageLetch.countDown();
 			}
-			return false;
 		}, new TcpSender() {
 
 			@Override
@@ -494,7 +485,6 @@ public class TcpNioConnectionReadTests implements TestApplicationContextAware {
 				errorMessageRef.set(((ErrorMessage) message).getPayload());
 				errorMessageLetch.countDown();
 			}
-			return false;
 		}, new TcpSender() {
 
 			@Override

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -361,10 +361,7 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 			final TcpNioConnection connection = new TcpNioConnection(channel, false, false,
 					null, null);
 			connection.setTaskExecutor(exec);
-			connection.registerListener(message -> {
-				messageLatch.countDown();
-				return false;
-			});
+			connection.registerListener(message -> messageLatch.countDown());
 			TcpMessageMapper mapper = new TcpMessageMapper();
 			mapper.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 			connection.setMapper(mapper);
@@ -535,7 +532,6 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 		TcpListener listener = message1 -> {
 			inboundMessage.set(message1);
 			latch.countDown();
-			return false;
 		};
 		inboundConnection.registerListener(listener);
 		inboundConnection.readPacket();
@@ -560,7 +556,6 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 				threadName.set(Thread.currentThread().getName());
 				latch.countDown();
 			}
-			return false;
 		});
 		factory.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		factory.afterPropertiesSet();
@@ -617,7 +612,6 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 			if (!(message instanceof ErrorMessage)) {
 				latch.countDown();
 			}
-			return false;
 		});
 		factory.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		factory.afterPropertiesSet();
@@ -720,7 +714,6 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 				assembler.set(Thread.currentThread());
 				assemblerLatch.countDown();
 			}
-			return false;
 		});
 		ThreadPoolTaskExecutor te = new ThreadPoolTaskExecutor();
 		te.setCorePoolSize(3); // selector, reader, assembler
@@ -797,7 +790,8 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 			watch.stop();
 			return null;
 		});
-		cf.registerListener(m -> false);
+		cf.registerListener(m -> {
+		});
 		final CountDownLatch listening = new CountDownLatch(1);
 		cf.setApplicationEventPublisher(e -> listening.countDown());
 		cf.afterPropertiesSet();
@@ -841,7 +835,6 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 			server.registerListener(m -> {
 				messages.add(m);
 				latch.countDown();
-				return false;
 			});
 			server.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 			server.afterPropertiesSet();

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpSenderTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpSenderTests.java
@@ -47,7 +47,8 @@ public class TcpSenderTests implements TestApplicationContextAware {
 		CountDownLatch latch = new CountDownLatch(1);
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
 		server.setTaskScheduler(new SimpleAsyncTaskScheduler());
-		server.registerListener(msg -> false);
+		server.registerListener(msg -> {
+		});
 		server.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		server.afterPropertiesSet();
 		server.setApplicationEventPublisher(event -> {
@@ -68,7 +69,8 @@ public class TcpSenderTests implements TestApplicationContextAware {
 		TcpNetServerConnectionFactory server = new TcpNetServerConnectionFactory(0);
 		server.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		server.setBeanFactory(TEST_INTEGRATION_CONTEXT);
-		server.registerListener(msg -> false);
+		server.registerListener(msg -> {
+		});
 		server.afterPropertiesSet();
 		server.setApplicationEventPublisher(event -> {
 			if (event instanceof TcpConnectionServerListeningEvent) {
@@ -168,4 +170,5 @@ public class TcpSenderTests implements TestApplicationContextAware {
 		assertThat(passedConnectionsToSenderViaAddNewConnection.get(0)).isSameAs(interceptorsPerInstance.get(3));
 		assertThat(passedConnectionsToSenderViaAddNewConnection.get(1)).isSameAs(interceptorsPerInstance.get(6));
 	}
+
 }

--- a/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/TcpSyslogReceivingChannelAdapter.java
+++ b/spring-integration-syslog/src/main/java/org/springframework/integration/syslog/inbound/TcpSyslogReceivingChannelAdapter.java
@@ -95,9 +95,8 @@ public class TcpSyslogReceivingChannelAdapter extends SyslogReceivingChannelAdap
 	}
 
 	@Override
-	public boolean onMessage(Message<?> message) {
+	public void onMessage(Message<?> message) {
 		convertAndSend(message);
-		return false;
 	}
 
 }


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10314

Looks like a `boolean` return for the `TcpListener.onMessage()` is a leftover of some earlier design or some idea which didn't make it into the project. On the other hand, all the logic in the project around this `onMessage()` usage is properly handled by the delegation or exceptions.

* Change `TcpListener.onMessage()` to have a `void` as return type
* Fix all the respective usages and simplify some implementations with removing those bogus `return false;` and using proper `if..else` logic if necessary
* Fix some code style in the affected classes, like proper `assertThat` or diamond operators

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
