### PR TITLE
GH-10345: Migrate Kafka module to Core Retry

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaInboundGatewaySpec.java
@@ -25,6 +25,7 @@ import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessagingGatewaySpec;
@@ -33,7 +34,6 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.ConsumerSeekAware;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaMessageDrivenChannelAdapterSpec.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageProducerSpec;
@@ -34,7 +35,6 @@ import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
 import org.springframework.kafka.support.converter.BatchMessageConverter;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
@@ -41,19 +41,19 @@ import org.springframework.kafka.support.Acknowledgment;
 public interface KafkaInboundEndpoint {
 
 	/**
-	 * {@link org.springframework.retry.RetryContext} attribute key for an acknowledgment
+	 * The {@link RetryContext} attribute key for an acknowledgment
 	 * if the listener is capable of acknowledging.
 	 */
 	String CONTEXT_ACKNOWLEDGMENT = "acknowledgment";
 
 	/**
-	 * {@link org.springframework.retry.RetryContext} attribute key for the consumer if
+	 * The {@link RetryContext} attribute key for the consumer if
 	 * the listener is consumer-aware.
 	 */
 	String CONTEXT_CONSUMER = "consumer";
 
 	/**
-	 * {@link org.springframework.retry.RetryContext} attribute key for the record.
+	 * The {@link RetryContext} attribute key for the record.
 	 */
 	String CONTEXT_RECORD = "record";
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundEndpoint.java
@@ -21,16 +21,20 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.AttributeAccessor;
+import org.springframework.core.AttributeAccessorSupport;
+import org.springframework.core.retry.RetryException;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.integration.core.RecoveryCallback;
 import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.support.Acknowledgment;
-import org.springframework.retry.RecoveryCallback;
-import org.springframework.retry.support.RetryTemplate;
 
 /**
  * Implementations of this interface will generally support a retry template for retrying
- * incoming deliveries and this supports adding common attributes to the retry context.
+ * incoming deliveries, and this supports adding common attributes to the retry context.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 6.0
  *
  */
@@ -53,7 +57,7 @@ public interface KafkaInboundEndpoint {
 	 */
 	String CONTEXT_RECORD = "record";
 
-	ThreadLocal<AttributeAccessor> ATTRIBUTES_HOLDER = new ThreadLocal<>();
+	ThreadLocal<@Nullable AttributeAccessor> ATTRIBUTES_HOLDER = new ThreadLocal<>();
 
 	/**
 	 * Execute the runnable with the retry template and recovery callback.
@@ -67,24 +71,46 @@ public interface KafkaInboundEndpoint {
 	default void doWithRetry(RetryTemplate template, @Nullable RecoveryCallback<?> callback, ConsumerRecord<?, ?> record,
 			@Nullable Acknowledgment acknowledgment, @Nullable Consumer<?, ?> consumer, Runnable runnable) {
 
+		RetryContext context = new RetryContext();
+		context.setAttribute(CONTEXT_RECORD, record);
+		context.setAttribute(CONTEXT_ACKNOWLEDGMENT, acknowledgment);
+		context.setAttribute(CONTEXT_CONSUMER, consumer);
+		ATTRIBUTES_HOLDER.set(context);
+
 		try {
-			template.execute(context -> {
-				if (context.getRetryCount() == 0) {
-					context.setAttribute(CONTEXT_RECORD, record);
-					context.setAttribute(CONTEXT_ACKNOWLEDGMENT, acknowledgment);
-					context.setAttribute(CONTEXT_CONSUMER, consumer);
-					ATTRIBUTES_HOLDER.set(context);
+			template.execute(() -> {
+				try {
+					runnable.run();
 				}
-				runnable.run();
+				catch (Throwable ex) {
+					context.retryCount++;
+					throw ex;
+				}
 				return null;
-			}, callback);
+			});
 		}
-		catch (Exception ex) {
-			throw new KafkaException("Failed to execute runnable", ex);
+		catch (RetryException ex) {
+			if (callback != null) {
+				callback.recover(context, ex);
+			}
+			else {
+				throw new KafkaException("Failed to execute runnable", ex);
+			}
 		}
 		finally {
 			ATTRIBUTES_HOLDER.remove();
 		}
+	}
+
+	@SuppressWarnings("serial")
+	final class RetryContext extends AttributeAccessorSupport {
+
+		private int retryCount;
+
+		public int getRetryCount() {
+			return this.retryCount;
+		}
+
 	}
 
 }

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaInboundGateway.java
@@ -293,7 +293,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 	private class IntegrationRecordMessageListener extends RecordMessagingMessageListenerAdapter<K, V> {
 
 		IntegrationRecordMessageListener() {
-			super(null, null); // NOSONAR - out of use
+			super(null, null);
 		}
 
 		@Override
@@ -327,7 +327,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 				sendAndReceive(record, message, acknowledgment, consumer);
 			}
 			else {
-				KafkaInboundGateway.this.logger.debug(() -> "Converter returned a null message for: " + record);
+				KafkaInboundGateway.this.logger.warn(() -> "Converter returned a null message for: " + record);
 			}
 		}
 
@@ -353,7 +353,7 @@ public class KafkaInboundGateway<K, V, R> extends MessagingGatewaySupport
 					KafkaInboundGateway.this.kafkaTemplate.send(reply);
 				}
 				else {
-					this.logger.debug(() -> "No reply received for " + message);
+					this.logger.warn(() -> "No reply received for " + message);
 				}
 			}
 			finally {

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundGatewayTests-context.xml
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundGatewayTests-context.xml
@@ -53,7 +53,7 @@
 
 	<bean id="ems" class="org.springframework.integration.kafka.support.RawRecordHeaderErrorMessageStrategy"/>
 
-	<bean id="retryTemplate" class="org.springframework.retry.support.RetryTemplate"/>
+	<bean id="retryTemplate" class="org.springframework.core.retry.RetryTemplate"/>
 
 	<bean id="recoveryCallback"
 		  class="org.springframework.integration.handler.advice.ErrorMessageSendingRecoverer"/>

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundGatewayTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundGatewayTests.java
@@ -66,9 +66,8 @@ public class KafkaInboundGatewayTests {
 				.isSameAs(this.context.getBean("ems"));
 		assertThat(TestUtils.getPropertyValue(this.gateway1, "retryTemplate"))
 				.isSameAs(this.context.getBean("retryTemplate"));
-		//		 TODO https://github.com/spring-projects/spring-integration/issues/10345
-//		assertThat(TestUtils.getPropertyValue(this.gateway1, "recoveryCallback"))
-//				.isSameAs(this.context.getBean("recoveryCallback"));
+		assertThat(TestUtils.getPropertyValue(this.gateway1, "recoveryCallback"))
+				.isSameAs(this.context.getBean("recoveryCallback"));
 		assertThat(TestUtils.getPropertyValue(this.gateway1, "onPartitionsAssignedSeekCallback"))
 				.isSameAs(this.context.getBean("onPartitionsAssignedSeekCallback"));
 		assertThat(TestUtils.getPropertyValue(this.gateway1, "messagingTemplate.sendTimeout")).isEqualTo(5000L);

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests-context.xml
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests-context.xml
@@ -84,7 +84,7 @@
 
 	<bean id="ems" class="org.springframework.integration.kafka.support.RawRecordHeaderErrorMessageStrategy"/>
 
-	<bean id="retryTemplate" class="org.springframework.retry.support.RetryTemplate"/>
+	<bean id="retryTemplate" class="org.springframework.core.retry.RetryTemplate"/>
 
 	<bean id="recoveryCallback" class="org.springframework.integration.handler.advice.ErrorMessageSendingRecoverer"/>
 

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests.java
@@ -16,12 +16,15 @@
 
 package org.springframework.integration.kafka.config.xml;
 
+import java.time.Duration;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.channel.PublishSubscribeChannel;
 import org.springframework.integration.channel.QueueChannel;
@@ -36,7 +39,6 @@ import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -95,8 +97,7 @@ class KafkaMessageDrivenChannelAdapterParserTests implements TestApplicationCont
 				.isEqualTo(String.class);
 		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "errorMessageStrategy")).isSameAs(this.ems);
 		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "retryTemplate")).isSameAs(this.retryTemplate);
-		//		 TODO https://github.com/spring-projects/spring-integration/issues/10345
-//		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "recoveryCallback")).isSameAs(this.recoveryCallback);
+		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "recoveryCallback")).isSameAs(this.recoveryCallback);
 		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "onPartitionsAssignedSeekCallback"))
 				.isSameAs(this.context.getBean("onPartitionsAssignedSeekCallback"));
 		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "bindSourceRecord", Boolean.class)).isTrue();
@@ -146,7 +147,7 @@ class KafkaMessageDrivenChannelAdapterParserTests implements TestApplicationCont
 		assertThat(delegate.getClass().getName()).contains("$IntegrationRecordMessageListener");
 
 		adapter.setRecordFilterStrategy(null);
-		adapter.setRetryTemplate(new RetryTemplate());
+		adapter.setRetryTemplate(new RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()));
 		container.getContainerProperties().setMessageListener(null);
 		adapter.afterPropertiesSet();
 

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
@@ -37,6 +37,8 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.core.retry.RetryTemplate;
 import org.springframework.integration.IntegrationMessageHeaderAccessor;
 import org.springframework.integration.MessageRejectedException;
 import org.springframework.integration.channel.QueueChannel;
@@ -80,7 +82,6 @@ import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.support.ErrorMessage;
 import org.springframework.messaging.support.GenericMessage;
-import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.backoff.FixedBackOff;
@@ -302,7 +303,8 @@ public class KafkaDslTests {
 											.idleEventInterval(100L)
 											.id("topic1ListenerContainer"))
 							.errorChannel(errorChannel())
-							.retryTemplate(new RetryTemplate())
+							.retryTemplate(
+									new RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()))
 							.onPartitionsAssignedSeekCallback((map, callback) ->
 									ContextConfiguration.this.onPartitionsAssignedCalledLatch.countDown()))
 					.filter(Message.class, m ->

--- a/spring-integration-kafka/src/test/kotlin/org/springframework/integration/kafka/dsl/kotlin/KafkaDslKotlinTests.kt
+++ b/spring-integration-kafka/src/test/kotlin/org/springframework/integration/kafka/dsl/kotlin/KafkaDslKotlinTests.kt
@@ -28,6 +28,8 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.core.retry.RetryPolicy
+import org.springframework.core.retry.RetryTemplate
 import org.springframework.integration.IntegrationMessageHeaderAccessor
 import org.springframework.integration.MessageRejectedException
 import org.springframework.integration.channel.PublishSubscribeChannel
@@ -56,7 +58,6 @@ import org.springframework.messaging.PollableChannel
 import org.springframework.messaging.handler.annotation.Header
 import org.springframework.messaging.support.ErrorMessage
 import org.springframework.messaging.support.GenericMessage
-import org.springframework.retry.support.RetryTemplate
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 import java.time.Duration
@@ -235,7 +236,7 @@ class KafkaDslKotlinTests {
 
 					}
 					.errorChannel(errorChannel())
-					.retryTemplate(RetryTemplate())
+					.retryTemplate(RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()))
 					.filterInRetry(true)) {
 				filter<Message<*>>({ m -> (m.headers[KafkaHeaders.RECEIVED_KEY] as Int) < 101 }) {
 					throwExceptionOnRejection(
@@ -258,7 +259,7 @@ class KafkaDslKotlinTests {
 							.groupId("kotlin_topic2_group")
 					}
 					.errorChannel(errorChannel())
-					.retryTemplate(RetryTemplate())
+					.retryTemplate(RetryTemplate(RetryPolicy.builder().maxAttempts(2).delay(Duration.ZERO).build()))
 					.filterInRetry(true)) {
 				filter<Message<*>>({ m -> (m.headers[KafkaHeaders.RECEIVED_KEY] as Int) < 101 }) {
 					throwExceptionOnRejection(


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10345

* Replace `RetryTemplate` from Spring Retry to `RetryTemplate` from Spring Core since Spring Retry is at its sunset.
There is no deprecation for Spring Retry API usage since the idea is to remove Spring Retry dependency altogether for the upcoming major for all projects in the Spring portfolio

* Introduce a `KafkaInboundEndpoint.RetryContext` as an `AttributeAccessorSupport` extension to track the number of retries for functional compatibility

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
