### PR TITLE
Upgrade to Dokka 2.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,11 @@ ext {
     ztZipVersion = '1.17'
 
     javaProjects = subprojects - project(':spring-integration-bom')
+
+    // Modules that have Kotlin sources to document using dokka
+    dokkaProjects = [
+            'spring-integration-core'
+    ]
 }
 
 allprojects {
@@ -188,8 +193,6 @@ configure(javaProjects) { subproject ->
     apply plugin: 'kotlin'
     apply plugin: 'kotlin-spring'
     apply plugin: 'io.spring.nullability'
-    apply plugin: 'org.jetbrains.dokka'
-
 
     apply from: "${rootDir}/gradle/publish-maven.gradle"
 
@@ -395,27 +398,6 @@ configure(javaProjects) { subproject ->
 
     check.dependsOn checkClasspathForConflicts, javadoc
 
-
-    dokka {
-        dokkaPublications.html {
-            outputDirectory.set(file(rootProject.layout.buildDirectory.file('kdoc')))
-        }
-        dokkaSourceSets.configureEach {
-            sourceRoots.setFrom(file('src/main/kotlin'))
-            classpath.from(sourceSets['main'].runtimeClasspath)
-            externalDocumentationLinks.register("spring-integration-api") {
-                url.set(uri("https://docs.spring.io/spring-integration/docs/$version/api/"))
-                packageListUrl.set(file('build/docs/javadoc/element-list').toURI())
-            }
-            externalDocumentationLinks.register("reactor-core") {
-                url.set(uri('https://projectreactor.io/docs/core/release/api/'))
-            }
-            externalDocumentationLinks.register("reactor-streams") {
-                url.set(uri('https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/'))
-            }
-        }
-    }
-
     publishing {
         publications {
             mavenJava(MavenPublication) {
@@ -427,6 +409,30 @@ configure(javaProjects) { subproject ->
                      pomDeps.'*'.find { it.artifactId.text() == dep.name }.scope.first().value = 'provided'
                     }
                 }
+            }
+        }
+    }
+}
+
+// Process only the modules that require kotlin docs
+configure(subprojects.findAll { dokkaProjects.contains(it.name) }) { subproject ->
+    apply plugin: 'org.jetbrains.dokka'
+    dokka {
+        dokkaPublications.html {
+            outputDirectory.set(file(rootProject.layout.buildDirectory.file('kdoc')))
+        }
+        dokkaSourceSets.configureEach {
+            sourceRoots.setFrom(file('src/main/kotlin'))
+            classpath.from(sourceSets['main'].runtimeClasspath)
+            externalDocumentationLinks.register("spring-integration-api") {
+                url.set(uri("https://docs.spring.io/spring-integration/docs/$version/api/"))
+                packageListUrl.set(file(rootProject.layout.buildDirectory.file('docs/javadoc/element-list')).toURI())
+            }
+            externalDocumentationLinks.register("reactor-core") {
+                url.set(uri('https://projectreactor.io/docs/core/release/api/'))
+            }
+            externalDocumentationLinks.register("reactive-streams") {
+                url.set(uri('https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/'))
             }
         }
     }
@@ -1137,7 +1143,7 @@ tasks.register('schemaZip', Zip) {
 }
 
 tasks.register('docsZip', Zip) {
-    dependsOn ':spring-integration-core:dokkaGenerate'
+    dependsOn dokkaProjects.collect { ":${it}:dokkaGenerate" }
     group = 'Distribution'
     archiveClassifier = 'docs'
     description = "Builds -${archiveClassifier} archive containing api and reference " +

--- a/build.gradle
+++ b/build.gradle
@@ -188,6 +188,8 @@ configure(javaProjects) { subproject ->
     apply plugin: 'kotlin'
     apply plugin: 'kotlin-spring'
     apply plugin: 'io.spring.nullability'
+    apply plugin: 'org.jetbrains.dokka'
+
 
     apply from: "${rootDir}/gradle/publish-maven.gradle"
 
@@ -393,6 +395,27 @@ configure(javaProjects) { subproject ->
 
     check.dependsOn checkClasspathForConflicts, javadoc
 
+
+    dokka {
+        dokkaPublications.html {
+            outputDirectory.set(file(rootProject.layout.buildDirectory.file('kdoc')))
+        }
+        dokkaSourceSets.configureEach {
+            sourceRoots.setFrom(file('src/main/kotlin'))
+            classpath.from(sourceSets['main'].runtimeClasspath)
+            externalDocumentationLinks.register("spring-integration-api") {
+                url.set(uri("https://docs.spring.io/spring-integration/docs/$version/api/"))
+                packageListUrl.set(file('build/docs/javadoc/element-list').toURI())
+            }
+            externalDocumentationLinks.register("reactor-core") {
+                url.set(uri('https://projectreactor.io/docs/core/release/api/'))
+            }
+            externalDocumentationLinks.register("reactor-streams") {
+                url.set(uri('https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/'))
+            }
+        }
+    }
+
     publishing {
         publications {
             mavenJava(MavenPublication) {
@@ -468,7 +491,6 @@ project('spring-integration-cassandra') {
 project('spring-integration-core') {
     description = 'Spring Integration Core'
 
-    apply plugin: 'org.jetbrains.dokka'
     apply plugin: 'com.google.protobuf'
 
     dependencies {
@@ -508,17 +530,6 @@ project('spring-integration-core') {
             exclude group: 'io.opentelemetry'
             exclude group: 'com.wavefront'
             exclude group: 'io.micrometer', module: 'micrometer-tracing-bridge-otel'
-        }
-    }
-
-dokka {
-        dokkaPublications.html {
-            outputDirectory.set(file('../build/kdoc'))
-        }
-        dokkaSourceSets.configureEach {
-            noJdkLink.set(false)
-            sourceRoots.setFrom(file('src/main/kotlin'))
-            classpath.from(sourceSets['main'].runtimeClasspath)
         }
     }
 
@@ -1088,17 +1099,6 @@ tasks.register('api') {
     dependsOn javadoc
 }
 
-dokka {
-    moduleName.set('spring-integration')
-    dokkaPublications.html {
-        outputDirectory.set(file('build/kdoc'))
-    }
-}
-
-tasks.named('dokkaGeneratePublicationHtml') {
-    dependsOn 'api'
-}
-
 apply from: "${rootDir}/gradle/docs.gradle"
 
 tasks.register('schemaZip', Zip) {
@@ -1137,7 +1137,6 @@ tasks.register('schemaZip', Zip) {
 }
 
 tasks.register('docsZip', Zip) {
-    dependsOn 'dokkaGeneratePublicationHtml'
     dependsOn ':spring-integration-core:dokkaGenerate'
     group = 'Distribution'
     archiveClassifier = 'docs'

--- a/build.gradle
+++ b/build.gradle
@@ -116,10 +116,6 @@ ext {
 
     javaProjects = subprojects - project(':spring-integration-bom')
 
-    // Modules that have Kotlin sources to document using dokka
-    dokkaProjects = [
-            'spring-integration-core'
-    ]
 }
 
 allprojects {
@@ -412,14 +408,12 @@ configure(javaProjects) { subproject ->
             }
         }
     }
-}
 
-// Process only the modules that require kotlin docs
-configure(subprojects.findAll { dokkaProjects.contains(it.name) }) { subproject ->
+    // Process only the modules that require kotlin docs
     apply plugin: 'org.jetbrains.dokka'
     dokka {
         dokkaPublications.html {
-            outputDirectory.set(file(rootProject.layout.buildDirectory.file('kdoc')))
+            outputDirectory.set(file(rootProject.layout.buildDirectory.dir('kdoc')))
         }
         dokkaSourceSets.configureEach {
             sourceRoots.setFrom(file('src/main/kotlin'))
@@ -1143,7 +1137,7 @@ tasks.register('schemaZip', Zip) {
 }
 
 tasks.register('docsZip', Zip) {
-    dependsOn dokkaProjects.collect { ":${it}:dokkaGenerate" }
+    dependsOn javaProjects.findAll { it.file('src/main/kotlin').exists() }.collect { ":${it.name}:dokkaGenerate" }
     group = 'Distribution'
     archiveClassifier = 'docs'
     description = "Builds -${archiveClassifier} archive containing api and reference " +

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'base'
     id 'io.spring.nohttp' version '0.0.11' apply false
     id 'io.spring.dependency-management' version '1.1.7'
-    id 'org.jetbrains.dokka' version '2.0.0'
+    id 'org.jetbrains.dokka' version '2.1.0'
     id 'org.antora' version '1.0.0'
     id 'io.spring.antora.generate-antora-yml' version '0.0.1'
     id 'com.google.protobuf' version '0.9.5' apply false
@@ -176,15 +176,6 @@ allprojects {
             mavenBom "org.mongodb:mongodb-driver-bom:$mongoDriverVersion"
         }
 
-    }
-
-    // TODO Remove when Dokka 2.1.0 is released
-    configurations.matching { it.name.startsWith('dokka') }.configureEach {
-        resolutionStrategy.eachDependency {
-            if (requested.group.startsWith('com.fasterxml.jackson')) {
-                useVersion('2.15.3')
-            }
-        }
     }
 
 }
@@ -520,24 +511,14 @@ project('spring-integration-core') {
         }
     }
 
-    dokkaHtmlPartial {
-        outputDirectory.set(new File('build', 'kdoc'))
-        dokkaSourceSets {
-            main {
-                sourceRoots.setFrom(file('src/main/kotlin'))
-                classpath.from(sourceSets['main'].runtimeClasspath)
-                noJdkLink.set(false)
-                externalDocumentationLink {
-                    url.set(new URL("https://docs.spring.io/spring-integration/docs/$version/api/"))
-                    packageListUrl.set(file('build/docs/javadoc/element-list').toURI().toURL())
-                }
-                externalDocumentationLink {
-                    url.set(new URL('https://projectreactor.io/docs/core/release/api/'))
-                }
-                externalDocumentationLink {
-                    url.set(new URL('https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/'))
-                }
-            }
+dokka {
+        dokkaPublications.html {
+            outputDirectory.set(file('../build/kdoc'))
+        }
+        dokkaSourceSets.configureEach {
+            noJdkLink.set(false)
+            sourceRoots.setFrom(file('src/main/kotlin'))
+            classpath.from(sourceSets['main'].runtimeClasspath)
         }
     }
 
@@ -1107,10 +1088,15 @@ tasks.register('api') {
     dependsOn javadoc
 }
 
-dokkaHtmlMultiModule {
-    dependsOn 'api'
+dokka {
     moduleName.set('spring-integration')
-    outputDirectory.set(file('build/kdoc'))
+    dokkaPublications.html {
+        outputDirectory.set(file('build/kdoc'))
+    }
+}
+
+tasks.named('dokkaGeneratePublicationHtml') {
+    dependsOn 'api'
 }
 
 apply from: "${rootDir}/gradle/docs.gradle"
@@ -1151,7 +1137,8 @@ tasks.register('schemaZip', Zip) {
 }
 
 tasks.register('docsZip', Zip) {
-    dependsOn 'dokkaHtmlMultiModule'
+    dependsOn 'dokkaGeneratePublicationHtml'
+    dependsOn ':spring-integration-core:dokkaGenerate'
     group = 'Distribution'
     archiveClassifier = 'docs'
     description = "Builds -${archiveClassifier} archive containing api and reference " +
@@ -1165,7 +1152,7 @@ tasks.register('docsZip', Zip) {
         into 'api'
     }
 
-    from(dokkaHtmlMultiModule.outputDirectory) {
+    from(file('build/kdoc')) {
         into 'kdoc-api'
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'base'
     id 'io.spring.nohttp' version '0.0.11' apply false
     id 'io.spring.dependency-management' version '1.1.7'
-    id 'org.jetbrains.dokka' version '2.1.0'
+    id 'org.jetbrains.dokka' version '2.1.0' apply false
     id 'org.antora' version '1.0.0'
     id 'io.spring.antora.generate-antora-yml' version '0.0.1'
     id 'com.google.protobuf' version '0.9.5' apply false
@@ -410,23 +410,25 @@ configure(javaProjects) { subproject ->
     }
 
     // Process only the modules that require kotlin docs
-    apply plugin: 'org.jetbrains.dokka'
-    dokka {
-        dokkaPublications.html {
-            outputDirectory.set(file(rootProject.layout.buildDirectory.dir('kdoc')))
-        }
-        dokkaSourceSets.configureEach {
-            sourceRoots.setFrom(file('src/main/kotlin'))
-            classpath.from(sourceSets['main'].runtimeClasspath)
-            externalDocumentationLinks.register("spring-integration-api") {
-                url.set(uri("https://docs.spring.io/spring-integration/docs/$version/api/"))
-                packageListUrl.set(file(rootProject.layout.buildDirectory.file('docs/javadoc/element-list')).toURI())
+    if (file('src/main/kotlin')) {
+        apply plugin: 'org.jetbrains.dokka'
+        dokka {
+            dokkaPublications.html {
+                outputDirectory = rootProject.layout.buildDirectory.dir('kdoc')
             }
-            externalDocumentationLinks.register("reactor-core") {
-                url.set(uri('https://projectreactor.io/docs/core/release/api/'))
-            }
-            externalDocumentationLinks.register("reactive-streams") {
-                url.set(uri('https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/'))
+            dokkaSourceSets.configureEach {
+                sourceRoots.setFrom(file('src/main/kotlin'))
+                classpath.from(sourceSets['main'].runtimeClasspath)
+                externalDocumentationLinks.register("spring-integration-api") {
+                    url.set(uri("https://docs.spring.io/spring-integration/docs/$version/api/"))
+                    packageListUrl.set(file(rootProject.layout.buildDirectory.file('docs/javadoc/element-list')).toURI())
+                }
+                externalDocumentationLinks.register("reactor-core") {
+                    url.set(uri('https://projectreactor.io/docs/core/release/api/'))
+                }
+                externalDocumentationLinks.register("reactive-streams") {
+                    url.set(uri('https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/'))
+                }
             }
         }
     }
@@ -1136,8 +1138,21 @@ tasks.register('schemaZip', Zip) {
     }
 }
 
+apply plugin: 'org.jetbrains.dokka'
+
+dependencies {
+    dokka project(':spring-integration-core')
+}
+
+dokka {
+    moduleName = "spring-integration"
+    dokkaPublications.html {
+        outputDirectory = project.layout.buildDirectory.dir('kdoc')
+    }
+}
+
 tasks.register('docsZip', Zip) {
-    dependsOn javaProjects.findAll { it.file('src/main/kotlin').exists() }.collect { ":${it.name}:dokkaGenerate" }
+    dependsOn 'dokkaGenerate'
     group = 'Distribution'
     archiveClassifier = 'docs'
     description = "Builds -${archiveClassifier} archive containing api and reference " +


### PR DESCRIPTION
- Update `org.jetbrains.dokka` plugin from 2.0.0 to 2.1.0
- Remove Jackson 2.15.3 version resolution strategy workaround that was needed to avoid conflicts in Dokka 2.0.0
- Migrate from deprecated V1 tasks (`dokkaHtmlPartial`, `dokkaHtmlMultiModule`) to V2 API (`dokkaGeneratePublicationHtml`, `dokkaGenerate`)
- Replace `dokkaSourceSets.main` configuration block with `dokkaSourceSets.configureEach`
- Update `docsZip` task to depend on new `dokkaGeneratePublicationHtml` task and add explicit dependency on `:spring-integration-core:dokkaGenerate`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
