### PR TITLE
GH-10083: Apply Nullability to `core` `store` package

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -831,7 +831,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 					}
 					else {
 						/*
-						 * By default empty groups are removed on the same schedule as non-empty
+						 * By default, empty groups are removed on the same schedule as non-empty
 						 * groups. A longer timeout for empty groups can be enabled by
 						 * setting minimumTimeoutForEmptyGroups.
 						 */
@@ -923,9 +923,9 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		}
 	}
 
+	@SuppressWarnings("NullAway") // Never called with empty group
 	protected void completeGroup(Object correlationKey, MessageGroup group, Lock lock) {
-		Message<?> first = group.getOne();
-		completeGroup(first, correlationKey, group, lock);
+		completeGroup(group.getOne(), correlationKey, group, lock);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -923,7 +923,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 		}
 	}
 
-	@SuppressWarnings("NullAway") // Never called with empty group
+	@SuppressWarnings("NullAway") // Never called with an empty group
 	protected void completeGroup(Object correlationKey, MessageGroup group, Lock lock) {
 		completeGroup(group.getOne(), correlationKey, group, lock);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -212,7 +212,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 			doAddMessage(message, groupId);
 			if (metadata != null) {
 				UUID id = message.getHeaders().getId();
-				Assert.notNull(id, "'id' must not be null");
+				Assert.state(id != null, () -> "Message 'id' must not be null: " + message);
 				metadata.add(id);
 			}
 			else {
@@ -243,7 +243,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 			List<UUID> ids = new ArrayList<>();
 			for (Message<?> messageToRemove : messages) {
 				UUID id = messageToRemove.getHeaders().getId();
-				Assert.notNull(id, "Message 'id' must not be null");
+				Assert.state(id != null, () -> "Message 'id' must not be null: " + messageToRemove);
 				ids.add(id);
 			}
 
@@ -359,7 +359,6 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	private @Nullable Message<?> removeMessageFromGroup(UUID id, Object groupId) {
-		Assert.notNull(id, "'id' must not be null");
 		Object object = doRemove(this.messagePrefix + groupId + '_' + id);
 		if (object != null) {
 			return extractMessage(object);
@@ -370,12 +369,14 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	@Override
-	public Message<?> getOneMessageFromGroup(Object groupId) {
+	public @Nullable Message<?> getOneMessageFromGroup(Object groupId) {
 		MessageGroupMetadata groupMetadata = getGroupMetadata(groupId);
 		Assert.state(groupMetadata != null, () -> "No group for: " + groupId);
 		UUID messageId = groupMetadata.firstId();
-		Assert.state(messageId != null, "The group must contain at least one message");
-		return getMessageFromGroup(messageId, groupId);
+		if (messageId != null) {
+			return getMessageFromGroup(messageId, groupId);
+		}
+		return null;
 	}
 
 	private Message<?> getMessageFromGroup(UUID messageId, Object groupId) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -145,7 +145,10 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	protected void doAddMessage(Message<?> message, @Nullable Object groupId) {
 		UUID messageId = message.getHeaders().getId();
 		Assert.notNull(messageId, "Cannot store messages without an ID header");
-		String messageKey = this.messagePrefix + (groupId != null ? groupId.toString() + '_' : "") + messageId;
+		String messageKey =
+				new StringBuilder(this.messagePrefix)
+						.append(groupId != null ? groupId.toString() + '_' : "")
+						.append(messageId).toString();
 		doStoreIfAbsent(messageKey, new MessageHolder(message));
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -18,6 +18,7 @@ package org.springframework.integration.store;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -66,7 +67,6 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	 * @since 4.3.12
 	 */
 	protected AbstractKeyValueMessageStore(String prefix) {
-		Assert.notNull(prefix, "'prefix' must not be null");
 		this.messagePrefix = prefix + MESSAGE_KEY_PREFIX;
 		this.groupPrefix = prefix + MESSAGE_GROUP_KEY_PREFIX;
 	}
@@ -96,8 +96,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	// MessageStore methods
 
 	@Override
-	public Message<?> getMessage(UUID messageId) {
-		Assert.notNull(messageId, "'messageId' must not be null");
+	public @Nullable Message<?> getMessage(UUID messageId) {
 		Object object = doRetrieve(this.messagePrefix + messageId);
 		if (object != null) {
 			return extractMessage(object);
@@ -122,8 +121,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	@Override
-	public MessageMetadata getMessageMetadata(UUID messageId) {
-		Assert.notNull(messageId, "'messageId' must not be null");
+	public @Nullable MessageMetadata getMessageMetadata(UUID messageId) {
 		Object object = doRetrieve(this.messagePrefix + messageId);
 		if (object != null) {
 			extractMessage(object);
@@ -135,10 +133,9 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
 	public <T> Message<T> addMessage(Message<T> message) {
 		doAddMessage(message);
-		return (Message<T>) getMessage(message.getHeaders().getId());
+		return message;
 	}
 
 	protected void doAddMessage(Message<?> message) {
@@ -146,7 +143,6 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	protected void doAddMessage(Message<?> message, @Nullable Object groupId) {
-		Assert.notNull(message, "'message' must not be null");
 		UUID messageId = message.getHeaders().getId();
 		Assert.notNull(messageId, "Cannot store messages without an ID header");
 		String messageKey = this.messagePrefix + (groupId != null ? groupId.toString() + '_' : "") + messageId;
@@ -154,8 +150,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	@Override
-	public Message<?> removeMessage(UUID id) {
-		Assert.notNull(id, "'id' must not be null");
+	public @Nullable Message<?> removeMessage(UUID id) {
 		Object object = doRemove(this.messagePrefix + id);
 		if (object != null) {
 			return extractMessage(object);
@@ -195,9 +190,8 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	@Override
-	public MessageGroupMetadata getGroupMetadata(Object groupId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-		Object mgm = this.doRetrieve(this.groupPrefix + groupId);
+	public @Nullable MessageGroupMetadata getGroupMetadata(Object groupId) {
+		Object mgm = doRetrieve(this.groupPrefix + groupId);
 		if (mgm != null) {
 			Assert.isInstanceOf(MessageGroupMetadata.class, mgm);
 			return (MessageGroupMetadata) mgm;
@@ -206,10 +200,8 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	@Override
+	@SuppressWarnings("NullAway") // dataflow analysis limitation
 	protected void doAddMessagesToGroup(Object groupId, Message<?>... messages) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-		Assert.notNull(messages, "'messages' must not be null");
-
 		MessageGroupMetadata metadata = getGroupMetadata(groupId);
 		SimpleMessageGroup group = null;
 		if (metadata == null) {
@@ -219,7 +211,9 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 		for (Message<?> message : messages) {
 			doAddMessage(message, groupId);
 			if (metadata != null) {
-				metadata.add(message.getHeaders().getId());
+				UUID id = message.getHeaders().getId();
+				Assert.notNull(id, "'id' must not be null");
+				metadata.add(id);
 			}
 			else {
 				group.add(message);
@@ -241,9 +235,6 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 
 	@Override
 	protected void doRemoveMessagesFromGroup(Object groupId, Collection<Message<?>> messages) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-		Assert.notNull(messages, "'messages' must not be null");
-
 		Object mgm = doRetrieve(this.groupPrefix + groupId);
 		if (mgm != null) {
 			Assert.isInstanceOf(MessageGroupMetadata.class, mgm);
@@ -251,7 +242,9 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 
 			List<UUID> ids = new ArrayList<>();
 			for (Message<?> messageToRemove : messages) {
-				ids.add(messageToRemove.getHeaders().getId());
+				UUID id = messageToRemove.getHeaders().getId();
+				Assert.notNull(id, "Message 'id' must not be null");
+				ids.add(id);
 			}
 
 			messageGroupMetadata.removeAll(ids);
@@ -269,10 +262,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	@Override
-	@Nullable
-	public Message<?> getMessageFromGroup(Object groupId, UUID messageId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-		Assert.notNull(messageId, "'messageId' must not be null");
+	public @Nullable Message<?> getMessageFromGroup(Object groupId, UUID messageId) {
 		Object object = doRetrieve(this.messagePrefix + groupId + '_' + messageId);
 		if (object != null) {
 			return extractMessage(object);
@@ -284,8 +274,6 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 
 	@Override
 	protected boolean doRemoveMessageFromGroupById(Object groupId, UUID messageId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-		Assert.notNull(messageId, "'messageId' must not be null");
 		Object mgm = doRetrieve(this.groupPrefix + groupId);
 		if (mgm != null) {
 			Assert.isInstanceOf(MessageGroupMetadata.class, mgm);
@@ -306,7 +294,6 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 
 	@Override
 	protected void doCompleteGroup(Object groupId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
 		MessageGroupMetadata metadata = getGroupMetadata(groupId);
 		if (metadata != null) {
 			metadata.complete();
@@ -320,7 +307,6 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	 */
 	@Override
 	protected void doRemoveMessageGroup(Object groupId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
 		Object mgm = doRemove(this.groupPrefix + groupId);
 		if (mgm != null) {
 			Assert.isInstanceOf(MessageGroupMetadata.class, mgm);
@@ -347,7 +333,6 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 
 	@Override
 	protected void doSetLastReleasedSequenceNumberForGroup(Object groupId, int sequenceNumber) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
 		MessageGroupMetadata metadata = getGroupMetadata(groupId);
 		if (metadata == null) {
 			SimpleMessageGroup messageGroup = new SimpleMessageGroup(groupId);
@@ -359,7 +344,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	}
 
 	@Override
-	protected Message<?> doPollMessageFromGroup(Object groupId) {
+	protected @Nullable Message<?> doPollMessageFromGroup(Object groupId) {
 		MessageGroupMetadata groupMetadata = getGroupMetadata(groupId);
 		if (groupMetadata != null) {
 			UUID firstId = groupMetadata.firstId();
@@ -373,7 +358,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 		return null;
 	}
 
-	private Message<?> removeMessageFromGroup(UUID id, Object groupId) {
+	private @Nullable Message<?> removeMessageFromGroup(UUID id, Object groupId) {
 		Assert.notNull(id, "'id' must not be null");
 		Object object = doRemove(this.messagePrefix + groupId + '_' + id);
 		if (object != null) {
@@ -387,25 +372,16 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	@Override
 	public Message<?> getOneMessageFromGroup(Object groupId) {
 		MessageGroupMetadata groupMetadata = getGroupMetadata(groupId);
-		if (groupMetadata != null) {
-			UUID messageId = groupMetadata.firstId();
-			if (messageId != null) {
-				return getMessageFromGroup(messageId, groupId);
-			}
-		}
-		return null;
+		Assert.state(groupMetadata != null, () -> "No group for: " + groupId);
+		UUID messageId = groupMetadata.firstId();
+		Assert.state(messageId != null, "The group must contain at least one message");
+		return getMessageFromGroup(messageId, groupId);
 	}
 
-	@Nullable
 	private Message<?> getMessageFromGroup(UUID messageId, Object groupId) {
-		Assert.notNull(messageId, "'messageId' must not be null");
 		Object object = doRetrieve(this.messagePrefix + groupId + '_' + messageId);
-		if (object != null) {
-			return extractMessage(object);
-		}
-		else {
-			return null;
-		}
+		Assert.state(object != null, () -> "No message found for: " + messageId);
+		return extractMessage(object);
 	}
 
 	@Override
@@ -423,7 +399,11 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 
 	@Override
 	public Stream<Message<?>> streamMessagesForGroup(Object groupId) {
-		return getGroupMetadata(groupId)
+		MessageGroupMetadata groupMetadata = getGroupMetadata(groupId);
+		if (groupMetadata == null) {
+			return Stream.empty();
+		}
+		return groupMetadata
 				.getMessageIds()
 				.stream()
 				.map((messageId) -> getMessageFromGroup(messageId, groupId));
@@ -432,9 +412,11 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	@Override
 	@SuppressWarnings("unchecked")
 	public Iterator<MessageGroup> iterator() {
-		final Iterator<?> idIterator = normalizeKeys(
-				(Collection<String>) doListKeys(this.groupPrefix + '*'))
-				.iterator();
+		Collection<?> objects = doListKeys(this.groupPrefix + '*');
+		if (objects == null) {
+			objects = Collections.emptyList();
+		}
+		Iterator<?> idIterator = normalizeKeys((Collection<String>) objects).iterator();
 		return new MessageGroupIterator(idIterator);
 	}
 
@@ -464,17 +446,17 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 		}
 	}
 
-	protected abstract Object doRetrieve(Object id);
+	protected abstract @Nullable Object doRetrieve(Object id);
 
 	protected abstract void doStore(Object id, Object objectToStore);
 
 	protected abstract void doStoreIfAbsent(Object id, Object objectToStore);
 
-	protected abstract Object doRemove(Object id);
+	protected abstract @Nullable Object doRemove(Object id);
 
 	protected abstract void doRemoveAll(Collection<Object> ids);
 
-	protected abstract Collection<?> doListKeys(String keyPattern);
+	protected abstract @Nullable Collection<?> doListKeys(String keyPattern);
 
 	private final class MessageGroupIterator implements Iterator<MessageGroup> {
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -280,9 +280,7 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 
 	protected abstract @Nullable Message<?> doPollMessageFromGroup(Object groupId);
 
-	protected <T, E extends RuntimeException> T executeLocked(Object groupId,
-			CheckedCallable<T, E> runnable) {
-
+	protected <T, E extends RuntimeException> T executeLocked(Object groupId, CheckedCallable<T, E> runnable) {
 		try {
 			return this.lockRegistry.executeLocked(groupId, runnable);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/BasicMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/BasicMessageGroupStore.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.store;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.messaging.Message;
 
@@ -23,6 +25,7 @@ import org.springframework.messaging.Message;
  * Defines a minimal message group store with basic capabilities.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 4.0
  *
@@ -59,6 +62,7 @@ public interface BasicMessageGroupStore {
 	 * @param groupId The group identifier.
 	 * @return The message.
 	 */
+	@Nullable
 	Message<?> pollMessageFromGroup(Object groupId);
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroup.java
@@ -108,6 +108,7 @@ public interface MessageGroup {
 	/**
 	 * @return a single message from the group
 	 */
+	@Nullable
 	Message<?> getOne();
 
 	/**
@@ -127,7 +128,7 @@ public interface MessageGroup {
 	 * @param condition statement which could be consulted later on, e.g. from the release strategy.
 	 * @since 5.5
 	 */
-	void setCondition(String condition);
+	void setCondition(@Nullable String condition);
 
 	/**
 	 * Return the condition for this group to consult with, e.g. from the release strategy.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupFactory.java
@@ -48,7 +48,7 @@ public interface MessageGroupFactory {
 	/**
 	 * Create a {@link MessageGroup} instance based on the provided {@code groupId}
 	 * and with the {@code messages} for the group.
-	 * In addition the creating {@code timestamp} and {@code complete} flag may be used to customize
+	 * In addition, the creating {@code timestamp} and {@code complete} flag may be used to customize
 	 * the target {@link MessageGroup} object.
 	 * @param messages the messages for the group.
 	 * @param groupId the group id to use.
@@ -71,7 +71,7 @@ public interface MessageGroupFactory {
 	/**
 	 * Create a {@link MessageGroup} instance based on the provided {@code groupId}.
 	 * The {@link MessageGroupStore} may be consulted for the messages and metadata for the {@link MessageGroup}.
-	 * In addition the creating {@code timestamp} and {@code complete} flag may be used to customize
+	 * In addition, the creating {@code timestamp} and {@code complete} flag may be used to customize
 	 * the target {@link MessageGroup} object.
 	 * @param messageGroupStore the {@link MessageGroupStore} for additional {@link MessageGroup} information.
 	 * @param groupId the group id to use.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupMetadata.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.store;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Iterator;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.UUID;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -41,6 +43,7 @@ import org.springframework.util.Assert;
  */
 public class MessageGroupMetadata implements Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	@SuppressWarnings("serial")
@@ -54,7 +57,7 @@ public class MessageGroupMetadata implements Serializable {
 
 	private volatile int lastReleasedMessageSequenceNumber;
 
-	private volatile String condition;
+	private volatile @Nullable String condition;
 
 	public MessageGroupMetadata() {
 		this.messageIds = new LinkedList<>();
@@ -69,7 +72,9 @@ public class MessageGroupMetadata implements Serializable {
 		this();
 		Assert.notNull(messageGroup, "'messageGroup' must not be null");
 		for (Message<?> message : messageGroup.getMessages()) {
-			this.messageIds.add(message.getHeaders().getId());
+			UUID id = message.getHeaders().getId();
+			Assert.notNull(id, "Message 'id' must not be null");
+			this.messageIds.add(id);
 		}
 		this.complete = messageGroup.isComplete();
 		this.timestamp = messageGroup.getTimestamp();
@@ -101,7 +106,7 @@ public class MessageGroupMetadata implements Serializable {
 		return this.messageIds.size();
 	}
 
-	public UUID firstId() {
+	public @Nullable UUID firstId() {
 		if (!this.messageIds.isEmpty()) {
 			return this.messageIds.get(0);
 		}
@@ -114,7 +119,7 @@ public class MessageGroupMetadata implements Serializable {
 	 * @return the list of messages ids stored in the group
 	 */
 	public List<UUID> getMessageIds() {
-		return new LinkedList<UUID>(this.messageIds);
+		return new LinkedList<>(this.messageIds);
 	}
 
 	public void complete() {
@@ -145,7 +150,7 @@ public class MessageGroupMetadata implements Serializable {
 		this.lastReleasedMessageSequenceNumber = lastReleasedMessageSequenceNumber;
 	}
 
-	public String getCondition() {
+	public @Nullable String getCondition() {
 		return this.condition;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupQueue.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupQueue.java
@@ -228,7 +228,6 @@ public class MessageGroupQueue extends AbstractQueue<Message<?>> implements Bloc
 
 	@Override
 	public int drainTo(Collection<? super Message<?>> collection, int maxElements) {
-		Assert.notNull(collection, "'collection' must not be null");
 		int originalSize = collection.size();
 		ArrayList<Message<?>> list = new ArrayList<>();
 		final Lock lock = this.storeLock;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -82,8 +82,7 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * @return message by id if it belongs to requested group.
 	 * @since 6.1.5
 	 */
-	@Nullable
-	default Message<?> getMessageFromGroup(Object groupId, UUID messageId) {
+	default @Nullable Message<?> getMessageFromGroup(Object groupId, UUID messageId) {
 		throw new UnsupportedOperationException("Not supported for this store");
 	}
 
@@ -154,7 +153,9 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * @return The metadata.
 	 * @since 4.0
 	 */
-	MessageGroupMetadata getGroupMetadata(Object groupId);
+	default @Nullable MessageGroupMetadata getGroupMetadata(Object groupId) {
+		throw new UnsupportedOperationException("Not yet implemented for this store");
+	}
 
 	/**
 	 * Return the one {@link Message} from {@link MessageGroup}.
@@ -162,6 +163,7 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * @return the {@link Message}.
 	 * @since 4.0
 	 */
+	@Nullable
 	Message<?> getOneMessageFromGroup(Object groupId);
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStore.java
@@ -163,8 +163,9 @@ public interface MessageGroupStore extends BasicMessageGroupStore {
 	 * @return the {@link Message}.
 	 * @since 4.0
 	 */
-	@Nullable
-	Message<?> getOneMessageFromGroup(Object groupId);
+	default @Nullable Message<?> getOneMessageFromGroup(Object groupId) {
+		throw new UnsupportedOperationException("The operation isn't implemented for this class.");
+	}
 
 	/**
 	 * Store messages with an association to a group id.

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStoreReaper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupStoreReaper.java
@@ -37,10 +37,11 @@ import org.springframework.util.Assert;
  */
 public class MessageGroupStoreReaper implements Runnable, DisposableBean, InitializingBean, SmartLifecycle {
 
-	private static Log logger = LogFactory.getLog(MessageGroupStoreReaper.class);
+	private static final Log logger = LogFactory.getLog(MessageGroupStoreReaper.class);
 
 	private final ReentrantLock lifecycleLock = new ReentrantLock();
 
+	@SuppressWarnings("NullAway.Init")
 	private MessageGroupStore messageGroupStore;
 
 	private boolean expireOnDestroy = false;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageHolder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageHolder.java
@@ -16,7 +16,11 @@
 
 package org.springframework.integration.store;
 
+import java.io.Serial;
 import java.io.Serializable;
+import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
@@ -30,21 +34,21 @@ import org.springframework.util.Assert;
  */
 public class MessageHolder implements Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	@SuppressWarnings("serial")
-	private Message<?> message;
+	private final Message<?> message;
 
-	private MessageMetadata messageMetadata;
+	private final MessageMetadata messageMetadata;
 
-	private MessageHolder() {
-		//For Jackson deserialization
-	}
-
+	@JsonCreator
 	public MessageHolder(Message<?> message) {
 		Assert.notNull(message, "'message' must not be null.");
 		this.message = message;
-		this.messageMetadata = new MessageMetadata(message.getHeaders().getId());
+		UUID id = message.getHeaders().getId();
+		Assert.notNull(id, "Message 'id' must not be null.");
+		this.messageMetadata = new MessageMetadata(id);
 		this.messageMetadata.setTimestamp(System.currentTimeMillis());
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageMetadata.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageMetadata.java
@@ -16,8 +16,11 @@
 
 package org.springframework.integration.store;
 
+import java.io.Serial;
 import java.io.Serializable;
 import java.util.UUID;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 
 /**
  * Value Object holding metadata about a Message in the MessageStore.
@@ -28,16 +31,14 @@ import java.util.UUID;
  */
 public class MessageMetadata implements Serializable {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
-	private UUID messageId;
+	private final UUID messageId;
 
 	private volatile long timestamp;
 
-	private MessageMetadata() {
-		//For Jackson deserialization
-	}
-
+	@JsonCreator
 	public MessageMetadata(UUID messageId) {
 		this.messageId = messageId;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageStore.java
@@ -18,6 +18,8 @@ package org.springframework.integration.store;
 
 import java.util.UUID;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.messaging.Message;
 
@@ -37,6 +39,7 @@ public interface MessageStore {
 	 * @param id The message identifier.
 	 * @return The Message with the given id, or <i>null</i> if no Message with that id exists in the MessageStore.
 	 */
+	@Nullable
 	Message<?> getMessage(UUID id);
 
 	/**
@@ -47,11 +50,12 @@ public interface MessageStore {
 	 * or the message has no metadata (legacy message from an earlier version).
 	 * @since 5.0
 	 */
+	@Nullable
 	MessageMetadata getMessageMetadata(UUID id);
 
 	/**
 	 * Put the provided Message into the MessageStore. The store may need to mutate the message internally, and if it
-	 * does then the return value can be different than the input. The id of the return value will be used as an index
+	 * does then the returned value can be different from the input. The id of the return value will be used as an index
 	 * so that the {@link #getMessage(UUID)} and {@link #removeMessage(UUID)} behave properly. Since messages are
 	 * immutable, putting the same message more than once is a no-op.
 	 *
@@ -69,6 +73,7 @@ public interface MessageStore {
 	 * @param id the message identifier.
 	 * @return the message (if any).
 	 */
+	@Nullable
 	Message<?> removeMessage(UUID id);
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageStoreException.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageStoreException.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.store;
 
+import java.io.Serial;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 
@@ -23,10 +25,12 @@ import org.springframework.messaging.MessagingException;
  * Exception for problems that occur when using a {@link MessageStore} implementation.
  *
  * @author Oleg Zhurakousky
+ *
  * @since 2.1
  */
 public class MessageStoreException extends MessagingException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/package-info.java
@@ -1,4 +1,5 @@
 /**
- * Provides classes releated to storing messages.
+ * Provides classes related to storing messages.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.store;

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/locks/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/locks/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes related to locking resources.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.support.locks;

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedCallable.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedCallable.java
@@ -18,6 +18,8 @@ package org.springframework.integration.util;
 
 import java.util.concurrent.Callable;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A Callable-like interface which allows throwing any Throwable.
  * Checked exceptions are wrapped in an IllegalStateException.
@@ -30,7 +32,7 @@ import java.util.concurrent.Callable;
  * @since 6.2
  */
 @FunctionalInterface
-public interface CheckedCallable<T, E extends Throwable> {
+public interface CheckedCallable<T extends @Nullable Object, E extends Throwable> {
 
 	T call() throws E;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedFunction.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedFunction.java
@@ -18,6 +18,8 @@ package org.springframework.integration.util;
 
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * A Function-like interface which allows throwing Error.
  *
@@ -30,7 +32,7 @@ import java.util.function.Function;
  * @since 6.1
  */
 @FunctionalInterface
-public interface CheckedFunction<T, R, E extends Throwable> {
+public interface CheckedFunction<T, R extends @Nullable Object, E extends Throwable> {
 
 	R apply(T t) throws E;
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/store/SimpleMessageGroupTests.java
@@ -20,19 +20,15 @@ import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.StopWatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Iwein Fuld
@@ -81,14 +77,11 @@ public class SimpleMessageGroupTests {
 		assertThat(this.sequenceAwareGroup.canAdd(message1)).isTrue();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void shouldIgnoreNullValuesWhenInitializedWithCollectionContainingNulls() {
-		Message<?> m1 = mock(Message.class);
-		willReturn(new MessageHeaders(mock(Map.class))).given(m1).getHeaders();
-		Message<?> m2 = mock(Message.class);
-		willReturn(new MessageHeaders(mock(Map.class))).given(m2).getHeaders();
-		final List<Message<?>> messages = new ArrayList<>();
+		Message<?> m1 = new GenericMessage<>("test1");
+		Message<?> m2 = new GenericMessage<>("test2");
+		List<Message<?>> messages = new ArrayList<>();
 		messages.add(m1);
 		messages.add(null);
 		messages.add(m2);

--- a/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/store/HazelcastMessageStore.java
+++ b/spring-integration-hazelcast/src/main/java/org/springframework/integration/hazelcast/store/HazelcastMessageStore.java
@@ -75,7 +75,7 @@ public class HazelcastMessageStore extends AbstractKeyValueMessageStore {
 	}
 
 	@Override
-	protected Collection<?> doListKeys(String keyPattern) {
+	protected @Nullable Collection<?> doListKeys(String keyPattern) {
 		Assert.hasText(keyPattern, "'keyPattern' must not be empty");
 		return this.map.keySet(Predicates.like(QueryConstants.KEY_ATTRIBUTE_NAME.value(),
 				keyPattern.replaceAll("\\*", "%")));

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundGatewaySpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsInboundGatewaySpec.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.expression.Expression;
 import org.springframework.integration.dsl.MessagingGatewaySpec;
@@ -164,7 +165,7 @@ public class JmsInboundGatewaySpec<S extends JmsInboundGatewaySpec<S>>
 	 * @since 6.1
 	 * @see ChannelPublishingJmsMessageListener#setReplyToExpression(Expression)
 	 */
-	public S replyToFunction(CheckedFunction<Message, ?, JMSException> replyToFunction) {
+	public S replyToFunction(CheckedFunction<Message, ? extends @Nullable Object, JMSException> replyToFunction) {
 		return replyToExpression(new FunctionExpression<>(replyToFunction.unchecked()));
 	}
 

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -281,11 +281,6 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 	}
 
 	@Override
-	public @Nullable Message<?> getOneMessageFromGroup(Object groupId) {
-		throw NOT_IMPLEMENTED;
-	}
-
-	@Override
 	protected void doAddMessagesToGroup(Object groupId, Message<?>... messages) {
 		throw NOT_IMPLEMENTED;
 	}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
@@ -63,8 +63,6 @@ import org.springframework.util.Assert;
 public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDbMessageStore
 		implements MessageStore {
 
-	private static final String GROUP_ID_MUST_NOT_BE_NULL = "'groupId' must not be null";
-
 	public static final String DEFAULT_COLLECTION_NAME = "configurableStoreMessages";
 
 	public ConfigurableMongoDbMessageStore(MongoTemplate mongoTemplate) {
@@ -97,14 +95,12 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	public <T> Message<T> addMessage(Message<T> message) {
-		Assert.notNull(message, "'message' must not be null");
 		this.addMessageDocument(new MessageDocument(message));
 		return message;
 	}
 
 	@Override
 	public @Nullable Message<?> removeMessage(UUID id) {
-		Assert.notNull(id, "'id' must not be null");
 		Query query = Query.query(Criteria.where(MessageDocumentFields.MESSAGE_ID).is(id)
 				.and(MessageDocumentFields.GROUP_ID).exists(false));
 		MessageDocument document = getMongoTemplate().findAndRemove(query, MessageDocument.class, this.collectionName);
@@ -120,8 +116,6 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	public MessageGroup getMessageGroup(Object groupId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-
 		Query query = groupOrderQuery(groupId);
 		MessageDocument messageDocument = getMongoTemplate().findOne(query, MessageDocument.class, this.collectionName);
 
@@ -151,9 +145,6 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	protected void doAddMessagesToGroup(Object groupId, Message<?>... messages) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-		Assert.notNull(messages, "'message' must not be null");
-
 		Query query = groupOrderQuery(groupId);
 		MessageDocument messageDocument = getMongoTemplate().findOne(query, MessageDocument.class, this.collectionName);
 
@@ -187,9 +178,6 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	protected void doRemoveMessagesFromGroup(Object groupId, Collection<Message<?>> messages) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-		Assert.notNull(messages, "'messageToRemove' must not be null");
-
 		Collection<UUID> ids = new ArrayList<>();
 		for (Message<?> messageToRemove : messages) {
 			ids.add(Objects.requireNonNull(messageToRemove.getHeaders().getId()));
@@ -206,8 +194,6 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	public @Nullable Message<?> getMessageFromGroup(Object groupId, UUID messageId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-		Assert.notNull(messageId, "'messageId' must not be null");
 		Query query =
 				Query.query(
 						Criteria.where(MessageDocumentFields.MESSAGE_ID).is(messageId)
@@ -218,8 +204,6 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	protected boolean doRemoveMessageFromGroupById(Object groupId, UUID messageId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-		Assert.notNull(messageId, "'messageId' must not be null");
 		Query query =
 				Query.query(
 						Criteria.where(MessageDocumentFields.MESSAGE_ID).is(messageId)
@@ -237,8 +221,6 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	protected @Nullable Message<?> doPollMessageFromGroup(final Object groupId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
-
 		Sort sort = Sort.by(MessageDocumentFields.LAST_MODIFIED_TIME, MessageDocumentFields.SEQUENCE);
 		Query query = groupIdQuery(groupId).with(sort);
 		MessageDocument document = getMongoTemplate().findAndRemove(query, MessageDocument.class, collectionName);
@@ -299,7 +281,6 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	public @Nullable Message<?> getOneMessageFromGroup(Object groupId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
 		Query query = groupOrderQuery(groupId);
 		MessageDocument messageDocument = getMongoTemplate().findOne(query, MessageDocument.class, this.collectionName);
 		if (messageDocument != null) {
@@ -312,7 +293,6 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	public Collection<Message<?>> getMessagesForGroup(Object groupId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
 		Query query = groupOrderQuery(groupId);
 		List<MessageDocument> documents = getMongoTemplate().find(query, MessageDocument.class, this.collectionName);
 
@@ -323,7 +303,6 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	public Stream<Message<?>> streamMessagesForGroup(Object groupId) {
-		Assert.notNull(groupId, GROUP_ID_MUST_NOT_BE_NULL);
 		Query query = groupOrderQuery(groupId);
 		Stream<MessageDocument> documents =
 				getMongoTemplate()

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageStoreTests.java
@@ -83,8 +83,7 @@ class RedisMessageStoreTests implements RedisContainerTest {
 		RedisMessageStore store = new RedisMessageStore(redisConnectionFactory);
 		Message<String> stringMessage = new GenericMessage<>("Hello Redis");
 		Message<String> storedMessage = store.addMessage(stringMessage);
-		assertThat(storedMessage).isNotSameAs(stringMessage);
-		assertThat(storedMessage.getPayload()).isEqualTo("Hello Redis");
+		assertThat(storedMessage).isSameAs(stringMessage);
 	}
 
 	@Test
@@ -96,8 +95,7 @@ class RedisMessageStoreTests implements RedisContainerTest {
 
 		Message<Person> objectMessage = new GenericMessage<>(person);
 		Message<Person> storedMessage = store.addMessage(objectMessage);
-		assertThat(storedMessage).isNotSameAs(objectMessage);
-		assertThat(storedMessage.getPayload().getName()).isEqualTo("Barak Obama");
+		assertThat(storedMessage).isSameAs(objectMessage);
 	}
 
 	@Test


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10083

* Update to `io.spring.nullability:0.0.4`
* Also apply Nullability to `core` `support.locks` package
* Add `@Nullable` to generic argument of the `CheckedCallable` and `CheckedFunction`
* To not use delegation in the `LockRegistry` to avoid unnecessary nullability carry-on
* Remove redundant ctors from the `MessageHolder` and `MessageMetadata`. Use `@JsonCreator` instead on the parameterized one
* Remove unnecessary now `Assert.notNull()` in the `MessageStore` methods

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
