### PR TITLE
GH-10345: Migrate AMQP module into Spring Core Retry

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpBaseInboundChannelAdapterSpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpBaseInboundChannelAdapterSpec.java
@@ -18,12 +18,12 @@ package org.springframework.integration.amqp.dsl;
 
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
+import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.dsl.MessageProducerSpec;
-import org.springframework.retry.RecoveryCallback;
-import org.springframework.retry.support.RetryTemplate;
 
 /**
  * The base {@link MessageProducerSpec} implementation for a {@link AmqpInboundChannelAdapter}.

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpBaseInboundGatewaySpec.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/dsl/AmqpBaseInboundGatewaySpec.java
@@ -19,12 +19,12 @@ package org.springframework.integration.amqp.dsl;
 import org.springframework.amqp.rabbit.batch.BatchingStrategy;
 import org.springframework.amqp.rabbit.retry.MessageRecoverer;
 import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.integration.amqp.inbound.AmqpInboundGateway;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
+import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.dsl.MessagingGatewaySpec;
-import org.springframework.retry.RecoveryCallback;
-import org.springframework.retry.support.RetryTemplate;
 
 /**
  * A base {@link MessagingGatewaySpec} implementation for {@link AmqpInboundGateway} endpoint options.

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/InboundEndpointTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.amqp.inbound;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,8 @@ import org.springframework.amqp.support.converter.MessageConversionException;
 import org.springframework.amqp.support.converter.MessageConverter;
 import org.springframework.amqp.support.converter.SimpleMessageConverter;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.integration.StaticMessageHeaderAccessor;
 import org.springframework.integration.amqp.inbound.AmqpInboundChannelAdapter.BatchMode;
 import org.springframework.integration.amqp.support.AmqpMessageHeaderErrorMessageStrategy;
@@ -66,7 +69,6 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.retry.support.RetryTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -346,7 +348,7 @@ public class InboundEndpointTests implements TestApplicationContextAware {
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
 		adapter.setOutputChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setRetryTemplate(new RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()));
 		QueueChannel errors = new QueueChannel();
 		ErrorMessageSendingRecoverer recoveryCallback = new ErrorMessageSendingRecoverer(errors);
 		recoveryCallback.setErrorMessageStrategy(new AmqpMessageHeaderErrorMessageStrategy());
@@ -375,7 +377,7 @@ public class InboundEndpointTests implements TestApplicationContextAware {
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
 		adapter.setOutputChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setRetryTemplate(new RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()));
 		AtomicReference<org.springframework.amqp.core.Message> recoveredMessage = new AtomicReference<>();
 		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
 		CountDownLatch recoveredLatch = new CountDownLatch(1);
@@ -409,7 +411,7 @@ public class InboundEndpointTests implements TestApplicationContextAware {
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
 		adapter.setRequestChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setRetryTemplate(new RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()));
 		QueueChannel errors = new QueueChannel();
 		ErrorMessageSendingRecoverer recoveryCallback = new ErrorMessageSendingRecoverer(errors);
 		recoveryCallback.setErrorMessageStrategy(new AmqpMessageHeaderErrorMessageStrategy());
@@ -438,7 +440,7 @@ public class InboundEndpointTests implements TestApplicationContextAware {
 		AbstractMessageListenerContainer container = new SimpleMessageListenerContainer(connectionFactory);
 		AmqpInboundGateway adapter = new AmqpInboundGateway(container);
 		adapter.setRequestChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setRetryTemplate(new RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()));
 		AtomicReference<org.springframework.amqp.core.Message> recoveredMessage = new AtomicReference<>();
 		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
 		CountDownLatch recoveredLatch = new CountDownLatch(1);
@@ -591,7 +593,7 @@ public class InboundEndpointTests implements TestApplicationContextAware {
 		adapter.setRetryTemplate(new RetryTemplate());
 		adapter.setMessageRecoverer((message, cause) -> {
 		});
-		adapter.setRecoveryCallback(context -> null);
+		adapter.setRecoveryCallback((context, cause) -> null);
 		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		assertThatIllegalStateException()
 				.isThrownBy(adapter::afterPropertiesSet)
@@ -721,7 +723,7 @@ public class InboundEndpointTests implements TestApplicationContextAware {
 		container.setConsumerBatchEnabled(true);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
 		adapter.setOutputChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setRetryTemplate(new RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()));
 		QueueChannel errors = new QueueChannel();
 		ErrorMessageSendingRecoverer recoveryCallback = new ErrorMessageSendingRecoverer(errors);
 		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
@@ -768,7 +770,7 @@ public class InboundEndpointTests implements TestApplicationContextAware {
 		container.setConsumerBatchEnabled(true);
 		AmqpInboundChannelAdapter adapter = new AmqpInboundChannelAdapter(container);
 		adapter.setOutputChannel(new DirectChannel());
-		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setRetryTemplate(new RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()));
 		AtomicReference<List<org.springframework.amqp.core.Message>> recoveredMessages = new AtomicReference<>();
 		AtomicReference<Throwable> recoveredError = new AtomicReference<>();
 		CountDownLatch recoveredLatch = new CountDownLatch(1);

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
@@ -109,7 +109,6 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 		return this.messagingTemplate;
 	}
 
-	@Nullable
 	protected DestinationResolver<MessageChannel> getChannelResolver() {
 		return this.channelResolver;
 	}
@@ -158,10 +157,10 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 	 * Publish an error message for the supplied throwable and context.
 	 * The {@link #errorMessageStrategy} is used to build a {@link ErrorMessage}
 	 * to publish.
-	 * @param throwable the throwable. May be null.
+	 * @param throwable the throwable. Maybe null.
 	 * @param context the context for {@link ErrorMessage} properties.
 	 */
-	public void publish(Throwable throwable, AttributeAccessor context) {
+	public void publish(@Nullable Throwable throwable, AttributeAccessor context) {
 		populateChannel();
 		Throwable payload = determinePayload(throwable, context);
 		ErrorMessage errorMessage = this.errorMessageStrategy.buildErrorMessage(payload, context);
@@ -179,7 +178,7 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 	 * @return the throwable for the {@link ErrorMessage} payload
 	 * @see ErrorMessageUtils
 	 */
-	protected Throwable determinePayload(Throwable throwable, AttributeAccessor context) {
+	protected Throwable determinePayload(@Nullable Throwable throwable, AttributeAccessor context) {
 		Throwable lastThrowable = throwable;
 		if (lastThrowable == null) {
 			lastThrowable = payloadWhenNull(context);
@@ -214,9 +213,7 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 				if (recoveryChannelName == null) {
 					recoveryChannelName = IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME;
 				}
-				if (this.channelResolver != null) {
-					this.channel = this.channelResolver.resolveDestination(recoveryChannelName);
-				}
+				this.channel = this.channelResolver.resolveDestination(recoveryChannelName);
 			}
 
 			this.messagingTemplate.setDefaultChannel(this.channel);

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/RecoveryCallback.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/RecoveryCallback.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.core;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.AttributeAccessor;
+
+/**
+ * Error handler-like strategy to provide fallback based on the {@link AttributeAccessor}.
+ * @param <T> the type that is returned from the recovery
+ *
+ * @author Artem Bilan
+ *
+ * @since 7.0
+ */
+public interface RecoveryCallback<T extends @Nullable Object> {
+
+	/**
+	 * @param context the context for failure
+	 * @param cause the cause of the failure
+	 * @return an Object that can be used to replace the callback result that failed
+	 */
+	T recover(AttributeAccessor context, Throwable cause);
+
+}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -16,16 +16,17 @@
 
 package org.springframework.integration.handler.advice;
 
+import java.io.Serial;
+
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.core.ErrorMessagePublisher;
+import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.support.DefaultErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessagingException;
-import org.springframework.retry.RecoveryCallback;
-import org.springframework.retry.RetryContext;
 
 /**
  * A {@link RecoveryCallback} that sends the final throwable as an
@@ -43,8 +44,8 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 
 	/**
 	 * Construct instance with the default {@code errorChannel}
-	 * to publish recovery error message.
-	 * The {@link DefaultErrorMessageStrategy} is used for building error message to publish.
+	 * to publish a recovery error message.
+	 * The {@link DefaultErrorMessageStrategy} is used for building an error message to publish.
 	 * @since 4.3.10
 	 */
 	public ErrorMessageSendingRecoverer() {
@@ -52,8 +53,8 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	}
 
 	/**
-	 * Construct instance based on the provided message channel.
-	 * The {@link DefaultErrorMessageStrategy} is used for building error message to publish.
+	 * Construct an instance based on the provided message channel.
+	 * The {@link DefaultErrorMessageStrategy} is used for building an error message to publish.
 	 * @param channel the message channel to publish error messages on recovery action.
 	 */
 	public ErrorMessageSendingRecoverer(MessageChannel channel) {
@@ -80,8 +81,8 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	}
 
 	@Override
-	public Object recover(RetryContext context) {
-		publish(context.getLastThrowable(), context);
+	public Object recover(AttributeAccessor context, Throwable cause) {
+		publish(cause, context);
 		return null;
 	}
 
@@ -91,7 +92,7 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 		String description = "No retry exception available; " +
 				"this can occur, for example, if the RetryPolicy allowed zero attempts " +
 				"to execute the handler; " +
-				"RetryContext: " + context.toString();
+				"RetryContext: " + context;
 		return message == null
 				? new RetryExceptionNotAvailableException(description)
 				: new RetryExceptionNotAvailableException(message, description);
@@ -99,6 +100,7 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 
 	public static class RetryExceptionNotAvailableException extends MessagingException {
 
+		@Serial
 		private static final long serialVersionUID = 1L;
 
 		RetryExceptionNotAvailableException(String description) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -16,11 +16,11 @@
 
 package org.springframework.integration.handler.advice;
 
+import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.support.ErrorMessageUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
-import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryListener;
@@ -47,7 +47,7 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice {
 
 	private RetryTemplate retryTemplate = new RetryTemplate();
 
-	private RecoveryCallback<Object> recoveryCallback;
+	private org.springframework.retry.RecoveryCallback<Object> recoveryCallback;
 
 	// Stateless unless a state generator is provided
 	private RetryStateGenerator retryStateGenerator = message -> null;
@@ -63,7 +63,8 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice {
 	}
 
 	public void setRecoveryCallback(RecoveryCallback<Object> recoveryCallback) {
-		this.recoveryCallback = recoveryCallback;
+		this.recoveryCallback = (context) ->
+				recoveryCallback.recover(context, context.getLastThrowable());
 	}
 
 	public void setRetryStateGenerator(RetryStateGenerator retryStateGenerator) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests.java
@@ -105,8 +105,9 @@ public class RetryAdviceParserTests {
 
 		assertThat(TestUtils.getPropertyValue(a1, "recoveryCallback")).isNull();
 		assertThat(TestUtils.getPropertyValue(a7, "recoveryCallback")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(a7, "recoveryCallback.channel")).isSameAs(this.foo);
-		assertThat(TestUtils.getPropertyValue(a7, "recoveryCallback.messagingTemplate.sendTimeout")).isEqualTo(4567L);
+//		 TODO https://github.com/spring-projects/spring-integration/issues/10345
+//		assertThat(TestUtils.getPropertyValue(a7, "recoveryCallback.channel")).isSameAs(this.foo);
+//		assertThat(TestUtils.getPropertyValue(a7, "recoveryCallback.messagingTemplate.sendTimeout")).isEqualTo(4567L);
 
 		assertThat(TestUtils.getPropertyValue(this.handler1, "adviceChain", List.class).get(0)).isSameAs(this.a1);
 		assertThat(TestUtils.getPropertyValue(

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -534,7 +534,7 @@ public class AdvisedMessageHandlerTests implements TestApplicationContextAware {
 	private void defaultStatefulRetryRecoverAfterThirdTryGuts(final AtomicInteger counter,
 			AbstractReplyProducingMessageHandler handler, QueueChannel replies, RequestHandlerRetryAdvice advice) {
 
-		advice.setRecoveryCallback(context -> "baz");
+		advice.setRecoveryCallback((context, cause) -> "baz");
 
 		List<Advice> adviceChain = new ArrayList<>();
 		adviceChain.add(advice);
@@ -619,11 +619,12 @@ public class AdvisedMessageHandlerTests implements TestApplicationContextAware {
 		Message<String> message = new GenericMessage<>("Hello, world!");
 		handler.handleMessage(message);
 		Message<?> error = errors.receive(10000);
-		assertThat(error).isNotNull();
-		assertThat(error.getPayload() instanceof ErrorMessageSendingRecoverer.RetryExceptionNotAvailableException)
-				.isTrue();
-		assertThat(((MessagingException) error.getPayload()).getFailedMessage()).isNotNull();
-		assertThat(((MessagingException) error.getPayload()).getFailedMessage()).isSameAs(message);
+		assertThat(error)
+				.isNotNull()
+				.extracting("payload").
+				isInstanceOf(ErrorMessageSendingRecoverer.RetryExceptionNotAvailableException.class)
+				.extracting("failedMessage")
+				.isSameAs(message);
 	}
 
 	@Test

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessagingGatewaySpec;
 import org.springframework.integration.kafka.inbound.KafkaInboundGateway;
@@ -32,7 +33,6 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.ConsumerSeekAware;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
-import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageProducerSpec;
 import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter;
@@ -33,7 +34,6 @@ import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
 import org.springframework.kafka.support.converter.BatchMessageConverter;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
-import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 

--- a/spring-integration-kafka/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka.xsd
+++ b/spring-integration-kafka/src/main/resources/org/springframework/integration/kafka/config/spring-integration-kafka.xsd
@@ -711,7 +711,7 @@
 				</xsd:documentation>
 				<xsd:appinfo>
 					<tool:annotation kind="ref">
-						<tool:expected-type type="org.springframework.retry.RecoveryCallback" />
+						<tool:expected-type type="org.springframework.integration.core.RecoveryCallback" />
 					</tool:annotation>
 				</xsd:appinfo>
 			</xsd:annotation>

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundGatewayTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundGatewayTests.java
@@ -66,8 +66,9 @@ public class KafkaInboundGatewayTests {
 				.isSameAs(this.context.getBean("ems"));
 		assertThat(TestUtils.getPropertyValue(this.gateway1, "retryTemplate"))
 				.isSameAs(this.context.getBean("retryTemplate"));
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "recoveryCallback"))
-				.isSameAs(this.context.getBean("recoveryCallback"));
+		//		 TODO https://github.com/spring-projects/spring-integration/issues/10345
+//		assertThat(TestUtils.getPropertyValue(this.gateway1, "recoveryCallback"))
+//				.isSameAs(this.context.getBean("recoveryCallback"));
 		assertThat(TestUtils.getPropertyValue(this.gateway1, "onPartitionsAssignedSeekCallback"))
 				.isSameAs(this.context.getBean("onPartitionsAssignedSeekCallback"));
 		assertThat(TestUtils.getPropertyValue(this.gateway1, "messagingTemplate.sendTimeout")).isEqualTo(5000L);

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests.java
@@ -25,6 +25,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter;
 import org.springframework.integration.kafka.inbound.KafkaMessageDrivenChannelAdapter.ListenerMode;
 import org.springframework.integration.support.ErrorMessageStrategy;
@@ -35,7 +36,6 @@ import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
-import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -95,7 +95,8 @@ class KafkaMessageDrivenChannelAdapterParserTests implements TestApplicationCont
 				.isEqualTo(String.class);
 		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "errorMessageStrategy")).isSameAs(this.ems);
 		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "retryTemplate")).isSameAs(this.retryTemplate);
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "recoveryCallback")).isSameAs(this.recoveryCallback);
+		//		 TODO https://github.com/spring-projects/spring-integration/issues/10345
+//		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "recoveryCallback")).isSameAs(this.recoveryCallback);
 		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "onPartitionsAssignedSeekCallback"))
 				.isSameAs(this.context.getBean("onPartitionsAssignedSeekCallback"));
 		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "bindSourceRecord", Boolean.class)).isTrue();


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10345

The Spring Retry project is in its sunset.
There is an alternative in `spring-core`.

* Fix AMQP module according to recent changes in the Spring AMQP project related to migration onto Spring Core Retry
* Introduce `org.springframework.integration.core.RecoveryCallback` as an alternative to `RecoveryCallback` from Spring Retry
* Rework `AmqpInboundChannelAdapter` & `AmqpInboundGateway` to always populate `ATTRIBUTES_HOLDER` when there is an `errorChannel` or `retryTemplate` since Spring Core Retry does not operation with a `context` abstraction.
* Make `ErrorMessageSendingRecoverer` based on the Spring Integration `RecoveryCallback`.
* Change `RequestHandlerRetryAdvice` to accept new `RecoveryCallback`
* Modify affected classes in Kafka module to use new `RecoveryCallback` API
* The other related (spotted) work is marked as `TODO` for subsequent fixes for this #10345

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
