### PR TITLE
GH-10264: Add Jackson 3 support to Kafka module

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/SubscribableKafkaChannel.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/SubscribableKafkaChannel.java
@@ -34,6 +34,7 @@ import org.springframework.kafka.listener.adapter.RecordMessagingMessageListener
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.kafka.support.JacksonPresent;
+import org.springframework.kafka.support.JsonKafkaHeaderMapper;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.messaging.MessageHandler;
@@ -45,6 +46,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Jooyoung Pyoung
  *
  * @since 5.4
  *
@@ -84,7 +86,16 @@ public class SubscribableKafkaChannel extends AbstractKafkaChannel implements Su
 		Assert.notNull(factory, "'factory' cannot be null");
 		this.factory = factory;
 
-		if (JacksonPresent.isJackson2Present()) {
+		if (JacksonPresent.isJackson3Present()) {
+			var messageConverter = new MessagingMessageConverter();
+			var headerMapper = new JsonKafkaHeaderMapper();
+			headerMapper.addTrustedPackages(
+					org.springframework.integration.support.json.JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
+			messageConverter.setHeaderMapper(headerMapper);
+			this.recordListener.setMessageConverter(messageConverter);
+		}
+		else if (JacksonPresent.isJackson2Present()) {
 			var messageConverter = new MessagingMessageConverter();
 			var headerMapper = new DefaultKafkaHeaderMapper();
 			headerMapper.addTrustedPackages(

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/SubscribableKafkaChannel.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/channel/SubscribableKafkaChannel.java
@@ -25,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.integration.dispatcher.MessageDispatcher;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
 import org.springframework.integration.dispatcher.UnicastingDispatcher;
+import org.springframework.integration.support.json.JacksonMessagingUtils;
 import org.springframework.integration.support.management.ManageableSmartLifecycle;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.KafkaOperations;
@@ -90,7 +91,7 @@ public class SubscribableKafkaChannel extends AbstractKafkaChannel implements Su
 			var messageConverter = new MessagingMessageConverter();
 			var headerMapper = new JsonKafkaHeaderMapper();
 			headerMapper.addTrustedPackages(
-					org.springframework.integration.support.json.JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
+					JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
 							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
 			this.recordListener.setMessageConverter(messageConverter);

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -37,6 +37,7 @@ import org.springframework.integration.kafka.support.RawRecordHeaderErrorMessage
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.json.JacksonMessagingUtils;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.ConsumerSeekAware;
@@ -114,7 +115,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 			MessagingMessageConverter messageConverter = new MessagingMessageConverter();
 			JsonKafkaHeaderMapper headerMapper = new JsonKafkaHeaderMapper();
 			headerMapper.addTrustedPackages(
-					org.springframework.integration.support.json.JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
+					JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
 							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
 			this.listener.setMessageConverter(messageConverter);

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -45,6 +45,7 @@ import org.springframework.kafka.listener.adapter.RecordMessagingMessageListener
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.kafka.support.JacksonPresent;
+import org.springframework.kafka.support.JsonKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.converter.ConversionException;
 import org.springframework.kafka.support.converter.KafkaMessageHeaders;
@@ -68,6 +69,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Urs Keller
+ * @author Jooyoung Pyoung
  *
  * @since 5.4
  *
@@ -108,7 +110,16 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 		this.messageListenerContainer.setAutoStartup(false);
 		this.kafkaTemplate = kafkaTemplate;
 		setErrorMessageStrategy(new RawRecordHeaderErrorMessageStrategy());
-		if (JacksonPresent.isJackson2Present()) {
+		if (JacksonPresent.isJackson3Present()) {
+			MessagingMessageConverter messageConverter = new MessagingMessageConverter();
+			JsonKafkaHeaderMapper headerMapper = new JsonKafkaHeaderMapper();
+			headerMapper.addTrustedPackages(
+					org.springframework.integration.support.json.JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
+			messageConverter.setHeaderMapper(headerMapper);
+			this.listener.setMessageConverter(messageConverter);
+		}
+		else if (JacksonPresent.isJackson2Present()) {
 			MessagingMessageConverter messageConverter = new MessagingMessageConverter();
 			DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper();
 			headerMapper.addTrustedPackages(

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -39,6 +39,7 @@ import org.springframework.integration.handler.advice.ErrorMessageSendingRecover
 import org.springframework.integration.kafka.support.RawRecordHeaderErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.json.JacksonMessagingUtils;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.BatchMessageListener;
 import org.springframework.kafka.listener.ConsumerSeekAware;
@@ -141,7 +142,7 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 		if (JacksonPresent.isJackson3Present()) {
 			JsonKafkaHeaderMapper headerMapper = new JsonKafkaHeaderMapper();
 			headerMapper.addTrustedPackages(
-					org.springframework.integration.support.json.JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
+					JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
 							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
 			this.recordListener.setMessageConverter(messageConverter);

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -52,6 +52,7 @@ import org.springframework.kafka.listener.adapter.RecordMessagingMessageListener
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.kafka.support.JacksonPresent;
+import org.springframework.kafka.support.JsonKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.converter.BatchMessageConverter;
 import org.springframework.kafka.support.converter.ConversionException;
@@ -76,6 +77,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Urs Keller
+ * @author Jooyoung Pyoung
  *
  * @since 5.4
  */
@@ -131,11 +133,21 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 		this.mode = mode;
 		setErrorMessageStrategy(new RawRecordHeaderErrorMessageStrategy());
 
-		if (JacksonPresent.isJackson2Present()) {
-			MessagingMessageConverter messageConverter = new MessagingMessageConverter();
-			// For consistency with the rest of Spring Integration channel adapters
-			messageConverter.setGenerateMessageId(true);
-			messageConverter.setGenerateTimestamp(true);
+		MessagingMessageConverter messageConverter = new MessagingMessageConverter();
+		// For consistency with the rest of Spring Integration channel adapters
+		messageConverter.setGenerateMessageId(true);
+		messageConverter.setGenerateTimestamp(true);
+
+		if (JacksonPresent.isJackson3Present()) {
+			JsonKafkaHeaderMapper headerMapper = new JsonKafkaHeaderMapper();
+			headerMapper.addTrustedPackages(
+					org.springframework.integration.support.json.JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
+			messageConverter.setHeaderMapper(headerMapper);
+			this.recordListener.setMessageConverter(messageConverter);
+			this.batchListener.setMessageConverter(messageConverter);
+		}
+		else if (JacksonPresent.isJackson2Present()) {
 			DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper();
 			headerMapper.addTrustedPackages(
 					org.springframework.integration.support.json.JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
@@ -67,6 +67,7 @@ import org.springframework.kafka.listener.LoggingCommitCallback;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.kafka.support.JacksonPresent;
+import org.springframework.kafka.support.JsonKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.kafka.support.LogIfLevelEnabled;
@@ -105,6 +106,7 @@ import org.springframework.util.StringUtils;
  * @author Anshul Mehra
  * @author Christian Tzolov
  * @author Ngoc Nhan
+ * @author Jooyoung Pyoung
  *
  * @since 5.4
  *
@@ -262,7 +264,14 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object>
 		messagingMessageConverter.setGenerateMessageId(true);
 		messagingMessageConverter.setGenerateTimestamp(true);
 
-		if (JacksonPresent.isJackson2Present()) {
+		if (JacksonPresent.isJackson3Present()) {
+			JsonKafkaHeaderMapper headerMapper = new JsonKafkaHeaderMapper();
+			headerMapper.addTrustedPackages(
+					org.springframework.integration.support.json.JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
+			messagingMessageConverter.setHeaderMapper(headerMapper);
+		}
+		else if (JacksonPresent.isJackson2Present()) {
 			DefaultKafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper();
 			headerMapper.addTrustedPackages(
 					org.springframework.integration.support.json.JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
@@ -58,6 +58,7 @@ import org.springframework.integration.acks.AcknowledgmentCallbackFactory;
 import org.springframework.integration.core.Pausable;
 import org.springframework.integration.endpoint.AbstractMessageSource;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
+import org.springframework.integration.support.json.JacksonMessagingUtils;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ConsumerAwareRebalanceListener;
@@ -267,7 +268,7 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object>
 		if (JacksonPresent.isJackson3Present()) {
 			JsonKafkaHeaderMapper headerMapper = new JsonKafkaHeaderMapper();
 			headerMapper.addTrustedPackages(
-					org.springframework.integration.support.json.JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
+					JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
 							.toArray(new String[0]));
 			messagingMessageConverter.setHeaderMapper(headerMapper);
 		}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -171,7 +171,7 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractReplyProducingMes
 
 	private Duration assignmentDuration = DEFAULT_ASSIGNMENT_TIMEOUT;
 
-	@SuppressWarnings("this-escape")
+	@SuppressWarnings({"this-escape", "removal"})
 	public KafkaProducerMessageHandler(final KafkaTemplate<K, V> kafkaTemplate) {
 		Assert.notNull(kafkaTemplate, "kafkaTemplate cannot be null");
 		this.kafkaTemplate = kafkaTemplate;

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandler.java
@@ -53,6 +53,7 @@ import org.springframework.kafka.requestreply.ReplyingKafkaTemplate;
 import org.springframework.kafka.requestreply.RequestReplyFuture;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.kafka.support.JacksonPresent;
+import org.springframework.kafka.support.JsonKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaNull;
@@ -91,6 +92,7 @@ import org.springframework.util.StringUtils;
  * @author Biju Kunjummen
  * @author Tom van den Berge
  * @author Ryan Riley
+ * @author Jooyoung Pyoung
  *
  * @since 5.4
  */
@@ -179,7 +181,10 @@ public class KafkaProducerMessageHandler<K, V> extends AbstractReplyProducingMes
 			updateNotPropagatedHeaders(
 					new String[] {KafkaHeaders.TOPIC, KafkaHeaders.PARTITION, KafkaHeaders.KEY}, false);
 		}
-		if (JacksonPresent.isJackson2Present()) {
+		if (JacksonPresent.isJackson3Present()) {
+			this.headerMapper = new JsonKafkaHeaderMapper();
+		}
+		else if (JacksonPresent.isJackson2Present()) {
 			this.headerMapper = new DefaultKafkaHeaderMapper();
 		}
 		else {

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests-context.xml
@@ -56,6 +56,6 @@
 
 	<int:channel id="successes" />
 
-	<bean id="customHeaderMapper" class="org.springframework.kafka.support.DefaultKafkaHeaderMapper" />
+	<bean id="customHeaderMapper" class="org.springframework.kafka.support.JsonKafkaHeaderMapper" />
 
 </beans>

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests-context.xml
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests-context.xml
@@ -38,6 +38,6 @@
 
 	<bean id="ems" class="org.springframework.integration.kafka.config.xml.KafkaOutboundGatewayParserTests$EMS"/>
 
-	<bean id="customHeaderMapper" class="org.springframework.kafka.support.DefaultKafkaHeaderMapper"/>
+	<bean id="customHeaderMapper" class="org.springframework.kafka.support.JsonKafkaHeaderMapper"/>
 
 </beans>

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
@@ -69,7 +69,7 @@ import org.springframework.kafka.listener.GenericMessageListenerContainer;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.support.Acknowledgment;
-import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
+import org.springframework.kafka.support.JsonKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
@@ -93,6 +93,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Biju Kunjummen
  * @author Gary Russell
  * @author Anshul Mehra
+ * @author Jooyoung Pyoung
  *
  * @since 5.4
  */
@@ -152,7 +153,7 @@ public class KafkaDslTests {
 	private KafkaTemplate<?, ?> kafkaTemplateTopic2;
 
 	@Autowired
-	private DefaultKafkaHeaderMapper mapper;
+	private JsonKafkaHeaderMapper mapper;
 
 	@Autowired
 	private ContextConfiguration config;
@@ -385,8 +386,8 @@ public class KafkaDslTests {
 		}
 
 		@Bean
-		public DefaultKafkaHeaderMapper mapper() {
-			return new DefaultKafkaHeaderMapper();
+		public JsonKafkaHeaderMapper mapper() {
+			return new JsonKafkaHeaderMapper();
 		}
 
 		@Bean

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
@@ -64,7 +64,7 @@ import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.support.Acknowledgment;
-import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
+import org.springframework.kafka.support.JsonKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaNull;
 import org.springframework.kafka.support.TopicPartitionOffset;
@@ -73,7 +73,7 @@ import org.springframework.kafka.support.converter.BatchMessagingMessageConverte
 import org.springframework.kafka.support.converter.ConversionException;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
-import org.springframework.kafka.support.converter.StringJsonMessageConverter;
+import org.springframework.kafka.support.converter.StringJacksonJsonMessageConverter;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.ContainerTestUtils;
@@ -108,6 +108,7 @@ import static org.mockito.Mockito.verify;
  * @author Biju Kunjummen
  * @author Cameron Mayfield
  * @author Urs Keller
+ * @author Jooyoung Pyoung
  *
  * @since 5.4
  *
@@ -500,7 +501,7 @@ class MessageDrivenAdapterTests implements TestApplicationContextAware {
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		KafkaMessageDrivenChannelAdapter<Integer, String> adapter = new KafkaMessageDrivenChannelAdapter<>(container);
-		adapter.setRecordMessageConverter(new StringJsonMessageConverter());
+		adapter.setRecordMessageConverter(new StringJacksonJsonMessageConverter());
 		QueueChannel out = new QueueChannel();
 		adapter.setOutputChannel(out);
 		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
@@ -514,7 +515,7 @@ class MessageDrivenAdapterTests implements TestApplicationContextAware {
 		template.setDefaultTopic(topic3);
 		Headers kHeaders = new RecordHeaders();
 		MessageHeaders siHeaders = new MessageHeaders(Collections.singletonMap("foo", "bar"));
-		new DefaultKafkaHeaderMapper().fromHeaders(siHeaders, kHeaders);
+		new JsonKafkaHeaderMapper().fromHeaders(siHeaders, kHeaders);
 		template.send(new ProducerRecord<>(topic3, 0, 1487694048607L, 1, "{\"bar\":\"baz\"}", kHeaders));
 
 		Message<?> received = out.receive(10000);
@@ -546,7 +547,7 @@ class MessageDrivenAdapterTests implements TestApplicationContextAware {
 
 		KafkaMessageDrivenChannelAdapter<Integer, Foo> adapter = Kafka
 				.messageDrivenChannelAdapter(container, ListenerMode.record)
-				.recordMessageConverter(new StringJsonMessageConverter())
+				.recordMessageConverter(new StringJacksonJsonMessageConverter())
 				.payloadType(Foo.class)
 				.getObject();
 		QueueChannel out = new QueueChannel();
@@ -562,7 +563,7 @@ class MessageDrivenAdapterTests implements TestApplicationContextAware {
 		template.setDefaultTopic(topic6);
 		Headers kHeaders = new RecordHeaders();
 		MessageHeaders siHeaders = new MessageHeaders(Collections.singletonMap("foo", "bar"));
-		new DefaultKafkaHeaderMapper().fromHeaders(siHeaders, kHeaders);
+		new JsonKafkaHeaderMapper().fromHeaders(siHeaders, kHeaders);
 
 		template.sendDefault(1, "{\"bar\":\"baz\"}");
 

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/outbound/KafkaProducerMessageHandlerTests.java
@@ -72,7 +72,7 @@ import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.ContainerProperties.AssignmentCommitOption;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.requestreply.ReplyingKafkaTemplate;
-import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
+import org.springframework.kafka.support.JsonKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaNull;
 import org.springframework.kafka.support.SendResult;
@@ -118,6 +118,7 @@ import static org.springframework.kafka.test.assertj.KafkaConditions.value;
  * @author Artem Bilan
  * @author Tom van den Berge
  * @author Ryan Riley
+ * @author Jooyoung Pyoung
  *
  * @since 5.4
  */
@@ -239,7 +240,7 @@ class KafkaProducerMessageHandlerTests implements TestApplicationContextAware {
 		assertThat(record).has(value("foo"));
 		assertThat(record).has(timestamp(1487694048607L));
 		Map<String, Object> headers = new HashMap<>();
-		new DefaultKafkaHeaderMapper().toHeaders(record.headers(), headers);
+		new JsonKafkaHeaderMapper().toHeaders(record.headers(), headers);
 		assertThat(headers.size()).isEqualTo(1);
 		assertThat(headers.get("baz")).isEqualTo("qux");
 
@@ -383,7 +384,7 @@ class KafkaProducerMessageHandlerTests implements TestApplicationContextAware {
 		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(producerFactory);
 		KafkaProducerMessageHandler<Integer, String> handler = new KafkaProducerMessageHandler<>(template);
 		handler.setBeanFactory(TEST_INTEGRATION_CONTEXT);
-		handler.setHeaderMapper(new DefaultKafkaHeaderMapper("!*"));
+		handler.setHeaderMapper(new JsonKafkaHeaderMapper("!*"));
 		handler.afterPropertiesSet();
 
 		Message<?> message = MessageBuilder.withPayload("foo")
@@ -459,7 +460,7 @@ class KafkaProducerMessageHandlerTests implements TestApplicationContextAware {
 		assertThat(record).has(partition(1));
 		assertThat(record).has(value("foo"));
 		Map<String, Object> headers = new HashMap<>();
-		new DefaultKafkaHeaderMapper().toHeaders(record.headers(), headers);
+		new JsonKafkaHeaderMapper().toHeaders(record.headers(), headers);
 		assertThat(headers.get(KafkaHeaders.REPLY_TOPIC)).isEqualTo(topic6.getBytes());
 		ProducerRecord<Integer, String> pr = new ProducerRecord<>(topic6, 0, 1, "FOO", record.headers());
 		template.send(pr);


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10264

* Update all Kafka components to conditionally use Jackson 3 classes
* Migrate test configurations and XML beans to use `JsonKafkaHeaderMapper`
* Suppress removal warning in `KafkaProducerMessageHandler`