### PR TITLE
GH-10137: Cache `session.list` result in the `AbstractInboundFileSynchronizer`

### DIFF
--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
@@ -62,7 +62,7 @@ public class AbstractRemoteFileSynchronizerTests implements TestApplicationConte
 
 	@Test
 	public void testRollback() throws Exception {
-		final AtomicBoolean failWhenCopyingBar = new AtomicBoolean(true);
+		final AtomicBoolean failWhenCopyingTestFile2 = new AtomicBoolean(true);
 		final AtomicInteger count = new AtomicInteger();
 		SessionFactory<String> sf = new StringSessionFactory();
 		AbstractInboundFileSynchronizer<String> sync = new AbstractInboundFileSynchronizer<>(sf) {
@@ -92,7 +92,7 @@ public class AbstractRemoteFileSynchronizerTests implements TestApplicationConte
 					EvaluationContext localFileEvaluationContext, String remoteFile,
 					File localDirectory, Session<String> session) throws IOException {
 
-				if ("bar".equals(remoteFile) && failWhenCopyingBar.getAndSet(false)) {
+				if ("testFile2".equals(remoteFile) && failWhenCopyingTestFile2.getAndSet(false)) {
 					throw new IOException("fail");
 				}
 				count.incrementAndGet();
@@ -125,13 +125,13 @@ public class AbstractRemoteFileSynchronizerTests implements TestApplicationConte
 		@SuppressWarnings("unchecked")
 		Map<String, List<String>> fetchCache = TestUtils.getPropertyValue(sync, "fetchCache", Map.class);
 		List<String> cachedFiles = fetchCache.get("testRemoteDirectory");
-		assertThat(cachedFiles).containsExactly("bar", "baz");
+		assertThat(cachedFiles).containsExactly("testFile2", "testFile3");
 
 		sync.synchronizeToLocalDirectory(localDirectory, 1);
 		assertThat(count.get()).isEqualTo(2);
 
 		cachedFiles = fetchCache.get("testRemoteDirectory");
-		assertThat(cachedFiles).containsExactly("baz");
+		assertThat(cachedFiles).containsExactly("testFile3");
 
 		sync.synchronizeToLocalDirectory(localDirectory, 1);
 		assertThat(count.get()).isEqualTo(3);
@@ -388,7 +388,7 @@ public class AbstractRemoteFileSynchronizerTests implements TestApplicationConte
 		@Override
 		public String[] list(String path) {
 			this.listCallCount++;
-			return new String[] {"foo", "bar", "baz"};
+			return new String[] {"testFile1", "testFile2", "testFile3"};
 		}
 
 		@Override

--- a/src/reference/antora/modules/ROOT/pages/ftp/max-fetch.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ftp/max-fetch.adoc
@@ -1,27 +1,6 @@
 [[ftp-max-fetch]]
 = Inbound Channel Adapters: Controlling Remote File Fetching
 
-There are two properties that you should consider when you configure inbound channel adapters.
-`max-messages-per-poll`, as with all pollers, can be used to limit the number of messages emitted on each poll (if more than the configured value are ready).
-`max-fetch-size` (since version 5.0) can limit the number of files retrieved from the remote server at one time.
-
-The following scenarios assume the starting state is an empty local directory:
-
-* `max-messages-per-poll=2` and `max-fetch-size=1`: The adapter fetches one file, emits it, fetches the next file, emits it, and then sleeps until the next poll.
-* `max-messages-per-poll=2` and `max-fetch-size=2`: The adapter fetches both files and then emits each one.
-* `max-messages-per-poll=2` and `max-fetch-size=4`: The adapter fetches up to four files (if available) and emits the first two (if there are at least two).
-The next two files are emitted on the next poll.
-* `max-messages-per-poll=2` and `max-fetch-size` not specified: The adapter fetches all remote files and emits the first two (if there are at least two).
-The subsequent files are emitted on subsequent polls (two at a time).
-When all files are consumed, the remote fetch is attempted again to pick up any new files.
-
-IMPORTANT: When you deploy multiple instances of an application, we recommend a small `max-fetch-size`, to avoid one instance "`grabbing`" all the files and starving other instances.
-
-Another use for `max-fetch-size` is if you want to stop fetching remote files but continue to process files that have already been fetched.
-Setting the `maxFetchSize` property on the `MessageSource` (programmatically, with JMX, or with a xref:control-bus.adoc[control bus]) effectively stops the adapter from fetching more files but lets the poller continue to emit messages for files that have previously been fetched.
-If the poller is active when the property is changed, the change takes effect on the next poll.
-
-Starting with version 5.1, the synchronizer can be provided with a `Comparator<FTPFile>`.
-This is useful when restricting the number of files fetched with `maxFetchSize`.
+See xref:sftp/max-fetch.adoc[SFTP: Controlling Remote File Fetching] for exactly the same generic functionality.
 
 Also see general xref:ftp/inbound.adoc[FTP Inbound Channel Adapter] chapter for information about `FileListFilter` configuration.

--- a/src/reference/antora/modules/ROOT/pages/sftp/max-fetch.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sftp/max-fetch.adoc
@@ -31,14 +31,14 @@ The references stay in cache because polling configuration does not allow proces
 Starting with version 7.0, the `AbstractInboundFileSynchronizer` caches a filtered `Session.list(remoteDirectory)` after applying a `maxFetchSize` slicing.
 The logic of the `AbstractInboundFileSynchronizer.transferFilesFromRemoteToLocal()` method is the following:
 
-- If `maxFetchSize > 0`, the lock is acquired against `remoteDirecy` to avoid race condition from different threads, when work is done around cache.
+- If `maxFetchSize > 0`, the lock is acquired against `remoteDirectory` to avoid race condition from different threads, when work is done around cache.
 The performance degradation is minimal since all the later synchronizations deal only with in-memory cached leftover;
-- If no cache entry for the `remoteDirecy`, the `Session.list(remoteDirectory)` is called and all returned remote files are filtered;
-- the filtered result then sliced by the `maxFetchSize`;
+- If no cache entry for the `remoteDirectory`, the `Session.list(remoteDirectory)` is called and all returned remote files are filtered;
+- the filtered result then sliced to the `maxFetchSize`;
 - then these file entries are being transferred to the local directory;
 - the rest of filtered remote files are cached for later synchronizations;
-- if there is a cache entry for the `remoteDirecy`, such a list is sliced `maxFetchSize` and iterated for the transfer to the local directory;
-- if one of the transfers fails, the `filter` is reset from this remote file to the end of the filtered list.
+- if there is a cache entry for the `remoteDirectory`, such a list is sliced to the maxFetchSize and iterated for the transfer to the local directory;
+- if one of the transfers fails, the `filter` is reset from the failed remote file.
 The cache is also evicted; therefore, the next synchronization would start from a clean state.
 
 Also see general xref:sftp/inbound.adoc[SFTP Inbound Channel Adapter] chapter for information about `FileListFilter` configuration.

--- a/src/reference/antora/modules/ROOT/pages/sftp/max-fetch.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sftp/max-fetch.adoc
@@ -26,6 +26,19 @@ Starting with version 5.1, the synchronizer can be provided with a `Comparator<?
 This is useful when restricting the number of files fetched with `maxFetchSize`.
 
 Starting with version 6.4, the `AbstractRemoteFileStreamingMessageSource` has now a convenient `clearFetchedCache()` API to remove references from cache for not processed remote files.
-The references stay in cache because polling configuration does not allow processing all of them in one cycle, and the target `SessionFactory` might be changed between polling cycles, e.g. via `RotatingServerAdvice`.
+The references stay in cache because polling configuration does not allow processing all of them in one cycle, and the target `SessionFactory` might be changed between polling cycles, e.g., via `RotatingServerAdvice`.
+
+Starting with version 7.0, the `AbstractInboundFileSynchronizer` caches a filtered `Session.list(remoteDirectory)` after applying a `maxFetchSize` slicing.
+The logic of the `AbstractInboundFileSynchronizer.transferFilesFromRemoteToLocal()` method is the following:
+
+- If `maxFetchSize > 0`, the lock is acquired against `remoteDirecy` to avoid race condition from different threads, when work is done around cache.
+The performance degradation is minimal since all the later synchronizations deal only with in-memory cached leftover;
+- If no cache entry for the `remoteDirecy`, the `Session.list(remoteDirectory)` is called and all returned remote files are filtered;
+- the filtered result then sliced by the `maxFetchSize`;
+- then these file entries are being transferred to the local directory;
+- the rest of filtered remote files are cached for later synchronizations;
+- if there is a cache entry for the `remoteDirecy`, such a list is sliced `maxFetchSize` and iterated for the transfer to the local directory;
+- if one of the transfers fails, the `filter` is reset from this remote file to the end of the filtered list.
+The cache is also evicted; therefore, the next synchronization would start from a clean state.
 
 Also see general xref:sftp/inbound.adoc[SFTP Inbound Channel Adapter] chapter for information about `FileListFilter` configuration.

--- a/src/reference/antora/modules/ROOT/pages/smb.adoc
+++ b/src/reference/antora/modules/ROOT/pages/smb.adoc
@@ -317,28 +317,7 @@ Notice that, in this example, the message handler downstream of the transformer 
 [[smb-max-fetch]]
 == Inbound Channel Adapters: Controlling Remote File Fetching
 
-There are two properties that you should consider when you configure inbound channel adapters.
-`max-messages-per-poll`, as with all pollers, can be used to limit the number of messages emitted on each poll (if more than the configured value are ready).
-`max-fetch-size` can limit the number of files retrieved from the remote server at one time.
-
-The following scenarios assume the starting state is an empty local directory:
-
-* `max-messages-per-poll=2` and `max-fetch-size=1`: The adapter fetches one file, emits it, fetches the next file, emits it, and then sleeps until the next poll.
-* `max-messages-per-poll=2` and `max-fetch-size=2`: The adapter fetches both files and then emits each one.
-* `max-messages-per-poll=2` and `max-fetch-size=4`: The adapter fetches up to four files (if available) and emits the first two (if there are at least two).
-The next two files are emitted on the next poll.
-* `max-messages-per-poll=2` and `max-fetch-size` not specified: The adapter fetches all remote files and emits the first two (if there are at least two).
-The subsequent files are emitted on later polls (two at a time).
-When all files are consumed, the remote fetch is attempted again to pick up any new files.
-
-IMPORTANT: When you deploy multiple instances of an application, we recommend a small `max-fetch-size`, to avoid one instance "`grabbing`" all the files and starving other instances.
-
-Another use for `max-fetch-size` is if you want to stop fetching remote files but continue to process files that have already been fetched.
-Setting the `maxFetchSize` property on the `MessageSource` (programmatically, with JMX, or with a xref:control-bus.adoc[control bus]) effectively stops the adapter from fetching more files but lets the poller continue to emit messages for files that have previously been fetched.
-If the poller is active when the property is changed, the change takes effect on the next poll.
-
-The synchronizer can be provided with a `Comparator<SmbFile>`.
-This is useful when restricting the number of files fetched with `maxFetchSize`.
+See xref:sftp/max-fetch.adoc[SFTP: Controlling Remote File Fetching] for exactly the same generic functionality.
 
 [[smb-outbound]]
 == SMB Outbound Channel Adapter

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -56,3 +56,10 @@ Previously deprecated classes in the `spring-integation-hazelcast` module, such 
 
 The `AbstractMqttMessageDrivenChannelAdapter` and `ClientManager` implementations now expose a `quiescentTimeout` option which is propagated in their `stop()` method down to the `disconnectForcibly()` API of the MQTT Paho clients.
 See xref:mqtt.adoc[] for more information.
+
+[[x7.0-remote-files-changes]]
+=== Remote Files Support Changes
+
+The `AbstractInboundFileSynchronizer` now caches a filtered result of the `Session.list(remoteDirectory)` after slicing by the `maxFetchSize`.
+So, later synchronizations deal with the cache only by the `maxFetchSize` until the cache is exhausted.
+See xref:sftp/max-fetch.adoc[] for more information.


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10137

When `maxFetchSize > 0`, the `AbstractInboundFileSynchronizer` performs unnecessary `Session.list()` every time.
Then we go over all those files to filter.
And only after filtering we apply the `maxFetchSize`.

* Add a cache for remote directory entries in the `AbstractInboundFileSynchronizer`
* Guard cache interaction with a `DefaultLockRegistry` per directory
* Rework `AbstractInboundFileSynchronizer.transferFilesFromRemoteToLocal()` to filter all the entries of the `Session.list()` on a first call. If `maxFetchSize > 0`, cache the remaining remote files

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
