### PR TITLE
GH-10345: Replace Spring Retry in the JDBC module

### DIFF
--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/postgres/PostgresChannelMessageTableSubscriberTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/postgres/PostgresChannelMessageTableSubscriberTests.java
@@ -43,6 +43,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.jdbc.channel.PgConnectionSupplier;
 import org.springframework.integration.jdbc.channel.PostgresChannelMessageTableSubscriber;
@@ -57,7 +59,6 @@ import org.springframework.jdbc.datasource.init.ScriptUtils;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -246,7 +247,8 @@ public class PostgresChannelMessageTableSubscriberTests implements PostgresConta
 		AtomicInteger actualTries = new AtomicInteger();
 
 		int maxAttempts = 2;
-		postgresSubscribableChannel.setRetryTemplate(RetryTemplate.builder().maxAttempts(maxAttempts).build());
+		postgresSubscribableChannel.setRetryTemplate(
+				new RetryTemplate(RetryPolicy.builder().maxAttempts(maxAttempts).build()));
 
 		if (transactionsEnabled) {
 			postgresSubscribableChannel.setTransactionManager(transactionManager);


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10345

Migrate the only class in the ` jdbc ` module - `PostgresSubscribableChannel`, - to the Core Retry

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
