### PR TITLE
GH-10083: Apply Nullability to HTTP module

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/context/ComponentSourceAware.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/ComponentSourceAware.java
@@ -75,7 +75,6 @@ public interface ComponentSourceAware extends BeanNameAware {
 	 * Return the bean name populated by the {@link BeanNameAware#setBeanName(String)}.
 	 * @return the bean name.
 	 */
-	@Nullable
 	String getBeanName();
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -117,7 +117,6 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	}
 
 	@Override
-	@Nullable
 	public String getBeanName() {
 		return this.beanName;
 	}
@@ -127,7 +126,6 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	 * If {@link #componentName} was not set this method will default to the 'beanName' of this component;
 	 */
 	@Override
-	@Nullable
 	public String getComponentName() {
 		return StringUtils.hasText(this.componentName) ? this.componentName : this.beanName;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlowAdapter.java
@@ -80,7 +80,6 @@ public abstract class IntegrationFlowAdapter
 		this.beanName = name;
 	}
 
-	@Nullable
 	@Override
 	public String getBeanName() {
 		return this.beanName;

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/StandardIntegrationFlow.java
@@ -76,7 +76,7 @@ public class StandardIntegrationFlow
 
 	private @Nullable MessageChannel inputChannel;
 
-	private @Nullable boolean running;
+	private boolean running;
 
 	@SuppressWarnings("NullAway.Init")
 	private String beanName;
@@ -125,7 +125,7 @@ public class StandardIntegrationFlow
 	}
 
 	@Override
-	public @Nullable String getBeanName() {
+	public String getBeanName() {
 		return this.beanName;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
@@ -376,6 +376,9 @@ public final class StandardIntegrationFlowContext implements IntegrationFlowCont
 
 		private final IntegrationFlow delegate;
 
+		@SuppressWarnings("NullAway.Init")
+		private String beanName;
+
 		private @Nullable Object beanSource;
 
 		private @Nullable String beanDescription;
@@ -404,15 +407,14 @@ public final class StandardIntegrationFlowContext implements IntegrationFlowCont
 			return this.beanDescription;
 		}
 
-		@Nullable
 		@Override
 		public String getBeanName() {
-			return null;
+			return beanName;
 		}
 
 		@Override
 		public void setBeanName(String name) {
-
+			this.beanName = name;
 		}
 
 		@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
@@ -409,7 +409,7 @@ public final class StandardIntegrationFlowContext implements IntegrationFlowCont
 
 		@Override
 		public String getBeanName() {
-			return beanName;
+			return this.beanName;
 		}
 
 		@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ControlBusMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ControlBusMessageProcessor.java
@@ -74,7 +74,7 @@ public class ControlBusMessageProcessor extends AbstractMessageProcessor<Object>
 		@SuppressWarnings("unchecked")
 		List<Object> arguments =
 				message.getHeaders().get(IntegrationMessageHeaderAccessor.CONTROL_BUS_ARGUMENTS, List.class);
-		Class<?>[] parameterTypes = new Class<?>[0];
+		Class<?>[] parameterTypes = {};
 		if (!CollectionUtils.isEmpty(arguments)) {
 			parameterTypes =
 					arguments.stream()

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/ControlBusControllerConfiguration.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/ControlBusControllerConfiguration.java
@@ -18,6 +18,7 @@ package org.springframework.integration.http.config;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -42,9 +43,10 @@ import org.springframework.integration.support.management.ControlBusCommandRegis
 @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
 public class ControlBusControllerConfiguration {
 
-	private static final Log LOGGER = LogFactory.getLog(IntegrationGraphControllerRegistrar.class);
+	private static final Log LOGGER = LogFactory.getLog(ControlBusControllerConfiguration.class);
 
 	@Bean
+	@Nullable
 	ControlBusController controlBusController(ControlBusCommandRegistry controlBusCommandRegistry,
 			ObjectProvider<FormattingConversionService> conversionService) {
 
@@ -56,7 +58,7 @@ public class ControlBusControllerConfiguration {
 
 		controlBusCommandRegistry.setEagerInitialization(true);
 
-		return new ControlBusController(controlBusCommandRegistry, conversionService.getIfUnique());
+		return new ControlBusController(controlBusCommandRegistry, conversionService.getObject());
 	}
 
 }

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpContextUtils.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpContextUtils.java
@@ -19,6 +19,8 @@ package org.springframework.integration.http.config;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ObjectUtils;
@@ -85,17 +87,18 @@ public final class HttpContextUtils {
 	 * @return the {@link RequestMapping} annotation.
 	 * @since 5.0
 	 */
-	public static RequestMapping convertRequestMappingToAnnotation(
+	public static @Nullable RequestMapping convertRequestMappingToAnnotation(
 			org.springframework.integration.http.inbound.RequestMapping requestMapping) {
 
-		if (ObjectUtils.isEmpty(requestMapping.getPathPatterns())) {
+		String[] pathPatterns = requestMapping.getPathPatterns();
+		if (ObjectUtils.isEmpty(pathPatterns)) {
 			return null;
 		}
 
 		Map<String, Object> requestMappingAttributes = new HashMap<>();
 		requestMappingAttributes.put("name", requestMapping.getName());
-		requestMappingAttributes.put("value", requestMapping.getPathPatterns());
-		requestMappingAttributes.put("path", requestMapping.getPathPatterns());
+		requestMappingAttributes.put("value", pathPatterns);
+		requestMappingAttributes.put("path", pathPatterns);
 		requestMappingAttributes.put("method", requestMapping.getRequestMethods());
 		requestMappingAttributes.put("params", requestMapping.getParams());
 		requestMappingAttributes.put("headers", requestMapping.getHeaders());

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
@@ -55,7 +55,6 @@ public class HttpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 			if (StringUtils.hasText(mappedRequestHeaders)) {
 				parserContext.getReaderContext().error("The 'mapped-request-headers' attribute is not " +
 						"allowed when a 'header-mapper' has been specified.", parserContext.extractSource(element));
-				return null;
 			}
 			builder.addPropertyReference("headerMapper", headerMapper);
 		}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
@@ -58,7 +58,6 @@ public class HttpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 						.error("Neither 'mapped-request-headers' or 'mapped-response-headers' " +
 										"attributes are allowed when a 'header-mapper' has been specified.",
 								parserContext.extractSource(element));
-				return null;
 			}
 			builder.addPropertyReference("headerMapper", headerMapper);
 		}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/IntegrationGraphControllerParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/IntegrationGraphControllerParser.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
 import org.w3c.dom.Element;
 
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -41,13 +42,13 @@ public class IntegrationGraphControllerParser implements BeanDefinitionParser {
 			new IntegrationGraphControllerRegistrar();
 
 	@Override
-	public BeanDefinition parse(final Element element, ParserContext parserContext) {
+	public @Nullable BeanDefinition parse(final Element element, ParserContext parserContext) {
 		this.graphControllerRegistrar.registerBeanDefinitions(
 				new AnnotationMetadataAdapter() {
 
 					@Override
-					public Map<String, Object> getAnnotationAttributes(String annotationType) {
-						return Collections.singletonMap("value", element.getAttribute("path"));
+					public Map<String, @Nullable Object> getAnnotationAttributes(String annotationType) {
+						return Collections.<String, @Nullable Object>singletonMap("value", element.getAttribute("path"));
 					}
 
 					@Override

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/IntegrationGraphControllerRegistrar.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/IntegrationGraphControllerRegistrar.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanDefinition;
@@ -42,6 +43,7 @@ import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.graph.IntegrationGraphServer;
 import org.springframework.integration.http.management.IntegrationGraphController;
+import org.springframework.util.Assert;
 
 /**
  * Registers the necessary beans for {@link EnableIntegrationGraphController}.
@@ -65,7 +67,7 @@ public class IntegrationGraphControllerRegistrar implements ImportBeanDefinition
 			return;
 		}
 
-		Map<String, Object> annotationAttributes =
+		Map<String, @Nullable Object> annotationAttributes =
 				importingClassMetadata.getAnnotationAttributes(EnableIntegrationGraphController.class.getName());
 		if (annotationAttributes == null) {
 			annotationAttributes = Collections.emptyMap(); // To satisfy sonar for subsequent references
@@ -76,14 +78,15 @@ public class IntegrationGraphControllerRegistrar implements ImportBeanDefinition
 					new RootBeanDefinition(IntegrationGraphServer.class));
 		}
 
-		String path = (String) annotationAttributes.get("value");
+		String path = (String) annotationAttributes.get(AnnotationUtils.VALUE);
+		Assert.state(path != null, "The 'path' has to be provided on the 'EnableIntegrationGraphController'.");
 		String[] allowedOrigins = (String[]) annotationAttributes.get("allowedOrigins");
 		if (allowedOrigins != null && allowedOrigins.length > 0) {
 			registerControllerCorsConfigurer(registry, path, allowedOrigins);
 		}
 
 		if (!registry.containsBeanDefinition(HttpContextUtils.GRAPH_CONTROLLER_BEAN_NAME)) {
-			registerIntegrationGraphController(registry, (String) annotationAttributes.get(AnnotationUtils.VALUE));
+			registerIntegrationGraphController(registry, path);
 		}
 	}
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/package-info.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes for configuration - parsers, namespace handlers.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.http.config;

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/converter/MultipartAwareFormHttpMessageConverter.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/converter/MultipartAwareFormHttpMessageConverter.java
@@ -21,6 +21,8 @@ import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -77,7 +79,7 @@ public class MultipartAwareFormHttpMessageConverter implements HttpMessageConver
 	}
 
 	@Override
-	public boolean canRead(Class<?> clazz, MediaType mediaType) {
+	public boolean canRead(Class<?> clazz, @Nullable MediaType mediaType) {
 		if (!(MultiValueMap.class.isAssignableFrom(clazz) || byte[].class.isAssignableFrom(clazz))) {
 			return false;
 		}
@@ -91,18 +93,17 @@ public class MultipartAwareFormHttpMessageConverter implements HttpMessageConver
 	}
 
 	@Override
-	public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+	public boolean canWrite(Class<?> clazz, @Nullable MediaType mediaType) {
 		return this.wrappedConverter.canWrite(clazz, mediaType);
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public MultiValueMap<String, ?> read(Class<? extends MultiValueMap<String, ?>> clazz,
 			HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
 
 		MediaType contentType = inputMessage.getHeaders().getContentType();
 		if (!MediaType.MULTIPART_FORM_DATA.includes(contentType)) {
-			return (MultiValueMap<String, ?>) this.wrappedConverter.read(clazz, inputMessage);
+			return this.wrappedConverter.read(clazz, inputMessage);
 		}
 		Assert.state(inputMessage instanceof MultipartHttpInputMessage,
 				"A request with 'multipart/form-data' Content-Type must be a MultipartHttpInputMessage. "
@@ -127,7 +128,7 @@ public class MultipartAwareFormHttpMessageConverter implements HttpMessageConver
 	}
 
 	@Override
-	public void write(MultiValueMap<String, ?> map, MediaType contentType, HttpOutputMessage outputMessage)
+	public void write(MultiValueMap<String, ?> map, @Nullable MediaType contentType, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException {
 
 		this.wrappedConverter.write(map, contentType, outputMessage);

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/converter/SerializingHttpMessageConverter.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/converter/SerializingHttpMessageConverter.java
@@ -22,6 +22,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -43,7 +45,9 @@ public class SerializingHttpMessageConverter extends AbstractHttpMessageConverte
 	private static final MediaType APPLICATION_JAVA_SERIALIZED_OBJECT =
 			new MediaType("application", "x-java-serialized-object");
 
-	/** Creates a new instance of the {@code SerializingHttpMessageConverter}. */
+	/**
+	 * Creates a new instance of the {@code SerializingHttpMessageConverter}.
+	 */
 	public SerializingHttpMessageConverter() {
 		super(APPLICATION_JAVA_SERIALIZED_OBJECT);
 	}
@@ -54,18 +58,19 @@ public class SerializingHttpMessageConverter extends AbstractHttpMessageConverte
 	}
 
 	@Override
-	public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+	public boolean canWrite(Class<?> clazz, @Nullable MediaType mediaType) {
 		return Serializable.class.isAssignableFrom(clazz) && canWrite(mediaType);
 	}
 
 	@Override
-	@SuppressWarnings("rawtypes")
-	public Serializable readInternal(Class clazz, HttpInputMessage inputMessage) throws IOException {
+	public Serializable readInternal(Class<? extends Serializable> clazz, HttpInputMessage inputMessage)
+			throws IOException {
+
 		try {
-			return (Serializable) new ObjectInputStream(inputMessage.getBody()).readObject(); //NOSONAR
+			return (Serializable) new ObjectInputStream(inputMessage.getBody()).readObject();
 		}
-		catch (ClassNotFoundException e) {
-			throw new IllegalArgumentException(e);
+		catch (ClassNotFoundException ex) {
+			throw new IllegalArgumentException(ex);
 		}
 	}
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/converter/package-info.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/converter/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes supporting message conversion.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.http.converter;

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/DynamicRequestMappingBeanPostProcessor.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/DynamicRequestMappingBeanPostProcessor.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.http.inbound;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -39,9 +41,10 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
 public class DynamicRequestMappingBeanPostProcessor
 		implements BeanFactoryAware, DestructionAwareBeanPostProcessor, SmartInitializingSingleton {
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
-	private IntegrationRequestMappingHandlerMapping integrationRequestMappingHandlerMapping;
+	private @Nullable IntegrationRequestMappingHandlerMapping integrationRequestMappingHandlerMapping;
 
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
@@ -64,7 +67,7 @@ public class DynamicRequestMappingBeanPostProcessor
 
 	@Override
 	public void postProcessBeforeDestruction(Object bean, String beanName) throws BeansException {
-		if (isHandler(bean.getClass())) {
+		if (this.integrationRequestMappingHandlerMapping != null && isHandler(bean.getClass())) {
 			RequestMappingInfo mapping =
 					this.integrationRequestMappingHandlerMapping.getMappingForEndpoint((BaseHttpInboundEndpoint) bean);
 			if (mapping != null) {

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingController.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingController.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.expression.Expression;
 import org.springframework.expression.common.LiteralExpression;
@@ -72,8 +73,9 @@ public class HttpRequestHandlingController extends HttpRequestHandlingEndpointSu
 	 */
 	public static final String DEFAULT_ERRORS_KEY = "errors";
 
-	private Expression viewExpression;
+	private @Nullable Expression viewExpression;
 
+	@SuppressWarnings("NullAway.Init")
 	private StandardEvaluationContext evaluationContext;
 
 	private String replyKey = DEFAULT_REPLY_KEY;
@@ -106,7 +108,7 @@ public class HttpRequestHandlingController extends HttpRequestHandlingEndpointSu
 	 * @param replyKey The reply key.
 	 */
 	public void setReplyKey(String replyKey) {
-		this.replyKey = (replyKey != null) ? replyKey : DEFAULT_REPLY_KEY;
+		this.replyKey = replyKey;
 	}
 
 	/**

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGateway.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGateway.java
@@ -118,12 +118,11 @@ public class HttpRequestHandlingMessagingGateway extends HttpRequestHandlingEndp
 
 		if (responseContent != null) {
 
-			if (responseContent instanceof HttpStatus) {
-				response.setStatusCode((HttpStatus) responseContent);
+			if (responseContent instanceof HttpStatus httpStatus) {
+				response.setStatusCode(httpStatus);
 			}
 			else {
-				if (responseContent instanceof ResponseEntity) {
-					ResponseEntity<?> responseEntity = (ResponseEntity<?>) responseContent;
+				if (responseContent instanceof ResponseEntity<?> responseEntity) {
 					responseContent = responseEntity.getBody();
 					response.setStatusCode(responseEntity.getStatusCode());
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/RequestMapping.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/RequestMapping.java
@@ -18,6 +18,8 @@ package org.springframework.integration.http.inbound;
 
 import java.util.Arrays;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.http.HttpMethod;
 import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -38,7 +40,7 @@ public class RequestMapping {
 
 	private String name = "";
 
-	private String[] pathPatterns;
+	private String @Nullable [] pathPatterns;
 
 	private HttpMethod[] methods = {HttpMethod.GET, HttpMethod.POST};
 
@@ -63,8 +65,8 @@ public class RequestMapping {
 		this.pathPatterns = Arrays.copyOf(pathPatterns, pathPatterns.length);
 	}
 
-	public String[] getPathPatterns() {
-		return this.pathPatterns; // NOSONAR - expose internals
+	public String @Nullable [] getPathPatterns() {
+		return this.pathPatterns;
 	}
 
 	/**

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/package-info.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes supporting inbound endpoints.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.http.inbound;

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/management/ControlBusController.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/management/ControlBusController.java
@@ -20,6 +20,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -52,8 +54,10 @@ public class ControlBusController implements BeanFactoryAware, InitializingBean 
 
 	private final FormattingConversionService conversionService;
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
+	@SuppressWarnings("NullAway.Init")
 	private EvaluationContext evaluationContext;
 
 	public ControlBusController(ControlBusCommandRegistry controlBusCommandRegistry,
@@ -83,10 +87,10 @@ public class ControlBusController implements BeanFactoryAware, InitializingBean 
 	}
 
 	@PostMapping(name = "invokeCommand", path = "/{command}")
-	public Object invokeCommand(@PathVariable String command,
+	public @Nullable Object invokeCommand(@PathVariable String command,
 			@RequestBody(required = false) List<CommandArgument> arguments) {
 
-		Class<?>[] parameterTypes = new Class<?>[0];
+		Class<?>[] parameterTypes = {};
 		if (!CollectionUtils.isEmpty(arguments)) {
 			parameterTypes = arguments.stream()
 					.map(CommandArgument::parameterType)
@@ -95,7 +99,7 @@ public class ControlBusController implements BeanFactoryAware, InitializingBean 
 
 		Expression commandExpression = this.controlBusCommandRegistry.getExpressionForCommand(command, parameterTypes);
 
-		Object[] parameterValues = null;
+		@Nullable Object[] parameterValues = null;
 
 		if (!CollectionUtils.isEmpty(arguments)) {
 			parameterValues = arguments.stream()

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/management/package-info.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/management/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes related to management support.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.http.management;

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/FileCopyingMultipartFileReader.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/FileCopyingMultipartFileReader.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.web.multipart.MultipartFile;
 
@@ -30,7 +31,7 @@ import org.springframework.web.multipart.MultipartFile;
  * is provided, the Files will be created in the default temporary directory.
  *
  * @author Mark Fisher
- * @author Artyem Bilan
+ * @author Artem Bilan
  *
  * @since 2.0
  */
@@ -38,7 +39,7 @@ public class FileCopyingMultipartFileReader implements MultipartFileReader<Multi
 
 	private static final Log LOGGER = LogFactory.getLog(FileCopyingMultipartFileReader.class);
 
-	private final File directory;
+	private final @Nullable File directory;
 
 	private String prefix = "si_";
 
@@ -57,7 +58,7 @@ public class FileCopyingMultipartFileReader implements MultipartFileReader<Multi
 	 * Files in the given directory.
 	 * @param directory The directory.
 	 */
-	public FileCopyingMultipartFileReader(File directory) {
+	public FileCopyingMultipartFileReader(@Nullable File directory) {
 		this.directory = directory;
 	}
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/MultipartHttpInputMessage.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/MultipartHttpInputMessage.java
@@ -21,6 +21,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -43,7 +45,7 @@ public class MultipartHttpInputMessage extends ServletServerHttpRequest implemen
 		this.multipartServletRequest = multipartServletRequest;
 	}
 
-	public MultipartFile getFile(String name) {
+	public @Nullable MultipartFile getFile(String name) {
 		return this.multipartServletRequest.getFile(name);
 	}
 
@@ -72,7 +74,7 @@ public class MultipartHttpInputMessage extends ServletServerHttpRequest implemen
 						LinkedMultiValueMap::addAll);
 	}
 
-	public String getMultipartContentType(String paramOrFileName) {
+	public @Nullable String getMultipartContentType(String paramOrFileName) {
 		return this.multipartServletRequest.getMultipartContentType(paramOrFileName);
 	}
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/SimpleMultipartFileReader.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/SimpleMultipartFileReader.java
@@ -25,11 +25,13 @@ import org.springframework.web.util.WebUtils;
 
 /**
  * {@link MultipartFileReader} implementation that does not maintain metadata from
- * the original {@link MultipartFile} instance. Instead this simply reads the file
+ * the original {@link MultipartFile} instance. Instead, this simply reads the file
  * content directly as either a String or byte array depending on the Content-Type.
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class SimpleMultipartFileReader implements MultipartFileReader<Object> {
@@ -39,12 +41,10 @@ public class SimpleMultipartFileReader implements MultipartFileReader<Object> {
 	/**
 	 * Specify the default charset name to use when converting multipart file
 	 * content into Strings if the multipart itself does not provide a charset.
-	 *
 	 * @param defaultCharset The default charset.
 	 */
 	public void setDefaultMultipartCharset(String defaultCharset) {
-		this.defaultCharset = Charset.forName(
-				defaultCharset != null ? defaultCharset : WebUtils.DEFAULT_CHARACTER_ENCODING);
+		this.defaultCharset = Charset.forName(defaultCharset);
 	}
 
 	@Override
@@ -56,7 +56,7 @@ public class SimpleMultipartFileReader implements MultipartFileReader<Object> {
 			if (charset == null) {
 				charset = this.defaultCharset;
 			}
-			return new String(multipartFile.getBytes(), charset.name());
+			return new String(multipartFile.getBytes(), charset);
 		}
 		else {
 			return multipartFile.getBytes();

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/UploadedMultipartFile.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/UploadedMultipartFile.java
@@ -23,6 +23,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.util.Assert;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.web.multipart.MultipartFile;
@@ -33,24 +35,27 @@ import org.springframework.web.multipart.MultipartFile;
  *
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  */
 public class UploadedMultipartFile implements MultipartFile {
 
-	private final File file;
+	private final @Nullable File file;
 
-	private final byte[] bytes;
+	private final byte @Nullable [] bytes;
 
 	private final long size;
 
-	private final String contentType;
+	private final @Nullable String contentType;
 
 	private final String formParameterName;
 
-	private final String originalFilename;
+	private final @Nullable String originalFilename;
 
-	public UploadedMultipartFile(File file, long size, String contentType, String formParameterName,
-			String originalFilename) {
+	public UploadedMultipartFile(File file, long size, @Nullable String contentType, String formParameterName,
+			@Nullable String originalFilename) {
+
 		Assert.notNull(file, "file must not be null");
 		Assert.hasText(contentType, "contentType is required");
 		Assert.hasText(formParameterName, "formParameterName is required");
@@ -63,8 +68,9 @@ public class UploadedMultipartFile implements MultipartFile {
 		this.originalFilename = originalFilename;
 	}
 
-	public UploadedMultipartFile(byte[] bytes, String contentType, String formParameterName, //NOSONAR - direct storage
-			String originalFilename) {
+	public UploadedMultipartFile(byte[] bytes, @Nullable String contentType, String formParameterName, //NOSONAR - direct storage
+			@Nullable String originalFilename) {
+
 		Assert.notNull(bytes, "bytes must not be null");
 		Assert.hasText(contentType, "contentType is required");
 		Assert.hasText(formParameterName, "formParameterName is required");
@@ -83,6 +89,7 @@ public class UploadedMultipartFile implements MultipartFile {
 	}
 
 	@Override
+	@SuppressWarnings("NullAway") // file is not null when bytes is
 	public byte[] getBytes() throws IOException {
 		if (this.bytes != null) {
 			return this.bytes; //NOSONAR - direct access
@@ -91,11 +98,12 @@ public class UploadedMultipartFile implements MultipartFile {
 	}
 
 	@Override
-	public String getContentType() {
+	public @Nullable String getContentType() {
 		return this.contentType;
 	}
 
 	@Override
+	@SuppressWarnings("NullAway") // file is not null when bytes is
 	public InputStream getInputStream() throws IOException {
 		if (this.bytes != null) {
 			return new ByteArrayInputStream(this.bytes);
@@ -104,7 +112,7 @@ public class UploadedMultipartFile implements MultipartFile {
 	}
 
 	@Override
-	public String getOriginalFilename() {
+	public @Nullable String getOriginalFilename() {
 		return this.originalFilename;
 	}
 
@@ -119,6 +127,7 @@ public class UploadedMultipartFile implements MultipartFile {
 	}
 
 	@Override
+	@SuppressWarnings("NullAway") // file is not null when bytes is
 	public void transferTo(File dest) throws IOException, IllegalStateException {
 		if (this.bytes != null) {
 			FileCopyUtils.copy(this.bytes, dest);

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/package-info.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/multipart/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes supporting multipart HTTP requests.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.http.multipart;

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/AbstractHttpRequestExecutingMessageHandler.java
@@ -298,6 +298,11 @@ public abstract class AbstractHttpRequestExecutingMessageHandler extends Abstrac
 		BeanFactory beanFactory = getBeanFactory();
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(beanFactory);
 		this.simpleEvaluationContext = ExpressionUtils.createSimpleEvaluationContext(beanFactory);
+
+		if (this.headerMapper instanceof DefaultHttpHeaderMapper defaultHttpHeaderMapper) {
+			defaultHttpHeaderMapper.setBeanFactory(beanFactory);
+			defaultHttpHeaderMapper.afterPropertiesSet();
+		}
 	}
 
 	@Override

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/package-info.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Base package for Http support.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.http;

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/IntegrationWebExchangeBindException.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/IntegrationWebExchangeBindException.java
@@ -18,6 +18,8 @@ package org.springframework.integration.http.support;
 
 import java.util.Objects;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.support.WebExchangeBindException;
@@ -39,10 +41,11 @@ public class IntegrationWebExchangeBindException extends WebExchangeBindExceptio
 
 	private final Object failedPayload;
 
+	@SuppressWarnings("NullAway") // The super ServerWebInputException accepts null for MethodParameter
 	public IntegrationWebExchangeBindException(String endpointId, Object failedPayload,
 			BindingResult bindingResult) {
 
-		super(null, bindingResult); // NOSONAR - we ignore a MethodParameter in favor of payload and endpoint context
+		super(null, bindingResult);
 		this.endpointId = endpointId;
 		this.failedPayload = failedPayload;
 	}
@@ -64,17 +67,16 @@ public class IntegrationWebExchangeBindException extends WebExchangeBindExceptio
 	}
 
 	@Override
-	public boolean equals(Object o) {
+	public boolean equals(@Nullable Object o) {
 		if (this == o) {
 			return true;
 		}
-		if (!(o instanceof IntegrationWebExchangeBindException)) {
+		if (!(o instanceof IntegrationWebExchangeBindException that)) {
 			return false;
 		}
 		if (!super.equals(o)) {
 			return false;
 		}
-		IntegrationWebExchangeBindException that = (IntegrationWebExchangeBindException) o;
 		return Objects.equals(this.endpointId, that.endpointId) &&
 				Objects.equals(this.failedPayload, that.failedPayload);
 	}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/package-info.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/package-info.java
@@ -2,4 +2,5 @@
  * Provides classes to support Http endpoints, including header
  * mapping.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.http.support;

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
@@ -48,6 +48,7 @@ import org.springframework.integration.handler.AbstractReplyProducingMessageHand
 import org.springframework.integration.http.multipart.UploadedMultipartFile;
 import org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandler;
 import org.springframework.integration.scheduling.PollerMetadata;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ErrorMessage;
@@ -66,8 +67,8 @@ import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
-import org.springframework.test.web.client.MockMvcClientHttpRequestFactory;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
@@ -123,7 +124,10 @@ public class HttpDslTests {
 
 	@Test
 	public void testHttpProxyFlow() throws Exception {
-		ClientHttpRequestFactory mockRequestFactory = new MockMvcClientHttpRequestFactory(this.mockMvc);
+		RestTestClient restTestClient = RestTestClient.bindTo(this.mockMvc).build();
+		ClientHttpRequestFactory mockRequestFactory =
+				TestUtils.getPropertyValue(restTestClient, "restClient.clientRequestFactory",
+						ClientHttpRequestFactory.class);
 		this.serviceInternalGatewayHandler.setRequestFactory(mockRequestFactory);
 
 		this.mockMvc.perform(

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -55,7 +55,6 @@ import org.springframework.integration.http.converter.SerializingHttpMessageConv
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.support.TestApplicationContextAware;
 import org.springframework.integration.test.util.TestUtils;
-import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHeaders;
@@ -840,9 +839,8 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		Sinks.One<HttpHeaders> httpHeadersSink = Sinks.one();
 		RestTemplate testRestTemplate = new RestTemplate() {
 
-			@Nullable
-			protected <T> T doExecute(URI url, @Nullable String uriTemplate, @Nullable HttpMethod method,
-					@Nullable RequestCallback requestCallback, @Nullable ResponseExtractor<T> responseExtractor)
+			protected <T> T doExecute(URI url, String uriTemplate, HttpMethod method,
+					RequestCallback requestCallback, ResponseExtractor<T> responseExtractor)
 					throws RestClientException {
 
 				try {
@@ -919,9 +917,8 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 
 		private final AtomicReference<String> actualUrl = new AtomicReference<>();
 
-		@Nullable
-		protected <T> T doExecute(URI url, @Nullable String uriTemplate, @Nullable HttpMethod method,
-				@Nullable RequestCallback requestCallback, @Nullable ResponseExtractor<T> responseExtractor)
+		protected <T> T doExecute(URI url, String uriTemplate, HttpMethod method,
+				RequestCallback requestCallback, ResponseExtractor<T> responseExtractor)
 				throws RestClientException {
 
 			this.actualUrl.set(url.toString());
@@ -942,9 +939,8 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 			setUriTemplateHandler(uriBuilderFactory);
 		}
 
-		@Nullable
-		protected <T> T doExecute(URI url, @Nullable String uriTemplate, @Nullable HttpMethod method,
-				@Nullable RequestCallback requestCallback, @Nullable ResponseExtractor<T> responseExtractor)
+		protected <T> T doExecute(URI url, String uriTemplate, HttpMethod method,
+				RequestCallback requestCallback, ResponseExtractor<T> responseExtractor)
 				throws RestClientException {
 
 			this.actualUrl.set(url.toString());

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageInboundTests.java
@@ -486,6 +486,11 @@ public class DefaultHttpHeaderMapperFromMessageInboundTests {
 	public void validateCustomHeadersWithNonStringValuesAndNoConverter() {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
 		mapper.setOutboundHeaderNames("customHeader*");
+		ConversionService cs = new DefaultConversionService();
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerSingleton("integrationConversionService", cs);
+		mapper.setBeanFactory(beanFactory);
+		mapper.afterPropertiesSet();
 
 		HttpHeaders headers = new HttpHeaders();
 		Map<String, Object> messageHeaders = new HashMap<>();

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/support/DefaultHttpHeaderMapperFromMessageOutboundTests.java
@@ -32,6 +32,9 @@ import java.util.TimeZone;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.integration.mapping.HeaderMapper;
@@ -689,6 +692,12 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		DefaultHttpHeaderMapper mapper = new DefaultHttpHeaderMapper();
 		mapper.setOutboundHeaderNames("*", "HTTP_REQUEST_HEADERS");
 		mapper.setUserDefinedHeaderPrefix("X-");
+		ConversionService cs = new DefaultConversionService();
+		DefaultListableBeanFactory beanFactory = new DefaultListableBeanFactory();
+		beanFactory.registerSingleton("integrationConversionService", cs);
+		mapper.setBeanFactory(beanFactory);
+		mapper.afterPropertiesSet();
+
 		Map<String, Object> messageHeaders = new HashMap<>();
 		messageHeaders.put("foobar", "abc");
 		messageHeaders.put("X-bar", "xbar");
@@ -697,13 +706,15 @@ public class DefaultHttpHeaderMapperFromMessageOutboundTests {
 		messageHeaders.put("Accept", "text/xml");
 		HttpHeaders headers = new HttpHeaders();
 		mapper.fromHeaders(new MessageHeaders(messageHeaders), headers);
-		assertThat(headers.size()).isEqualTo(5);
+		assertThat(headers.size()).isEqualTo(7);
 		assertThat(headers.get("X-foobar")).hasSize(1);
 		assertThat(headers.get("x-foobar")).hasSize(1);
 		assertThat(headers.get("X-bar")).hasSize(1);
 		assertThat(headers.get("x-bar")).hasSize(1);
 		assertThat(headers.get("X-baz")).hasSize(1);
 		assertThat(headers.get("x-baz")).hasSize(1);
+		assertThat(headers.get("x-id")).hasSize(1);
+		assertThat(headers.get("x-timestamp")).hasSize(1);
 	}
 
 	@Test

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxInboundEndpoint.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxInboundEndpoint.java
@@ -235,17 +235,17 @@ public class WebFluxInboundEndpoint extends BaseHttpInboundEndpoint implements W
 
 		Map<String, Object> readHints = Collections.emptyMap();
 		if (adapter != null && adapter.isMultiValue()) {
-			Flux<?> flux = httpMessageReader.read(bodyType, elementType, request, response, readHints);
-			if (getValidator() != null) {
-				flux = flux.doOnNext(this::validate);
-			}
+			Flux<?> flux =
+					httpMessageReader
+							.read(bodyType, elementType, request, response, readHints)
+							.doOnNext(this::validate);
 			return Mono.just(adapter.fromPublisher(flux));
 		}
 		else {
-			Mono<?> mono = httpMessageReader.readMono(bodyType, elementType, request, response, readHints);
-			if (getValidator() != null) {
-				mono = mono.doOnNext(this::validate);
-			}
+			Mono<?> mono =
+					httpMessageReader
+							.readMono(bodyType, elementType, request, response, readHints)
+							.doOnNext(this::validate);
 			if (adapter != null) {
 				return Mono.just(adapter.fromPublisher(mono));
 			}


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10083

The change affects some core classes, since `getBeanName()` cannot be null after a proper bean initialization

* Add slight code flow improvement in the `BaseHttpInboundEndpoint` implementations regarding `validate()` method
* Fix `DefaultHttpHeaderMapper` tests where a `ConversionService` is required

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
