### PR TITLE
GH-7971: Add `FileReadingMessageSource.directoryExpression`

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
@@ -23,13 +23,16 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.expression.Expression;
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageSourceSpec;
 import org.springframework.integration.expression.FunctionExpression;
+import org.springframework.integration.expression.SupplierExpression;
 import org.springframework.integration.file.DirectoryScanner;
 import org.springframework.integration.file.FileLocker;
 import org.springframework.integration.file.RecursiveDirectoryScanner;
@@ -70,13 +73,13 @@ public class FileInboundChannelAdapterSpec
 	}
 
 	/**
-	 * Specify the input directory.
-	 * @param directory the directory.
+	 * Specify the Supplier for input directory.
+	 * @param directorySupplier the Supplier for directory to poll.
 	 * @return the spec.
-	 * @see FileReadingMessageSource#setDirectory(File)
+	 * @see FileReadingMessageSource#setDirectoryExpression(Expression)
 	 */
-	FileInboundChannelAdapterSpec directory(File directory) {
-		this.target.setDirectory(directory);
+	FileInboundChannelAdapterSpec directory(Supplier<File> directorySupplier) {
+		this.target.setDirectoryExpression(new SupplierExpression<>(directorySupplier));
 		return _this();
 	}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/Files.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/Files.java
@@ -19,6 +19,7 @@ package org.springframework.integration.file.dsl;
 import java.io.File;
 import java.util.Comparator;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
 
@@ -42,7 +43,17 @@ public abstract class Files {
 	 * @return the {@link FileInboundChannelAdapterSpec} instance.
 	 */
 	public static FileInboundChannelAdapterSpec inboundAdapter(File directory) {
-		return inboundAdapter(directory, null);
+		return inboundAdapter(() -> directory);
+	}
+
+	/**
+	 * Create a {@link FileInboundChannelAdapterSpec} builder for the {@code FileReadingMessageSource}.
+	 * @param directorySupplier the Supplier for directory to scan files.
+	 * @return the {@link FileInboundChannelAdapterSpec} instance.
+	 * @since 7.0
+	 */
+	public static FileInboundChannelAdapterSpec inboundAdapter(Supplier<File> directorySupplier) {
+		return inboundAdapter(directorySupplier, null);
 	}
 
 	/**
@@ -54,7 +65,20 @@ public abstract class Files {
 	public static FileInboundChannelAdapterSpec inboundAdapter(File directory,
 			@Nullable Comparator<File> receptionOrderComparator) {
 
-		return new FileInboundChannelAdapterSpec(receptionOrderComparator).directory(directory);
+		return inboundAdapter(() -> directory, null);
+	}
+
+	/**
+	 * Create a {@link FileInboundChannelAdapterSpec} builder for the {@code FileReadingMessageSource}.
+	 * @param directorySupplier the Supplier for directory to scan files.
+	 * @param receptionOrderComparator the {@link Comparator} for ordering file objects.
+	 * @return the {@link FileInboundChannelAdapterSpec} instance.
+	 * @since 7.0
+	 */
+	public static FileInboundChannelAdapterSpec inboundAdapter(Supplier<File> directorySupplier,
+			@Nullable Comparator<File> receptionOrderComparator) {
+
+		return new FileInboundChannelAdapterSpec(receptionOrderComparator).directory(directorySupplier);
 	}
 
 	/**

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.concurrent.PriorityBlockingQueue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -91,7 +90,7 @@ public class FileInboundChannelAdapterParserTests {
 	@Test
 	public void inputDirectory() {
 		File expected = new File(System.getProperty("java.io.tmpdir"));
-		File actual = (File) this.accessor.getPropertyValue("directory");
+		File actual = (File) this.accessor.getPropertyValue("directoryExpression.value");
 		assertThat(actual).as("'directory' should be set").isEqualTo(expected);
 		assertThat(this.accessor.getPropertyValue("scanEachPoll")).isEqualTo(Boolean.TRUE);
 		assertThat(this.inputDirPollerSource.getComponentName()).isEqualTo("inputDirPoller.adapter.source");
@@ -117,15 +116,6 @@ public class FileInboundChannelAdapterParserTests {
 					.isIn(FileReadingMessageSource.WatchEventType.MODIFY,
 							FileReadingMessageSource.WatchEventType.DELETE);
 		}
-	}
-
-	@Test
-	public void comparator() {
-		Object priorityQueue = accessor.getPropertyValue("toBeReceived");
-		assertThat(priorityQueue).isInstanceOf(PriorityBlockingQueue.class);
-		Object expected = context.getBean("testComparator");
-		Object actual = ((PriorityBlockingQueue) priorityQueue).comparator();
-		assertThat(actual).as("comparator reference not set, ").isSameAs(expected);
 	}
 
 	static class TestComparator implements Comparator<File> {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithClasspathInPropertiesTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithClasspathInPropertiesTests.java
@@ -62,7 +62,7 @@ public class FileInboundChannelAdapterWithClasspathInPropertiesTests {
 	@SuppressWarnings("unchecked")
 	public void inputDirectory() throws Exception {
 		File expected = new ClassPathResource("").getFile();
-		File actual = (File) accessor.getPropertyValue("directory");
+		File actual = (File) accessor.getPropertyValue("directoryExpression.value");
 		assertThat(actual).as("'directory' should be set").isEqualTo(expected);
 
 		FileListFilter<File> fileListFilter =

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithPatternParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithPatternParserTests.java
@@ -72,7 +72,7 @@ public class FileInboundChannelAdapterWithPatternParserTests {
 	@Test
 	public void inputDirectory() {
 		File expected = new File(System.getProperty("java.io.tmpdir"));
-		File actual = TestUtils.getPropertyValue(this.source, "directory", File.class);
+		File actual = TestUtils.getPropertyValue(this.source, "directoryExpression.value", File.class);
 		assertThat(actual).isEqualTo(expected);
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileInboundTransactionTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileInboundTransactionTests.java
@@ -90,13 +90,11 @@ public class FileInboundTransactionTests {
 
 		new DirectFieldAccessor(scanner).setPropertyValue("filter", fileListFilter);
 
-		final CountDownLatch latch = new CountDownLatch(1);
 		final AtomicBoolean crash = new AtomicBoolean();
 		input.subscribe(message -> {
 			if (crash.get()) {
 				throw new MessagingException("eek");
 			}
-			latch.countDown();
 		});
 		pseudoTx.start();
 		File file = new File(tmpDir, "si-test1/foo");
@@ -112,11 +110,11 @@ public class FileInboundTransactionTests {
 		assertThat(result).isNotNull();
 		assertThat(file.delete()).isTrue();
 		assertThat(result.getPayload()).isEqualTo("foo");
-		pseudoTx.stop();
 		assertThat(transactionManager.getCommitted()).isFalse();
 		assertThat(transactionManager.getRolledBack()).isFalse();
-
 		verify(fileListFilter).remove(new File(tmpDir, "si-test1/foo"));
+
+		pseudoTx.stop();
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileReadingMessageSourceIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileReadingMessageSourceIntegrationTests.java
@@ -66,7 +66,7 @@ public class FileReadingMessageSourceIntegrationTests {
 
 	@Test
 	public void configured() {
-		assertThat(TestUtils.getPropertyValue(this.pollableFileSource, "directory")).isEqualTo(inputDir);
+		assertThat(TestUtils.getPropertyValue(this.pollableFileSource, "directoryExpression.value")).isEqualTo(inputDir);
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileReadingMessageSourcePersistentFilterIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileReadingMessageSourcePersistentFilterIntegrationTests.java
@@ -64,7 +64,7 @@ public class FileReadingMessageSourcePersistentFilterIntegrationTests {
 	@Test
 	public void configured() {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(this.pollableFileSource);
-		assertThat(accessor.getPropertyValue("directory")).isEqualTo(inputDir);
+		assertThat(accessor.getPropertyValue("directoryExpression.value")).isEqualTo(inputDir);
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileReadingMessageSourceTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileReadingMessageSourceTests.java
@@ -57,6 +57,7 @@ class FileReadingMessageSourceTests implements TestApplicationContextAware {
 	public void prepResource() {
 		when(inputDirectoryMock.toPath()).thenReturn(Path.of("[dir]"));
 		when(fileMock.toPath()).thenReturn(Path.of("[dir]/fileMock"));
+		when(fileMock.getAbsolutePath()).thenReturn("[dir]/fileMock");
 		when(locker.lock(isA(File.class))).thenReturn(true);
 	}
 

--- a/src/reference/antora/modules/ROOT/pages/file/reading.adoc
+++ b/src/reference/antora/modules/ROOT/pages/file/reading.adoc
@@ -184,6 +184,10 @@ See https://docs.spring.io/spring-integration/api/org/springframework/integratio
 
 NOTE: Starting with version 5.5, the `FileInboundChannelAdapterSpec` of the Java DSL has a convenient `recursive(boolean)` option to use a `RecursiveDirectoryScanner` in the target `FileReadingMessageSource` instead of the default one.
 
+Starting with version 7.0, the `FileReadingMessageSource` can be configured with a SpEL expression for its `directory` property.
+This expression evaluated each time when a new scan is requested.
+Such a logic might be useful in scenarios when input directory should be changed after scanning is exhausted, or when it is based on the timestamp rotation.
+
 [[file-namespace-support]]
 == Namespace Support
 

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -103,6 +103,12 @@ Previously deprecated classes in the `spring-integation-hazelcast` module, such 
 The `AbstractMqttMessageDrivenChannelAdapter` and `ClientManager` implementations now expose a `quiescentTimeout` option which is propagated in their `stop()` method down to the `disconnectForcibly()` API of the MQTT Paho clients.
 See xref:mqtt.adoc[] for more information.
 
+[[x7.0-files-changes]]
+=== Files Changes
+
+The `FileReadingMessageSource` now can be configured with a SpEL `Expression` for its `directory` property.
+See xref:file/reading.adoc[] for more information.
+
 [[x7.0-remote-files-changes]]
 === Remote Files Support Changes
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/7971

Extend a `FileReadingMessageSource.directory` logic to the SpEL expression to evaluate on each scan

* Introduce an internal `record DirFile` to keep the `File` and scanned directory per file
* Propagate a new directory down to the `WatchServiceDirectoryScanner` and restart it
* Calculate a root directory from the failed `Message` we offer back to the queue
* Fix tests for a new `FileReadingMessageSource.directoryExpression` property
* Expose a `Supplier<File>` configuration for Java DSL
* Modify `FileTests.MyService.pollDirectories()` for a `Supplier<File>` configuration
* Document this new feature

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
