### PR TITLE
Fix Files DSL for auto-create input directory

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/FileInboundChannelAdapterSpec.java
@@ -23,7 +23,6 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import org.jspecify.annotations.Nullable;
 
@@ -32,7 +31,6 @@ import org.springframework.expression.Expression;
 import org.springframework.integration.dsl.ComponentsRegistration;
 import org.springframework.integration.dsl.MessageSourceSpec;
 import org.springframework.integration.expression.FunctionExpression;
-import org.springframework.integration.expression.SupplierExpression;
 import org.springframework.integration.file.DirectoryScanner;
 import org.springframework.integration.file.FileLocker;
 import org.springframework.integration.file.RecursiveDirectoryScanner;
@@ -54,7 +52,7 @@ public class FileInboundChannelAdapterSpec
 		extends MessageSourceSpec<FileInboundChannelAdapterSpec, FileReadingMessageSource>
 		implements ComponentsRegistration {
 
-	protected final FileListFilterFactoryBean fileListFilterFactoryBean = new FileListFilterFactoryBean(); // NOSONAR
+	protected final FileListFilterFactoryBean fileListFilterFactoryBean = new FileListFilterFactoryBean();
 
 	private @Nullable FileLocker locker;
 
@@ -73,18 +71,18 @@ public class FileInboundChannelAdapterSpec
 	}
 
 	/**
-	 * Specify the Supplier for input directory.
-	 * @param directorySupplier the Supplier for directory to poll.
+	 * Specify the SpEL expression for the input directory.
+	 * @param directoryExpression the SpEL expression for directory to poll.
 	 * @return the spec.
 	 * @see FileReadingMessageSource#setDirectoryExpression(Expression)
 	 */
-	FileInboundChannelAdapterSpec directory(Supplier<File> directorySupplier) {
-		this.target.setDirectoryExpression(new SupplierExpression<>(directorySupplier));
+	FileInboundChannelAdapterSpec directory(Expression directoryExpression) {
+		this.target.setDirectoryExpression(directoryExpression);
 		return _this();
 	}
 
 	/**
-	 * A convenient flag to determine if target message source should use a
+	 * A convenient flag to determine if a target message source should use a
 	 * {@link RecursiveDirectoryScanner} or stay with a default one.
 	 * @param recursive to set or not a {@link RecursiveDirectoryScanner}.
 	 * @return the spec.

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/Files.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/dsl/Files.java
@@ -24,6 +24,8 @@ import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.expression.Expression;
+import org.springframework.integration.expression.SupplierExpression;
+import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.file.transformer.FileToByteArrayTransformer;
 import org.springframework.integration.file.transformer.FileToStringTransformer;
 import org.springframework.messaging.Message;
@@ -43,7 +45,7 @@ public abstract class Files {
 	 * @return the {@link FileInboundChannelAdapterSpec} instance.
 	 */
 	public static FileInboundChannelAdapterSpec inboundAdapter(File directory) {
-		return inboundAdapter(() -> directory);
+		return inboundAdapter(directory, null);
 	}
 
 	/**
@@ -65,7 +67,8 @@ public abstract class Files {
 	public static FileInboundChannelAdapterSpec inboundAdapter(File directory,
 			@Nullable Comparator<File> receptionOrderComparator) {
 
-		return inboundAdapter(() -> directory, null);
+		return new FileInboundChannelAdapterSpec(receptionOrderComparator)
+				.directory(new ValueExpression<>(directory));
 	}
 
 	/**
@@ -78,7 +81,8 @@ public abstract class Files {
 	public static FileInboundChannelAdapterSpec inboundAdapter(Supplier<File> directorySupplier,
 			@Nullable Comparator<File> receptionOrderComparator) {
 
-		return new FileInboundChannelAdapterSpec(receptionOrderComparator).directory(directorySupplier);
+		return new FileInboundChannelAdapterSpec(receptionOrderComparator)
+				.directory(new SupplierExpression<>(directorySupplier));
 	}
 
 	/**
@@ -92,7 +96,7 @@ public abstract class Files {
 
 	/**
 	 * Create a {@link FileWritingMessageHandlerSpec} builder for the one-way {@code FileWritingMessageHandler}.
-	 * @param directoryExpression the SpEL expression to evaluate target directory for writing files.
+	 * @param directoryExpression the SpEL expression to evaluate the target directory for writing files.
 	 * @return the {@link FileWritingMessageHandlerSpec} instance.
 	 */
 	public static FileWritingMessageHandlerSpec outboundAdapter(String directoryExpression) {
@@ -129,7 +133,7 @@ public abstract class Files {
 
 	/**
 	 * Create a {@link FileWritingMessageHandlerSpec} builder for the gateway {@code FileWritingMessageHandler}.
-	 * @param directoryExpression the SpEL expression to evaluate target directory for writing files.
+	 * @param directoryExpression the SpEL expression to evaluate the target directory for writing files.
 	 * @return the {@link FileWritingMessageHandlerSpec} instance.
 	 */
 	public static FileWritingMessageHandlerSpec outboundGateway(String directoryExpression) {
@@ -193,7 +197,7 @@ public abstract class Files {
 	}
 
 	/**
-	 * Create a {@link FileToStringTransformer} instance with default {@code charset} and no delete files afterwards.
+	 * Create a {@link FileToStringTransformer} instance with default {@code charset} and no delete files afterward.
 	 * @return the {@link FileToStringTransformer}.
 	 */
 	public static FileToStringTransformer toStringTransformer() {
@@ -201,7 +205,7 @@ public abstract class Files {
 	}
 
 	/**
-	 * Create a {@link FileToStringTransformer} instance with default {@code charset} and with delete files flag.
+	 * Create a {@link FileToStringTransformer} instance with default {@code charset} and the flag to delete files.
 	 * @param deleteFiles true to delete the file.
 	 * @return the {@link FileToStringTransformer}.
 	 */
@@ -210,7 +214,7 @@ public abstract class Files {
 	}
 
 	/**
-	 * Create a {@link FileToStringTransformer} instance with provided {@code charset} and no delete files afterwards.
+	 * Create a {@link FileToStringTransformer} instance with provided {@code charset} and no delete files afterward.
 	 * @param charset The charset.
 	 * @return the {@link FileToStringTransformer}.
 	 */
@@ -219,7 +223,7 @@ public abstract class Files {
 	}
 
 	/**
-	 * Create a {@link FileToStringTransformer} instance with provided {@code charset} and delete files flag.
+	 * Create a {@link FileToStringTransformer} instance with provided {@code charset} and the flag to delete files.
 	 * @param charset The charset.
 	 * @param deleteFiles true to delete the file.
 	 * @return the {@link FileToStringTransformer}.
@@ -244,7 +248,7 @@ public abstract class Files {
 	/**
 	 * Create a {@link FileToByteArrayTransformer} instance.
 	 * @param deleteFiles specify whether to delete the File after transformation.
-	 * Default is <em>false</em>.
+	 * Default is {@code false}.
 	 * @return the {@link FileToByteArrayTransformer}.
 	 */
 	public static FileToByteArrayTransformer toByteArrayTransformer(boolean deleteFiles) {


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/7971

The `FileReadingMessageSource` has always had a feature to create a directory to scan on startup. After introducing an expression variant, such a logic is limited only for the `ValueExpression` as only this one comes with a static value.
The Java DSL has been changed to support a `Supplier` variant for an input directory. The `Supplier` does not always give us the same value; therefore, we cannot assume directory auto-creation on startup.

* Fix `FileInboundChannelAdapterSpec` for the `directory(Expression directoryExpression)` instead of `Supplier`
* Fix `Files` to use a `ValueExpression` for statically provided `File directory`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
