### PR TITLE
GH-10362: Block on PostgresSubscribableChannel.unsubscribe

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/channel/PostgresSubscribableChannel.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/channel/PostgresSubscribableChannel.java
@@ -19,6 +19,7 @@ package org.springframework.integration.jdbc.channel;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.jspecify.annotations.Nullable;
 
@@ -53,6 +54,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Rafael Winterhalter
  * @author Artem Bilan
  * @author Igor Lovich
+ * @author Norbert Schneider
  *
  * @since 6.0
  */
@@ -70,6 +72,8 @@ public class PostgresSubscribableChannel extends AbstractSubscribableChannel
 	private final PostgresChannelMessageTableSubscriber messageTableSubscriber;
 
 	private final UnicastingDispatcher dispatcher = new UnicastingDispatcher();
+
+	private final ReentrantReadWriteLock hasHandlersLock = new ReentrantReadWriteLock();
 
 	private @Nullable TransactionTemplate transactionTemplate;
 
@@ -164,12 +168,18 @@ public class PostgresSubscribableChannel extends AbstractSubscribableChannel
 
 	@Override
 	public boolean unsubscribe(MessageHandler handle) {
-		boolean unsubscribed = super.unsubscribe(handle);
-		if (this.dispatcher.getHandlerCount() == 0) {
-			this.messageTableSubscriber.unsubscribe(this);
-			this.hasHandlers = false;
+		this.hasHandlersLock.writeLock().lock();
+		try {
+			boolean unsubscribed = super.unsubscribe(handle);
+			if (this.dispatcher.getHandlerCount() == 0) {
+				this.messageTableSubscriber.unsubscribe(this);
+				this.hasHandlers = false;
+			}
+			return unsubscribed;
 		}
-		return unsubscribed;
+		finally {
+			this.hasHandlersLock.writeLock().unlock();
+		}
 	}
 
 	@Override
@@ -209,25 +219,23 @@ public class PostgresSubscribableChannel extends AbstractSubscribableChannel
 	}
 
 	private Optional<?> doPollAndDispatchMessage() {
-		if (this.hasHandlers) {
-			TransactionTemplate transactionTemplateToUse = this.transactionTemplate;
-			if (transactionTemplateToUse != null) {
-				return executeWithRetry(() ->
-						transactionTemplateToUse.execute(status ->
-								pollMessage()
-										.filter(message -> {
-											if (!this.hasHandlers) {
-												status.setRollbackOnly();
-												return false;
-											}
-											return true;
-										})
-										.map(this::dispatch)));
+		this.hasHandlersLock.readLock().lock();
+		try {
+			if (this.hasHandlers) {
+				TransactionTemplate transactionTemplateToUse = this.transactionTemplate;
+				if (transactionTemplateToUse != null) {
+					return executeWithRetry(() ->
+							transactionTemplateToUse.execute(status ->
+									pollMessage().map(this::dispatch)));
+				}
+				else {
+					return pollMessage()
+							.map(message -> executeWithRetry(() -> dispatch(message)));
+				}
 			}
-			else {
-				return pollMessage()
-						.map(message -> executeWithRetry(() -> dispatch(message)));
-			}
+		}
+		finally {
+			this.hasHandlersLock.readLock().unlock();
 		}
 		return Optional.empty();
 	}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/postgres/PostgresChannelMessageTableSubscriberTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/postgres/PostgresChannelMessageTableSubscriberTests.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.stream.IntStream;
 
 import javax.sql.DataSource;
 
@@ -72,6 +73,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Igor Lovich
  * @author Adama Sorho
  * @author Johannes Edmeier
+ * @author Norbert Schneider
  *
  * @since 6.0
  */
@@ -308,6 +310,49 @@ public class PostgresChannelMessageTableSubscriberTests implements PostgresConta
 		messageStore.addMessageToGroup(groupId, new GenericMessage<>("2"));
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(payloads).containsExactlyInAnyOrder("1", "2");
+	}
+
+	@Test
+	public void testUnsubscribeHandlerDuringDispatch() throws InterruptedException {
+		int numberOfMessages = 200;
+		CountDownLatch messagesUntilUnsubscribe = new CountDownLatch(10);
+		AtomicInteger receivedMessages = new AtomicInteger();
+		AtomicReference<Throwable> receivedException = new AtomicReference<>();
+
+		postgresChannelMessageTableSubscriber.start();
+		postgresSubscribableChannel.setErrorHandler(receivedException::set);
+
+		MessageHandler messageHandlerOne = message -> {
+			receivedMessages.getAndIncrement();
+			messagesUntilUnsubscribe.countDown();
+		};
+		postgresSubscribableChannel.subscribe(messageHandlerOne);
+
+		MessageHandler messageHandlerTwo = message -> {
+			receivedMessages.getAndIncrement();
+			messagesUntilUnsubscribe.countDown();
+		};
+		postgresSubscribableChannel.subscribe(messageHandlerTwo);
+
+		IntStream.range(0, numberOfMessages).forEach(i -> {
+			taskExecutor.execute(() ->
+				messageStore.addMessageToGroup(groupId, new GenericMessage<>(i)));
+		});
+
+		taskExecutor.execute(postgresSubscribableChannel::notifyUpdate);
+		taskExecutor.execute(postgresSubscribableChannel::notifyUpdate);
+		taskExecutor.execute(postgresSubscribableChannel::notifyUpdate);
+		taskExecutor.execute(postgresSubscribableChannel::notifyUpdate);
+		taskExecutor.execute(postgresSubscribableChannel::notifyUpdate);
+
+		assertThat(messagesUntilUnsubscribe.await(10, TimeUnit.SECONDS)).isTrue();
+		postgresSubscribableChannel.unsubscribe(messageHandlerOne);
+		postgresSubscribableChannel.unsubscribe(messageHandlerTwo);
+
+		int undeliveredMessages = messageStore.messageGroupSize(groupId);
+		int processedMessages = undeliveredMessages + receivedMessages.get();
+		assertThat(processedMessages).isEqualTo(numberOfMessages);
+		assertThat(receivedException).hasNullValue();
 	}
 
 	@Configuration


### PR DESCRIPTION
Unsubscribing message handlers while processing an in-flight message may lead to a MessageDeliveryException.

Fixes: GH-10362

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
