### PR TITLE
Drop switch from Redis unlink to delete

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -96,6 +96,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Roman Zabaluev
  * @author Alex Peelman
  * @author Youbin Wu
+ * @author Michal Domagala
  *
  * @since 4.0
  *

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -802,7 +802,7 @@ public final class RedisLockRegistry
 
 		private static final RedisScript<Boolean>
 				UNLINK_UNLOCK_REDIS_SCRIPT = new DefaultRedisScript<>(UNLINK_UNLOCK_SCRIPT, Boolean.class);
-		
+
 		private RedisSpinLock(String path) {
 			super(path);
 		}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -580,7 +580,8 @@ public final class RedisLockRegistry
 			if (unlinkResult) {
 				// Lock key successfully removed
 				stopRenew();
-			} else  {
+			}
+			else {
 				throw new ConcurrentModificationException("Lock was released in the store due to expiration. " +
 						"The integrity of data protected by this lock may have been compromised.");
 			}
@@ -801,8 +802,7 @@ public final class RedisLockRegistry
 
 		private static final RedisScript<Boolean>
 				UNLINK_UNLOCK_REDIS_SCRIPT = new DefaultRedisScript<>(UNLINK_UNLOCK_SCRIPT, Boolean.class);
-
-
+		
 		private RedisSpinLock(String path) {
 			super(path);
 		}


### PR DESCRIPTION
Drop support for Redis 3, which is not maintained since 2018

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
