### PR TITLE
Update Javadoc references deprecated javadocs

### DIFF
--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/HeaderMatcher.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/HeaderMatcher.java
@@ -31,7 +31,7 @@ import org.springframework.messaging.MessageHeaders;
  * Are the {@link MessageHeaders} of a {@link Message} containing any entry
  * or multiple that match?
  * <p>
- * For example using {@link org.junit.Assert#assertThat(Object, Matcher)} for a single
+ * For example using {@link org.hamcrest.MatcherAssert#assertThat(Object, Matcher)} for a single
  * entry:
  *
  * <pre class="code">

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/PayloadMatcher.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/PayloadMatcher.java
@@ -52,6 +52,20 @@ import org.springframework.messaging.Message;
  * }
  * </pre>
  *
+ * <p>
+ * When using AssertJ, the {@link org.assertj.core.api.HamcrestCondition} can be used to combine the AssertJ API
+ * with Hamcrest matchers:
+ *
+ * <pre class="code">
+ * {@code
+ * ANY_PAYLOAD = new BigDecimal("1.123");
+ * Message<BigDecimal> message = MessageBuilder.withPayload(ANY_PAYLOAD).build();
+ * assertThat(message).is(matching(hasPayload(ANY_PAYLOAD)));
+ * assertThat(message).has(matching(hasPayload(notNullValue())));
+ * assertThat(message).isNot(matching(hasPayload(is(String.class))));
+ * }
+ * </pre>
+ *
  *
  *
  * @author Alex Peters

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/PayloadMatcher.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/matcher/PayloadMatcher.java
@@ -27,7 +27,7 @@ import org.springframework.messaging.Message;
  * Is the payload of a {@link Message} equal to a given value or is matching
  * a given matcher?
  * <p>
- * A Junit example using {@link org.junit.Assert#assertThat(Object, Matcher)} could look
+ * A Junit example using {@link org.hamcrest.MatcherAssert#assertThat(Object, Matcher)} could look
  * like this to test a payload value:
  *
  * <pre class="code">
@@ -39,7 +39,7 @@ import org.springframework.messaging.Message;
  * </pre>
  *
  * <p>
- * An example using {@link org.junit.Assert#assertThat(Object, Matcher)} delegating to
+ * An example using {@link org.hamcrest.MatcherAssert#assertThat(Object, Matcher)} delegating to
  * another {@link Matcher}.
  *
  * <pre class="code">


### PR DESCRIPTION
Replace deprecated `org.junit.Assert#assertThat` references with `org.hamcrest.MatcherAssert#assertThat` in test matcher documentation.

This change updates documentation in HeaderMatcher and PayloadMatcher classes to reference the correct assertThat method location after JUnit Jupiter migration removed Assert.assertThat in favor of the Hamcrest implementation.

This is an optional PR.  Wanted to remove the last of the deprecated markers in SI.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
