### PR TITLE
Bump junitJupiterVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ ext {
     jrubyVersion = '10.0.2.0'
     jsonpathVersion = '2.9.0'
     junit4Version = '4.13.2'
-    junitJupiterVersion = '5.13.4'
+    junitJupiterVersion = '6.0.0-RC2'
     kotlinCoroutinesVersion = '1.10.2'
     kryoVersion = '5.6.2'
     lettuceVersion = '6.8.1.RELEASE'

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/condition/LogLevelsCondition.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/condition/LogLevelsCondition.java
@@ -67,6 +67,7 @@ public class LogLevelsCondition
 	}
 
 	@Override
+	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	public void beforeEach(ExtensionContext context) {
 		Store store = context.getStore(Namespace.create(getClass(), context));
 		LogLevels logLevels = store.get(STORE_ANNOTATION_KEY, LogLevels.class);
@@ -82,6 +83,7 @@ public class LogLevelsCondition
 	}
 
 	@Override
+	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	public void afterEach(ExtensionContext context) {
 		Store store = context.getStore(Namespace.create(getClass(), context));
 		LevelsContainer container = store.get(STORE_CONTAINER_KEY, LevelsContainer.class);


### PR DESCRIPTION
- Update JUnit Jupiter from 5.13.4 to 6.0.0-RC2 in build.gradle
- Add @SuppressWarnings("NullAway") annotations to LogLevelsCondition beforeEach() and afterEach() methods due to dataflow analysis limitations
- Verified that JUnit version did not require an update

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
