### PR TITLE
Support for PubSub Lock on AWS Elasticache Valkey

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -53,7 +53,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.data.redis.core.script.RedisScript;
-import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.listener.Topic;
 import org.springframework.integration.support.locks.DistributedLock;
@@ -97,6 +97,7 @@ import org.springframework.util.ReflectionUtils;
  * @author Alex Peelman
  * @author Youbin Wu
  * @author Michal Domagala
+ * @author Severin Kistler
  *
  * @since 4.0
  *
@@ -213,7 +214,7 @@ public final class RedisLockRegistry
 				"'unlockNotifyMessageListener' must not have been re-initialized.");
 		RedisLockRegistry.this.redisMessageListenerContainer = new RedisMessageListenerContainer();
 		RedisLockRegistry.this.unlockNotifyMessageListener = new RedisPubSubLock.RedisUnLockNotifyMessageListener();
-		final Topic topic = new ChannelTopic(this.unLockChannelKey);
+		final Topic topic = new PatternTopic(this.unLockChannelKey + ":*");
 		RedisMessageListenerContainer container = RedisLockRegistry.this.redisMessageListenerContainer;
 		RedisPubSubLock.RedisUnLockNotifyMessageListener listener = RedisLockRegistry.this.unlockNotifyMessageListener;
 		container.setConnectionFactory(connectionFactory);
@@ -690,7 +691,7 @@ public final class RedisLockRegistry
 		protected boolean removeLockKeyInnerUnlink() {
 			return Boolean.TRUE.equals(RedisLockRegistry.this.redisTemplate.execute(
 					UNLINK_UNLOCK_REDIS_SCRIPT, Collections.singletonList(this.lockKey),
-					RedisLockRegistry.this.clientId, RedisLockRegistry.this.unLockChannelKey));
+					RedisLockRegistry.this.clientId, RedisLockRegistry.this.unLockChannelKey + ":" + this.lockKey));
 		}
 
 		private boolean subscribeLock(long time, long expireAfter) throws ExecutionException, InterruptedException {


### PR DESCRIPTION
This is an attempt to make issue #10471 work without support for `SPUBLISH`.
I append the `lockKey` to the `channelUnlockKey`. This allows us to control the cluster slot cache this operation is hashed into, by including a hash tag (`{...}`) in the `lockKey`. Refer to the issue description for an explanation of why this matters.

As a consequence, I had to change the `ChannelTopic` to a `PatternTopic` to keep receiving subscription events for the PubSub lock.
