### PR TITLE
GH-10090: Add channel adapters for AMQP 1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -436,7 +436,7 @@ project('spring-integration-test-support') {
 project('spring-integration-amqp') {
     description = 'Spring Integration AMQP Support'
     dependencies {
-        api 'org.springframework.amqp:spring-rabbit'
+        api 'org.springframework.amqp:spring-rabbitmq-client'
         optionalApi 'org.springframework.amqp:spring-rabbit-stream'
 
         testImplementation 'org.springframework.amqp:spring-rabbit-junit'

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpClientMessageProducer.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpClientMessageProducer.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.inbound;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import com.rabbitmq.client.amqp.Consumer;
+import com.rabbitmq.client.amqp.Resource;
+import org.aopalliance.aop.Advice;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.amqp.core.AmqpAcknowledgment;
+import org.springframework.amqp.core.MessagePostProcessor;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.rabbitmq.client.AmqpConnectionFactory;
+import org.springframework.amqp.rabbitmq.client.RabbitAmqpUtils;
+import org.springframework.amqp.rabbitmq.client.listener.RabbitAmqpListenerContainer;
+import org.springframework.amqp.rabbitmq.client.listener.RabbitAmqpMessageListener;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.amqp.support.postprocessor.MessagePostProcessorUtils;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.StaticMessageHeaderAccessor;
+import org.springframework.integration.acks.AcknowledgmentCallback;
+import org.springframework.integration.acks.SimpleAcknowledgment;
+import org.springframework.integration.amqp.support.AmqpHeaderMapper;
+import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
+import org.springframework.integration.core.Pausable;
+import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.support.MutableMessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.scheduling.TaskScheduler;
+
+/**
+ * A {@link MessageProducerSupport} implementation for AMQP 1.0 client.
+ * <p>
+ * Based on the {@link RabbitAmqpListenerContainer} and requires an {@link AmqpConnectionFactory}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 7.0
+ *
+ * @see RabbitAmqpListenerContainer
+ * @see org.springframework.amqp.rabbitmq.client.listener.RabbitAmqpMessageListenerAdapter
+ */
+public class AmqpClientMessageProducer extends MessageProducerSupport implements Pausable {
+
+	private final RabbitAmqpListenerContainer listenerContainer;
+
+	private @Nullable MessageConverter messageConverter = new SimpleMessageConverter();
+
+	private AmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.inboundMapper();
+
+	private @Nullable Collection<MessagePostProcessor> afterReceivePostProcessors;
+
+	private volatile boolean paused;
+
+	public AmqpClientMessageProducer(AmqpConnectionFactory connectionFactory, String... queueNames) {
+		this.listenerContainer = new RabbitAmqpListenerContainer(connectionFactory);
+		this.listenerContainer.setQueueNames(queueNames);
+	}
+
+	public void setInitialCredits(int initialCredits) {
+		this.listenerContainer.setInitialCredits(initialCredits);
+	}
+
+	public void setPriority(int priority) {
+		this.listenerContainer.setPriority(priority);
+	}
+
+	public void setStateListeners(Resource.StateListener... stateListeners) {
+		this.listenerContainer.setStateListeners(stateListeners);
+	}
+
+	public void setAfterReceivePostProcessors(MessagePostProcessor... afterReceivePostProcessors) {
+		this.afterReceivePostProcessors = MessagePostProcessorUtils.sort(Arrays.asList(afterReceivePostProcessors));
+	}
+
+	public void setBatchSize(int batchSize) {
+		this.listenerContainer.setBatchSize(batchSize);
+	}
+
+	public void setBatchReceiveTimeout(long batchReceiveTimeout) {
+		this.listenerContainer.setBatchReceiveTimeout(batchReceiveTimeout);
+	}
+
+	@Override
+	public void setTaskScheduler(TaskScheduler taskScheduler) {
+		this.listenerContainer.setTaskScheduler(taskScheduler);
+	}
+
+	public void setAdviceChain(Advice... advices) {
+		this.listenerContainer.setAdviceChain(advices);
+	}
+
+	public void setAutoSettle(boolean autoSettle) {
+		this.listenerContainer.setAutoSettle(autoSettle);
+	}
+
+	public void setDefaultRequeue(boolean defaultRequeue) {
+		this.listenerContainer.setDefaultRequeue(defaultRequeue);
+	}
+
+	public void setGracefulShutdownPeriod(Duration gracefulShutdownPeriod) {
+		this.listenerContainer.setGracefulShutdownPeriod(gracefulShutdownPeriod);
+	}
+
+	public void setConsumersPerQueue(int consumersPerQueue) {
+		this.listenerContainer.setConsumersPerQueue(consumersPerQueue);
+	}
+
+	/**
+	 * Set a {@link MessageConverter} to replace the default {@link SimpleMessageConverter}.
+	 * If set to null, an AMQP message is sent as is into a {@link Message} payload.
+	 * @param messageConverter the {@link MessageConverter} to use or null.
+	 */
+	public void setMessageConverter(@Nullable MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
+	}
+
+	public void setHeaderMapper(AmqpHeaderMapper headerMapper) {
+		this.headerMapper = headerMapper;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "amqp:inbound-channel-adapter";
+	}
+
+	@Override
+	protected void onInit() {
+		super.onInit();
+		this.listenerContainer.setBeanName(getComponentName() + ".listenerContainer");
+		this.listenerContainer.setupMessageListener(new IntegrationRabbitAmqpMessageListener());
+		this.listenerContainer.afterPropertiesSet();
+	}
+
+	@Override
+	protected void doStart() {
+		super.doStart();
+		this.listenerContainer.start();
+	}
+
+	@Override
+	protected void doStop() {
+		super.doStop();
+		this.listenerContainer.stop();
+	}
+
+	@Override
+	public void destroy() {
+		super.destroy();
+		this.listenerContainer.destroy();
+	}
+
+	@Override
+	public void pause() {
+		this.listenerContainer.pause();
+		this.paused = true;
+	}
+
+	@Override
+	public void resume() {
+		this.listenerContainer.resume();
+		this.paused = false;
+	}
+
+	@Override
+	public boolean isPaused() {
+		return this.paused;
+	}
+
+	private class IntegrationRabbitAmqpMessageListener implements RabbitAmqpMessageListener {
+
+		@Override
+		public void onAmqpMessage(com.rabbitmq.client.amqp.Message amqpMessage, Consumer.@Nullable Context context) {
+			org.springframework.amqp.core.Message message = RabbitAmqpUtils.fromAmqpMessage(amqpMessage, context);
+			Message<?> messageToSend = toSpringMessage(message);
+
+			sendMessage(messageToSend);
+		}
+
+		@Override
+		public void onMessageBatch(List<org.springframework.amqp.core.Message> messages) {
+			SimpleAcknowledgment acknowledgmentCallback = null;
+			List<Message<?>> springMessages = new ArrayList<>(messages.size());
+			for (org.springframework.amqp.core.Message message : messages) {
+				Message<?> springMessage = toSpringMessage(message);
+				if (acknowledgmentCallback == null) {
+					acknowledgmentCallback = StaticMessageHeaderAccessor.getAcknowledgment(springMessage);
+				}
+				springMessages.add(springMessage);
+			}
+
+			Message<List<Message<?>>> messageToSend =
+					MutableMessageBuilder.withPayload(springMessages)
+							.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgmentCallback)
+							.build();
+
+			sendMessage(messageToSend);
+		}
+
+		private Message<?> toSpringMessage(org.springframework.amqp.core.Message message) {
+			if (AmqpClientMessageProducer.this.afterReceivePostProcessors != null) {
+				for (MessagePostProcessor processor : AmqpClientMessageProducer.this.afterReceivePostProcessors) {
+					message = processor.postProcessMessage(message);
+				}
+			}
+			MessageProperties messageProperties = message.getMessageProperties();
+			AmqpAcknowledgment amqpAcknowledgment = messageProperties.getAmqpAcknowledgment();
+			AmqpAcknowledgmentCallback acknowledgmentCallback = null;
+			if (amqpAcknowledgment != null) {
+				acknowledgmentCallback = new AmqpAcknowledgmentCallback(amqpAcknowledgment);
+			}
+
+			Object payload = message;
+			Map<String, @Nullable Object> headers = null;
+			if (AmqpClientMessageProducer.this.messageConverter != null) {
+				payload = AmqpClientMessageProducer.this.messageConverter.fromMessage(message);
+				headers = AmqpClientMessageProducer.this.headerMapper.toHeadersFromRequest(messageProperties);
+			}
+
+			return getMessageBuilderFactory()
+					.withPayload(payload)
+					.copyHeaders(headers)
+					.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK, acknowledgmentCallback)
+					.build();
+		}
+
+		@Override
+		public void onMessage(org.springframework.amqp.core.Message message) {
+			throw new UnsupportedOperationException("The 'RabbitAmqpMessageListener' does not implement 'onMessage()'");
+		}
+
+	}
+
+	/**
+	 * The {@link AcknowledgmentCallback} adapter for an {@link AmqpAcknowledgment}.
+	 * @param delegate the {@link AmqpAcknowledgment} to delegate to.
+	 */
+	private record AmqpAcknowledgmentCallback(AmqpAcknowledgment delegate) implements AcknowledgmentCallback {
+
+		@Override
+		public void acknowledge(Status status) {
+			this.delegate.acknowledge(AmqpAcknowledgment.Status.valueOf(status.name()));
+		}
+
+		@Override
+		public boolean isAutoAck() {
+			return false;
+		}
+
+	}
+
+}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpClientMessageHandler.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpClientMessageHandler.java
@@ -1,0 +1,317 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.outbound;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.amqp.core.AsyncAmqpTemplate;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageProperties;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.amqp.support.converter.SimpleMessageConverter;
+import org.springframework.amqp.support.converter.SmartMessageConverter;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.ResolvableType;
+import org.springframework.expression.Expression;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.integration.amqp.support.AmqpHeaderMapper;
+import org.springframework.integration.amqp.support.DefaultAmqpHeaderMapper;
+import org.springframework.integration.expression.ExpressionUtils;
+import org.springframework.integration.expression.ValueExpression;
+import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
+import org.springframework.integration.mapping.AbstractHeaderMapper;
+import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+/**
+ * An {@link AbstractReplyProducingMessageHandler} implementation for AMQP 1.0 client.
+ * <p>
+ * With the {@link #setRequiresReply(boolean)} configured as {@code true}, this message handler
+ * behaves as a gateway - the RPC over AMQP.
+ * In this case, the {@link AsyncAmqpTemplate} must be able to convert
+ * a reply into a provided {@link #replyPayloadTypeExpression}.
+ * <p>
+ * This handler is {@code async} by default.
+ * <p>
+ * In async mode, the error is sent to the error channel even if not in a gateway mode.
+ * <p>
+ * The {@link #exchangeExpression}, {@link #routingKeyExpression} and {@link #queueExpression}
+ * are optional.
+ * Then they have to be supplied by the {@link AsyncAmqpTemplate}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 7.0
+ */
+public class AmqpClientMessageHandler extends AbstractReplyProducingMessageHandler {
+
+	private final AsyncAmqpTemplate amqpTemplate;
+
+	private AmqpHeaderMapper headerMapper = DefaultAmqpHeaderMapper.outboundMapper();
+
+	private MessageConverter messageConverter = new SimpleMessageConverter();
+
+	private @Nullable Expression exchangeExpression;
+
+	private @Nullable Expression routingKeyExpression;
+
+	private @Nullable Expression queueExpression;
+
+	private @Nullable Expression replyPayloadTypeExpression;
+
+	private boolean returnMessage;
+
+	@SuppressWarnings("NullAway.Init")
+	private StandardEvaluationContext evaluationContext;
+
+	/**
+	 * Construct an instance with the provided {@link AsyncAmqpTemplate}.
+	 * The {@link AsyncAmqpTemplate} must be an implementation for AMQP 1.0 protocol,
+	 * e.g. {@link org.springframework.amqp.rabbitmq.client.RabbitAmqpTemplate}.
+	 * @param amqpTemplate the {@link AsyncAmqpTemplate} to use.
+	 */
+	@SuppressWarnings("this-escape")
+	public AmqpClientMessageHandler(AsyncAmqpTemplate amqpTemplate) {
+		this.amqpTemplate = amqpTemplate;
+		setAsync(true);
+	}
+
+	public void setHeaderMapper(AmqpHeaderMapper headerMapper) {
+		this.headerMapper = headerMapper;
+	}
+
+	public void setMessageConverter(MessageConverter messageConverter) {
+		this.messageConverter = messageConverter;
+	}
+
+	public void setExchange(String exchange) {
+		setExchangeExpression(new ValueExpression<>(exchange));
+	}
+
+	public void setExchangeExpressionString(String exchangeExpression) {
+		setExchangeExpression(EXPRESSION_PARSER.parseExpression(exchangeExpression));
+	}
+
+	public void setExchangeExpression(Expression exchangeExpression) {
+		this.exchangeExpression = exchangeExpression;
+	}
+
+	public void setRoutingKey(String routingKey) {
+		setRoutingKeyExpression(new ValueExpression<>(routingKey));
+	}
+
+	public void setRoutingKeyExpressionString(String routingKeyExpression) {
+		setRoutingKeyExpression(EXPRESSION_PARSER.parseExpression(routingKeyExpression));
+	}
+
+	public void setRoutingKeyExpression(Expression routingKeyExpression) {
+		this.routingKeyExpression = routingKeyExpression;
+	}
+
+	public void setQueue(String queue) {
+		setQueueExpression(new ValueExpression<>(queue));
+	}
+
+	public void setQueueExpressionString(String queueExpression) {
+		setQueueExpression(EXPRESSION_PARSER.parseExpression(queueExpression));
+	}
+
+	public void setQueueExpression(Expression queueExpression) {
+		this.queueExpression = queueExpression;
+	}
+
+	/**
+	 * Set the reply payload type.
+	 * Used only if {@link #setRequiresReply(boolean)} is {@code true}.
+	 * @param replyPayloadType the reply payload type.
+	 */
+	public void setReplyPayloadType(Class<?> replyPayloadType) {
+		setReplyPayloadType(ResolvableType.forClass(replyPayloadType));
+	}
+
+	/**
+	 * Set the reply payload type.
+	 * Used only if {@link #setRequiresReply(boolean)} is {@code true}.
+	 * @param replyPayloadType the reply payload type.
+	 */
+	public void setReplyPayloadType(ResolvableType replyPayloadType) {
+		setReplyPayloadTypeExpression(new ValueExpression<>(replyPayloadType));
+	}
+
+	/**
+	 * Set a SpEL expression for the reply payload type.
+	 * Used only if {@link #setRequiresReply(boolean)} is {@code true}.
+	 * Must be evaluated to a {@link Class} or {@link ResolvableType}.
+	 * @param replyPayloadTypeExpression the expression for a reply payload type.
+	 */
+	public void setReplyPayloadTypeExpressionString(String replyPayloadTypeExpression) {
+		setReplyPayloadTypeExpression(EXPRESSION_PARSER.parseExpression(replyPayloadTypeExpression));
+	}
+
+	/**
+	 * Set a SpEL expression for the reply payload type.
+	 * Used only if {@link #setRequiresReply(boolean)} is {@code true}.
+	 * Must be evaluated to a {@link Class} or {@link ResolvableType}.
+	 * @param replyPayloadTypeExpression the expression for a reply payload type.
+	 */
+	public void setReplyPayloadTypeExpression(Expression replyPayloadTypeExpression) {
+		this.replyPayloadTypeExpression = replyPayloadTypeExpression;
+	}
+
+	/**
+	 * Set to true to return the reply as a whole AMQP message.
+	 * Used only in the gateway mode.
+	 * @param returnMessage true to return the reply as a whole AMQP message.
+	 */
+	public void setReturnMessage(boolean returnMessage) {
+		this.returnMessage = returnMessage;
+	}
+
+	@Override
+	public String getComponentType() {
+		return getRequiresReply() ? "amqp:outbound-gateway" : "amqp:outbound-channel-adapter";
+	}
+
+	@Override
+	protected void doInit() {
+		super.doInit();
+		if (this.headerMapper instanceof AbstractHeaderMapper<?> abstractHeaderMapper) {
+			abstractHeaderMapper.setBeanClassLoader(getBeanClassLoader());
+		}
+		this.evaluationContext = ExpressionUtils.createStandardEvaluationContext(getBeanFactory());
+
+		Assert.state(this.exchangeExpression == null || this.queueExpression == null,
+				"The 'exchange' (and optional 'routingKey') is mutually exclusive with 'queue'");
+
+		Assert.state(this.replyPayloadTypeExpression == null || this.messageConverter instanceof SmartMessageConverter,
+				"The 'messageConverter' must be a 'SmartMessageConverter' when 'replyPayloadTypeExpression' is provided");
+
+		Assert.state(this.replyPayloadTypeExpression == null || !this.returnMessage,
+				"The 'returnMessage == true' and 'replyPayloadTypeExpression' are mutually exclusive");
+	}
+
+	@Override
+	protected @Nullable Object handleRequestMessage(org.springframework.messaging.Message<?> requestMessage) {
+		MessageProperties messageProperties = new MessageProperties();
+		this.headerMapper.fromHeadersToRequest(requestMessage.getHeaders(), messageProperties);
+		Message amqpMessage = this.messageConverter.toMessage(requestMessage.getPayload(), messageProperties);
+
+		String queue = null;
+		if (this.queueExpression != null) {
+			queue = this.queueExpression.getValue(this.evaluationContext, requestMessage, String.class);
+		}
+
+		String exchange = null;
+		if (this.exchangeExpression != null) {
+			exchange = this.exchangeExpression.getValue(this.evaluationContext, requestMessage, String.class);
+		}
+
+		String routingKey = null;
+		if (this.routingKeyExpression != null) {
+			routingKey = this.routingKeyExpression.getValue(this.evaluationContext, requestMessage, String.class);
+		}
+
+		if (getRequiresReply()) {
+			return doSendAndReceive(requestMessage, amqpMessage, queue, exchange, routingKey);
+		}
+		else {
+			doSend(requestMessage, amqpMessage, queue, exchange, routingKey);
+			return null;
+		}
+	}
+
+	private void doSend(org.springframework.messaging.Message<?> requestMessage, Message amqpMessage,
+			@Nullable String queue, @Nullable String exchange, @Nullable String routingKey) {
+
+		CompletableFuture<Boolean> sendResultFuture;
+
+		if (StringUtils.hasText(queue)) {
+			sendResultFuture = this.amqpTemplate.send(queue, amqpMessage);
+		}
+		else if (StringUtils.hasText(exchange)) {
+			sendResultFuture = this.amqpTemplate.send(exchange, routingKey, amqpMessage);
+		}
+		else {
+			sendResultFuture = this.amqpTemplate.send(amqpMessage);
+		}
+
+		if (isAsync()) {
+			sendResultFuture.whenComplete((aBoolean, throwable) -> {
+				if (throwable != null) {
+					sendErrorMessage(requestMessage, throwable);
+				}
+			});
+		}
+		else {
+			sendResultFuture.join();
+		}
+	}
+
+	private Object doSendAndReceive(org.springframework.messaging.Message<?> requestMessage, Message amqpMessage,
+			@Nullable String queue, @Nullable String exchange, @Nullable String routingKey) {
+
+		ParameterizedTypeReference<?> replyType = null;
+		if (this.replyPayloadTypeExpression != null) {
+			Object type = this.replyPayloadTypeExpression.getValue(this.evaluationContext, requestMessage);
+
+			Assert.state(type instanceof Class<?> || type instanceof ResolvableType,
+					"The 'replyPayloadTypeExpression' must evaluate to 'Class' or 'ResolvableType'");
+
+			ResolvableType replyResolvableType =
+					type instanceof Class<?> aClass
+							? ResolvableType.forClass(aClass)
+							: (ResolvableType) type;
+
+			replyType = ParameterizedTypeReference.forType(replyResolvableType.getType());
+		}
+
+		CompletableFuture<?> replyFuture;
+
+		if (StringUtils.hasText(queue)) {
+			replyFuture = this.amqpTemplate.sendAndReceive(queue, amqpMessage);
+		}
+		else if (StringUtils.hasText(exchange)) {
+			replyFuture = this.amqpTemplate.sendAndReceive(exchange, routingKey, amqpMessage);
+		}
+		else {
+			replyFuture = this.amqpTemplate.sendAndReceive(amqpMessage);
+		}
+
+		if (!this.returnMessage) {
+			ParameterizedTypeReference<?> replyTypeToUse = replyType;
+			replyFuture = replyFuture.thenApply((reply) -> buildReplyMessage((Message) reply, replyTypeToUse));
+		}
+
+		return isAsync() ? replyFuture : replyFuture.join();
+	}
+
+	private AbstractIntegrationMessageBuilder<?> buildReplyMessage(Message message,
+			@Nullable ParameterizedTypeReference<?> replyType) {
+
+		Object replyPayload =
+				replyType != null
+						? ((SmartMessageConverter) this.messageConverter).fromMessage(message, replyType)
+						: this.messageConverter.fromMessage(message);
+
+		return getMessageBuilderFactory().withPayload(replyPayload)
+				.copyHeaders(this.headerMapper.toHeadersFromReply(message.getMessageProperties()));
+	}
+
+}

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpClientMessageHandler.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/outbound/AmqpClientMessageHandler.java
@@ -54,7 +54,7 @@ import org.springframework.util.StringUtils;
  * <p>
  * The {@link #exchangeExpression}, {@link #routingKeyExpression} and {@link #queueExpression}
  * are optional.
- * Then they have to be supplied by the {@link AsyncAmqpTemplate}.
+ * In this case they have to be supplied by the {@link AsyncAmqpTemplate}.
  *
  * @author Artem Bilan
  *

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpClientMessageProducerTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpClientMessageProducerTests.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.inbound;
+
+import java.util.List;
+
+import com.rabbitmq.client.amqp.Environment;
+import com.rabbitmq.client.amqp.impl.AmqpEnvironmentBuilder;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbitmq.client.AmqpConnectionFactory;
+import org.springframework.amqp.rabbitmq.client.RabbitAmqpAdmin;
+import org.springframework.amqp.rabbitmq.client.RabbitAmqpTemplate;
+import org.springframework.amqp.rabbitmq.client.SingleAmqpConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.StaticMessageHeaderAccessor;
+import org.springframework.integration.acks.SimpleAcknowledgment;
+import org.springframework.integration.amqp.support.RabbitTestContainer;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.messaging.Message;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 7.0
+ */
+@SpringJUnitConfig
+@DirtiesContext
+public class AmqpClientMessageProducerTests implements RabbitTestContainer {
+
+	@Autowired
+	RabbitAmqpTemplate rabbitTemplate;
+
+	@Autowired
+	QueueChannel inputChannel;
+
+	@Test
+	void receiveSimpleMessageFromAmqp() {
+		this.rabbitTemplate.convertAndSend("q1", "test data");
+
+		Message<?> receive = this.inputChannel.receive(10_000);
+
+		assertThat(receive)
+				.extracting(Message::getPayload)
+				.isEqualTo("test data");
+	}
+
+	@Test
+	void receiveAndAck() {
+		this.rabbitTemplate.convertAndSend("q2", "test data #2");
+
+		Message<?> receive = this.inputChannel.receive(10_000);
+
+		assertThat(receive)
+				.extracting(Message::getPayload)
+				.isEqualTo("test data #2");
+
+		SimpleAcknowledgment acknowledgment = StaticMessageHeaderAccessor.getAcknowledgment(receive);
+		assertThat(acknowledgment).isNotNull();
+		acknowledgment.acknowledge();
+	}
+
+	@Test
+	void receiveBatch() {
+		this.rabbitTemplate.convertAndSend("q3", "test data #3");
+		this.rabbitTemplate.convertAndSend("q3", "test data #4");
+
+		Message<?> receive = this.inputChannel.receive(10_000);
+
+		assertThat(receive)
+				.extracting(Message::getPayload)
+				.asInstanceOf(InstanceOfAssertFactories.list(Message.class))
+				.hasSize(2)
+				.extracting(Message::getPayload)
+				.contains("test data #3", "test data #4");
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean
+		Environment environment() {
+			return new AmqpEnvironmentBuilder()
+					.connectionSettings()
+					.port(RabbitTestContainer.amqpPort())
+					.environmentBuilder()
+					.build();
+		}
+
+		@Bean
+		AmqpConnectionFactory connectionFactory(Environment environment) {
+			return new SingleAmqpConnectionFactory(environment);
+		}
+
+		@Bean
+		RabbitAmqpAdmin admin(AmqpConnectionFactory connectionFactory) {
+			return new RabbitAmqpAdmin(connectionFactory);
+		}
+
+		@Bean
+		Queue q1() {
+			return new Queue("q1");
+		}
+
+		@Bean
+		Queue q2() {
+			return new Queue("q2");
+		}
+
+		@Bean
+		Queue q3() {
+			return new Queue("q3");
+		}
+
+		@Bean
+		RabbitAmqpTemplate rabbitTemplate(AmqpConnectionFactory connectionFactory) {
+			return new RabbitAmqpTemplate(connectionFactory);
+		}
+
+		@Bean
+		QueueChannel inputChannel() {
+			return new QueueChannel();
+		}
+
+		@Bean
+		AmqpClientMessageProducer amqpClientMessageProducer(AmqpConnectionFactory connectionFactory,
+				QueueChannel inputChannel) {
+
+			AmqpClientMessageProducer amqpClientMessageProducer = new AmqpClientMessageProducer(connectionFactory, "q1");
+			amqpClientMessageProducer.setOutputChannel(inputChannel);
+			return amqpClientMessageProducer;
+		}
+
+		@Bean
+		AmqpClientMessageProducer manualAckAmqpClientMessageProducer(AmqpConnectionFactory connectionFactory,
+				QueueChannel inputChannel) {
+
+			AmqpClientMessageProducer amqpClientMessageProducer = new AmqpClientMessageProducer(connectionFactory, "q2");
+			amqpClientMessageProducer.setOutputChannel(inputChannel);
+			amqpClientMessageProducer.setAutoSettle(false);
+			return amqpClientMessageProducer;
+		}
+
+		@Bean
+		AmqpClientMessageProducer batchAmqpClientMessageProducer(AmqpConnectionFactory connectionFactory,
+				QueueChannel inputChannel) {
+
+			AmqpClientMessageProducer amqpClientMessageProducer = new AmqpClientMessageProducer(connectionFactory, "q3");
+			amqpClientMessageProducer.setOutputChannel(inputChannel);
+			amqpClientMessageProducer.setBatchSize(2);
+			return amqpClientMessageProducer;
+		}
+
+	}
+
+}

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/ManualAckTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/ManualAckTests.java
@@ -30,7 +30,6 @@ import org.springframework.amqp.support.AmqpHeaders;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.integration.amqp.support.RabbitTestContainer;
 import org.springframework.integration.annotation.MessageEndpoint;
@@ -93,7 +92,6 @@ public class ManualAckTests implements RabbitTestContainer {
 
 	@Configuration
 	@EnableIntegration
-	@ComponentScan
 	@MessageEndpoint
 	public static class ManualAckConfig {
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpClientMessageHandlerTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpClientMessageHandlerTests.java
@@ -72,7 +72,7 @@ public class AmqpClientMessageHandlerTests implements RabbitTestContainer {
 	AmqpClientMessageHandler amqpClientGateway;
 
 	@Test
-	void noExchangeOrQueue() {
+	void neitherExchangeAndQueue() {
 		Message<String> message = new GenericMessage<>("test data");
 
 		assertThatExceptionOfType(MessageHandlingException.class)

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpClientMessageHandlerTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpClientMessageHandlerTests.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.amqp.outbound;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+import com.rabbitmq.client.amqp.Environment;
+import com.rabbitmq.client.amqp.impl.AmqpEnvironmentBuilder;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.amqp.core.Binding;
+import org.springframework.amqp.core.BindingBuilder;
+import org.springframework.amqp.core.DirectExchange;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbitmq.client.AmqpConnectionFactory;
+import org.springframework.amqp.rabbitmq.client.RabbitAmqpAdmin;
+import org.springframework.amqp.rabbitmq.client.RabbitAmqpTemplate;
+import org.springframework.amqp.rabbitmq.client.SingleAmqpConnectionFactory;
+import org.springframework.amqp.support.converter.JacksonJsonMessageConverter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.amqp.support.RabbitTestContainer;
+import org.springframework.integration.annotation.ServiceActivator;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandlingException;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 7.0
+ */
+@SpringJUnitConfig
+@DirtiesContext
+public class AmqpClientMessageHandlerTests implements RabbitTestContainer {
+
+	@Autowired
+	RabbitAmqpTemplate rabbitTemplate;
+
+	@Autowired
+	MessageChannel amqpClientSendChannel;
+
+	@Autowired
+	MessageChannel amqpClientSendAndReceiveChannel;
+
+	@Autowired
+	AmqpClientMessageHandler amqpClientGateway;
+
+	@Test
+	void noExchangeOrQueue() {
+		Message<String> message = new GenericMessage<>("test data");
+
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> this.amqpClientSendChannel.send(message))
+				.withRootCauseExactlyInstanceOf(IllegalStateException.class)
+				.withStackTraceContaining(
+						"For send with defaults, an 'exchange' (and optional 'routingKey') or 'queue' must be provided");
+	}
+
+	@Test
+	void verifyMessagePublishedProperlyWithCustomHeader() {
+		Message<String> message =
+				MessageBuilder.withPayload("test data")
+						.setHeader("exchange", "e1")
+						.setHeader("routingKey", "k1")
+						.setHeader("testHeader", "testValue")
+						.build();
+
+		this.amqpClientSendChannel.send(message);
+
+		CompletableFuture<org.springframework.amqp.core.Message> received = this.rabbitTemplate.receive("q1");
+
+		assertThat(received).succeedsWithin(Duration.ofSeconds(10))
+				.satisfies(m -> {
+					// Converted to JSON
+					assertThat(m.getBody()).isEqualTo("test data".getBytes());
+					assertThat(m.getMessageProperties().getHeaders()).containsEntry("testHeader", "testValue");
+				});
+	}
+
+	@Test
+	void verifySendAndReceive() {
+		this.amqpClientGateway.setReturnMessage(false);
+		QueueChannel replyChannel = new QueueChannel();
+
+		Message<String> message =
+				MessageBuilder.withPayload("request")
+						.setReplyChannel(replyChannel)
+						.build();
+
+		this.amqpClientSendAndReceiveChannel.send(message);
+
+		this.rabbitTemplate.receiveAndReply("q1", payload -> "reply");
+
+		Message<?> reply = replyChannel.receive(10000);
+
+		assertThat(reply).isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("reply");
+	}
+
+	@Test
+	void verifySendAndReceiveAsMessage() {
+		this.amqpClientGateway.setReturnMessage(true);
+		QueueChannel replyChannel = new QueueChannel();
+
+		Message<String> message =
+				MessageBuilder.withPayload("request")
+						.setReplyChannel(replyChannel)
+						.build();
+
+		this.amqpClientSendAndReceiveChannel.send(message);
+
+		this.rabbitTemplate.receiveAndReply("q1", payload -> "reply");
+
+		Message<?> reply = replyChannel.receive(10000);
+
+		assertThat(reply).isNotNull()
+				.extracting(Message::getPayload)
+				.isInstanceOf(org.springframework.amqp.core.Message.class)
+				.extracting("body")
+				.isEqualTo("\"reply\"".getBytes());
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Bean
+		Environment environment() {
+			return new AmqpEnvironmentBuilder()
+					.connectionSettings()
+					.port(RabbitTestContainer.amqpPort())
+					.environmentBuilder()
+					.build();
+		}
+
+		@Bean
+		AmqpConnectionFactory connectionFactory(Environment environment) {
+			return new SingleAmqpConnectionFactory(environment);
+		}
+
+		@Bean
+		RabbitAmqpAdmin admin(AmqpConnectionFactory connectionFactory) {
+			return new RabbitAmqpAdmin(connectionFactory);
+		}
+
+		@Bean
+		DirectExchange e1() {
+			return new DirectExchange("e1");
+		}
+
+		@Bean
+		Queue q1() {
+			return new Queue("q1");
+		}
+
+		@Bean
+		Binding b1(Queue q1, DirectExchange e1) {
+			return BindingBuilder.bind(q1).to(e1).with("k1");
+		}
+
+		@Bean
+		RabbitAmqpTemplate rabbitTemplate(AmqpConnectionFactory connectionFactory) {
+			RabbitAmqpTemplate rabbitAmqpTemplate = new RabbitAmqpTemplate(connectionFactory);
+			rabbitAmqpTemplate.setMessageConverter(new JacksonJsonMessageConverter());
+			return rabbitAmqpTemplate;
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "amqpClientSendChannel")
+		AmqpClientMessageHandler amqpClientMessageHandler(RabbitAmqpTemplate rabbitTemplate) {
+			AmqpClientMessageHandler messageHandler = new AmqpClientMessageHandler(rabbitTemplate);
+			messageHandler.setExchangeExpressionString("headers[exchange]");
+			messageHandler.setRoutingKeyExpressionString("headers[routingKey]");
+			return messageHandler;
+		}
+
+		@Bean
+		@ServiceActivator(inputChannel = "amqpClientSendAndReceiveChannel")
+		AmqpClientMessageHandler amqpClientGateway(RabbitAmqpTemplate rabbitTemplate) {
+			AmqpClientMessageHandler messageHandler = new AmqpClientMessageHandler(rabbitTemplate);
+			messageHandler.setRequiresReply(true);
+			messageHandler.setReplyPayloadType(String.class);
+			messageHandler.setMessageConverter(new JacksonJsonMessageConverter());
+			messageHandler.setQueue("q1");
+			return messageHandler;
+		}
+
+	}
+
+}

--- a/src/reference/antora/modules/ROOT/nav.adoc
+++ b/src/reference/antora/modules/ROOT/nav.adoc
@@ -121,6 +121,7 @@
 ** xref:amqp/strict-ordering.adoc[]
 ** xref:amqp/samples.adoc[]
 ** xref:amqp/rmq-streams.adoc[]
+** xref:amqp/amqp-1.0.adoc[]
 * xref:camel.adoc[]
 * xref:cassandra.adoc[]
 * xref:debezium.adoc[]

--- a/src/reference/antora/modules/ROOT/pages/amqp.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp.adoc
@@ -35,6 +35,7 @@ The following adapters are available:
 * xref:amqp/async-outbound-gateway.adoc[Async Outbound Gateway]
 * xref:amqp/rmq-streams.adoc#rmq-stream-inbound-channel-adapter[RabbitMQ Stream Queue Inbound Channel Adapter]
 * xref:amqp/rmq-streams.adoc#rmq-stream-outbound-channel-adapter[RabbitMQ Stream Queue Outbound Channel Adapter]
+* xref:amqp/amqp-1.0.adoc[AMQP 1.0 Channel Adapters]
 
 Spring Integration also provides a point-to-point message channel and a publish-subscribe message channel backed by AMQP Exchanges and Queues.
 

--- a/src/reference/antora/modules/ROOT/pages/amqp/amqp-1.0.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/amqp-1.0.adoc
@@ -1,0 +1,55 @@
+[[amqp-1.0]]
+= AMQP 1.0 Support
+
+Starting with version 7.0, Spring Integration provides channel adapters for RabbitMQ AMQP 1.0 support.
+These channel adapters are based on the `org.springframework.amqp:spring-rabbitmq-client` library.
+
+The Spring AMQP documentation talks about https://docs.spring.io/spring-amqp/reference/4.0/rabbitmq-amqp-client.html[RabbitMQ AMQP 1.0 support] in more detail.
+
+[[amqp-1.0-outbound]]
+== AMQP 1.0 Outbound Channel Adapters
+
+The `AmqpClientMessageHandler` is an `AbstractReplyProducingMessageHandler` implementation and can act as a one-way channel adapter or as an outbound gateway depending on the `setRequiresReply()` configuration.
+The instance of this channel adapter requires an `AsyncAmqpTemplate` implementation for AMQP 1.0 protocol, e.g. `RabbitAmqpTemplate` from the mentioned above `spring-rabbitmq-client` library.
+This message handler is asynchronous by default; therefore, publication errors should be handled via `errorChannel` header in the request message or global default `errorChannel` in the application context.
+
+The `exchange` to publish message (together with optional `routingKey`) is mutually exclusive with a `queue` to publish.
+If neith is provided, then `AsyncAmqpTemplate` implementation must ensure some defaults for those destination parts; otherwise the message is going to be rejected as not delivered.
+
+A default `MessageConverter` is a `org.springframework.amqp.support.converter.SimpleMessageConverter` that can work with `String`, `Serializable` instances, or byte arrays.
+Also, a default `AmqpHeaderMapper` is a xref:amqp/message-headers.adoc[`DefaultAmqpHeaderMapper.outboundMapper()`].
+This header mapper is also used for mapping AMQP message properties to headers back on the reply.
+
+In a gateway mode, the `replyPayloadType` could be supplied to convert a reply message body.
+However, the `MessageConverter` has to be an implementation of the `SmartMessageConverter` like a `JacksonJsonMessageConverter`.
+Also, a mutually exclusive to the `replyPayloadType`, a `returnMessage` flag could be set to `true` to return the whole instance of `org.springframework.amqp.core.Message` as a reply message payload.
+
+The following example demonstrates how to configure `AmqpClientMessageHandler` as a simple `@ServiceActivator`:
+
+[source, java]
+----
+@Bean
+@ServiceActivator(inputChannel = "amqpClientSendChannel")
+AmqpClientMessageHandler amqpClientMessageHandler(RabbitAmqpTemplate rabbitTemplate) {
+    AmqpClientMessageHandler messageHandler = new AmqpClientMessageHandler(rabbitTemplate);
+    messageHandler.setExchangeExpressionString("headers[exchange]");
+    messageHandler.setRoutingKeyExpressionString("headers[routingKey]");
+    return messageHandler;
+}
+----
+
+The gateway variant for the `AmqpClientMessageHandler` could be like:
+
+[source, java]
+----
+@Bean
+@ServiceActivator(inputChannel = "amqpClientSendAndReceiveChannel")
+AmqpClientMessageHandler amqpClientGateway(RabbitAmqpTemplate rabbitTemplate) {
+    AmqpClientMessageHandler messageHandler = new AmqpClientMessageHandler(rabbitTemplate);
+    messageHandler.setRequiresReply(true);
+    messageHandler.setReplyPayloadType(String.class);
+    messageHandler.setMessageConverter(new JacksonJsonMessageConverter());
+    messageHandler.setQueue("q1");
+    return messageHandler;
+}
+----

--- a/src/reference/antora/modules/ROOT/pages/amqp/amqp-1.0.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp/amqp-1.0.adoc
@@ -4,7 +4,7 @@
 Starting with version 7.0, Spring Integration provides channel adapters for RabbitMQ AMQP 1.0 support.
 These channel adapters are based on the `org.springframework.amqp:spring-rabbitmq-client` library.
 
-The Spring AMQP documentation talks about https://docs.spring.io/spring-amqp/reference/4.0/rabbitmq-amqp-client.html[RabbitMQ AMQP 1.0 support] in more detail.
+The Spring AMQP documentation provides more details about https://docs.spring.io/spring-amqp/reference/4.0/rabbitmq-amqp-client.html[RabbitMQ AMQP 1.0 support].
 
 [[amqp-1.0-outbound]]
 == AMQP 1.0 Outbound Channel Adapters
@@ -14,9 +14,9 @@ The instance of this channel adapter requires an `AsyncAmqpTemplate` implementat
 This message handler is asynchronous by default; therefore, publication errors should be handled via `errorChannel` header in the request message or global default `errorChannel` in the application context.
 
 The `exchange` to publish message (together with optional `routingKey`) is mutually exclusive with a `queue` to publish.
-If neith is provided, then `AsyncAmqpTemplate` implementation must ensure some defaults for those destination parts; otherwise the message is going to be rejected as not delivered.
+If neither is provided, then `AsyncAmqpTemplate` implementation must ensure some defaults for those destination parts; otherwise the message is going to be rejected as not delivered.
 
-A default `MessageConverter` is a `org.springframework.amqp.support.converter.SimpleMessageConverter` that can work with `String`, `Serializable` instances, or byte arrays.
+By default, the `MessageConverter` is an `org.springframework.amqp.support.converter.SimpleMessageConverter` that handles String, Serializable instances, and byte arrays.
 Also, a default `AmqpHeaderMapper` is a xref:amqp/message-headers.adoc[`DefaultAmqpHeaderMapper.outboundMapper()`].
 This header mapper is also used for mapping AMQP message properties to headers back on the reply.
 
@@ -24,7 +24,7 @@ In a gateway mode, the `replyPayloadType` could be supplied to convert a reply m
 However, the `MessageConverter` has to be an implementation of the `SmartMessageConverter` like a `JacksonJsonMessageConverter`.
 Also, a mutually exclusive to the `replyPayloadType`, a `returnMessage` flag could be set to `true` to return the whole instance of `org.springframework.amqp.core.Message` as a reply message payload.
 
-The following example demonstrates how to configure `AmqpClientMessageHandler` as a simple `@ServiceActivator`:
+The following example demonstrates how to configure an `AmqpClientMessageHandler` as a simple `@ServiceActivator`:
 
 [source, java]
 ----
@@ -51,5 +51,41 @@ AmqpClientMessageHandler amqpClientGateway(RabbitAmqpTemplate rabbitTemplate) {
     messageHandler.setMessageConverter(new JacksonJsonMessageConverter());
     messageHandler.setQueue("q1");
     return messageHandler;
+}
+----
+
+[[amqp-1.0-message-driver]]
+== AMQP 1.0 Message-Driver Channel Adapter
+
+The `AmqpClientMessageProducer` is a `MessageProducerSupport` implementation as a Message-Driver Channel Adapter to consume messages from queues over RabbitMQ AMQP 1.0 protocol.
+It requires an `AmqpConnectionFactory` and at least one queue to consume.
+Its logic internally is based on the `RabbitAmqpListenerContainer` and `IntegrationRabbitAmqpMessageListener` to relay consumed AMQP messages (after conversion) to the `outputChannel`.
+Some of `RabbitAmqpListenerContainer` configuration options are exposed as setters from the `AmqpClientMessageProducer`.
+
+By default, the `MessageConverter` is an `org.springframework.amqp.support.converter.SimpleMessageConverter` that handles String, Serializable instances, and byte arrays.
+Also, a default `AmqpHeaderMapper` is a xref:amqp/message-headers.adoc[`DefaultAmqpHeaderMapper.inboundMapper()`].
+The `messageConverter` option can be set to `null` to fully skip conversion (including headers mapping), and return the received AMQP message as a payload of Spring message to produce.
+
+Also, the `AmqpClientMessageProducer` implements a `Pausable` contract and delegates to the respective `RabbitAmqpListenerContainer` API.
+
+When `AmqpClientMessageProducer.setBatchSize() > 1`, this channel adapter works in a batch mode.
+In this case received messages are gathered until the batch size is fulfilled, or `batchReceiveTimeout` period is exhausted.
+All the batched AMQP messages then converted to Spring messages, and result list is produced as a payload of wrapping message to send to the `outputChannel`.
+The batch mode gives some performance gain due to the settlement for all the batched message at once.
+
+When `autoSettle` flag is set to `false`, the `AcknowledgmentCallback` instance is provided as an `IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK` message header to make settlement decision for received message or the whole batch.
+
+The following example demonstrates how to configure an `AmqpClientMessageProducer` as a simple inbound endpoint:
+
+[source, java]
+----
+@Bean
+AmqpClientMessageProducer batchAmqpClientMessageProducer(AmqpConnectionFactory connectionFactory,
+        QueueChannel inputChannel) {
+
+    AmqpClientMessageProducer amqpClientMessageProducer = new AmqpClientMessageProducer(connectionFactory, "q3");
+    amqpClientMessageProducer.setOutputChannel(inputChannel);
+    amqpClientMessageProducer.setBatchSize(2);
+    return amqpClientMessageProducer;
 }
 ----

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -67,6 +67,9 @@ The Jackson 2 support has been deprecated for removal.
 Jackson 3 is now the default with new components: `JacksonJsonObjectMapper`, `JacksonPropertyAccessor`, `JacksonIndexAccessor`, and `JacksonMessagingUtils`.
 See their Javadocs for more information and deprecated classes for a migration path.
 
+The `spring-integration-amqp` module now implements channel adapters for RabbitMQ AMQP 1.0 support.
+The dedicated xref:amqp/amqp-1.0.adoc[AMQP 1.0 Support] chapter provides more information.
+
 [[x7.0-jdbc-changes]]
 === JDBC Changes
 


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/10090

Spring AMQP now provides the `org.springframework.amqp:spring-rabbitmq-client` library to communicate to RabbitMQ with AMQP 1.0 protocol.

* Replace `spring-rabbit` with the `spring-rabbitmq-client` since the latter brings the AMQP 0.9 protocol library as transitive dependency
* Introduce an `AmqpClientMessageHandler` based on the `AsyncAmqpTemplate` where its implementation should be for AMQP 1.0, e.g. `org.springframework.amqp.rabbitmq.client.RabbitAmqpTemplate`
* This outbound channel adapter can behave as a gateway when `setRequiresReply(true)`
* Cover basic `AmqpClientMessageHandler` with integration tests
* Document this new feature

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
