### PR TITLE
GH-3189: Properly handle `async` in `ScatterGatherHandler`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/scattergather/ScatterGatherHandler.java
@@ -53,6 +53,9 @@ import org.springframework.util.ClassUtils;
 /**
  * The {@link MessageHandler} implementation for the
  * <a href="https://www.enterpriseintegrationpatterns.com/BroadcastAggregate.html">Scatter-Gather</a> EIP pattern.
+ * <p>
+ * When {@link #setAsync(boolean)} is {@code true}, the {@link ScatterGatherHandler} produces
+ * a {@link Mono} as a reply based on the gather result.
  *
  * @author Artem Bilan
  * @author Abdul Zaheer

--- a/src/reference/antora/modules/ROOT/pages/scatter-gather.adoc
+++ b/src/reference/antora/modules/ROOT/pages/scatter-gather.adoc
@@ -154,6 +154,10 @@ Mutually exclusive with `scatter-channel` attribute.
 <13> The `<aggregator>` options.
 Required.
 
+NOTE: Starting with version `6.5.3`, when a `ScatterGatherHandler` is configured for the `async = true` option, the request message handling thread is not blocked anymore waiting for a gather result on an internal `((PollableChannel) gatherResultChannel).receive(this.gatherTimeout)` operation.
+Instead, a `reactor.core.publisher.Mono` is returned as a reply object based on a gather result eventually produced from the `gatherResultChannel`.
+Such a `Mono` is handled then according to the xref:reactive-streams.adoc#reactive-reply-payload[Reactive Streams support] in the framework.
+
 [[scatter-gather-error-handling]]
 == Error Handling
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/3189

Despite supporting `async = true`, the `ScatterGatherHandler` does blocking in its `handleRequestMessage()`
on the `gatherResultChannel.receive()` call.

* Fix `ScatterGatherHandler` to handle an `async` mode via internal `Mono` for the reply object
* Use pattern variable expressions for `ifs` in the `ScatterGatherHandler.doInit()` for the better readability
* Extract `ScatterGatherHandler.replyFromGatherResult()` method to avoid code duplication
* Document a new (fixed) functionality

**Auto-cherry-pick to `6.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
