### PR TITLE
Use isNoop() instead of Observation.NOOP

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -22,7 +22,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
@@ -480,7 +479,7 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 
 		if (!ObservationRegistry.NOOP.equals(this.observationRegistry)
 				&& (this.observationRegistry.getCurrentObservation() == null
-				|| Observation.NOOP.equals(this.observationRegistry.getCurrentObservation()))) {
+				|| this.observationRegistry.getCurrentObservation().isNoop())) {
 
 			sendWithObservation(channel, requestMessage);
 		}


### PR DESCRIPTION
TL;DR: this is a polishing PR as long as https://github.com/micrometer-metrics/micrometer/pull/6700 is not merged (`1.16.0`). If that will happen, things can break without this change.

Details:
The Micrometer team is considering some improvements in the Observation API which involves changing the behavior of `Observation.NOOP`: https://github.com/micrometer-metrics/micrometer/pull/6700
`Observation.NOOP` is not truly no-op right now, it does context propagation, we are trying to make it truly no-op in the PR above. The non-truly no-op version will still be used in certain scenarios (see `NoopButScopeHandlingObservation`). `observation.isNoop()` should be used for checking if an Observation is no-op or not instead of `Observation.NOOP`.
