### PR TITLE
GH-10083 Add Nullability to the mapping package

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Stephane Nicoll
  * @author Steve Singer
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -107,8 +108,8 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 	 * Extract "standard" headers from an AMQP MessageProperties instance.
 	 */
 	@Override
-	protected Map<String, Object> extractStandardHeaders(MessageProperties amqpMessageProperties) {
-		Map<String, Object> headers = new HashMap<>();
+	protected Map<String, @Nullable Object> extractStandardHeaders(MessageProperties amqpMessageProperties) {
+		Map<String, @Nullable Object> headers = new HashMap<>();
 		try {
 			JavaUtils.INSTANCE
 					.acceptIfNotNull(AmqpHeaders.APP_ID, amqpMessageProperties.getAppId(), headers::put)
@@ -326,13 +327,13 @@ public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessagePropert
 	}
 
 	@Override
-	public Map<String, Object> toHeadersFromRequest(MessageProperties source) {
-		Map<String, Object> headersFromRequest = super.toHeadersFromRequest(source);
+	public Map<String, @Nullable Object> toHeadersFromRequest(MessageProperties source) {
+		Map<String, @Nullable Object> headersFromRequest = super.toHeadersFromRequest(source);
 		addConsumerMetadata(source, headersFromRequest);
 		return headersFromRequest;
 	}
 
-	private void addConsumerMetadata(MessageProperties messageProperties, Map<String, Object> headers) {
+	private void addConsumerMetadata(MessageProperties messageProperties, Map<String, @Nullable Object> headers) {
 		String consumerTag = messageProperties.getConsumerTag();
 		if (consumerTag != null) {
 			headers.put(AmqpHeaders.CONSUMER_TAG, consumerTag);

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -310,9 +310,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 			@Nullable Object keyId) {
 
 		try {
-			var classLoader = getClassLoader();
-			Assert.state(classLoader != null, "No ClassLoader available");
-			return JsonHeaders.buildResolvableType(classLoader, typeId, contentId, keyId);
+			return JsonHeaders.buildResolvableType(getClassLoader(), typeId, contentId, keyId);
 		}
 		catch (Exception e) {
 			this.logger.debug("Cannot build a ResolvableType from 'json__TypeId__' header", e);

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -324,8 +324,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	}
 
 	@SuppressWarnings("unchecked")
-	@Nullable
-	protected <V> V getHeaderIfAvailable(Map<String, Object> headers, String name, Class<V> type) {
+	protected @Nullable <V> V getHeaderIfAvailable(Map<String, Object> headers, String name, Class<V> type) {
 		Object value = headers.get(name);
 		if (value == null) {
 			return null;

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/package-info.java
@@ -1,5 +1,5 @@
 /**
  * Provides classes related to mapping to/from message headers.
  */
-@org.springframework.lang.NonNullApi
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.mapping;

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/JsonHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/JsonHeaders.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -32,6 +33,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 3.0
  */
@@ -103,9 +105,9 @@ public final class JsonHeaders {
 	 * @return the {@link ResolvableType} based on provided class components
 	 * @since 5.2.4
 	 */
-	public static ResolvableType buildResolvableType(Class<?> targetClass, @Nullable Class<?> contentClass,
+	public static ResolvableType buildResolvableType(@Nullable Class<?> targetClass, @Nullable Class<?> contentClass,
 			@Nullable Class<?> keyClass) {
-
+		Assert.state(targetClass != null, "The targetClass must not be null");
 		if (keyClass != null) {
 			return TypeDescriptor
 					.map(targetClass,

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/JsonHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/JsonHeaders.java
@@ -24,6 +24,7 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.lang.Contract;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -69,18 +70,18 @@ public final class JsonHeaders {
 	 * @return the {@link ResolvableType} based on provided class components
 	 * @since 5.2.4
 	 */
-	public static ResolvableType buildResolvableType(ClassLoader classLoader, Object targetClassValue,
+	public static ResolvableType buildResolvableType(@Nullable ClassLoader classLoader, Object targetClassValue,
 			@Nullable Object contentClassValue, @Nullable Object keyClassValue) {
 
 		Class<?> targetClass = getClassForValue(classLoader, targetClassValue);
 		Class<?> keyClass = getClassForValue(classLoader, keyClassValue);
 		Class<?> contentClass = getClassForValue(classLoader, contentClassValue);
-
+		Assert.notNull(targetClass, "targetClass must not be null");
 		return buildResolvableType(targetClass, contentClass, keyClass);
 	}
 
 	@Nullable
-	private static Class<?> getClassForValue(ClassLoader classLoader, @Nullable Object classValue) {
+	private static Class<?> getClassForValue(@Nullable ClassLoader classLoader, @Nullable Object classValue) {
 		if (classValue instanceof Class<?>) {
 			return (Class<?>) classValue;
 		}
@@ -105,9 +106,9 @@ public final class JsonHeaders {
 	 * @return the {@link ResolvableType} based on provided class components
 	 * @since 5.2.4
 	 */
-	public static ResolvableType buildResolvableType(@Nullable Class<?> targetClass, @Nullable Class<?> contentClass,
+	@Contract("_, !null, _ -> !null; _, _, !null -> !null")
+	public static ResolvableType buildResolvableType(Class<?> targetClass, @Nullable Class<?> contentClass,
 			@Nullable Class<?> keyClass) {
-		Assert.state(targetClass != null, "The targetClass must not be null");
 		if (keyClass != null) {
 			return TypeDescriptor
 					.map(targetClass,

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/JsonHeaders.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/JsonHeaders.java
@@ -25,7 +25,6 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.lang.Contract;
-import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -76,12 +75,11 @@ public final class JsonHeaders {
 		Class<?> targetClass = getClassForValue(classLoader, targetClassValue);
 		Class<?> keyClass = getClassForValue(classLoader, keyClassValue);
 		Class<?> contentClass = getClassForValue(classLoader, contentClassValue);
-		Assert.notNull(targetClass, "targetClass must not be null");
 		return buildResolvableType(targetClass, contentClass, keyClass);
 	}
 
-	@Nullable
-	private static Class<?> getClassForValue(@Nullable ClassLoader classLoader, @Nullable Object classValue) {
+	@Contract("_, null -> null; _, !null -> !null")
+	private static @Nullable Class<?> getClassForValue(@Nullable ClassLoader classLoader, @Nullable Object classValue) {
 		if (classValue instanceof Class<?>) {
 			return (Class<?>) classValue;
 		}
@@ -106,7 +104,6 @@ public final class JsonHeaders {
 	 * @return the {@link ResolvableType} based on provided class components
 	 * @since 5.2.4
 	 */
-	@Contract("_, !null, _ -> !null; _, _, !null -> !null")
 	public static ResolvableType buildResolvableType(Class<?> targetClass, @Nullable Class<?> contentClass,
 			@Nullable Class<?> keyClass) {
 		if (keyClass != null) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/package-info.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/support/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Support classes for mapping.
  */
+@org.jspecify.annotations.NullMarked
 package org.springframework.integration.mapping.support;

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
@@ -56,6 +56,7 @@ import org.springframework.xml.transform.TransformerHelper;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Jooyoung Pyoung
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -74,10 +75,10 @@ public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapMessage> i
 	}
 
 	@Override
-	protected Map<String, Object> extractStandardHeaders(SoapMessage source) {
+	protected Map<String, @Nullable Object> extractStandardHeaders(SoapMessage source) {
 		final String soapAction = source.getSoapAction();
 		if (StringUtils.hasText(soapAction)) {
-			Map<String, Object> headers = new HashMap<>(1);
+			Map<String, @Nullable Object> headers = new HashMap<>(1);
 			headers.put(WebServiceHeaders.SOAP_ACTION, soapAction);
 			return headers;
 		}

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
@@ -41,6 +41,7 @@ import org.springframework.util.StringUtils;
  * @author Florian Schmaus
  * @author Stephane Nicoll
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -61,8 +62,8 @@ public class DefaultXmppHeaderMapper extends AbstractHeaderMapper<MessageBuilder
 	}
 
 	@Override
-	protected Map<String, Object> extractStandardHeaders(MessageBuilder source) {
-		Map<String, Object> headers = new HashMap<>();
+	protected Map<String, @Nullable Object> extractStandardHeaders(MessageBuilder source) {
+		Map<String, @Nullable Object> headers = new HashMap<>();
 		Jid from = source.getFrom();
 		if (from != null) {
 			headers.put(XmppHeaders.FROM, from.toString());


### PR DESCRIPTION
Related to: #10083
* AbstractHeaderMapper.java - Enhanced null safety by adding @Nullable annotations to fields and methods.
* Updated method signatures to match those in AbstractHeaderMapper for the following classes:
   - DefaultAmqpHeaderMapper.java
   - DefaultSoapHeaderMapper.java
   - DefaultXmppHeaderMapper.java

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
