### PR TITLE
Disable Oracle tests on Mac M1 Arch

### DIFF
--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/oracle/OracleContainerTest.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/oracle/OracleContainerTest.java
@@ -20,6 +20,7 @@ import javax.sql.DataSource;
 
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.testcontainers.containers.OracleContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
@@ -36,6 +37,7 @@ import org.testcontainers.utility.DockerImageName;
  * @since 6.0.8
  */
 @Testcontainers(disabledWithoutDocker = true)
+@DisabledIfSystemProperty(named = "os.arch", matches = ".*aarch64.*")
 public interface OracleContainerTest {
 
 	OracleContainer ORACLE_CONTAINER =

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/oracle/OracleJdbcMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/oracle/OracleJdbcMessageStoreTests.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -60,6 +61,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @SpringJUnitConfig
 @DirtiesContext
+@DisabledIfSystemProperty(named = "os.arch", matches = ".*aarch64.*")
 public class OracleJdbcMessageStoreTests implements OracleContainerTest {
 
 	private static final Log LOG = LogFactory.getLog(OracleJdbcMessageStoreTests.class);

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/oracle/OracleLockRegistryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/oracle/OracleLockRegistryTests.java
@@ -23,6 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -48,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  */
 @SpringJUnitConfig
 @DirtiesContext
+@DisabledIfSystemProperty(named = "os.arch", matches = ".*aarch64.*")
 public class OracleLockRegistryTests implements OracleContainerTest {
 
 	@Autowired

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/OracleTxTimeoutMessageStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/store/channel/OracleTxTimeoutMessageStoreTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.jdbc.store.channel;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import org.springframework.integration.jdbc.oracle.OracleContainerTest;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -30,6 +31,7 @@ import org.springframework.transaction.support.TransactionTemplate;
  *
  */
 @ContextConfiguration
+@DisabledIfSystemProperty(named = "os.arch", matches = ".*aarch64.*")
 public class OracleTxTimeoutMessageStoreTests extends AbstractTxTimeoutMessageStoreTests implements OracleContainerTest {
 
 	@AfterEach


### PR DESCRIPTION
Oracle does not have support for docker images on M1 Arch

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
