### PR TITLE
GH-10304: Refine Jackson 3 classes to accept only `JsonMapper` instances

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/json/JacksonPropertyAccessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/json/JacksonPropertyAccessor.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import org.jspecify.annotations.Nullable;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.NullNode;
@@ -55,13 +54,13 @@ public class JacksonPropertyAccessor implements PropertyAccessor {
 					JsonNode.class
 			};
 
-	private ObjectMapper objectMapper = JsonMapper.builder()
+	private JsonMapper jsonMapper = JsonMapper.builder()
 			.findAndAddModules(JacksonPropertyAccessor.class.getClassLoader())
 			.build();
 
-	public void setObjectMapper(ObjectMapper objectMapper) {
-		Assert.notNull(objectMapper, "'objectMapper' cannot be null");
-		this.objectMapper = objectMapper;
+	public void setObjectMapper(JsonMapper jsonMapper) {
+		Assert.notNull(jsonMapper, "'jsonMapper' cannot be null");
+		this.jsonMapper = jsonMapper;
 	}
 
 	@Override
@@ -94,7 +93,7 @@ public class JacksonPropertyAccessor implements PropertyAccessor {
 		}
 		else if (target instanceof String content) {
 			try {
-				return this.objectMapper.readTree(content);
+				return this.jsonMapper.readTree(content);
 			}
 			catch (JacksonException e) {
 				throw new AccessException("Exception while trying to deserialize String", e);

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonMessagingUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/JacksonMessagingUtils.java
@@ -29,7 +29,6 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.DatabindContext;
 import tools.jackson.databind.DefaultTyping;
 import tools.jackson.databind.JavaType;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.cfg.MapperConfig;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
@@ -45,7 +44,7 @@ import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
 
 /**
- * Utility for creating Jackson {@link ObjectMapper} instance for Spring messaging.
+ * Utility for creating Jackson {@link JsonMapper} instance for Spring messaging.
  *
  * <p>Provides custom serializers/deserializers for Spring messaging types
  * and validates deserialization against trusted package patterns.
@@ -75,15 +74,15 @@ public final class JacksonMessagingUtils {
 	}
 
 	/**
-	 * Return an {@link ObjectMapper} if available,
+	 * Return an {@link JsonMapper} if available,
 	 * supplied with Message specific serializers and deserializers.
 	 * Also configured to store typo info in the {@code @class} property.
 	 * @param trustedPackages the trusted Java packages for deserialization.
-	 * @return the mapper.
+	 * @return the JSON mapper.
 	 * @throws IllegalStateException if an implementation is not available.
 	 * @since 7.0
 	 */
-	public static ObjectMapper messagingAwareMapper(String @Nullable ... trustedPackages) {
+	public static JsonMapper messagingAwareMapper(String @Nullable ... trustedPackages) {
 		if (JacksonPresent.isJackson3Present()) {
 			GenericMessageJsonDeserializer genericMessageDeserializer = new GenericMessageJsonDeserializer();
 			ErrorMessageJsonDeserializer errorMessageDeserializer = new ErrorMessageJsonDeserializer();
@@ -98,7 +97,7 @@ public final class JacksonMessagingUtils {
 					.addDeserializer(AdviceMessage.class, adviceMessageDeserializer)
 					.addDeserializer(MutableMessage.class, mutableMessageDeserializer);
 
-			ObjectMapper mapper = JsonMapper.builder()
+			JsonMapper mapper = JsonMapper.builder()
 					.findAndAddModules(JacksonMessagingUtils.class.getClassLoader())
 					.setDefaultTyping(new AllowListTypeResolverBuilder(trustedPackages))
 					.addModules(simpleModule)

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/json/MessageJsonDeserializer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/json/MessageJsonDeserializer.java
@@ -24,8 +24,8 @@ import tools.jackson.core.JsonParser;
 import tools.jackson.databind.DeserializationContext;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.deser.std.StdNodeBasedDeserializer;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.jsontype.TypeDeserializer;
 import tools.jackson.databind.type.TypeFactory;
 
@@ -46,13 +46,13 @@ public abstract class MessageJsonDeserializer<T extends Message<?>> extends StdN
 
 	private JavaType payloadType = TypeFactory.createDefaultInstance().constructType(Object.class);
 
-	private ObjectMapper mapper = new ObjectMapper();
+	private JsonMapper mapper = new JsonMapper();
 
 	protected MessageJsonDeserializer(Class<T> targetType) {
 		super(targetType);
 	}
 
-	public void setMapper(ObjectMapper mapper) {
+	public void setMapper(JsonMapper mapper) {
 		Assert.notNull(mapper, "'mapper' must not be null");
 		this.mapper = mapper;
 	}
@@ -62,7 +62,7 @@ public abstract class MessageJsonDeserializer<T extends Message<?>> extends StdN
 		this.payloadType = payloadType;
 	}
 
-	protected ObjectMapper getMapper() {
+	protected JsonMapper getMapper() {
 		return this.mapper;
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/AbstractJacksonAccessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/AbstractJacksonAccessorTests.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ArrayNode;
 import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.node.StringNode;
@@ -56,7 +56,7 @@ public abstract class AbstractJacksonAccessorTests {
 
 	protected final SpelExpressionParser parser = new SpelExpressionParser();
 
-	protected final ObjectMapper mapper = new ObjectMapper();
+	protected final JsonMapper mapper = new JsonMapper();
 
 	protected final StandardEvaluationContext context = new StandardEvaluationContext();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerTests.java
@@ -21,7 +21,6 @@ import java.util.List;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.json.JsonReadFeature;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.core.ParameterizedTypeReference;
@@ -84,7 +83,7 @@ public class JsonToObjectTransformerTests {
 
 	@Test
 	public void objectPayloadWithCustomMapper() {
-		ObjectMapper customMapper = JsonMapper.builder()
+		JsonMapper customMapper = JsonMapper.builder()
 				.configure(JsonReadFeature.ALLOW_UNQUOTED_PROPERTY_NAMES, true)
 				.configure(JsonReadFeature.ALLOW_SINGLE_QUOTES, true)
 				.build();

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerTests.java
@@ -24,7 +24,6 @@ import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.json.JsonWriteFeature;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.ObjectNode;
 import tools.jackson.databind.node.StringNode;
@@ -149,7 +148,7 @@ public class ObjectToJsonTransformerTests {
 
 	@Test
 	public void objectPayloadWithCustomObjectMapper() {
-		ObjectMapper customMapper = JsonMapper.builder()
+		JsonMapper customMapper = JsonMapper.builder()
 				.configure(JsonWriteFeature.QUOTE_PROPERTY_NAMES, false)
 				.build();
 		ObjectToJsonTransformer transformer = new ObjectToJsonTransformer(new JacksonJsonObjectMapper(customMapper));

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/json/EmbeddedHeadersJsonMessageMapperTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/json/EmbeddedHeadersJsonMessageMapperTests.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import tools.jackson.core.type.TypeReference;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
@@ -53,9 +53,9 @@ public class EmbeddedHeadersJsonMessageMapperTests {
 		assertThat(decoded.getPayload()).isEqualTo(message.getPayload());
 		assertThat(decoded.getHeaders().getTimestamp()).isNotEqualTo(message.getHeaders().getTimestamp());
 
-		ObjectMapper objectMapper = new ObjectMapper();
+		JsonMapper jsonMapper = new JsonMapper();
 		Map<String, Object> encodedMessageToCheck =
-				objectMapper.readValue(encodedMessage, new TypeReference<>() {
+				jsonMapper.readValue(encodedMessage, new TypeReference<>() {
 
 				});
 
@@ -136,9 +136,9 @@ public class EmbeddedHeadersJsonMessageMapperTests {
 		GenericMessage<String> message = new GenericMessage<>("foo", Collections.singletonMap("bar", "baz"));
 		byte[] encodedMessage = mapper.fromMessage(message);
 
-		ObjectMapper objectMapper = new ObjectMapper();
+		JsonMapper jsonMapper = new JsonMapper();
 		Map<String, Object> encodedMessageToCheck =
-				objectMapper.readValue(encodedMessage, new TypeReference<>() {
+				jsonMapper.readValue(encodedMessage, new TypeReference<>() {
 
 				});
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/json/JacksonJsonObjectMapperTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/json/JacksonJsonObjectMapperTests.java
@@ -45,7 +45,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import tools.jackson.databind.JacksonModule;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.module.kotlin.KotlinModule;
 
@@ -69,7 +68,7 @@ class JacksonJsonObjectMapperTests {
 	@Test
 	void compareAutoDiscoveryVsManualModules() {
 		KotlinModule kotlinModule = new KotlinModule.Builder().build();
-		ObjectMapper manualMapper = JsonMapper.builder()
+		JsonMapper manualMapper = JsonMapper.builder()
 				.addModules(kotlinModule)
 				.build();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/json/JacksonMessagingUtilsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/json/JacksonMessagingUtilsTests.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import tools.jackson.databind.JacksonModule;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.module.kotlin.KotlinModule;
 
 import org.springframework.integration.message.AdviceMessage;
@@ -42,7 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class JacksonMessagingUtilsTests {
 
-	private ObjectMapper mapper;
+	private JsonMapper mapper;
 
 	@BeforeEach
 	void setUp() {

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/ObjectToMapTransformerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/ObjectToMapTransformerTests.java
@@ -27,7 +27,7 @@ import java.util.Objects;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.context.expression.MapAccessor;
 import org.springframework.expression.Expression;
@@ -184,7 +184,7 @@ public class ObjectToMapTransformerTests {
 	public void testCustomMapperSupport_DisableTimestampFlag_SerializesDateAsString() {
 		Employee employee = buildEmployee();
 
-		ObjectMapper customMapper = new ObjectMapper();
+		JsonMapper customMapper = new JsonMapper();
 		Map<String, Object> transformedMap =
 				new ObjectToMapTransformer(new JacksonJsonObjectMapper(customMapper))
 						.transformPayload(employee);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/HttpRequestHandlingMessagingGatewayTests.java
@@ -27,7 +27,7 @@ import java.util.List;
 import jakarta.servlet.http.HttpServletRequest;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.ResolvableType;
@@ -294,7 +294,7 @@ public class HttpRequestHandlingMessagingGatewayTests extends AbstractHttpInboun
 		TestBean testBean = new TestBean();
 		testBean.setName("T. Bean");
 		testBean.setAge(42);
-		request.setContent(new ObjectMapper().writeValueAsBytes(new TestBean[] {testBean}));
+		request.setContent(new JsonMapper().writeValueAsBytes(new TestBean[] {testBean}));
 		MockHttpServletResponse response = new MockHttpServletResponse();
 		gateway.handleRequest(request, response);
 		byte[] bytes = response.getContentAsByteArray();

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisChannelMessageStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisChannelMessageStoreTests.java
@@ -23,7 +23,7 @@ import java.util.List;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.serializer.GenericJackson3JsonRedisSerializer;
@@ -182,7 +182,7 @@ class RedisChannelMessageStoreTests implements RedisContainerTest {
 	@Test
 	void testJsonSerialization() {
 		RedisChannelMessageStore store = new RedisChannelMessageStore(RedisContainerTest.connectionFactory());
-		ObjectMapper mapper = JacksonMessagingUtils.messagingAwareMapper();
+		JsonMapper mapper = JacksonMessagingUtils.messagingAwareMapper();
 		GenericJackson3JsonRedisSerializer serializer = new GenericJackson3JsonRedisSerializer(mapper);
 		store.setValueSerializer(serializer);
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/store/RedisMessageGroupStoreTests.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
@@ -391,7 +391,7 @@ class RedisMessageGroupStoreTests implements RedisContainerTest {
 
 	@Test
 	void testJsonSerialization() {
-		ObjectMapper mapper = JacksonMessagingUtils.messagingAwareMapper();
+		JsonMapper mapper = JacksonMessagingUtils.messagingAwareMapper();
 
 		GenericJackson3JsonRedisSerializer serializer = new GenericJackson3JsonRedisSerializer(mapper);
 		store.setValueSerializer(serializer);


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/pull/10304

Enhances type safety and consistency with Jackson 3 JSON-specific handling.

* Replace `ObjectMapper` with `JsonMapper` across Spring Integration:
  - Core components: `EmbeddedHeadersJsonMessageMapper`, `JacksonJsonObjectMapper`, `JacksonPropertyAccessor`, `MessageJsonDeserializer`
  - Utilities: `JacksonMessagingUtils.messagingAwareMapper()`
  - Tests: Update test classes to use `JsonMapper`
* Clean up unused `IOException` declaration in `EmbeddedHeadersJsonMessageMapper`

