### PR TITLE
upgrade jcifs version from 2.1.40 to 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ ext {
     jacksonVersion = '2.20.0'
     jackson3Version = '3.0.1'
     jaxbVersion = '4.0.6'
-    jcifsVersion = '2.1.40'
+    jcifsVersion = '3.0.0'
     jeroMqVersion = '0.6.0'
     jmsApiVersion = '3.1.0'
     jpaApiVersion = '3.2.0'

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/Smb.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/Smb.java
@@ -19,7 +19,7 @@ package org.springframework.integration.smb.dsl;
 import java.io.File;
 import java.util.Comparator;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.file.remote.MessageSessionCallback;
@@ -35,6 +35,7 @@ import org.springframework.integration.smb.session.SmbRemoteFileTemplate;
  *
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/SmbInboundChannelAdapterSpec.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/SmbInboundChannelAdapterSpec.java
@@ -19,7 +19,7 @@ package org.springframework.integration.smb.dsl;
 import java.io.File;
 import java.util.Comparator;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.file.dsl.RemoteFileInboundChannelAdapterSpec;
@@ -38,6 +38,7 @@ import org.springframework.integration.smb.inbound.SmbInboundFileSynchronizingMe
  *
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/SmbMessageHandlerSpec.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/SmbMessageHandlerSpec.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.smb.dsl;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.dsl.FileTransferringMessageHandlerSpec;
 import org.springframework.integration.file.remote.session.SessionFactory;
@@ -28,6 +28,7 @@ import org.springframework.integration.smb.session.SmbRemoteFileTemplate;
  * A {@link FileTransferringMessageHandlerSpec} for SMB.
  *
  * @author Gregory Bragg
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/SmbOutboundGatewaySpec.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/SmbOutboundGatewaySpec.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.smb.dsl;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.dsl.RemoteFileOutboundGatewaySpec;
 import org.springframework.integration.smb.filters.SmbRegexPatternFileListFilter;
@@ -27,6 +27,7 @@ import org.springframework.integration.smb.outbound.SmbOutboundGateway;
  * A {@link RemoteFileOutboundGatewaySpec} for SMB.
  *
  * @author Gregory Bragg
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/SmbStreamingInboundChannelAdapterSpec.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/dsl/SmbStreamingInboundChannelAdapterSpec.java
@@ -18,7 +18,7 @@ package org.springframework.integration.smb.dsl;
 
 import java.util.Comparator;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.file.dsl.RemoteFileStreamingInboundChannelAdapterSpec;
@@ -36,6 +36,7 @@ import org.springframework.integration.smb.inbound.SmbStreamingMessageSource;
  *
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbLastModifiedFileListFilter.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbLastModifiedFileListFilter.java
@@ -20,7 +20,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.function.Consumer;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.filters.AbstractLastModifiedFileListFilter;
 
@@ -33,6 +33,7 @@ import org.springframework.integration.file.filters.AbstractLastModifiedFileList
  * When discardCallback {@link #addDiscardCallback(Consumer)} is provided, it called for all the rejected files.
  *
  * @author Adama Sorho
+ * @author Daniel Frey
  *
  * @since 6.2
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbPersistentAcceptOnceFileListFilter.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbPersistentAcceptOnceFileListFilter.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.smb.filters;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.filters.AbstractPersistentAcceptOnceFileListFilter;
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
@@ -26,6 +26,7 @@ import org.springframework.integration.metadata.ConcurrentMetadataStore;
  *
  * @author Prafull Kumar Soni
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbRecentFileListFilter.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbRecentFileListFilter.java
@@ -19,7 +19,7 @@ package org.springframework.integration.smb.filters;
 import java.time.Duration;
 import java.time.Instant;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.filters.AbstractRecentFileListFilter;
 
@@ -27,6 +27,7 @@ import org.springframework.integration.file.filters.AbstractRecentFileListFilter
  * The {@link AbstractRecentFileListFilter} implementation for SMB protocol.
  *
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.2
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbRegexPatternFileListFilter.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbRegexPatternFileListFilter.java
@@ -19,8 +19,8 @@ package org.springframework.integration.smb.filters;
 import java.io.UncheckedIOException;
 import java.util.regex.Pattern;
 
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.filters.AbstractRegexPatternFileListFilter;
 
@@ -29,6 +29,7 @@ import org.springframework.integration.file.filters.AbstractRegexPatternFileList
  *
  * @author Markus Spann
  * @author Prafull Kumar Soni
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbSimplePatternFileListFilter.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbSimplePatternFileListFilter.java
@@ -18,8 +18,8 @@ package org.springframework.integration.smb.filters;
 
 import java.io.UncheckedIOException;
 
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.filters.AbstractSimplePatternFileListFilter;
 
@@ -28,6 +28,7 @@ import org.springframework.integration.file.filters.AbstractSimplePatternFileLis
  *
  * @author Markus Spann
  * @author Prafull Kumar Soni
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbSystemMarkerFilePresentFileListFilter.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/filters/SmbSystemMarkerFilePresentFileListFilter.java
@@ -19,7 +19,7 @@ package org.springframework.integration.smb.filters;
 import java.util.Map;
 import java.util.function.Function;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.filters.AbstractMarkerFilePresentFileListFilter;
 import org.springframework.integration.file.filters.FileListFilter;
@@ -28,6 +28,7 @@ import org.springframework.integration.file.filters.FileListFilter;
  * Implementation of {@link AbstractMarkerFilePresentFileListFilter} for SMB.
  *
  * @author Prafull Kumar Soni
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbInboundFileSynchronizer.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbInboundFileSynchronizer.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.smb.inbound;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.remote.session.SessionFactory;
 import org.springframework.integration.file.remote.synchronizer.AbstractInboundFileSynchronizer;
@@ -26,6 +26,7 @@ import org.springframework.integration.file.remote.synchronizer.AbstractInboundF
  *
  * @author Markus Spann
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbInboundFileSynchronizingMessageSource.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbInboundFileSynchronizingMessageSource.java
@@ -19,7 +19,7 @@ package org.springframework.integration.smb.inbound;
 import java.io.File;
 import java.util.Comparator;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.file.remote.synchronizer.AbstractInboundFileSynchronizer;
@@ -29,6 +29,7 @@ import org.springframework.integration.file.remote.synchronizer.AbstractInboundF
  * A {@link org.springframework.integration.core.MessageSource} implementation for SMB.
  *
  * @author Markus Spann
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbStreamingMessageSource.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbStreamingMessageSource.java
@@ -21,8 +21,8 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.file.remote.AbstractFileInfo;
@@ -37,6 +37,7 @@ import org.springframework.integration.smb.session.SmbFileInfo;
  *
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  *

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbMessageHandler.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.smb.outbound;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.integration.file.remote.handler.FileTransferringMessageHandler;
 import org.springframework.integration.file.remote.session.SessionFactory;
@@ -29,6 +29,7 @@ import org.springframework.integration.smb.session.SmbRemoteFileTemplate;
  *
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  *

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbOutboundGateway.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbOutboundGateway.java
@@ -20,8 +20,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.file.remote.AbstractFileInfo;
@@ -37,6 +37,7 @@ import org.springframework.integration.smb.session.SmbRemoteFileTemplate;
  *
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbConfig.java
@@ -21,7 +21,7 @@ import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
-import jcifs.DialectVersion;
+import org.codelibs.jcifs.smb.DialectVersion;
 
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -37,6 +37,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Gregory Bragg
  * @author Jelle Smits
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbFileInfo.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbFileInfo.java
@@ -18,11 +18,11 @@ package org.springframework.integration.smb.session;
 
 import java.io.IOException;
 
-import jcifs.internal.dtyp.ACE;
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codelibs.jcifs.smb.ACE;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.file.remote.AbstractFileInfo;
@@ -33,6 +33,7 @@ import org.springframework.util.Assert;
  *
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */
@@ -103,8 +104,8 @@ public class SmbFileInfo extends AbstractFileInfo<SmbFile> {
 	 * </pre>
 	 * @return a list of Access Control Entry (ACE) objects representing the security
 	 * descriptor entry and permissions associated with this file or directory.
-	 * @see jcifs.ACE
-	 * @see jcifs.SID
+	 * @see org.codelibs.jcifs.smb.ACE
+	 * @see org.codelibs.jcifs.smb.SID
 	 */
 	@Override
 	public @Nullable String getPermissions() {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbRemoteFileTemplate.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbRemoteFileTemplate.java
@@ -18,9 +18,9 @@ package org.springframework.integration.smb.session;
 
 import java.util.List;
 
-import jcifs.smb.NtStatus;
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.NtStatus;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.file.remote.RemoteFileTemplate;
@@ -30,6 +30,7 @@ import org.springframework.integration.file.remote.session.SessionFactory;
  * The SMB-specific {@link RemoteFileTemplate} implementation.
  *
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSession.java
@@ -25,9 +25,9 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.util.Arrays;
 
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
-import jcifs.smb.SmbFileOutputStream;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFileOutputStream;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.log.LogAccessor;
@@ -55,6 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Gregory Bragg
  * @author Adam Jones
  * @author Paolo Fosser
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSessionFactory.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbSessionFactory.java
@@ -19,10 +19,10 @@ package org.springframework.integration.smb.session;
 import java.io.IOException;
 import java.util.Properties;
 
-import jcifs.CIFSContext;
-import jcifs.smb.SmbFile;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.integration.file.remote.session.SessionFactory;
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * @author Markus Spann
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/session/SmbShare.java
@@ -22,16 +22,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
-import jcifs.CIFSContext;
-import jcifs.CIFSException;
-import jcifs.config.PropertyConfiguration;
-import jcifs.context.BaseContext;
-import jcifs.context.SingletonContext;
-import jcifs.smb.NtlmPasswordAuthenticator;
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.CIFSException;
+import org.codelibs.jcifs.smb.config.PropertyConfiguration;
+import org.codelibs.jcifs.smb.context.BaseContext;
+import org.codelibs.jcifs.smb.context.SingletonContext;
+import org.codelibs.jcifs.smb.impl.NtlmPasswordAuthenticator;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  * @author Adam Jones
  * @author Artem Bilan
  * @author Christian Tzolov
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbTestSupport.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/SmbTestSupport.java
@@ -21,9 +21,9 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
-import jcifs.DialectVersion;
-import jcifs.smb.SmbFile;
 import org.apache.commons.io.IOUtils;
+import org.codelibs.jcifs.smb.DialectVersion;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -59,6 +59,7 @@ import org.springframework.integration.smb.session.SmbSessionFactory;
  * @author Gregory Bragg
  * @author Artem Vozhdayenko
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/dsl/SmbTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/dsl/SmbTests.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 
-import jcifs.smb.SmbException;
-import jcifs.smb.SmbFile;
-import jcifs.smb.SmbFileInputStream;
+import org.codelibs.jcifs.smb.impl.SmbException;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFileInputStream;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -72,6 +72,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gregory Bragg
  * @author Artem Vozhdayenko
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.0
  */

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/filters/SmbLastModifiedFileListFilterTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/filters/SmbLastModifiedFileListFilterTests.java
@@ -19,7 +19,7 @@ package org.springframework.integration.smb.filters;
 import java.time.Duration;
 import java.time.Instant;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Adama Sorho
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.2
  */

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/filters/SmbRecentFileListFilterTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/filters/SmbRecentFileListFilterTests.java
@@ -19,7 +19,7 @@ package org.springframework.integration.smb.filters;
 import java.time.Duration;
 import java.time.Instant;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 /**
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  * @since 6.5
  */

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/inbound/SmbInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/inbound/SmbInboundRemoteFileSystemSynchronizerTests.java
@@ -21,7 +21,7 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.junit.jupiter.api.BeforeEach;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Markus Spann
  * @author Gunnar Hillert
+ * @author Daniel Frey
  */
 public class SmbInboundRemoteFileSystemSynchronizerTests extends AbstractBaseTests {
 

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/outbound/SmbSendingMessageHandlerTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/outbound/SmbSendingMessageHandlerTests.java
@@ -20,7 +20,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.when;
  * @author Artem Bilan
  * @author Prafull Kumar Soni
  * @author Gregory Bragg
+ * @author Daniel Frey
  */
 public class SmbSendingMessageHandlerTests extends AbstractBaseTests implements TestApplicationContextAware {
 

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionFactoryWithCIFSContextTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionFactoryWithCIFSContextTests.java
@@ -20,10 +20,10 @@ import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import jcifs.CIFSContext;
-import jcifs.context.SingletonContext;
-import jcifs.smb.SmbFile;
-import jcifs.util.Strings;
+import org.codelibs.jcifs.smb.CIFSContext;
+import org.codelibs.jcifs.smb.context.SingletonContext;
+import org.codelibs.jcifs.smb.impl.SmbFile;
+import org.codelibs.jcifs.smb.util.Strings;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  */
 public class SmbSessionFactoryWithCIFSContextTests extends AbstractBaseTests implements TestApplicationContextAware {
 

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
@@ -18,7 +18,7 @@ package org.springframework.integration.smb.session;
 
 import java.io.IOException;
 
-import jcifs.smb.SmbFile;
+import org.codelibs.jcifs.smb.impl.SmbFile;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.file.remote.session.CachingSessionFactory;
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gunnar Hillert
  * @author Gregory Bragg
  * @author Artem Bilan
+ * @author Daniel Frey
  *
  */
 public class SmbSessionTests extends SmbTestSupport {

--- a/src/reference/antora/modules/ROOT/pages/smb.adoc
+++ b/src/reference/antora/modules/ROOT/pages/smb.adoc
@@ -76,9 +76,9 @@ public SmbSessionFactory smbSessionFactory() {
 }
 ----
 
-The `SmbSessionFactory` can be initialized with a custom `jcifs.CIFSContext`.
+The `SmbSessionFactory` can be initialized with a custom `org.codelibs.jcifs.smb.CIFSContext`.
 
-NOTE: Setting of the SMB protocol Min/Max versions must be done in your implementation of `jcifs.CIFSContext`.
+NOTE: Setting of the SMB protocol Min/Max versions must be done in your implementation of `org.codelibs.jcifs.smb.CIFSContext`.
 
 [source,java]
 ----

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -129,3 +129,8 @@ See xref:file/remote-persistent-flf.adoc[Remote Persistent File List Filters] fo
 === Null Safety
 Updated the codebase to use JSpecify and NullAway, adding a comprehensive null safety implementation that uses `@NullMarked` annotations to default all types to non-null at the package level and `@Nullable` annotations to explicitly mark types that can be null.
 See xref:null-safety.adoc[] for more information.
+
+[[x7.0-smb-upgrade]]
+=== SMB JCIFS Upgrade to 3.0.0
+The JCIFS library behind SMB support has been upgraded to 3.0.0. It is a major rewrite of the codebase and implements a new package structure. This is a breaking change and direct references to components of the JCIFS library will need to be updated.
+See xref:smb.adoc[] for more information.


### PR DESCRIPTION
This PR upgrades the jcifs library from 2.1.40 to 3.0.0, which supports modern Samba server connections, athentication, etc, while retains backwards compatibility with SMB1 (which, is mostly no longer supported by Windows).

closes #10533

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
