### PR TITLE
GH-10162: The full file path for `PersistentAcceptOnceFileListFilter`

### DIFF
--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/filters/FtpPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/filters/FtpPersistentAcceptOnceFileListFilter.java
@@ -19,13 +19,16 @@ package org.springframework.integration.ftp.filters;
 import org.apache.commons.net.ftp.FTPFile;
 
 import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
+import org.springframework.integration.ftp.session.EnhancedFTPFile;
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
+import org.springframework.util.StringUtils;
 
 /**
  * Persistent file list filter using the server's file timestamp to detect if we've already
  * 'seen' this file.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @since 3.0
  *
@@ -43,6 +46,13 @@ public class FtpPersistentAcceptOnceFileListFilter extends AbstractPersistentAcc
 
 	@Override
 	protected String fileName(FTPFile file) {
+		if (file instanceof EnhancedFTPFile enhancedFTPFile) {
+			String longFileName = enhancedFTPFile.getLongFileName();
+			if (StringUtils.hasText(longFileName)) {
+				return longFileName;
+			}
+		}
+
 		return file.getName();
 	}
 

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/EnhancedFTPFile.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/EnhancedFTPFile.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.ftp.session;
+
+import java.io.Serial;
+import java.time.Instant;
+import java.util.Calendar;
+
+import org.apache.commons.net.ftp.FTPFile;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The {@link FTPFile} extension to provide additional information,
+ * e.g., long file name with directory included.
+ * The instance of this class is based on the original {@link FTPFile}
+ * with delegation from all the methods.
+ *
+ * @author Artem Bilan
+ *
+ * @since 7.0
+ */
+public class EnhancedFTPFile extends FTPFile {
+
+	@Serial
+	private static final long serialVersionUID = 9010790363003271996L;
+
+	private final FTPFile delegate;
+
+	private @Nullable String longFileName;
+
+	public EnhancedFTPFile(FTPFile delegate) {
+		this.delegate = delegate;
+	}
+
+	@Override
+	public String getGroup() {
+		return this.delegate.getGroup();
+	}
+
+	@Override
+	public int getHardLinkCount() {
+		return this.delegate.getHardLinkCount();
+	}
+
+	@Override
+	public String getLink() {
+		return this.delegate.getLink();
+	}
+
+	@Override
+	public String getName() {
+		return this.delegate.getName();
+	}
+
+	@Override
+	public String getRawListing() {
+		return this.delegate.getRawListing();
+	}
+
+	@Override
+	public long getSize() {
+		return this.delegate.getSize();
+	}
+
+	@Override
+	public Calendar getTimestamp() {
+		return this.delegate.getTimestamp();
+	}
+
+	@Override
+	public Instant getTimestampInstant() {
+		return this.delegate.getTimestampInstant();
+	}
+
+	@Override
+	public int getType() {
+		return this.delegate.getType();
+	}
+
+	@Override
+	public String getUser() {
+		return this.delegate.getUser();
+	}
+
+	@Override
+	public boolean hasPermission(int access, int permission) {
+		return this.delegate.hasPermission(access, permission);
+	}
+
+	@Override
+	public boolean isDirectory() {
+		return this.delegate.isDirectory();
+	}
+
+	@Override
+	public boolean isFile() {
+		return this.delegate.isFile();
+	}
+
+	@Override
+	public boolean isSymbolicLink() {
+		return this.delegate.isSymbolicLink();
+	}
+
+	@Override
+	public boolean isUnknown() {
+		return this.delegate.isUnknown();
+	}
+
+	@Override
+	public boolean isValid() {
+		return this.delegate.isValid();
+	}
+
+	@Override
+	public void setGroup(String group) {
+		this.delegate.setGroup(group);
+	}
+
+	@Override
+	public void setHardLinkCount(int hardLinkCount) {
+		this.delegate.setHardLinkCount(hardLinkCount);
+	}
+
+	@Override
+	public void setLink(String link) {
+		this.delegate.setLink(link);
+	}
+
+	@Override
+	public void setName(String name) {
+		this.delegate.setName(name);
+	}
+
+	@Override
+	public void setPermission(int access, int permission, boolean value) {
+		this.delegate.setPermission(access, permission, value);
+	}
+
+	@Override
+	public void setRawListing(String rawListing) {
+		this.delegate.setRawListing(rawListing);
+	}
+
+	@Override
+	public void setSize(long size) {
+		this.delegate.setSize(size);
+	}
+
+	@Override
+	public void setTimestamp(Calendar calendar) {
+		this.delegate.setTimestamp(calendar);
+	}
+
+	@Override
+	public void setType(int type) {
+		this.delegate.setType(type);
+	}
+
+	@Override
+	public void setUser(String user) {
+		this.delegate.setUser(user);
+	}
+
+	@Override
+	public String toFormattedString() {
+		return this.delegate.toFormattedString();
+	}
+
+	@Override
+	public String toFormattedString(String timezone) {
+		return this.delegate.toFormattedString(timezone);
+	}
+
+	@Override
+	public String toString() {
+		return this.delegate.toString();
+	}
+
+	public @Nullable String getLongFileName() {
+		return this.longFileName;
+	}
+
+	public void setLongFileName(@Nullable String longFileName) {
+		this.longFileName = longFileName;
+	}
+
+}

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
@@ -19,8 +19,6 @@ package org.springframework.integration.ftp.session;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
@@ -75,16 +73,16 @@ public class FtpSession implements Session<FTPFile> {
 	@Override
 	public FTPFile[] list(@Nullable String path) throws IOException {
 		FTPFile[] ftpFiles = this.client.listFiles(path);
-		if (StringUtils.hasText(path)) {
-			List<EnhancedFTPFile> enhancedFtpFiles = new LinkedList<>();
-			for (FTPFile ftpFile : ftpFiles) {
-				EnhancedFTPFile enhancedFTPFile = new EnhancedFTPFile(ftpFile);
-				enhancedFTPFile.setLongFileName(path + '/' + ftpFile.getName());
-				enhancedFtpFiles.add(enhancedFTPFile);
-			}
-			return enhancedFtpFiles.toArray(new FTPFile[0]);
+		String remoteDir = StringUtils.hasText(path) ? path : ".";
+		EnhancedFTPFile[] enhancedFtpFiles = new EnhancedFTPFile[ftpFiles.length];
+		for (int i = 0; i < ftpFiles.length; i++) {
+			FTPFile ftpFile = ftpFiles[i];
+			EnhancedFTPFile enhancedFTPFile = new EnhancedFTPFile(ftpFile);
+			enhancedFTPFile.setLongFileName(remoteDir + '/' + ftpFile.getName());
+			enhancedFtpFiles[i] = enhancedFTPFile;
 		}
-		return ftpFiles;
+
+		return enhancedFtpFiles;
 	}
 
 	@Override

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/session/FtpSession.java
@@ -19,6 +19,8 @@ package org.springframework.integration.ftp.session;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
@@ -31,6 +33,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.integration.file.remote.session.Session;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Implementation of {@link Session} for FTP.
@@ -71,7 +74,17 @@ public class FtpSession implements Session<FTPFile> {
 
 	@Override
 	public FTPFile[] list(@Nullable String path) throws IOException {
-		return this.client.listFiles(path);
+		FTPFile[] ftpFiles = this.client.listFiles(path);
+		if (StringUtils.hasText(path)) {
+			List<EnhancedFTPFile> enhancedFtpFiles = new LinkedList<>();
+			for (FTPFile ftpFile : ftpFiles) {
+				EnhancedFTPFile enhancedFTPFile = new EnhancedFTPFile(ftpFile);
+				enhancedFTPFile.setLongFileName(path + '/' + ftpFile.getName());
+				enhancedFtpFiles.add(enhancedFTPFile);
+			}
+			return enhancedFtpFiles.toArray(new FTPFile[0]);
+		}
+		return ftpFiles;
 	}
 
 	@Override

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
@@ -24,6 +24,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.commons.net.ftp.FTPClient;
 import org.apache.commons.net.ftp.FTPFile;
@@ -69,7 +70,7 @@ import static org.mockito.Mockito.when;
  */
 public class FtpInboundRemoteFileSystemSynchronizerTests implements TestApplicationContextAware {
 
-	private static FTPClient ftpClient = mock(FTPClient.class);
+	private static final FTPClient ftpClient = mock(FTPClient.class);
 
 	@BeforeEach
 	@AfterEach
@@ -85,7 +86,7 @@ public class FtpInboundRemoteFileSystemSynchronizerTests implements TestApplicat
 		TestFtpSessionFactory ftpSessionFactory = new TestFtpSessionFactory();
 		ftpSessionFactory.setUsername("kermit");
 		ftpSessionFactory.setPassword("frog");
-		ftpSessionFactory.setHost("foo.com");
+		ftpSessionFactory.setHost("some-host.com");
 		FtpInboundFileSynchronizer synchronizer = spy(new FtpInboundFileSynchronizer(ftpSessionFactory));
 		synchronizer.setDeleteRemoteFiles(true);
 		synchronizer.setPreserveTimestamp(true);
@@ -97,7 +98,7 @@ public class FtpInboundRemoteFileSystemSynchronizerTests implements TestApplicat
 		store.setBaseDirectory("test");
 		store.afterPropertiesSet();
 		FtpPersistentAcceptOnceFileListFilter persistFilter =
-				new FtpPersistentAcceptOnceFileListFilter(store, "foo");
+				new FtpPersistentAcceptOnceFileListFilter(store, "someKey/");
 		List<FileListFilter<FTPFile>> filters = new ArrayList<>();
 		filters.add(persistFilter);
 		filters.add(patternFilter);
@@ -166,6 +167,10 @@ public class FtpInboundRemoteFileSystemSynchronizerTests implements TestApplicat
 
 		Map<?, ?> metadata = TestUtils.getPropertyValue(remoteFileMetadataStore, "metadata", Map.class);
 		assertThat(metadata).isEmpty();
+
+		Properties metadataProperties = TestUtils.getPropertyValue(store, "metadata", Properties.class);
+		metadataProperties.stringPropertyNames()
+				.forEach(name -> assertThat(name).startsWith("someKey/remote-test-dir/"));
 	}
 
 	@Test

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -68,6 +68,7 @@ import org.springframework.integration.ftp.server.PathMovedEvent;
 import org.springframework.integration.ftp.server.PathRemovedEvent;
 import org.springframework.integration.ftp.server.SessionClosedEvent;
 import org.springframework.integration.ftp.server.SessionOpenedEvent;
+import org.springframework.integration.ftp.session.EnhancedFTPFile;
 import org.springframework.integration.ftp.session.FtpRemoteFileTemplate;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.PartialSuccessException;
@@ -516,7 +517,7 @@ public class FtpServerOutboundTests extends FtpTestSupport {
 			FTPFile[] files = (FTPFile[]) invocation.callRealMethod();
 			// add an extra file where the get will fail
 			files = Arrays.copyOf(files, files.length + 1);
-			FTPFile bogusFile = new FTPFile();
+			FTPFile bogusFile = new EnhancedFTPFile(new FTPFile());
 			bogusFile.setName("bogus.txt");
 			files[files.length - 1] = bogusFile;
 			return files;
@@ -542,7 +543,7 @@ public class FtpServerOutboundTests extends FtpTestSupport {
 			FTPFile[] files = (FTPFile[]) invocation.callRealMethod();
 			// add an extra file where the get will fail
 			files = Arrays.copyOf(files, files.length + 1);
-			FTPFile bogusFile = new FTPFile();
+			FTPFile bogusFile = new EnhancedFTPFile(new FTPFile());
 			bogusFile.setName("bogus.txt");
 			bogusFile.setTimestamp(Calendar.getInstance());
 			files[files.length - 1] = bogusFile;

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/filters/SftpPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/filters/SftpPersistentAcceptOnceFileListFilter.java
@@ -20,6 +20,7 @@ import org.apache.sshd.sftp.client.SftpClient;
 
 import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
+import org.springframework.util.StringUtils;
 
 /**
  * Persistent file list filter using the server's file timestamp to detect if we've already
@@ -46,7 +47,8 @@ public class SftpPersistentAcceptOnceFileListFilter
 
 	@Override
 	protected String fileName(SftpClient.DirEntry file) {
-		return file.getFilename();
+		String longFilename = file.getLongFilename();
+		return StringUtils.hasText(longFilename) ? longFilename : file.getFilename();
 	}
 
 	@Override

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -126,8 +126,17 @@ public class SftpSession implements Session<SftpClient.DirEntry> {
 			}
 		}
 		remoteDir = normalizePath(remoteDir);
-		return StreamSupport.stream(this.sftpClient.readDir(remoteDir).spliterator(), false)
-				.filter((entry) -> !isPattern || PatternMatchUtils.simpleMatch(remoteFile, entry.getFilename()));
+		String remoteDirToUse = remoteDir;
+		return StreamSupport.stream(this.sftpClient.readDir(remoteDirToUse).spliterator(), false)
+				.filter((entry) -> !isPattern || PatternMatchUtils.simpleMatch(remoteFile, entry.getFilename()))
+				.map((entry) -> {
+					String longFilename = entry.getLongFilename();
+					if (StringUtils.hasText(longFilename)) {
+						return entry;
+					}
+					String filename = entry.getFilename();
+					return new SftpClient.DirEntry(filename, remoteDirToUse + '/' + filename, entry.getAttributes());
+				});
 	}
 
 	@Override

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/filters/SftpPersistentAcceptOnceFileListFilterTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/filters/SftpPersistentAcceptOnceFileListFilterTests.java
@@ -44,21 +44,22 @@ public class SftpPersistentAcceptOnceFileListFilterTests {
 				new SimpleMetadataStore(), "rollback:");
 		SftpClient.Attributes attrs = new SftpClient.Attributes();
 		attrs.setModifyTime(FileTime.from(Instant.now()));
-		SftpClient.DirEntry sftpFile1 = new SftpClient.DirEntry("foo", "foo", attrs);
-		SftpClient.DirEntry sftpFile2 = new SftpClient.DirEntry("bar", "bar", attrs);
-		SftpClient.DirEntry sftpFile3 = new SftpClient.DirEntry("baz", "baz", attrs);
+		SftpClient.DirEntry sftpFile1 = new SftpClient.DirEntry("file1", null, attrs);
+		SftpClient.DirEntry sftpFile2 = new SftpClient.DirEntry("file2", null, attrs);
+		SftpClient.DirEntry sftpFile3 = new SftpClient.DirEntry("file3", null, attrs);
 		SftpClient.DirEntry[] files = new SftpClient.DirEntry[] {sftpFile1, sftpFile2, sftpFile3};
 		List<SftpClient.DirEntry> passed = filter.filterFiles(files);
-		assertThat(Arrays.equals(files, passed.toArray())).isTrue();
+		assertThat(passed.toArray()).isEqualTo(files);
 		List<SftpClient.DirEntry> now = filter.filterFiles(files);
-		assertThat(now.size()).isEqualTo(0);
+		assertThat(now).isEmpty();
 		filter.rollback(passed.get(1), passed);
 		now = filter.filterFiles(files);
-		assertThat(now.size()).isEqualTo(2);
-		assertThat(now.get(0).getFilename()).isEqualTo("bar");
-		assertThat(now.get(1).getFilename()).isEqualTo("baz");
+		assertThat(now)
+				.hasSize(2)
+				.extracting(SftpClient.DirEntry::getFilename)
+				.contains("file2", "file3");
 		now = filter.filterFiles(files);
-		assertThat(now.size()).isEqualTo(0);
+		assertThat(now).isEmpty();
 		filter.close();
 	}
 
@@ -68,13 +69,14 @@ public class SftpPersistentAcceptOnceFileListFilterTests {
 				new SimpleMetadataStore(), "rollback:");
 		SftpClient.Attributes attrs = new SftpClient.Attributes();
 		attrs.setModifyTime(FileTime.from(Instant.now()));
-		SftpClient.DirEntry sftpFile1 = new SftpClient.DirEntry("foo", "same", attrs);
-		SftpClient.DirEntry sftpFile2 = new SftpClient.DirEntry("bar", "same", attrs);
+		SftpClient.DirEntry sftpFile1 = new SftpClient.DirEntry("same", "dir1/same", attrs);
+		SftpClient.DirEntry sftpFile2 = new SftpClient.DirEntry("same", "dir2/same", attrs);
 		SftpClient.DirEntry[] files = new SftpClient.DirEntry[] {sftpFile1, sftpFile2};
 		List<SftpClient.DirEntry> now = filter.filterFiles(files);
-		assertThat(now.size()).isEqualTo(2);
-		assertThat(now.get(0).getFilename()).isEqualTo("foo");
-		assertThat(now.get(1).getFilename()).isEqualTo("bar");
+		assertThat(now)
+				.hasSize(2)
+				.extracting(SftpClient.DirEntry::getFilename)
+				.contains("same", "same");
 		filter.close();
 	}
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/filters/SftpPersistentAcceptOnceFileListFilterTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/filters/SftpPersistentAcceptOnceFileListFilterTests.java
@@ -18,7 +18,6 @@ package org.springframework.integration.sftp.filters;
 
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.sshd.sftp.client.SftpClient;

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbPersistentAcceptOnceFileListFilter.java
@@ -25,6 +25,7 @@ import org.springframework.integration.metadata.ConcurrentMetadataStore;
  * Implementation of {@link AbstractPersistentAcceptOnceFileListFilter} for SMB.
  *
  * @author Prafull Kumar Soni
+ * @author Artem Bilan
  *
  * @since 6.0
  */
@@ -41,7 +42,7 @@ public class SmbPersistentAcceptOnceFileListFilter extends AbstractPersistentAcc
 
 	@Override
 	protected String fileName(SmbFile file) {
-		return file.getName();
+		return file.getUncPath();
 	}
 
 }

--- a/src/reference/antora/modules/ROOT/pages/file/remote-persistent-flf.adoc
+++ b/src/reference/antora/modules/ROOT/pages/file/remote-persistent-flf.adoc
@@ -7,7 +7,7 @@ These filters are used to prevent fetching the same file multiple times (unless 
 Starting with version 5.2, a file is added to the filter immediately before the file is fetched (and reversed if the fetch fails).
 
 Starting with version 7.0, all the `AbstractPersistentAcceptOnceFileListFilter` implementations uses a "long file name" (fetching directory plus simple file name) for the metadata entry key.
-Perviously, just a file name may cause the metadata overriding problem when the same filter is used for different directories with same file names.
+Previously, just a file name may cause the metadata overriding problem when the same filter is used for different directories with same file names.
 For example, the `RotatingServerAdvice` may switch to directories based on the timestamp, but files are placed there with the same name according to business logic.
 If `directory1` and `directory2` contain a `someFile`, the metadata for them is stored with a `directory1/someFile` and `directory2/someFile`, respectively.
 That is if filter's `prefix` option is provided as an empty string, otherwise such a prefix is added to the final key.

--- a/src/reference/antora/modules/ROOT/pages/file/remote-persistent-flf.adoc
+++ b/src/reference/antora/modules/ROOT/pages/file/remote-persistent-flf.adoc
@@ -1,10 +1,16 @@
 [[remote-persistent-flf]]
 = Remote Persistent File List Filters
 
-Inbound and streaming inbound remote file channel adapters (`FTP`, `SFTP`, and other technologies) are configured with corresponding implementations of `AbstractPersistentFileListFilter` by default, configured with an in-memory `MetadataStore`.
+Inbound and streaming inbound remote file channel adapters (`FTP`, `SFTP`, and other technologies) are configured with corresponding implementations of `AbstractPersistentAcceptOnceFileListFilter` by default, configured with an in-memory `MetadataStore`.
 To run in a cluster, these can be replaced with filters using a shared `MetadataStore` (see xref:meta-data-store.adoc[Metadata Store] for more information).
 These filters are used to prevent fetching the same file multiple times (unless its modified time changes).
 Starting with version 5.2, a file is added to the filter immediately before the file is fetched (and reversed if the fetch fails).
+
+Starting with version 7.0, all the `AbstractPersistentAcceptOnceFileListFilter` implementations uses a "long file name" (fetching directory plus simple file name) for the metadata entry key.
+Perviously, just a file name may cause the metadata overriding problem when the same filter is used for different directories with same file names.
+For example, the `RotatingServerAdvice` may switch to directories based on the timestamp, but files are placed there with the same name according to business logic.
+If `directory1` and `directory2` contain a `someFile`, the metadata for them is stored with a `directory1/someFile` and `directory2/someFile`, respectively.
+That is if filter's `prefix` option is provided as an empty string, otherwise such a prefix is added to the final key.
 
 IMPORTANT: In the event of a catastrophic failure (such as power loss), it is possible that the file currently being fetched will remain in the filter and won't be re-fetched when restarting the application.
 In this case you would need to manually remove this file from the `MetadataStore`.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -100,6 +100,11 @@ The `AbstractInboundFileSynchronizer` now caches a filtered result of the `Sessi
 So, later synchronizations deal with the cache only by the `maxFetchSize` until the cache is exhausted.
 See xref:sftp/max-fetch.adoc[] for more information.
 
+All the `AbstractPersistentAcceptOnceFileListFilter` implementations now use a "long file name" for the metadata entry key.
+Perviously, just a file name may cause the metadata overriding problem when the same filter is used for different directories with same file names.
+For example, the `RotatingServerAdvice` may switch to directories based on the timestamp, but files are placed there with the same name according to business logic.
+See xref:file/remote-persistent-flf.adoc[Remote Persistent File List Filters] for more information.
+
 [[x7.0-null-safety]]
 === Null Safety
 Updated the codebase to use JSpecify and NullAway, adding a comprehensive null safety implementation that uses `@NullMarked` annotations to default all types to non-null at the package level and `@Nullable` annotations to explicitly mark types that can be null.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -101,7 +101,7 @@ So, later synchronizations deal with the cache only by the `maxFetchSize` until 
 See xref:sftp/max-fetch.adoc[] for more information.
 
 All the `AbstractPersistentAcceptOnceFileListFilter` implementations now use a "long file name" for the metadata entry key.
-Perviously, just a file name may cause the metadata overriding problem when the same filter is used for different directories with same file names.
+Previously, just a file name may cause the metadata overriding problem when the same filter is used for different directories with same file names.
 For example, the `RotatingServerAdvice` may switch to directories based on the timestamp, but files are placed there with the same name according to business logic.
 See xref:file/remote-persistent-flf.adoc[Remote Persistent File List Filters] for more information.
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10162

The `AbstractPersistentAcceptOnceFileListFilter` may cause a problem with entries in the `MetadataStore` when the same file name is used from different directories. Let's imagine a scenario when remote directories are created every day with respective timestamp, e.g. today `20250828`, tomorrow `20250829`.
 The files in those directories are based on customer names: `customer1.xml`, `customer2.xml` etc.
Since most of the `AbstractPersistentAcceptOnceFileListFilter` implementations do just something like this: `return file.getName();` that would lead to the same key for the `MetadataStore` operations.

* Fix `SmbPersistentAcceptOnceFileListFilter` to use `SmbFile.getUncPath()` as a notation of the full path file
* Fix `SftpPersistentAcceptOnceFileListFilter` to use `SftpClient.DirEntry.getLongFilename()` if it is not empty.
* Fix `SftpSession.list()` to populated the mentioned `longFileName` into a new `SftpClient.DirEntry` instance based on just fetched
* Introduce an `EnhancedFTPFile` adapter to delegate to the original `FTPFile` and populate an additional `longFileName` property
* Check for this new class in the `FtpPersistentAcceptOnceFileListFilter` to extract its `longFileName` property

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
