### PR TITLE
GH-10379: Optimize Observability API usage

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -255,18 +255,27 @@ public abstract class MessageProducerSupport extends AbstractEndpoint
 		}
 
 		try {
-			IntegrationObservation.HANDLER.observation(
-							this.observationConvention,
-							DefaultMessageReceiverObservationConvention.INSTANCE,
-							() -> new MessageReceiverContext(message, getComponentName(), "message-producer"),
-							this.observationRegistry)
-					.observe(() -> this.messagingTemplate.send(getRequiredOutputChannel(), trackMessageIfAny(message)));
+			if (isObserved()) {
+				IntegrationObservation.HANDLER.observation(
+								this.observationConvention,
+								DefaultMessageReceiverObservationConvention.INSTANCE,
+								() -> new MessageReceiverContext(message, getComponentName(), "message-producer"),
+								this.observationRegistry)
+						.observe(() -> sendMessageWithTracking(message));
+			}
+			else {
+				sendMessageWithTracking(message);
+			}
 		}
 		catch (RuntimeException ex) {
 			if (!sendErrorMessageIfNecessary(message, ex)) {
 				throw ex;
 			}
 		}
+	}
+
+	private void sendMessageWithTracking(Message<?> message) {
+		this.messagingTemplate.send(getRequiredOutputChannel(), trackMessageIfAny(message));
 	}
 
 	protected void subscribeToPublisher(Publisher<? extends Message<?>> publisher) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/SourcePollingChannelAdapter.java
@@ -262,13 +262,15 @@ public class SourcePollingChannelAdapter extends AbstractPollingEndpoint
 	 */
 	@Override
 	protected void messageReceived(@Nullable IntegrationResourceHolder holder, Message<?> message) {
-		Observation observation =
-				IntegrationObservation.HANDLER.observation(this.observationConvention,
-						DefaultMessageReceiverObservationConvention.INSTANCE,
-						() -> new MessageReceiverContext(message, getComponentName(), "message-source"),
-						this.observationRegistry);
+		if (isObserved()) {
+			Observation observation =
+					IntegrationObservation.HANDLER.observation(this.observationConvention,
+							DefaultMessageReceiverObservationConvention.INSTANCE,
+							() -> new MessageReceiverContext(message, getComponentName(), "message-source"),
+							this.observationRegistry);
 
-		observation.start().openScope();
+			observation.start().openScope();
+		}
 		super.messageReceived(holder, message);
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10379

The `ObservationRegistry.NOOP` still brings some performance overhead.

* Fix `MessageProducerSupport` & `SourcePollingChannelAdapter` to check for `isObserved()` before using the `IntegrationObservation`

**Auto-cherry-pick to `6.5.x` & `6.4.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
