### PR TITLE
GH-10083: Apply Nullability to `core` `handler` package

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/ErrorMessagePublisher.java
@@ -70,7 +70,7 @@ public class ErrorMessagePublisher implements BeanFactoryAware {
 		this.errorMessageStrategy = errorMessageStrategy;
 	}
 
-	public final void setChannel(MessageChannel channel) {
+	public final void setChannel(@Nullable MessageChannel channel) {
 		this.channel = channel;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/RecoveryCallback.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/RecoveryCallback.java
@@ -35,6 +35,6 @@ public interface RecoveryCallback<T extends @Nullable Object> {
 	 * @param cause the cause of the failure
 	 * @return an Object that can be used to replace the callback result that failed
 	 */
-	T recover(AttributeAccessor context, Throwable cause);
+	T recover(AttributeAccessor context, @Nullable Throwable cause);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/RecoveryCallback.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/RecoveryCallback.java
@@ -35,6 +35,6 @@ public interface RecoveryCallback<T extends @Nullable Object> {
 	 * @param cause the cause of the failure
 	 * @return an Object that can be used to replace the callback result that failed
 	 */
-	T recover(AttributeAccessor context, @Nullable Throwable cause);
+	T recover(AttributeAccessor context, Throwable cause);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProcessorMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProcessorMessageSource.java
@@ -19,6 +19,8 @@ package org.springframework.integration.endpoint;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.handler.MessageProcessor;
+import org.springframework.integration.support.MutableMessageBuilder;
+import org.springframework.messaging.Message;
 
 /**
  * The {@link org.springframework.integration.core.MessageSource} strategy implementation
@@ -45,7 +47,9 @@ public class MessageProcessorMessageSource extends AbstractMessageSource<Object>
 
 	@Override
 	protected @Nullable Object doReceive() {
-		return this.messageProcessor.processMessage(null);
+		Message<Object> fakeMessage = MutableMessageBuilder.withPayload(new Object(), false).build();
+		// provide a fake message here since the contract of processMessage requires a NonNull Message.
+		return this.messageProcessor.processMessage(fakeMessage);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProcessorMessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProcessorMessageSource.java
@@ -29,10 +29,14 @@ import org.springframework.messaging.Message;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Jiandong Ma
  *
  * @since 5.0
  */
 public class MessageProcessorMessageSource extends AbstractMessageSource<Object> {
+
+	// provide a fake message since the contract of processMessage requires a NonNull Message.
+	static final Message<Object> FAKE_MESSAGE = MutableMessageBuilder.withPayload(new Object(), false).build();
 
 	private final MessageProcessor<?> messageProcessor;
 
@@ -47,9 +51,7 @@ public class MessageProcessorMessageSource extends AbstractMessageSource<Object>
 
 	@Override
 	protected @Nullable Object doReceive() {
-		Message<Object> fakeMessage = MutableMessageBuilder.withPayload(new Object(), false).build();
-		// provide a fake message here since the contract of processMessage requires a NonNull Message.
-		return this.messageProcessor.processMessage(fakeMessage);
+		return this.messageProcessor.processMessage(FAKE_MESSAGE);
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/filter/MessageFilter.java
@@ -176,7 +176,7 @@ public class MessageFilter extends AbstractReplyProducingPostProcessingMessageHa
 	}
 
 	@Override
-	public Object postProcess(Message<?> message, Object result) {
+	public @Nullable Object postProcess(Message<?> message, @Nullable Object result) {
 		if (result == null) {
 			MessageChannel channelToDiscard = getDiscardChannel();
 			if (channelToDiscard != null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageHandler.java
@@ -55,7 +55,7 @@ public abstract class AbstractMessageHandler extends MessageHandlerSupport
 		this.observationConvention = observationConvention;
 	}
 
-	@Override // NOSONAR
+	@Override
 	public void handleMessage(Message<?> message) {
 		Assert.notNull(message, "Message must not be null");
 		if (isLoggingEnabled()) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -551,13 +551,11 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		return true;
 	}
 
-	protected void sendErrorMessage(Message<?> requestMessage, @Nullable Throwable ex) {
+	protected void sendErrorMessage(Message<?> requestMessage, Throwable ex) {
 		Object errorChannel = resolveErrorChannel(requestMessage.getHeaders());
 		Throwable result = ex;
 		if (!(result instanceof MessagingException)) {
-			result = ex == null
-					? new MessageHandlingException(requestMessage)
-					: new MessageHandlingException(requestMessage, ex);
+			result = new MessageHandlingException(requestMessage, ex);
 		}
 		if (errorChannel == null) {
 			logger.error(result,
@@ -633,7 +631,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 				}
 				catch (Exception ex) {
 					Exception exceptionToLogAndSend = ex;
-					if (!(ex instanceof MessagingException)) { // NOSONAR
+					if (!(ex instanceof MessagingException)) {
 						exceptionToLogAndSend = new MessageHandlingException(this.requestMessage, ex);
 						if (replyMessage != null) {
 							exceptionToLogAndSend = new MessagingException(replyMessage, exceptionToLogAndSend);
@@ -644,11 +642,12 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 				}
 			}
 			else if (exception != null) {
-				onFailure(exception instanceof CompletionException ? exception.getCause() : exception);
+				onFailure(exception instanceof CompletionException && exception.getCause() != null
+						? exception.getCause() : exception);
 			}
 		}
 
-		private void onFailure(@Nullable Throwable ex) {
+		private void onFailure(Throwable ex) {
 			sendErrorMessage(this.requestMessage, ex);
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -31,7 +31,6 @@ import org.springframework.integration.IntegrationPatternType;
 import org.springframework.integration.handler.advice.HandleMessageAdvice;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 
 /**
  * Base class for MessageHandlers that are capable of producing replies.
@@ -53,11 +52,12 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 
 	private final List<Advice> adviceChain = new LinkedList<>();
 
-	private ClassLoader beanClassLoader = ClassUtils.getDefaultClassLoader();
+	@SuppressWarnings("NullAway.Init")
+	private ClassLoader beanClassLoader;
 
 	private boolean requiresReply = false;
 
-	private volatile RequestHandler advisedRequestHandler;
+	private volatile @Nullable RequestHandler advisedRequestHandler;
 
 	/**
 	 * Flag whether a reply is required. If true an incoming message MUST result in a reply message being sent.
@@ -160,6 +160,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 		}
 	}
 
+	@SuppressWarnings("NullAway") // dataflow analysis limitation
 	@Nullable
 	protected Object doInvokeAdvisedRequestHandler(Message<?> message) {
 		return this.advisedRequestHandler.handleRequestMessage(message);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractReplyProducingMessageHandler.java
@@ -161,8 +161,7 @@ public abstract class AbstractReplyProducingMessageHandler extends AbstractMessa
 	}
 
 	@SuppressWarnings("NullAway") // dataflow analysis limitation
-	@Nullable
-	protected Object doInvokeAdvisedRequestHandler(Message<?> message) {
+	protected @Nullable Object doInvokeAdvisedRequestHandler(Message<?> message) {
 		return this.advisedRequestHandler.handleRequestMessage(message);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/BeanNameMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/BeanNameMessageProcessor.java
@@ -37,13 +37,15 @@ public class BeanNameMessageProcessor<T> implements MessageProcessor<T>, BeanFac
 
 	private final String beanName;
 
-	private final String methodName;
+	private final @Nullable String methodName;
 
+	@SuppressWarnings("NullAway.Init")
 	private MessageProcessor<T> delegate;
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
-	public BeanNameMessageProcessor(String object, String methodName) {
+	public BeanNameMessageProcessor(String object, @Nullable String methodName) {
 		this.beanName = object;
 		this.methodName = methodName;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ControlBusMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ControlBusMessageProcessor.java
@@ -18,6 +18,8 @@ package org.springframework.integration.handler;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.expression.Expression;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.IntegrationPattern;
@@ -41,6 +43,7 @@ import org.springframework.util.CollectionUtils;
 public class ControlBusMessageProcessor extends AbstractMessageProcessor<Object>
 		implements IntegrationPattern {
 
+	@SuppressWarnings("NullAway.Init")
 	private ControlBusCommandRegistry controlBusCommandRegistry;
 
 	public ControlBusMessageProcessor() {
@@ -69,7 +72,7 @@ public class ControlBusMessageProcessor extends AbstractMessageProcessor<Object>
 	}
 
 	@Override
-	public Object processMessage(Message<?> message) {
+	public @Nullable Object processMessage(Message<?> message) {
 		String command = message.getPayload().toString();
 		@SuppressWarnings("unchecked")
 		List<Object> arguments =

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageHandler.java
@@ -35,8 +35,7 @@ public class ExpressionEvaluatingMessageHandler extends AbstractMessageHandler {
 
 	private final ExpressionEvaluatingMessageProcessor<Void> processor;
 
-	@SuppressWarnings("NullAway.Init")
-	private String componentType;
+	private String componentType = "expression-evaluating-handler";
 
 	@SuppressWarnings("this-escape")
 	public ExpressionEvaluatingMessageHandler(Expression expression) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageHandler.java
@@ -35,6 +35,7 @@ public class ExpressionEvaluatingMessageHandler extends AbstractMessageHandler {
 
 	private final ExpressionEvaluatingMessageProcessor<Void> processor;
 
+	@SuppressWarnings("NullAway.Init")
 	private String componentType;
 
 	@SuppressWarnings("this-escape")

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ExpressionEvaluatingMessageProcessor.java
@@ -39,7 +39,7 @@ public class ExpressionEvaluatingMessageProcessor<T> extends AbstractMessageProc
 
 	private final Expression expression;
 
-	private final Class<T> expectedType;
+	private final @Nullable Class<T> expectedType;
 
 	/**
 	 * Create an {@link ExpressionEvaluatingMessageProcessor} for the given expression.

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
@@ -61,8 +61,7 @@ public class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFac
 
 	private final Method method;
 
-	@Nullable
-	private final Class<?> expectedType;
+	private final @Nullable Class<?> expectedType;
 
 	private final Class<?>[] parameterTypes;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/LambdaMessageProcessor.java
@@ -66,6 +66,7 @@ public class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFac
 
 	private final Class<?>[] parameterTypes;
 
+	@SuppressWarnings("NullAway.Init")
 	private MessageConverter messageConverter;
 
 	/**
@@ -114,8 +115,8 @@ public class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFac
 	}
 
 	@Override
-	public Object processMessage(Message<?> message) {
-		Object[] args = buildArgs(message);
+	public @Nullable Object processMessage(Message<?> message) {
+		@Nullable Object[] args = buildArgs(message);
 
 		try {
 			Object result = invokeMethod(args);
@@ -149,8 +150,8 @@ public class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFac
 		}
 	}
 
-	private Object[] buildArgs(Message<?> message) {
-		Object[] args = new Object[this.parameterTypes.length];
+	private @Nullable Object[] buildArgs(Message<?> message) {
+		@Nullable Object[] args = new Object[this.parameterTypes.length];
 		for (int i = 0; i < this.parameterTypes.length; i++) {
 			Class<?> parameterType = this.parameterTypes[i];
 			if (Message.class.isAssignableFrom(parameterType)) {
@@ -189,8 +190,9 @@ public class LambdaMessageProcessor implements MessageProcessor<Object>, BeanFac
 		return args;
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes"})
-	private Object invokeMethod(Object[] args) throws InvocationTargetException, IllegalAccessException {
+	@SuppressWarnings({"unchecked", "rawtypes", "NullAway"})
+	// allow null items passing into the underlying functional method
+	private @Nullable Object invokeMethod(@Nullable Object[] args) throws InvocationTargetException, IllegalAccessException {
 		if (this.target instanceof Consumer consumer) {
 			consumer.accept(args[0]);
 			return null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/LoggingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/LoggingHandler.java
@@ -23,8 +23,6 @@ import java.util.Objects;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import org.jspecify.annotations.Nullable;
-
 import org.springframework.core.log.LogAccessor;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.Expression;
@@ -189,19 +187,18 @@ public class LoggingHandler extends AbstractMessageHandler {
 		}
 	}
 
-	@Nullable
 	private String createLogMessage(Message<?> message) {
 		Object logMessage = this.expression.getValue(this.evaluationContext, message);
-		return logMessage instanceof Throwable
-				? createLogMessage((Throwable) logMessage)
+		return logMessage instanceof Throwable throwableMessage
+				? createLogMessage(throwableMessage)
 				: Objects.toString(logMessage);
 	}
 
 	private static String createLogMessage(Throwable throwable) {
 		StringWriter stringWriter = new StringWriter();
-		if (throwable instanceof AggregateMessageDeliveryException) {
+		if (throwable instanceof AggregateMessageDeliveryException aggregateMessageDeliveryException) {
 			stringWriter.append(throwable.getMessage());
-			for (Exception exception : ((AggregateMessageDeliveryException) throwable).getAggregatedExceptions()) {
+			for (Exception exception : aggregateMessageDeliveryException.getAggregatedExceptions()) {
 				printStackTrace(exception, stringWriter);
 			}
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerChain.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerChain.java
@@ -76,6 +76,7 @@ public class MessageHandlerChain extends AbstractMessageProducingHandler
 
 	private final ReentrantLock lifecycleLock = new ReentrantLock();
 
+	@SuppressWarnings("NullAway.Init")
 	private List<MessageHandler> handlers;
 
 	private volatile boolean initialized;
@@ -137,14 +138,14 @@ public class MessageHandlerChain extends AbstractMessageProducingHandler
 
 				// If this 'handler' is a nested non-last &lt;chain&gt;, it is  necessary
 				// to 'force' re-init it for check its configuration in conjunction with current MessageHandlerChain.
-				if (handler instanceof MessageHandlerChain) {
-					((MessageHandlerChain) handler).initialized = false;
-					((MessageHandlerChain) handler).afterPropertiesSet();
+				if (handler instanceof MessageHandlerChain messageHandlerChain) {
+					messageHandlerChain.initialized = false;
+					messageHandlerChain.afterPropertiesSet();
 				}
 			}
-			else if (handler instanceof MessageProducer) {
+			else if (handler instanceof MessageProducer messageProducer) {
 				MessageChannel replyChannel = new ReplyForwardingMessageChannel();
-				((MessageProducer) handler).setOutputChannel(replyChannel);
+				messageProducer.setOutputChannel(replyChannel);
 			}
 			else {
 				Assert.isNull(getOutputChannel(),
@@ -221,16 +222,16 @@ public class MessageHandlerChain extends AbstractMessageProducingHandler
 
 	private void doStop() {
 		for (MessageHandler handler : this.handlers) {
-			if (handler instanceof Lifecycle) {
-				((Lifecycle) handler).stop();
+			if (handler instanceof Lifecycle lifecycle) {
+				lifecycle.stop();
 			}
 		}
 	}
 
 	private void doStart() {
 		for (MessageHandler handler : this.handlers) {
-			if (handler instanceof Lifecycle) {
-				((Lifecycle) handler).start();
+			if (handler instanceof Lifecycle lifecycle) {
+				lifecycle.start();
 			}
 		}
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MessageHandlerSupport.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import io.micrometer.observation.ObservationRegistry;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.Ordered;
 import org.springframework.integration.IntegrationPattern;
@@ -62,17 +63,17 @@ public abstract class MessageHandlerSupport extends IntegrationObjectSupport
 
 	private boolean loggingEnabled = true;
 
-	private MetricsCaptor metricsCaptor;
+	private @Nullable MetricsCaptor metricsCaptor;
 
 	private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
 	private int order = Ordered.LOWEST_PRECEDENCE;
 
-	private String managedName;
+	private @Nullable String managedName;
 
-	private String managedType;
+	private @Nullable String managedType;
 
-	private TimerFacade successTimer;
+	private @Nullable TimerFacade successTimer;
 
 	@Override
 	public boolean isLoggingEnabled() {
@@ -90,7 +91,7 @@ public abstract class MessageHandlerSupport extends IntegrationObjectSupport
 		this.metricsCaptor = metricsCaptorToRegister;
 	}
 
-	protected MetricsCaptor getMetricsCaptor() {
+	protected @Nullable MetricsCaptor getMetricsCaptor() {
 		return this.metricsCaptor;
 	}
 
@@ -150,10 +151,11 @@ public abstract class MessageHandlerSupport extends IntegrationObjectSupport
 		return this.successTimer;
 	}
 
+	@SuppressWarnings("NullAway") // dataflow analysis limitation
 	protected TimerFacade buildSendTimer(boolean success, String exception) {
 		TimerFacade timer = this.metricsCaptor.timerBuilder(SEND_TIMER_NAME)
 				.tag("type", "handler")
-				.tag("name", getComponentName() == null ? "unknown" : getComponentName())
+				.tag("name", getComponentName())
 				.tag("result", success ? "success" : "failure")
 				.tag("exception", exception)
 				.description("Send processing time")
@@ -166,7 +168,7 @@ public abstract class MessageHandlerSupport extends IntegrationObjectSupport
 		this.managedName = managedName;
 	}
 
-	public String getManagedName() {
+	public @Nullable String getManagedName() {
 		return this.managedName;
 	}
 
@@ -174,7 +176,7 @@ public abstract class MessageHandlerSupport extends IntegrationObjectSupport
 		this.managedType = managedType;
 	}
 
-	public String getManagedType() {
+	public @Nullable String getManagedType() {
 		return this.managedType;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
@@ -36,8 +36,7 @@ public class MethodInvokingMessageHandler extends AbstractMessageHandler impleme
 
 	private final MethodInvokingMessageProcessor<Object> processor;
 
-	@SuppressWarnings("NullAway.Init")
-	private String componentType;
+	private String componentType = "method-invoking-handler";
 
 	public MethodInvokingMessageHandler(Object object, Method method) {
 		Assert.isTrue(method.getReturnType().equals(void.class),

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageHandler.java
@@ -36,6 +36,7 @@ public class MethodInvokingMessageHandler extends AbstractMessageHandler impleme
 
 	private final MethodInvokingMessageProcessor<Object> processor;
 
+	@SuppressWarnings("NullAway.Init")
 	private String componentType;
 
 	public MethodInvokingMessageHandler(Object object, Method method) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/MethodInvokingMessageProcessor.java
@@ -53,11 +53,11 @@ public class MethodInvokingMessageProcessor<T> extends AbstractMessageProcessor<
 		this.delegate = new MessagingMethodInvokerHelper(targetObject, method, false);
 	}
 
-	public MethodInvokingMessageProcessor(Object targetObject, String methodName) {
+	public MethodInvokingMessageProcessor(Object targetObject, @Nullable String methodName) {
 		this.delegate = new MessagingMethodInvokerHelper(targetObject, methodName, false);
 	}
 
-	public MethodInvokingMessageProcessor(Object targetObject, String methodName, boolean canProcessMessageList) {
+	public MethodInvokingMessageProcessor(Object targetObject, @Nullable String methodName, boolean canProcessMessageList) {
 		this.delegate = new MessagingMethodInvokerHelper(targetObject, methodName, canProcessMessageList);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/PostProcessingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/PostProcessingMessageHandler.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.handler;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 
 /**
@@ -36,6 +38,6 @@ public interface PostProcessingMessageHandler {
 	 * @param message The message.
 	 * @return The post-processed result.
 	 */
-	Object postProcess(Message<?> message, Object result);
+	@Nullable Object postProcess(Message<?> message, @Nullable Object result);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ReplyProducingMessageHandlerWrapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ReplyProducingMessageHandlerWrapper.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.handler;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.context.Lifecycle;
 import org.springframework.integration.IntegrationPattern;
 import org.springframework.integration.IntegrationPatternType;
@@ -49,35 +51,35 @@ public class ReplyProducingMessageHandlerWrapper extends AbstractReplyProducingM
 
 	@Override
 	public IntegrationPatternType getIntegrationPatternType() {
-		return (this.target instanceof IntegrationPattern)
-				? ((IntegrationPattern) this.target).getIntegrationPatternType()
+		return (this.target instanceof IntegrationPattern integrationPattern)
+				? integrationPattern.getIntegrationPatternType()
 				: IntegrationPatternType.service_activator;
 	}
 
 	@Override
-	protected Object handleRequestMessage(Message<?> requestMessage) {
+	protected @Nullable Object handleRequestMessage(Message<?> requestMessage) {
 		this.target.handleMessage(requestMessage);
 		return null;
 	}
 
 	@Override
 	public void start() {
-		if (this.target instanceof Lifecycle) {
-			((Lifecycle) this.target).start();
+		if (this.target instanceof Lifecycle lifecycle) {
+			lifecycle.start();
 		}
 
 	}
 
 	@Override
 	public void stop() {
-		if (this.target instanceof Lifecycle) {
-			((Lifecycle) this.target).stop();
+		if (this.target instanceof Lifecycle lifecycle) {
+			lifecycle.stop();
 		}
 	}
 
 	@Override
 	public boolean isRunning() {
-		return !(this.target instanceof Lifecycle) || ((Lifecycle) this.target).isRunning();
+		return !(this.target instanceof Lifecycle lifecycle) || lifecycle.isRunning();
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/ServiceActivatingHandler.java
@@ -59,8 +59,8 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 
 	@Override
 	public IntegrationPatternType getIntegrationPatternType() {
-		return (this.processor instanceof IntegrationPattern)
-				? ((IntegrationPattern) this.processor).getIntegrationPatternType()
+		return (this.processor instanceof IntegrationPattern integrationPattern)
+				? integrationPattern.getIntegrationPatternType()
 				: IntegrationPatternType.service_activator;
 	}
 
@@ -71,21 +71,21 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 
 	@Override
 	public void start() {
-		if (this.processor instanceof Lifecycle) {
-			((Lifecycle) this.processor).start();
+		if (this.processor instanceof Lifecycle lifecycle) {
+			lifecycle.start();
 		}
 	}
 
 	@Override
 	public void stop() {
-		if (this.processor instanceof Lifecycle) {
-			((Lifecycle) this.processor).stop();
+		if (this.processor instanceof Lifecycle lifecycle) {
+			lifecycle.stop();
 		}
 	}
 
 	@Override
 	public boolean isRunning() {
-		return !(this.processor instanceof Lifecycle) || ((Lifecycle) this.processor).isRunning();
+		return !(this.processor instanceof Lifecycle lifecycle) || lifecycle.isRunning();
 	}
 
 	@Override
@@ -97,7 +97,7 @@ public class ServiceActivatingHandler extends AbstractReplyProducingMessageHandl
 	@Override
 	public String toString() {
 		return "ServiceActivator for [" + this.processor + "]"
-				+ (getComponentName() == null ? "" : " (" + getComponentName() + ")");
+				+ " (" + getComponentName() + ")";
 	}
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractHandleMessageAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractHandleMessageAdvice.java
@@ -19,6 +19,7 @@ package org.springframework.integration.handler.advice;
 import java.lang.reflect.Method;
 
 import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.messaging.Message;
@@ -35,11 +36,12 @@ import org.springframework.messaging.MessageHandler;
  */
 public abstract class AbstractHandleMessageAdvice extends IntegrationObjectSupport implements HandleMessageAdvice {
 
+	@SuppressWarnings("NullAway") // dataflow analysis limitation, invocationThis and message won't be null.
 	@Override
-	public final Object invoke(MethodInvocation invocation) throws Throwable { // NOSONAR
+	public final @Nullable Object invoke(MethodInvocation invocation) throws Throwable {
 		Method method = invocation.getMethod();
 		Object invocationThis = invocation.getThis();
-		Object[] arguments = invocation.getArguments();
+		@Nullable Object[] arguments = invocation.getArguments();
 		boolean isMessageHandler = invocationThis instanceof MessageHandler;
 		boolean isMessageMethod = method.getName().equals("handleMessage")
 				&& (arguments.length == 1 && arguments[0] instanceof Message);
@@ -59,6 +61,6 @@ public abstract class AbstractHandleMessageAdvice extends IntegrationObjectSuppo
 		return doInvoke(invocation, message);
 	}
 
-	protected abstract Object doInvoke(MethodInvocation invocation, Message<?> message) throws Throwable; // NOSONAR
+	protected abstract @Nullable Object doInvoke(MethodInvocation invocation, Message<?> message) throws Throwable;
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/AbstractRequestHandlerAdvice.java
@@ -27,7 +27,6 @@ import org.springframework.integration.context.IntegrationObjectSupport;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.MessagingException;
-import org.springframework.util.Assert;
 
 /**
  * Base class for {@link MessageHandler} advice classes. Subclasses should provide an
@@ -113,9 +112,8 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 	 */
 	protected Throwable unwrapThrowableIfNecessary(Exception e) {
 		Throwable actualThrowable = e;
-		if (e instanceof ThrowableHolderException) {
-			actualThrowable = e.getCause();
-			Assert.state(actualThrowable != null, "'actualThrowable' must not be null");
+		if (e instanceof ThrowableHolderException throwableHolderException) {
+			actualThrowable = throwableHolderException.getCause();
 		}
 		return actualThrowable;
 	}
@@ -201,6 +199,12 @@ public abstract class AbstractRequestHandlerAdvice extends IntegrationObjectSupp
 
 		ThrowableHolderException(Throwable cause) {
 			super(cause);
+		}
+
+		@Override
+		public synchronized Throwable getCause() {
+			Throwable cause = super.getCause();
+			return cause != null ? cause : this;
 		}
 
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ContextHolderRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ContextHolderRequestHandlerAdvice.java
@@ -19,6 +19,8 @@ package org.springframework.integration.handler.advice;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
@@ -58,7 +60,7 @@ public class ContextHolderRequestHandlerAdvice extends AbstractRequestHandlerAdv
 	}
 
 	@Override
-	protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
+	protected @Nullable Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
 		Object value = this.valueProvider.apply(message);
 		logger.trace(() -> "Setting context value to: " + value + " from message: " + message);
 		try {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -59,8 +59,9 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	 * The {@link DefaultErrorMessageStrategy} is used for building an error message to publish.
 	 * @param channel the message channel to publish error messages on recovery action.
 	 */
+	@SuppressWarnings("this-escape")
 	public ErrorMessageSendingRecoverer(@Nullable MessageChannel channel) {
-		this(channel, null);
+		setChannel(channel);
 	}
 
 	/**
@@ -74,7 +75,7 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	 * @since 4.3.10
 	 */
 	@SuppressWarnings("this-escape")
-	public ErrorMessageSendingRecoverer(@Nullable MessageChannel channel, @Nullable ErrorMessageStrategy errorMessageStrategy) {
+	public ErrorMessageSendingRecoverer(MessageChannel channel, ErrorMessageStrategy errorMessageStrategy) {
 		setChannel(channel);
 		setErrorMessageStrategy(
 				errorMessageStrategy == null
@@ -83,7 +84,7 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	}
 
 	@Override
-	public @Nullable Object recover(AttributeAccessor context, @Nullable Throwable cause) {
+	public @Nullable Object recover(AttributeAccessor context, Throwable cause) {
 		publish(cause, context);
 		return null;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ErrorMessageSendingRecoverer.java
@@ -18,6 +18,8 @@ package org.springframework.integration.handler.advice;
 
 import java.io.Serial;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.AttributeAccessor;
 import org.springframework.integration.core.ErrorMessagePublisher;
 import org.springframework.integration.core.RecoveryCallback;
@@ -40,7 +42,7 @@ import org.springframework.messaging.MessagingException;
  * @since 2.2
  *
  */
-public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implements RecoveryCallback<Object> {
+public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implements RecoveryCallback<@Nullable Object> {
 
 	/**
 	 * Construct instance with the default {@code errorChannel}
@@ -57,7 +59,7 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	 * The {@link DefaultErrorMessageStrategy} is used for building an error message to publish.
 	 * @param channel the message channel to publish error messages on recovery action.
 	 */
-	public ErrorMessageSendingRecoverer(MessageChannel channel) {
+	public ErrorMessageSendingRecoverer(@Nullable MessageChannel channel) {
 		this(channel, null);
 	}
 
@@ -72,7 +74,7 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	 * @since 4.3.10
 	 */
 	@SuppressWarnings("this-escape")
-	public ErrorMessageSendingRecoverer(MessageChannel channel, ErrorMessageStrategy errorMessageStrategy) {
+	public ErrorMessageSendingRecoverer(@Nullable MessageChannel channel, @Nullable ErrorMessageStrategy errorMessageStrategy) {
 		setChannel(channel);
 		setErrorMessageStrategy(
 				errorMessageStrategy == null
@@ -81,7 +83,7 @@ public class ErrorMessageSendingRecoverer extends ErrorMessagePublisher implemen
 	}
 
 	@Override
-	public Object recover(AttributeAccessor context, Throwable cause) {
+	public @Nullable Object recover(AttributeAccessor context, @Nullable Throwable cause) {
 		publish(cause, context);
 		return null;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ExpressionEvaluatingRequestHandlerAdvice.java
@@ -235,7 +235,7 @@ public class ExpressionEvaluatingRequestHandlerAdvice extends AbstractRequestHan
 		}
 	}
 
-	@SuppressWarnings("NullAway") // dataflow analysis limitation
+	@SuppressWarnings("NullAway") // dataflow analysis limitation, onSuccessExpression won't be null
 	private void evaluateSuccessExpression(Message<?> message) {
 		Object evalResult;
 		try {
@@ -257,7 +257,7 @@ public class ExpressionEvaluatingRequestHandlerAdvice extends AbstractRequestHan
 		}
 	}
 
-	@SuppressWarnings("NullAway") // dataflow analysis limitation
+	@SuppressWarnings("NullAway") // dataflow analysis limitation, onFailureExpression won't be null
 	private @Nullable Object evaluateFailureExpression(Message<?> message, Exception exception) {
 		Object evalResult;
 		try {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/HandleMessageAdviceAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/HandleMessageAdviceAdapter.java
@@ -18,6 +18,7 @@ package org.springframework.integration.handler.advice;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.util.Assert;
 
@@ -43,7 +44,7 @@ public class HandleMessageAdviceAdapter implements HandleMessageAdvice {
 	}
 
 	@Override
-	public Object invoke(MethodInvocation invocation) throws Throwable {
+	public @Nullable Object invoke(MethodInvocation invocation) throws Throwable {
 		return this.delegate.invoke(invocation);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/IdempotentReceiverInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/IdempotentReceiverInterceptor.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.handler.advice;
 
 import org.aopalliance.intercept.MethodInvocation;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.MessageRejectedException;
@@ -58,9 +59,9 @@ public class IdempotentReceiverInterceptor extends AbstractHandleMessageAdvice {
 
 	private final MessageSelector messageSelector;
 
-	private MessageChannel discardChannel;
+	private @Nullable MessageChannel discardChannel;
 
-	private String discardChannelName;
+	private @Nullable String discardChannelName;
 
 	private boolean throwExceptionOnRejection;
 
@@ -141,7 +142,7 @@ public class IdempotentReceiverInterceptor extends AbstractHandleMessageAdvice {
 	}
 
 	@Override
-	protected Object doInvoke(MethodInvocation invocation, Message<?> message) throws Throwable {
+	protected @Nullable Object doInvoke(MethodInvocation invocation, Message<?> message) throws Throwable {
 		boolean accept = this.messageSelector.accept(message);
 		if (!accept) {
 			boolean discarded = false;
@@ -169,7 +170,7 @@ public class IdempotentReceiverInterceptor extends AbstractHandleMessageAdvice {
 		return invocation.proceed();
 	}
 
-	private MessageChannel obtainDiscardChannel() {
+	private @Nullable MessageChannel obtainDiscardChannel() {
 		if (this.discardChannel == null && this.discardChannelName != null) {
 			this.discardChannel = getChannelResolver().resolveDestination(this.discardChannelName);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/LockRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/LockRequestHandlerAdvice.java
@@ -59,6 +59,7 @@ public class LockRequestHandlerAdvice extends AbstractRequestHandlerAdvice {
 	@Nullable
 	private Expression waitLockDurationExpression;
 
+	@SuppressWarnings("NullAway.Init")
 	private EvaluationContext evaluationContext;
 
 	/**
@@ -152,7 +153,7 @@ public class LockRequestHandlerAdvice extends AbstractRequestHandlerAdvice {
 	}
 
 	@Override
-	protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
+	protected @Nullable Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
 		Object lockKey = this.lockKeyExpression.getValue(this.evaluationContext, message);
 		if (lockKey != null) {
 			Duration waitLockDuration = getWaitLockDuration(message);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/LockRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/LockRequestHandlerAdvice.java
@@ -152,6 +152,7 @@ public class LockRequestHandlerAdvice extends AbstractRequestHandlerAdvice {
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
 	}
 
+	@SuppressWarnings("NullAway") // CheckedCallable.call() is nullable
 	@Override
 	protected @Nullable Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
 		Object lockKey = this.lockKeyExpression.getValue(this.evaluationContext, message);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RateLimiterRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RateLimiterRequestHandlerAdvice.java
@@ -22,6 +22,7 @@ import java.time.Duration;
 import io.github.resilience4j.ratelimiter.RateLimiter;
 import io.github.resilience4j.ratelimiter.RateLimiterConfig;
 import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
@@ -126,7 +127,7 @@ public class RateLimiterRequestHandlerAdvice extends AbstractRequestHandlerAdvic
 	}
 
 	@Override
-	protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
+	protected @Nullable Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
 		try {
 			return RateLimiter.decorateSupplier(this.rateLimiter, callback::execute).get();
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ReactiveRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/ReactiveRequestHandlerAdvice.java
@@ -23,6 +23,7 @@ import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 
@@ -58,13 +59,14 @@ public class ReactiveRequestHandlerAdvice implements MethodInterceptor {
 		this.replyCustomizer = replyCustomizer;
 	}
 
+	@SuppressWarnings("NullAway") // dataflow analysis limitation, replyMono won't be null.
 	@Override
-	public final Object invoke(MethodInvocation invocation) throws Throwable {
+	public final @Nullable Object invoke(MethodInvocation invocation) throws Throwable {
 		Object result = invocation.proceed();
 
 		Method method = invocation.getMethod();
 		Object invocationThis = invocation.getThis();
-		Object[] arguments = invocation.getArguments();
+		@Nullable Object[] arguments = invocation.getArguments();
 		boolean isReactiveMethod =
 				method.getName().equals("handleRequestMessage") &&
 						(arguments.length == 1 && arguments[0] instanceof Message) &&

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerCircuitBreakerAdvice.java
@@ -20,6 +20,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 
@@ -62,7 +64,7 @@ public class RequestHandlerCircuitBreakerAdvice extends AbstractRequestHandlerAd
 	}
 
 	@Override
-	protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
+	protected @Nullable Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
 		AdvisedMetadata metadata = this.metadataMap.get(target);
 		if (metadata == null) {
 			this.metadataMap.putIfAbsent(target, new AdvisedMetadata());
@@ -83,8 +85,8 @@ public class RequestHandlerCircuitBreakerAdvice extends AbstractRequestHandlerAd
 		catch (Exception e) {
 			metadata.getFailures().incrementAndGet();
 			metadata.setLastFailure(System.currentTimeMillis());
-			if (e instanceof ThrowableHolderException) { // NOSONAR
-				throw (ThrowableHolderException) e;
+			if (e instanceof ThrowableHolderException ex) {
+				throw ex;
 			}
 			else {
 				throw new ThrowableHolderException(e);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -64,6 +64,7 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice {
 		this.retryTemplate = retryTemplate;
 	}
 
+	@SuppressWarnings("NullAway") // need rework on retry
 	public void setRecoveryCallback(RecoveryCallback<Object> recoveryCallback) {
 		this.recoveryCallback = (context) ->
 				recoveryCallback.recover(context, context.getLastThrowable());

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RequestHandlerRetryAdvice.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.handler.advice;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.support.ErrorMessageUtils;
@@ -47,7 +49,7 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice {
 
 	private RetryTemplate retryTemplate = new RetryTemplate();
 
-	private org.springframework.retry.RecoveryCallback<Object> recoveryCallback;
+	private org.springframework.retry.@Nullable RecoveryCallback<Object> recoveryCallback;
 
 	// Stateless unless a state generator is provided
 	private RetryStateGenerator retryStateGenerator = message -> null;
@@ -119,7 +121,7 @@ public class RequestHandlerRetryAdvice extends AbstractRequestHandlerAdvice {
 			implements RetryCallback<Object, Exception> {
 
 		@Override
-		public Object doWithRetry(RetryContext context) {
+		public @Nullable Object doWithRetry(RetryContext context) {
 			return this.callback.cloneAndExecute();
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RetryStateGenerator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/RetryStateGenerator.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.handler.advice;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 import org.springframework.retry.RetryState;
 
@@ -29,6 +31,7 @@ import org.springframework.retry.RetryState;
 @FunctionalInterface
 public interface RetryStateGenerator {
 
+	@Nullable
 	RetryState determineRetryState(Message<?> message);
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/SpelExpressionRetryStateGenerator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/SpelExpressionRetryStateGenerator.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.handler.advice;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -41,15 +43,15 @@ public class SpelExpressionRetryStateGenerator implements RetryStateGenerator, B
 
 	private final Expression keyExpression;
 
-	private final Expression forceRefreshExpression;
+	private final @Nullable Expression forceRefreshExpression;
 
-	private volatile Classifier<? super Throwable, Boolean> classifier;
+	private volatile @Nullable Classifier<? super Throwable, Boolean> classifier;
 
 	public SpelExpressionRetryStateGenerator(String keyExpression) {
 		this(keyExpression, null);
 	}
 
-	public SpelExpressionRetryStateGenerator(String keyExpression, String forceRefreshExpression) {
+	public SpelExpressionRetryStateGenerator(String keyExpression, @Nullable String forceRefreshExpression) {
 		Assert.notNull(keyExpression, "keyExpression must not be null");
 		this.keyExpression = new SpelExpressionParser().parseExpression(keyExpression);
 		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext();
@@ -76,7 +78,7 @@ public class SpelExpressionRetryStateGenerator implements RetryStateGenerator, B
 				? Boolean.FALSE
 				: this.forceRefreshExpression.getValue(this.evaluationContext, message, Boolean.class);
 		return new DefaultRetryState(this.keyExpression.getValue(this.evaluationContext, message),
-				forceRefresh == null ? false : forceRefresh,
+				forceRefresh != null && forceRefresh,
 				this.classifier);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/package-info.java
@@ -3,4 +3,5 @@
  * {@link org.springframework.messaging.MessageHandler}s with
  * cross-cutting concerns.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.handler.advice;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes implementing various types of message handler.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.handler;

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/CollectionArgumentResolver.java
@@ -22,6 +22,8 @@ import java.util.Iterator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.integration.util.AbstractExpressionEvaluator;
@@ -66,7 +68,7 @@ public class CollectionArgumentResolver extends AbstractExpressionEvaluator
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+	public @Nullable Object resolveArgument(MethodParameter parameter, Message<?> message) {
 		Object value = message.getPayload();
 
 		if (this.canProcessMessageList) {
@@ -86,8 +88,8 @@ public class CollectionArgumentResolver extends AbstractExpressionEvaluator
 		}
 
 		if (Iterator.class.isAssignableFrom(parameter.getParameterType())) {
-			if (value instanceof Iterable) {
-				return ((Iterable<?>) value).iterator();
+			if (value instanceof Iterable<?> iterablePayload) {
+				return iterablePayload.iterator();
 			}
 			else {
 				return Collections.singleton(value).iterator();

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationInvocableHandlerMethod.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationInvocableHandlerMethod.java
@@ -18,6 +18,8 @@ package org.springframework.integration.handler.support;
 
 import java.lang.reflect.Method;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.CoroutinesUtils;
 import org.springframework.core.KotlinDetector;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
@@ -36,7 +38,7 @@ public class IntegrationInvocableHandlerMethod extends InvocableHandlerMethod {
 	}
 
 	@Override
-	protected Object doInvoke(Object... args) throws Exception {
+	protected @Nullable Object doInvoke(@Nullable Object... args) throws Exception {
 		Method method = getBridgedMethod();
 		if (KotlinDetector.isSuspendingFunction(method)) {
 			return CoroutinesUtils.invokeSuspendingFunction(method, getBean(), args);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationMessageHandlerMethodFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationMessageHandlerMethodFactory.java
@@ -46,8 +46,10 @@ public class IntegrationMessageHandlerMethodFactory extends DefaultMessageHandle
 
 	private final boolean listCapable;
 
+	@SuppressWarnings("NullAway.Init")
 	private MessageConverter messageConverter;
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanFactory beanFactory;
 
 	public IntegrationMessageHandlerMethodFactory() {
@@ -104,12 +106,12 @@ public class IntegrationMessageHandlerMethodFactory extends DefaultMessageHandle
 		}
 
 		for (HandlerMethodArgumentResolver resolver : resolvers) {
-			if (resolver instanceof BeanFactoryAware) {
-				((BeanFactoryAware) resolver).setBeanFactory(this.beanFactory);
+			if (resolver instanceof BeanFactoryAware beanFactoryAware) {
+				beanFactoryAware.setBeanFactory(this.beanFactory);
 			}
-			if (resolver instanceof InitializingBean) {
+			if (resolver instanceof InitializingBean initializingBean) {
 				try {
-					((InitializingBean) resolver).afterPropertiesSet();
+					initializingBean.afterPropertiesSet();
 				}
 				catch (Exception ex) {
 					throw new BeanInitializationException("Cannot initialize 'HandlerMethodArgumentResolver'", ex);

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MapArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MapArgumentResolver.java
@@ -19,6 +19,8 @@ package org.springframework.integration.handler.support;
 import java.util.Map;
 import java.util.Properties;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.integration.util.AbstractExpressionEvaluator;
@@ -58,7 +60,7 @@ public class MapArgumentResolver extends AbstractExpressionEvaluator
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+	public @Nullable Object resolveArgument(MethodParameter parameter, Message<?> message) {
 		Object payload = message.getPayload();
 		if (Properties.class.isAssignableFrom(parameter.getParameterType())) {
 			Map<String, Object> map = message.getHeaders();

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -1088,15 +1088,13 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			this.invocableHandlerMethod = newInvocableHandlerMethod;
 		}
 
-		@Nullable
-		public Object invoke(ParametersWrapper parameters) {
+		@SuppressWarnings("NullAway") // critical execution path, invocableHandlerMethod and message won't be null
+		public @Nullable Object invoke(ParametersWrapper parameters) {
 			Message<?> message = parameters.getMessage();
 			if (this.canProcessMessageList) {
 				message = new MutableMessage<>(parameters.getMessages(), parameters.getHeaders());
 			}
 			try {
-				Assert.state(message != null, "'message' must not be null");
-				Assert.state(this.invocableHandlerMethod != null, "'invocableHandlerMethod' must not be null");
 				Object result = this.invocableHandlerMethod.invoke(message);
 				if (result != null
 						&& org.springframework.integration.util.ClassUtils.isKotlinUnit(result.getClass())) {
@@ -1401,11 +1399,11 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			return this.message;
 		}
 
+		@SuppressWarnings("NullAway") // dataflow analysis limitation, messages won't be null
 		public Class<?> getFirstParameterType() {
 			if (this.payload != null) {
 				return this.payload.getClass();
 			}
-			Assert.state(this.messages != null, "'messages' must not be null");
 			return this.messages.getClass();
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -169,43 +169,45 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 	private final Object targetObject;
 
-	private final JsonObjectMapper<?, ?> jsonObjectMapper;
+	private final @Nullable JsonObjectMapper<?, ?> jsonObjectMapper;
 
-	private final Map<Class<?>, HandlerMethod> handlerMethods;
+	private final @Nullable Map<Class<?>, HandlerMethod> handlerMethods;
 
-	private final Map<Class<?>, HandlerMethod> handlerMessageMethods;
+	private final @Nullable Map<Class<?>, HandlerMethod> handlerMessageMethods;
 
 	private final List<Map<Class<?>, HandlerMethod>> handlerMethodsList = new LinkedList<>();
 
-	private final TypeDescriptor expectedType;
+	private final @Nullable TypeDescriptor expectedType;
 
 	private final boolean canProcessMessageList;
 
-	private final String methodName;
+	private final @Nullable String methodName;
 
-	private final Method method;
+	private final @Nullable Method method;
 
-	private final Class<? extends Annotation> annotationType;
+	private final @Nullable Class<? extends Annotation> annotationType;
 
-	private final HandlerMethod handlerMethod;
+	private final @Nullable HandlerMethod handlerMethod;
 
 	private final String displayString;
 
 	private final boolean requiresReply;
 
-	private HandlerMethod defaultHandlerMethod;
+	private @Nullable HandlerMethod defaultHandlerMethod;
 
 	private BeanExpressionResolver resolver = new StandardBeanExpressionResolver();
 
+	@SuppressWarnings("NullAway.Init")
 	private BeanExpressionContext expressionContext;
 
 	private boolean useSpelInvoker;
 
+	@SuppressWarnings("NullAway.Init")
 	private volatile MessageHandlerMethodFactory messageHandlerMethodFactory;
 
 	private volatile boolean initialized;
 
-	public MessagingMethodInvokerHelper(Object targetObject, Method method, Class<?> expectedType,
+	public MessagingMethodInvokerHelper(Object targetObject, Method method, @Nullable Class<?> expectedType,
 			boolean canProcessMessageList) {
 
 		this(targetObject, null, method, expectedType, canProcessMessageList);
@@ -215,13 +217,13 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		this(targetObject, method, null, canProcessMessageList);
 	}
 
-	public MessagingMethodInvokerHelper(Object targetObject, String methodName, Class<?> expectedType,
+	public MessagingMethodInvokerHelper(Object targetObject, @Nullable String methodName, @Nullable Class<?> expectedType,
 			boolean canProcessMessageList) {
 
 		this(targetObject, null, methodName, expectedType, canProcessMessageList);
 	}
 
-	public MessagingMethodInvokerHelper(Object targetObject, String methodName, boolean canProcessMessageList) {
+	public MessagingMethodInvokerHelper(Object targetObject, @Nullable String methodName, boolean canProcessMessageList) {
 		this(targetObject, methodName, null, canProcessMessageList);
 	}
 
@@ -232,13 +234,13 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 	}
 
 	public MessagingMethodInvokerHelper(Object targetObject, Class<? extends Annotation> annotationType,
-			Class<?> expectedType, boolean canProcessMessageList) {
+			@Nullable Class<?> expectedType, boolean canProcessMessageList) {
 
 		this(targetObject, annotationType, (String) null, expectedType, canProcessMessageList);
 	}
 
-	private MessagingMethodInvokerHelper(Object targetObject, Class<? extends Annotation> annotationType,
-			Method method, Class<?> expectedType, boolean canProcessMessageList) {
+	private MessagingMethodInvokerHelper(Object targetObject, @Nullable Class<? extends Annotation> annotationType,
+			Method method, @Nullable Class<?> expectedType, boolean canProcessMessageList) {
 
 		this.annotationType = annotationType;
 		this.canProcessMessageList = canProcessMessageList;
@@ -266,8 +268,8 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		this.jsonObjectMapper = configureJsonObjectMapperIfAny();
 	}
 
-	private MessagingMethodInvokerHelper(Object targetObject, Class<? extends Annotation> annotationType,
-			String methodName, Class<?> expectedType, boolean canProcessMessageList) {
+	private MessagingMethodInvokerHelper(Object targetObject, @Nullable Class<? extends Annotation> annotationType,
+			@Nullable String methodName, @Nullable Class<?> expectedType, boolean canProcessMessageList) {
 
 		Assert.notNull(targetObject, "targetObject must not be null");
 		this.annotationType = annotationType;
@@ -300,6 +302,8 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		Map<String, Map<Class<?>, HandlerMethod>> handlerMethodsForTarget = findHandlerMethodsForTarget();
 		Map<Class<?>, HandlerMethod> methods = handlerMethodsForTarget.get(CANDIDATE_METHODS);
 		Map<Class<?>, HandlerMethod> messageMethods = handlerMethodsForTarget.get(CANDIDATE_MESSAGE_METHODS);
+		Assert.state(methods != null, "candidate methods must not be null");
+		Assert.state(messageMethods != null, "candidate messageMethods must not be null");
 		if ((methods.size() == 1 && messageMethods.isEmpty()) ||
 				(messageMethods.size() == 1 && methods.isEmpty())) {
 			if (methods.size() == 1) {
@@ -323,7 +327,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		this.jsonObjectMapper = configureJsonObjectMapperIfAny();
 	}
 
-	private JsonObjectMapper<?, ?> configureJsonObjectMapperIfAny() {
+	private @Nullable JsonObjectMapper<?, ?> configureJsonObjectMapperIfAny() {
 		try {
 			return JsonObjectMapperProvider.newInstance();
 		}
@@ -362,7 +366,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 	}
 
 	@Nullable
-	public Object process(Collection<Message<?>> messages, Map<String, Object> headers) {
+	public Object process(Collection<Message<?>> messages, @Nullable Map<String, Object> headers) {
 		ParametersWrapper parameters = new ParametersWrapper(messages, headers);
 		return processInternal(parameters);
 	}
@@ -406,12 +410,12 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		return this.messageHandlerMethodFactory.createInvocableHandlerMethod(this.targetObject, method);
 	}
 
-	private String buildDisplayString(Object targetObject, Object targetMethod) {
+	private String buildDisplayString(Object targetObject, @Nullable Object targetMethod) {
 		StringBuilder sb =
 				new StringBuilder(targetObject.getClass().getName())
 						.append('.');
-		if (targetMethod instanceof Method) {
-			sb.append(((Method) targetMethod).getName());
+		if (targetMethod instanceof Method target) {
+			sb.append(target.getName());
 		}
 		else if (targetMethod instanceof String) {
 			sb.append(targetMethod);
@@ -555,11 +559,12 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			parser = EXPRESSION_PARSER_DEFAULT;
 		}
 		else {
-			String compilerMode = resolveExpression(candidate.useSpelInvoker.compilerMode()).toUpperCase();
+			String compilerMode = resolveExpression(candidate.useSpelInvoker.compilerMode());
 			parser = !StringUtils.hasText(compilerMode)
 					? EXPRESSION_PARSER_DEFAULT
-					: SPEL_COMPILERS.get(SpelCompilerMode.valueOf(compilerMode));
+					: SPEL_COMPILERS.get(SpelCompilerMode.valueOf(compilerMode.toUpperCase()));
 		}
+		Assert.state(parser != null, "'parser' must not be null");
 		candidate.expression = parser.parseExpression(candidate.expressionString);
 		if (!this.useSpelInvoker && !candidate.spelOnly) {
 			candidate.setInvocableHandlerMethod(createInvocableHandlerMethod(candidate.method));
@@ -583,7 +588,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		}
 	}
 
-	private Object processInvokeExceptionAndFallbackToExpressionIfAny(HandlerMethod handlerMethod,
+	private @Nullable Object processInvokeExceptionAndFallbackToExpressionIfAny(HandlerMethod handlerMethod,
 			ParametersWrapper parameters, RuntimeException ex) {
 
 		if (ex instanceof MessageConversionException) {
@@ -592,10 +597,11 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 				throw ex;
 			}
 		}
-		else if (ex instanceof IllegalStateException && // NOSONAR complex boolean expression
+		else if (ex instanceof IllegalStateException &&
 				(!(ex.getCause() instanceof IllegalArgumentException) ||
 						!ex.getStackTrace()[0].getClassName().equals(InvocableHandlerMethod.class.getName()) ||
 						(!"argument type mismatch".equals(ex.getCause().getMessage()) &&
+								ex.getCause().getMessage() != null &&
 								// JVM generates GeneratedMethodAccessor### after several calls with less error
 								// checking
 								!ex.getCause().getMessage().startsWith("java.lang.ClassCastException@")))) {
@@ -605,7 +611,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		return fallbackToInvokeExpression(handlerMethod, parameters);
 	}
 
-	private Object fallbackToInvokeExpression(HandlerMethod handlerMethod, ParametersWrapper parameters) {
+	private @Nullable Object fallbackToInvokeExpression(HandlerMethod handlerMethod, ParametersWrapper parameters) {
 		Expression expression = handlerMethod.expression;
 
 		if (++handlerMethod.failedAttempts >= FAILED_ATTEMPTS_THRESHOLD) {
@@ -619,7 +625,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		return invokeExpression(expression, parameters);
 	}
 
-	private Object invokeExpression(Expression expression, ParametersWrapper parameters) {
+	private @Nullable Object invokeExpression(Expression expression, ParametersWrapper parameters) {
 		try {
 
 			convertJsonPayloadIfNecessary(parameters);
@@ -663,6 +669,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		}
 	}
 
+	@SuppressWarnings("NullAway") // dataflow analysis limitation
 	private void doConvertJsonPayload(ParametersWrapper parameters) {
 		try {
 			Object targetPayload =
@@ -695,8 +702,8 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		Map<Class<?>, HandlerMethod> candidateMessageMethods = new HashMap<>();
 		Map<Class<?>, HandlerMethod> fallbackMethods = new HashMap<>();
 		Map<Class<?>, HandlerMethod> fallbackMessageMethods = new HashMap<>();
-		AtomicReference<Class<?>> ambiguousFallbackType = new AtomicReference<>();
-		AtomicReference<Class<?>> ambiguousFallbackMessageGenericType = new AtomicReference<>();
+		AtomicReference<@Nullable Class<?>> ambiguousFallbackType = new AtomicReference<>();
+		AtomicReference<@Nullable Class<?>> ambiguousFallbackMessageGenericType = new AtomicReference<>();
 		Class<?> targetClass = getTargetClass(this.targetObject);
 
 		processMethodsFromTarget(candidateMethods, candidateMessageMethods, fallbackMethods, fallbackMessageMethods,
@@ -735,8 +742,8 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 	}
 
 	private void validateFallbackMethods(Map<Class<?>, HandlerMethod> fallbackMethods,
-			Map<Class<?>, HandlerMethod> fallbackMessageMethods, AtomicReference<Class<?>> ambiguousFallbackType,
-			AtomicReference<Class<?>> ambiguousFallbackMessageGenericType) {
+			Map<Class<?>, HandlerMethod> fallbackMessageMethods, AtomicReference<@Nullable Class<?>> ambiguousFallbackType,
+			AtomicReference<@Nullable Class<?>> ambiguousFallbackMessageGenericType) {
 		Assert.state(!fallbackMethods.isEmpty() || !fallbackMessageMethods.isEmpty(),
 				() -> "Target object of type [" + this.targetObject.getClass() +
 						"] has no eligible methods for handling Messages.");
@@ -753,8 +760,8 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 	private void processMethodsFromTarget(Map<Class<?>, HandlerMethod> candidateMethods,
 			Map<Class<?>, HandlerMethod> candidateMessageMethods, Map<Class<?>, HandlerMethod> fallbackMethods,
-			Map<Class<?>, HandlerMethod> fallbackMessageMethods, AtomicReference<Class<?>> ambiguousFallbackType,
-			AtomicReference<Class<?>> ambiguousFallbackMessageGenericType, Class<?> targetClass) {
+			Map<Class<?>, HandlerMethod> fallbackMessageMethods, AtomicReference<@Nullable Class<?>> ambiguousFallbackType,
+			AtomicReference<@Nullable Class<?>> ambiguousFallbackMessageGenericType, Class<?> targetClass) {
 
 		ReflectionUtils.doWithMethods(targetClass, method1 -> {
 			boolean matchesAnnotation = false;
@@ -828,8 +835,8 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 	private void populateHandlerMethod(Map<Class<?>, HandlerMethod> candidateMethods,
 			Map<Class<?>, HandlerMethod> candidateMessageMethods, Map<Class<?>, HandlerMethod> fallbackMethods,
-			Map<Class<?>, HandlerMethod> fallbackMessageMethods, AtomicReference<Class<?>> ambiguousFallbackType,
-			AtomicReference<Class<?>> ambiguousFallbackMessageGenericType, boolean matchesAnnotation,
+			Map<Class<?>, HandlerMethod> fallbackMessageMethods, AtomicReference<@Nullable Class<?>> ambiguousFallbackType,
+			AtomicReference<@Nullable Class<?>> ambiguousFallbackMessageGenericType, boolean matchesAnnotation,
 			HandlerMethod handlerMethod1) {
 
 		Class<?> targetParameterType = handlerMethod1.getTargetParameterType();
@@ -898,7 +905,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 	private void findSingleSpecificMethodOnInterfacesIfProxy(Map<Class<?>, HandlerMethod> candidateMessageMethods,
 			Map<Class<?>, HandlerMethod> candidateMethods) {
 		if (AopUtils.isAopProxy(this.targetObject)) {
-			final AtomicReference<Method> targetMethod = new AtomicReference<>();
+			final AtomicReference<@Nullable Method> targetMethod = new AtomicReference<>();
 			Class<?>[] interfaces = ((Advised) this.targetObject).getProxiedInterfaces();
 			for (Class<?> clazz : interfaces) {
 				ReflectionUtils.doWithMethods(clazz, method1 -> {
@@ -953,10 +960,10 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		}
 	}
 
-	private String resolveExpression(String value) {
+	private @Nullable String resolveExpression(String value) {
 		String resolvedValue = resolve(value);
 
-		if (!(resolvedValue.startsWith("#{") && value.endsWith("}"))) {
+		if (!(resolvedValue != null && resolvedValue.startsWith("#{") && value.endsWith("}"))) {
 			return resolvedValue;
 		}
 
@@ -965,10 +972,10 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		return (String) evaluated;
 	}
 
-	private String resolve(String value) {
+	private @Nullable String resolve(String value) {
 		BeanFactory beanFactory = getBeanFactory();
-		if (beanFactory instanceof ConfigurableBeanFactory) {
-			return ((ConfigurableBeanFactory) beanFactory).resolveEmbeddedValue(value);
+		if (beanFactory instanceof ConfigurableBeanFactory configurableBeanFactory) {
+			return configurableBeanFactory.resolveEmbeddedValue(value);
 		}
 		return value;
 	}
@@ -991,7 +998,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		return targetClass;
 	}
 
-	private HandlerMethod findHandlerMethodForParameters(ParametersWrapper parameters) {
+	private @Nullable HandlerMethod findHandlerMethodForParameters(ParametersWrapper parameters) {
 		if (this.handlerMethod != null) {
 			return this.handlerMethod;
 		}
@@ -1004,6 +1011,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 		}
 
+		Assert.state(this.handlerMethods != null, "'handlerMethods' must not be null");
 		if (Iterable.class.isAssignableFrom(payloadType) && this.handlerMethods.containsKey(Iterator.class)) {
 			return this.handlerMethods.get(Iterator.class);
 		}
@@ -1012,7 +1020,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 		}
 	}
 
-	private HandlerMethod findClosestMatch(Class<?> payloadType) {
+	private @Nullable HandlerMethod findClosestMatch(Class<?> payloadType) {
 		for (Map<Class<?>, HandlerMethod> methods : this.handlerMethodsList) {
 			Set<Class<?>> candidates = methods.keySet();
 			Class<?> match = null;
@@ -1046,19 +1054,20 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 		private final Method method;
 
-		private InvocableHandlerMethod invocableHandlerMethod;
+		private @Nullable InvocableHandlerMethod invocableHandlerMethod;
 
+		@SuppressWarnings("NullAway.Init")
 		private Expression expression;
 
-		private TypeDescriptor targetParameterTypeDescriptor;
+		private @Nullable TypeDescriptor targetParameterTypeDescriptor;
 
 		private Class<?> targetParameterType = Void.class;
 
-		private MethodParameter exclusiveMethodParameter;
+		private @Nullable MethodParameter exclusiveMethodParameter;
 
 		private boolean messageMethod;
 
-		private UseSpelInvoker useSpelInvoker;
+		private @Nullable UseSpelInvoker useSpelInvoker;
 
 		private volatile boolean spelOnly;
 
@@ -1086,6 +1095,8 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 				message = new MutableMessage<>(parameters.getMessages(), parameters.getHeaders());
 			}
 			try {
+				Assert.state(message != null, "'message' must not be null");
+				Assert.state(this.invocableHandlerMethod != null, "'invocableHandlerMethod' must not be null");
 				Object result = this.invocableHandlerMethod.invoke(message);
 				if (result != null
 						&& org.springframework.integration.util.ClassUtils.isKotlinUnit(result.getClass())) {
@@ -1146,7 +1157,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 		private boolean processMethodParameterForExpression(StringBuilder sb, boolean hasUnqualifiedMapParameter,
 				MethodParameter methodParameter, TypeDescriptor parameterTypeDescriptor, Class<?> parameterType,
-				Type genericParameterType, Annotation mappingAnnotation) {
+				Type genericParameterType, @Nullable Annotation mappingAnnotation) {
 
 			if (mappingAnnotation != null) {
 				processMappingAnnotationForExpression(sb, methodParameter, parameterTypeDescriptor, parameterType,
@@ -1337,13 +1348,13 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 
 	public static class ParametersWrapper {
 
-		private final Collection<Message<?>> messages;
+		private final @Nullable Collection<Message<?>> messages;
 
-		private final Map<String, Object> headers;
+		private final @Nullable Map<String, Object> headers;
 
-		private Message<?> message;
+		private @Nullable Message<?> message;
 
-		private Object payload;
+		private @Nullable Object payload;
 
 		ParametersWrapper(Message<?> message) {
 			this.message = message;
@@ -1352,7 +1363,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			this.messages = null;
 		}
 
-		ParametersWrapper(Collection<Message<?>> messages, Map<String, Object> headers) {
+		ParametersWrapper(Collection<Message<?>> messages, @Nullable Map<String, Object> headers) {
 			this.messages = messages;
 			this.headers = headers;
 		}
@@ -1382,11 +1393,11 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			return this.messages;
 		}
 
-		public Map<String, Object> getHeaders() {
+		public @Nullable Map<String, Object> getHeaders() {
 			return this.headers;
 		}
 
-		public Message<?> getMessage() {
+		public @Nullable Message<?> getMessage() {
 			return this.message;
 		}
 
@@ -1394,6 +1405,7 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 			if (this.payload != null) {
 				return this.payload.getClass();
 			}
+			Assert.state(this.messages != null, "'messages' must not be null");
 			return this.messages.getClass();
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadExpressionArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadExpressionArgumentResolver.java
@@ -19,12 +19,15 @@ package org.springframework.integration.handler.support;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.expression.Expression;
 import org.springframework.integration.util.AbstractExpressionEvaluator;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -50,11 +53,12 @@ public class PayloadExpressionArgumentResolver extends AbstractExpressionEvaluat
 	}
 
 	@Override
-	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+	public @Nullable Object resolveArgument(MethodParameter parameter, Message<?> message) {
 		Expression expression = this.expressionCache.get(parameter);
 		if (expression == null) {
 			Payload ann = parameter.getParameterAnnotation(Payload.class);
-			expression = EXPRESSION_PARSER.parseExpression(ann.expression()); // NOSONAR never null - supportsParameter()
+			Assert.state(ann != null, "'Payload' annotation must not be null");
+			expression = EXPRESSION_PARSER.parseExpression(ann.expression());
 			this.expressionCache.put(parameter, expression);
 		}
 		return evaluateExpression(expression, message.getPayload(), parameter.getParameterType());

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadsArgumentResolver.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/PayloadsArgumentResolver.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.MethodParameter;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.expression.Expression;
@@ -47,7 +49,7 @@ import org.springframework.util.StringUtils;
 public class PayloadsArgumentResolver extends AbstractExpressionEvaluator
 		implements HandlerMethodArgumentResolver {
 
-	private final Map<MethodParameter, Expression> expressionCache = new HashMap<>();
+	private final Map<MethodParameter, @Nullable Expression> expressionCache = new HashMap<>();
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
@@ -56,7 +58,7 @@ public class PayloadsArgumentResolver extends AbstractExpressionEvaluator
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+	public @Nullable Object resolveArgument(MethodParameter parameter, Message<?> message) {
 		Object payload = message.getPayload();
 		Assert.state(payload instanceof Collection,
 				"This Argument Resolver support only messages with payload as Collection<Message<?>>");
@@ -64,7 +66,8 @@ public class PayloadsArgumentResolver extends AbstractExpressionEvaluator
 
 		if (!this.expressionCache.containsKey(parameter)) {
 			Payloads payloads = parameter.getParameterAnnotation(Payloads.class);
-			String expression = payloads.value(); // NOSONAR never null - supportsParameter()
+			Assert.state(payloads != null, "'Payload' annotation must not be null");
+			String expression = payloads.value();
 			if (StringUtils.hasText(expression)) {
 				this.expressionCache.put(parameter, EXPRESSION_PARSER.parseExpression("![payload." + expression + "]"));
 			}

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes for message handlers support.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.handler.support;

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -245,7 +245,8 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 
 	@Override
 	public boolean removeMessageFromGroupById(Object groupId, UUID messageId) {
-		return executeLocked(groupId, () -> doRemoveMessageFromGroupById(groupId, messageId));
+		Boolean removed = executeLocked(groupId, () -> doRemoveMessageFromGroupById(groupId, messageId));
+		return removed != null && removed;
 	}
 
 	protected boolean doRemoveMessageFromGroupById(Object groupId, UUID messageId) {
@@ -280,7 +281,7 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 
 	protected abstract @Nullable Message<?> doPollMessageFromGroup(Object groupId);
 
-	protected <T, E extends RuntimeException> T executeLocked(Object groupId, CheckedCallable<T, E> runnable) {
+	protected <T, E extends RuntimeException> @Nullable T executeLocked(Object groupId, CheckedCallable<T, E> runnable) {
 		try {
 			return this.lockRegistry.executeLocked(groupId, runnable);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractMessageGroupStore.java
@@ -245,8 +245,7 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 
 	@Override
 	public boolean removeMessageFromGroupById(Object groupId, UUID messageId) {
-		Boolean removed = executeLocked(groupId, () -> doRemoveMessageFromGroupById(groupId, messageId));
-		return removed != null && removed;
+		return executeLocked(groupId, () -> doRemoveMessageFromGroupById(groupId, messageId));
 	}
 
 	protected boolean doRemoveMessageFromGroupById(Object groupId, UUID messageId) {
@@ -281,7 +280,7 @@ public abstract class AbstractMessageGroupStore extends AbstractBatchingMessageG
 
 	protected abstract @Nullable Message<?> doPollMessageFromGroup(Object groupId);
 
-	protected <T, E extends RuntimeException> @Nullable T executeLocked(Object groupId, CheckedCallable<T, E> runnable) {
+	protected <T, E extends RuntimeException> T executeLocked(Object groupId, CheckedCallable<T, E> runnable) {
 		try {
 			return this.lockRegistry.executeLocked(groupId, runnable);
 		}

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/locks/LockRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/locks/LockRegistry.java
@@ -21,6 +21,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.util.CheckedCallable;
 import org.springframework.integration.util.CheckedRunnable;
 
@@ -75,7 +77,7 @@ public interface LockRegistry<L extends Lock> {
 	 * @throws InterruptedException from a lock operation
 	 * @since 6.2
 	 */
-	default <T, E extends Throwable> T executeLocked(Object lockKey,
+	default <T, E extends Throwable> @Nullable T executeLocked(Object lockKey,
 			CheckedCallable<T, E> callable)
 			throws E, InterruptedException {
 
@@ -126,7 +128,7 @@ public interface LockRegistry<L extends Lock> {
 	 * @throws TimeoutException when {@link Lock#tryLock(long, TimeUnit)} has elapsed
 	 * @since 6.2
 	 */
-	default <T, E extends Throwable> T executeLocked(Object lockKey, Duration waitLockDuration,
+	default <T, E extends Throwable> @Nullable T executeLocked(Object lockKey, Duration waitLockDuration,
 			CheckedCallable<T, E> callable) throws E, InterruptedException, TimeoutException {
 
 		Lock lock = obtain(lockKey);

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/locks/LockRegistry.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/locks/LockRegistry.java
@@ -21,8 +21,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 
-import org.jspecify.annotations.Nullable;
-
 import org.springframework.integration.util.CheckedCallable;
 import org.springframework.integration.util.CheckedRunnable;
 
@@ -77,7 +75,7 @@ public interface LockRegistry<L extends Lock> {
 	 * @throws InterruptedException from a lock operation
 	 * @since 6.2
 	 */
-	default <T, E extends Throwable> @Nullable T executeLocked(Object lockKey,
+	default <T, E extends Throwable> T executeLocked(Object lockKey,
 			CheckedCallable<T, E> callable)
 			throws E, InterruptedException {
 
@@ -128,7 +126,7 @@ public interface LockRegistry<L extends Lock> {
 	 * @throws TimeoutException when {@link Lock#tryLock(long, TimeUnit)} has elapsed
 	 * @since 6.2
 	 */
-	default <T, E extends Throwable> @Nullable T executeLocked(Object lockKey, Duration waitLockDuration,
+	default <T, E extends Throwable> T executeLocked(Object lockKey, Duration waitLockDuration,
 			CheckedCallable<T, E> callable) throws E, InterruptedException, TimeoutException {
 
 		Lock lock = obtain(lockKey);

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/AbstractExpressionEvaluator.java
@@ -174,7 +174,7 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 	}
 
 	@Nullable
-	protected Object evaluateExpression(Expression expression, Object input) {
+	protected Object evaluateExpression(Expression expression, @Nullable Object input) {
 		return evaluateExpression(expression, input, null);
 	}
 
@@ -189,7 +189,7 @@ public abstract class AbstractExpressionEvaluator implements BeanFactoryAware, I
 	}
 
 	@Nullable
-	protected <T> T evaluateExpression(Expression expression, Object input, @Nullable Class<T> expectedType) {
+	protected <T> T evaluateExpression(Expression expression, @Nullable Object input, @Nullable Class<T> expectedType) {
 		return expression.getValue(getEvaluationContext(), input, expectedType);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/AnnotatedMethodFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/AnnotatedMethodFilter.java
@@ -21,6 +21,8 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.expression.MethodFilter;
 import org.springframework.util.StringUtils;
@@ -39,13 +41,14 @@ import org.springframework.util.StringUtils;
  */
 public class AnnotatedMethodFilter implements MethodFilter {
 
-	private final Class<? extends Annotation> annotationType;
+	private final @Nullable Class<? extends Annotation> annotationType;
 
-	private final String methodName;
+	private final @Nullable String methodName;
 
 	private final boolean requiresReply;
 
-	public AnnotatedMethodFilter(Class<? extends Annotation> annotationType, String methodName, boolean requiresReply) {
+	public AnnotatedMethodFilter(@Nullable Class<? extends Annotation> annotationType, @Nullable String methodName,
+			boolean requiresReply) {
 		this.annotationType = annotationType;
 		this.methodName = methodName;
 		this.requiresReply = requiresReply;

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedCallable.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedCallable.java
@@ -34,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 @FunctionalInterface
 public interface CheckedCallable<T extends @Nullable Object, E extends Throwable> {
 
+	@Nullable
 	T call() throws E;
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedCallable.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CheckedCallable.java
@@ -34,7 +34,6 @@ import org.jspecify.annotations.Nullable;
 @FunctionalInterface
 public interface CheckedCallable<T extends @Nullable Object, E extends Throwable> {
 
-	@Nullable
 	T call() throws E;
 
 	/**


### PR DESCRIPTION
Related to: #10083

`MessageProcessorMessageSource` now provides a fake message to the underlying messageProcessor since the contract requires.

add `@Nullable` on `CheckedCallable.call()`, since in `LockRequestHandlerAdvice.doInvoke()`, there is a lambda `ExecutionCallback::execute` which will be running inside the `call()`, and its Nullable.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
