### PR TITLE
GH-10083: Nullability for graph in core module

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/CompositeMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/CompositeMessageHandlerNode.java
@@ -35,7 +35,7 @@ public class CompositeMessageHandlerNode extends MessageHandlerNode {
 
 	private final List<InnerHandler> handlers = new ArrayList<>();
 
-	public CompositeMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input, @Nullable String output,
+	public CompositeMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input, @Nullable String output,
 			List<InnerHandler> handlers) {
 
 		super(nodeId, name, handler, input, output);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/CompositeMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/CompositeMessageHandlerNode.java
@@ -19,6 +19,8 @@ package org.springframework.integration.graph;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.MessageHandler;
 
 /**
@@ -33,7 +35,7 @@ public class CompositeMessageHandlerNode extends MessageHandlerNode {
 
 	private final List<InnerHandler> handlers = new ArrayList<>();
 
-	public CompositeMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input, String output,
+	public CompositeMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input, @Nullable String output,
 			List<InnerHandler> handlers) {
 
 		super(nodeId, name, handler, input, output);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/DiscardingMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/DiscardingMessageHandlerNode.java
@@ -32,7 +32,7 @@ public class DiscardingMessageHandlerNode extends MessageHandlerNode {
 
 	private final @Nullable String discards;
 
-	public DiscardingMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input,
+	public DiscardingMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input,
 			@Nullable String output, @Nullable String discards) {
 
 		super(nodeId, name, handler, input, output);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/DiscardingMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/DiscardingMessageHandlerNode.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.graph;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.MessageHandler;
 
 /**
@@ -28,16 +30,16 @@ import org.springframework.messaging.MessageHandler;
  */
 public class DiscardingMessageHandlerNode extends MessageHandlerNode {
 
-	private final String discards;
+	private final @Nullable String discards;
 
-	public DiscardingMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input, String output,
-			String discards) {
+	public DiscardingMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input,
+			@Nullable String output, @Nullable String discards) {
 
 		super(nodeId, name, handler, input, output);
 		this.discards = discards;
 	}
 
-	public String getDiscards() {
+	public @Nullable String getDiscards() {
 		return this.discards;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/EndpointNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/EndpointNode.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.graph;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Base class for all endpoints.
  *
@@ -26,14 +28,14 @@ package org.springframework.integration.graph;
  */
 public abstract class EndpointNode extends IntegrationNode {
 
-	private final String output;
+	private final @Nullable String output;
 
-	protected EndpointNode(int nodeId, String name, Object nodeObject, String output) {
+	protected EndpointNode(int nodeId, String name, Object nodeObject, @Nullable String output) {
 		super(nodeId, name, nodeObject);
 		this.output = output;
 	}
 
-	public String getOutput() {
+	public @Nullable String getOutput() {
 		return this.output;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableCompositeMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableCompositeMessageHandlerNode.java
@@ -18,6 +18,8 @@ package org.springframework.integration.graph;
 
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.handler.CompositeMessageHandler;
 
 /**
@@ -31,17 +33,17 @@ import org.springframework.integration.handler.CompositeMessageHandler;
  */
 public class ErrorCapableCompositeMessageHandlerNode extends CompositeMessageHandlerNode implements ErrorCapableNode {
 
-	private final String errors;
+	private final @Nullable String errors;
 
-	public ErrorCapableCompositeMessageHandlerNode(int nodeId, String name, CompositeMessageHandler handler, String input,
-			String output, String errors, List<InnerHandler> handlers) {
+	public ErrorCapableCompositeMessageHandlerNode(int nodeId, String name, CompositeMessageHandler handler,
+			@Nullable String input, @Nullable String output, @Nullable String errors, List<InnerHandler> handlers) {
 
 		super(nodeId, name, handler, input, output, handlers);
 		this.errors = errors;
 	}
 
 	@Override
-	public String getErrors() {
+	public @Nullable String getErrors() {
 		return this.errors;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableCompositeMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableCompositeMessageHandlerNode.java
@@ -36,7 +36,7 @@ public class ErrorCapableCompositeMessageHandlerNode extends CompositeMessageHan
 	private final @Nullable String errors;
 
 	public ErrorCapableCompositeMessageHandlerNode(int nodeId, String name, CompositeMessageHandler handler,
-			@Nullable String input, @Nullable String output, @Nullable String errors, List<InnerHandler> handlers) {
+			String input, @Nullable String output, @Nullable String errors, List<InnerHandler> handlers) {
 
 		super(nodeId, name, handler, input, output, handlers);
 		this.errors = errors;

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableDiscardingMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableDiscardingMessageHandlerNode.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.graph;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.MessageHandler;
 
 /**
@@ -29,17 +31,17 @@ import org.springframework.messaging.MessageHandler;
  */
 public class ErrorCapableDiscardingMessageHandlerNode extends DiscardingMessageHandlerNode implements ErrorCapableNode {
 
-	private final String errors;
+	private final @Nullable String errors;
 
-	public ErrorCapableDiscardingMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input,
-			String output, String discards, String errors) {
+	public ErrorCapableDiscardingMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input,
+			@Nullable String output, @Nullable String discards, @Nullable String errors) {
 
 		super(nodeId, name, handler, input, output, discards);
 		this.errors = errors;
 	}
 
 	@Override
-	public String getErrors() {
+	public @Nullable String getErrors() {
 		return this.errors;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableDiscardingMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableDiscardingMessageHandlerNode.java
@@ -33,7 +33,7 @@ public class ErrorCapableDiscardingMessageHandlerNode extends DiscardingMessageH
 
 	private final @Nullable String errors;
 
-	public ErrorCapableDiscardingMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input,
+	public ErrorCapableDiscardingMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input,
 			@Nullable String output, @Nullable String discards, @Nullable String errors) {
 
 		super(nodeId, name, handler, input, output, discards);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableEndpointNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableEndpointNode.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.graph;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Represents nodes that can natively handle errors.
  *
@@ -26,15 +28,15 @@ package org.springframework.integration.graph;
  */
 public class ErrorCapableEndpointNode extends EndpointNode implements ErrorCapableNode {
 
-	private final String errors;
+	private final @Nullable String errors;
 
-	protected ErrorCapableEndpointNode(int nodeId, String name, Object nodeObject, String output, String errors) {
+	protected ErrorCapableEndpointNode(int nodeId, String name, Object nodeObject, @Nullable String output, @Nullable String errors) {
 		super(nodeId, name, nodeObject, output);
 		this.errors = errors;
 	}
 
 	@Override
-	public String getErrors() {
+	public @Nullable String getErrors() {
 		return this.errors;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableMessageHandlerNode.java
@@ -31,7 +31,7 @@ public class ErrorCapableMessageHandlerNode extends MessageHandlerNode implement
 
 	private final @Nullable String errors;
 
-	public ErrorCapableMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input,
+	public ErrorCapableMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input,
 			@Nullable String output, @Nullable String errors) {
 
 		super(nodeId, name, handler, input, output);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableMessageHandlerNode.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.graph;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.MessageHandler;
 
 /**
@@ -27,17 +29,17 @@ import org.springframework.messaging.MessageHandler;
  */
 public class ErrorCapableMessageHandlerNode extends MessageHandlerNode implements ErrorCapableNode {
 
-	private final String errors;
+	private final @Nullable String errors;
 
-	public ErrorCapableMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input,
-			String output, String errors) {
+	public ErrorCapableMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input,
+			@Nullable String output, @Nullable String errors) {
 
 		super(nodeId, name, handler, input, output);
 		this.errors = errors;
 	}
 
 	@Override
-	public String getErrors() {
+	public @Nullable String getErrors() {
 		return this.errors;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableNode.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.graph;
 
+import org.jspecify.annotations.Nullable;
+
 /**
  * Nodes implementing this interface are capable of emitting errors.
  *
@@ -26,6 +28,7 @@ package org.springframework.integration.graph;
  */
 public interface ErrorCapableNode {
 
+	@Nullable
 	String getErrors();
 
 }

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableRoutingNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableRoutingNode.java
@@ -35,7 +35,7 @@ public class ErrorCapableRoutingNode extends RoutingMessageHandlerNode implement
 
 	private final @Nullable String errors;
 
-	public ErrorCapableRoutingNode(int nodeId, String name, MessageHandler handler, @Nullable String input, @Nullable String output,
+	public ErrorCapableRoutingNode(int nodeId, String name, MessageHandler handler, String input, @Nullable String output,
 			@Nullable String errors, Collection<String> routes) {
 
 		super(nodeId, name, handler, input, output, routes);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableRoutingNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/ErrorCapableRoutingNode.java
@@ -18,6 +18,8 @@ package org.springframework.integration.graph;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.MessageHandler;
 
 /**
@@ -31,17 +33,17 @@ import org.springframework.messaging.MessageHandler;
  */
 public class ErrorCapableRoutingNode extends RoutingMessageHandlerNode implements ErrorCapableNode {
 
-	private final String errors;
+	private final @Nullable String errors;
 
-	public ErrorCapableRoutingNode(int nodeId, String name, MessageHandler handler, String input, String output,
-			String errors, Collection<String> routes) {
+	public ErrorCapableRoutingNode(int nodeId, String name, MessageHandler handler, @Nullable String input, @Nullable String output,
+			@Nullable String errors, Collection<String> routes) {
 
 		super(nodeId, name, handler, input, output, routes);
 		this.errors = errors;
 	}
 
 	@Override
-	public String getErrors() {
+	public @Nullable String getErrors() {
 		return this.errors;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphRuntimeHints.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphRuntimeHints.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.graph;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.aot.hint.BindingReflectionHintsRegistrar;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
@@ -31,7 +33,7 @@ import org.springframework.aot.hint.RuntimeHintsRegistrar;
 class IntegrationGraphRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override
-	public void registerHints(RuntimeHints hints, ClassLoader classLoader) {
+	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
 		new BindingReflectionHintsRegistrar()
 				.registerReflectionHints(hints.reflection(),
 						Graph.class,

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphServer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/IntegrationGraphServer.java
@@ -93,11 +93,11 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
-		this.applicationContext = applicationContext; // NOSONAR (sync)
+		this.applicationContext = applicationContext;
 	}
 
-	protected @Nullable ApplicationContext getApplicationContext() {
-		return this.applicationContext;  // NOSONAR (sync)
+	protected ApplicationContext getApplicationContext() {
+		return this.applicationContext;
 	}
 
 	/**
@@ -107,7 +107,7 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 	 * @param applicationName the application name.
 	 */
 	public void setApplicationName(String applicationName) {
-		this.applicationName = applicationName; //NOSONAR (sync)
+		this.applicationName = applicationName;
 	}
 
 	/**
@@ -136,19 +136,20 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 	 * @see #rebuild()
 	 */
 	public Graph getGraph() {
-		if (this.graph == null) {
+		var localGraph = this.graph;
+		if (localGraph == null) {
 			this.lock.lock();
 			try {
-				if (this.graph == null) {
-					this.graph = buildGraph();
+				localGraph = this.graph;
+				if (localGraph == null) {
+					localGraph = buildGraph();
 				}
 			}
 			finally {
 				this.lock.unlock();
 			}
 		}
-		var graph = this.graph;
-		return graph;
+		return localGraph;
 	}
 
 	/**
@@ -216,9 +217,9 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 		gateways(nodes, links, channelNodes);
 		producers(nodes, links, channelNodes);
 		consumers(nodes, links, channelNodes);
-		var graph = new Graph(descriptor, nodes, links);
-		this.graph = graph;
-		return graph;
+		var localGraph = new Graph(descriptor, nodes, links);
+		this.graph = localGraph;
+		return localGraph;
 	}
 
 	private Map<String, MessageChannelNode> channels(Collection<IntegrationNode> nodes) {
@@ -228,8 +229,8 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 				.map(e -> {
 					MessageChannel messageChannel = e.getValue();
 					MessageChannelNode messageChannelNode = this.nodeFactory.channelNode(e.getKey(), messageChannel);
-					if (messageChannel instanceof NamedComponent) {
-						messageChannelNode.addProperties(getAdditionalPropertiesIfAny((NamedComponent) messageChannel));
+					if (messageChannel instanceof NamedComponent namedComponent) {
+						messageChannelNode.addProperties(getAdditionalPropertiesIfAny(namedComponent));
 					}
 					return messageChannelNode;
 				})
@@ -323,8 +324,8 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 				.map(e -> {
 					IntegrationConsumer consumer = e.getValue();
 					MessageHandlerNode handlerNode =
-							consumer instanceof PollingConsumer
-									? this.nodeFactory.polledHandlerNode(e.getKey(), (PollingConsumer) consumer)
+							consumer instanceof PollingConsumer pollingConsumer
+									? this.nodeFactory.polledHandlerNode(e.getKey(), pollingConsumer)
 									: this.nodeFactory.handlerNode(e.getKey(), consumer);
 					handlerNode.addProperties(getAdditionalPropertiesIfAny(consumer));
 					return handlerNode;
@@ -357,20 +358,20 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 		if (channelNode != null) {
 			links.add(new LinkNode(endpointNode.getNodeId(), channelNode.getNodeId(), LinkNode.Type.output));
 		}
-		if (endpointNode instanceof ErrorCapableNode) {
-			channelNode = channelNodes.get(((ErrorCapableNode) endpointNode).getErrors());
+		if (endpointNode instanceof ErrorCapableNode errorCapableNode) {
+			channelNode = channelNodes.get(errorCapableNode.getErrors());
 			if (channelNode != null) {
 				links.add(new LinkNode(endpointNode.getNodeId(), channelNode.getNodeId(), LinkNode.Type.error));
 			}
 		}
-		if (endpointNode instanceof DiscardingMessageHandlerNode) {
-			channelNode = channelNodes.get(((DiscardingMessageHandlerNode) endpointNode).getDiscards());
+		if (endpointNode instanceof DiscardingMessageHandlerNode discardingMessageHandlerNode) {
+			channelNode = channelNodes.get(discardingMessageHandlerNode.getDiscards());
 			if (channelNode != null) {
 				links.add(new LinkNode(endpointNode.getNodeId(), channelNode.getNodeId(), LinkNode.Type.discard));
 			}
 		}
-		if (endpointNode instanceof RoutingMessageHandlerNode) {
-			Collection<String> routes = ((RoutingMessageHandlerNode) endpointNode).getRoutes();
+		if (endpointNode instanceof RoutingMessageHandlerNode routingMessageHandlerNode) {
+			Collection<String> routes = routingMessageHandlerNode.getRoutes();
 			for (String route : routes) {
 				channelNode = channelNodes.get(route);
 				if (channelNode != null) {
@@ -410,13 +411,6 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 			String errorChannel = channelToBeanName(gateway.getErrorChannel());
 			String requestChannel = channelToBeanName(gateway.getRequestChannel());
 			return new MessageGatewayNode(this.nodeId.incrementAndGet(), name, gateway, requestChannel, errorChannel);
-		}
-
-		@Contract("null -> null; !null -> !null")
-		private @Nullable String channelToBeanName(@Nullable MessageChannel messageChannel) {
-			return messageChannel instanceof NamedComponent namedComponent
-					? namedComponent.getBeanName()
-					: Objects.toString(messageChannel, null);
 		}
 
 		MessageProducerNode producerNode(String name, MessageProducerSupport producer) {
@@ -554,18 +548,19 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 		}
 
 		MessageHandlerNode recipientListRoutingHandler(String name, IntegrationConsumer consumer,
-				MessageHandler handler, RecipientListRouterManagement router, @Nullable String output, @Nullable String errors,
-				boolean polled) {
+				MessageHandler handler, RecipientListRouterManagement router, @Nullable String output,
+				@Nullable String errors, boolean polled) {
 
 			List<String> routes =
 					router.getRecipients()
 							.stream()
 							.map(recipient -> {
 								var messageChannel = channelToBeanName(((Recipient) recipient).getChannel());
-								Assert.state(messageChannel != null, "messageChannel must not be null for " + recipient);
+								Assert.state(messageChannel != null,
+										"messageChannel must not be null for " + recipient);
 								return messageChannel;
 							})
-							.collect(Collectors.toList());
+							.toList();
 
 			String inputChannel = channelToBeanName(consumer.getInputChannel());
 			return polled
@@ -577,6 +572,13 @@ public class IntegrationGraphServer implements ApplicationContextAware, Applicat
 
 		void reset() {
 			this.nodeId.set(0);
+		}
+
+		@Contract("null -> null; !null -> !null")
+		private static @Nullable String channelToBeanName(@Nullable MessageChannel messageChannel) {
+			return messageChannel instanceof NamedComponent namedComponent
+					? namedComponent.getBeanName()
+					: Objects.toString(messageChannel, null);
 		}
 
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageChannelNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageChannelNode.java
@@ -33,7 +33,7 @@ import org.springframework.messaging.MessageChannel;
  */
 public class MessageChannelNode extends IntegrationNode implements SendTimersAware {
 
-	private Supplier<SendTimers> sendTimers;
+	private @Nullable Supplier<SendTimers> sendTimers;
 
 	public MessageChannelNode(int nodeId, String name, MessageChannel channel) {
 		super(nodeId, name, channel);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageGatewayNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageGatewayNode.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.graph;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.gateway.MessagingGatewaySupport;
 
 /**
@@ -28,7 +30,7 @@ import org.springframework.integration.gateway.MessagingGatewaySupport;
  */
 public class MessageGatewayNode extends ErrorCapableEndpointNode {
 
-	public MessageGatewayNode(int nodeId, String name, MessagingGatewaySupport gateway, String output, String errors) {
+	public MessageGatewayNode(int nodeId, String name, MessagingGatewaySupport gateway, @Nullable String output, @Nullable String errors) {
 		super(nodeId, name, gateway, output, errors);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageHandlerNode.java
@@ -33,21 +33,20 @@ import org.springframework.messaging.MessageHandler;
  */
 public class MessageHandlerNode extends EndpointNode implements SendTimersAware {
 
-	private final @Nullable String input;
+	private final String input;
 
 	private @Nullable Supplier<SendTimers> sendTimers;
 
-	public MessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input, @Nullable String output) {
+	public MessageHandlerNode(int nodeId, String name, MessageHandler handler, String input, @Nullable String output) {
 		super(nodeId, name, handler, output);
 		this.input = input;
 	}
 
-	public @Nullable String getInput() {
+	public String getInput() {
 		return this.input;
 	}
 
-	@Nullable
-	public SendTimers getSendTimers() {
+	public @Nullable SendTimers getSendTimers() {
 		return this.sendTimers != null ? this.sendTimers.get() : null;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageHandlerNode.java
@@ -33,16 +33,16 @@ import org.springframework.messaging.MessageHandler;
  */
 public class MessageHandlerNode extends EndpointNode implements SendTimersAware {
 
-	private final String input;
+	private final @Nullable String input;
 
-	private Supplier<SendTimers> sendTimers;
+	private @Nullable Supplier<SendTimers> sendTimers;
 
-	public MessageHandlerNode(int nodeId, String name, MessageHandler handler, String input, String output) {
+	public MessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input, @Nullable String output) {
 		super(nodeId, name, handler, output);
 		this.input = input;
 	}
 
-	public String getInput() {
+	public @Nullable String getInput() {
 		return this.input;
 	}
 
@@ -57,4 +57,3 @@ public class MessageHandlerNode extends EndpointNode implements SendTimersAware 
 	}
 
 }
-

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageProducerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageProducerNode.java
@@ -30,7 +30,7 @@ import org.springframework.integration.endpoint.MessageProducerSupport;
  */
 public class MessageProducerNode extends ErrorCapableEndpointNode {
 
-	public MessageProducerNode(int nodeId, String name, MessageProducerSupport producer, @Nullable String output, @Nullable String errors) {
+	public MessageProducerNode(int nodeId, String name, MessageProducerSupport producer, String output, @Nullable String errors) {
 		super(nodeId, name, producer, output, errors);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageProducerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageProducerNode.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.graph;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.integration.endpoint.MessageProducerSupport;
 
 /**
@@ -28,7 +30,7 @@ import org.springframework.integration.endpoint.MessageProducerSupport;
  */
 public class MessageProducerNode extends ErrorCapableEndpointNode {
 
-	public MessageProducerNode(int nodeId, String name, MessageProducerSupport producer, String output, String errors) {
+	public MessageProducerNode(int nodeId, String name, MessageProducerSupport producer, @Nullable String output, @Nullable String errors) {
 		super(nodeId, name, producer, output, errors);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageSourceNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageSourceNode.java
@@ -35,7 +35,7 @@ public class MessageSourceNode extends ErrorCapableEndpointNode implements Recei
 
 	private @Nullable Supplier<ReceiveCounters> receiveCounters;
 
-	public MessageSourceNode(int nodeId, String name, MessageSource<?> messageSource, @Nullable String output, @Nullable String errors) {
+	public MessageSourceNode(int nodeId, String name, MessageSource<?> messageSource, String output, @Nullable String errors) {
 		super(nodeId, name, messageSource, output, errors);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageSourceNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MessageSourceNode.java
@@ -33,9 +33,9 @@ import org.springframework.integration.core.MessageSource;
  */
 public class MessageSourceNode extends ErrorCapableEndpointNode implements ReceiveCountersAware {
 
-	private Supplier<ReceiveCounters> receiveCounters;
+	private @Nullable Supplier<ReceiveCounters> receiveCounters;
 
-	public MessageSourceNode(int nodeId, String name, MessageSource<?> messageSource, String output, String errors) {
+	public MessageSourceNode(int nodeId, String name, MessageSource<?> messageSource, @Nullable String output, @Nullable String errors) {
 		super(nodeId, name, messageSource, output, errors);
 	}
 
@@ -50,4 +50,3 @@ public class MessageSourceNode extends ErrorCapableEndpointNode implements Recei
 	}
 
 }
-

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/MicrometerNodeEnhancer.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/MicrometerNodeEnhancer.java
@@ -57,11 +57,14 @@ public class MicrometerNodeEnhancer {
 
 	private static final TimerStats ZERO_TIMER_STATS = new TimerStats(0L, 0.0, 0.0);
 
-	private final @Nullable MeterRegistry registry;
+	@SuppressWarnings("NullAway.Init")
+	private final MeterRegistry registry;
 
 	MicrometerNodeEnhancer(ApplicationContext applicationContext) {
 		ObjectProvider<MeterRegistry> meterRegistryProvider = applicationContext.getBeanProvider(MeterRegistry.class);
-		this.registry = meterRegistryProvider.getIfUnique();
+		var registry = meterRegistryProvider.getIfUnique();
+		Assert.state(registry != null, "MeterRegistry must not be null");
+		this.registry = registry;
 	}
 
 	/**

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/PollableChannelNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/PollableChannelNode.java
@@ -33,7 +33,7 @@ import org.springframework.messaging.MessageChannel;
  */
 public class PollableChannelNode extends MessageChannelNode implements ReceiveCountersAware {
 
-	private Supplier<ReceiveCounters> receiveCounters;
+	private @Nullable Supplier<ReceiveCounters> receiveCounters;
 
 	public PollableChannelNode(int nodeId, String name, MessageChannel channel) {
 		super(nodeId, name, channel);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/RoutingMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/RoutingMessageHandlerNode.java
@@ -34,7 +34,7 @@ public class RoutingMessageHandlerNode extends MessageHandlerNode {
 
 	private final Collection<String> routes;
 
-	public RoutingMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input, @Nullable String output,
+	public RoutingMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input, @Nullable String output,
 			Collection<String> routes) {
 
 		super(nodeId, name, handler, input, output);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/RoutingMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/RoutingMessageHandlerNode.java
@@ -18,6 +18,8 @@ package org.springframework.integration.graph;
 
 import java.util.Collection;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.MessageHandler;
 
 /**
@@ -32,7 +34,7 @@ public class RoutingMessageHandlerNode extends MessageHandlerNode {
 
 	private final Collection<String> routes;
 
-	public RoutingMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input, String output,
+	public RoutingMessageHandlerNode(int nodeId, String name, MessageHandler handler, @Nullable String input, @Nullable String output,
 			Collection<String> routes) {
 
 		super(nodeId, name, handler, input, output);

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides classes related to the runtime object graph.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.graph;


### PR DESCRIPTION
* Add Nullability to core module's graph package.
* `buildGraph` and `getGraph` methods in the `IntegrationGraphServer` because Nullify could not see the creation of the graph
* `IntegrationGraphServer.receiptListRoutingHandler` required a change where the messageChannel could not be null in the `map` portion of expression.  So it was extracted into a var and the var was checked for null.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
