### PR TITLE
GH-6786: Demonstrate `#xpath()` with a `recipient-list-router`

### DIFF
--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/xpath/XPathTests-context.xml
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/xpath/XPathTests-context.xml
@@ -36,4 +36,9 @@
 
 	<bean id="testNodeMapper" class="org.springframework.integration.xml.xpath.XPathTests$TestNodeMapper"/>
 
+	<int:recipient-list-router input-channel="xpathRecipientsInput">
+		<int:recipient channel="channelA" selector-expression="#xpath(payload, '/passenger/age/text() &lt;= 2', 'boolean')"/>
+		<int:recipient channel="channelB" selector-expression="#xpath(payload, '/passenger/age/text() > 12', 'boolean')"/>
+	</int:recipient-list-router>
+
 </beans>

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/xpath/XPathTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/xpath/XPathTests.java
@@ -77,6 +77,9 @@ public class XPathTests {
 	@Autowired
 	private MessageChannel xpathRouterInput;
 
+	@Autowired
+	private MessageChannel xpathRecipientsInput;
+
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testXPathUtils() {
@@ -203,6 +206,22 @@ public class XPathTests {
 		receive = this.channelZ.receive(1000);
 		assertThat(receive).isNotNull();
 		assertThat(receive.getPayload()).isEqualTo("<name>X</name>");
+	}
+
+	@Test
+	public void recipientListRouteByXpath() {
+		this.xpathRecipientsInput.send(new GenericMessage<>("<passenger><age>2</age></passenger>"));
+		this.xpathRecipientsInput.send(new GenericMessage<>("<passenger><age>16</age></passenger>"));
+
+		Message<?> receive = this.channelA.receive(1000);
+		assertThat(receive)
+				.extracting(Message::getPayload)
+				.isEqualTo("<passenger><age>2</age></passenger>");
+
+		receive = this.channelB.receive(1000);
+		assertThat(receive)
+				.extracting(Message::getPayload)
+				.isEqualTo("<passenger><age>16</age></passenger>");
 	}
 
 	public static class TestNodeMapper implements NodeMapper<String> {

--- a/src/reference/antora/modules/ROOT/pages/xml/xpath-routing.adoc
+++ b/src/reference/antora/modules/ROOT/pages/xml/xpath-routing.adoc
@@ -89,7 +89,16 @@ For example, if we want to route based on the name of the root node, we can use 
         evaluate-as-string="true">
     <int-xml:xpath-expression expression="name(./node())"/>
 </int-xml:xpath-router>
+----
 
+The out-of-the-box `#xpath()` xref:spel.adoc#built-in-spel-functions[SpEL function] is also powerful enough to use with a generic router definition, including recipient list router:
+
+[source,xml]
+----
+<int:recipient-list-router input-channel="xpathRecipientsInput">
+    <int:recipient channel="channelA" selector-expression="#xpath(payload, '/passenger/age/text() &lt;= 2', 'boolean')"/>
+    <int:recipient channel="channelB" selector-expression="#xpath(payload, '/passenger/age/text() > 12', 'boolean')"/>
+</int:recipient-list-router>
 ----
 
 [[xpath-routing-converter]]


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/6786

The original request was about an `xpath-router`, however using the `#xpath()` SpEL function we don't need anything else

* Show-case the `#xpath()` with a `<int:recipient-list-router>`
* Mention such a feature in the `xpath-routing.adoc`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
