### PR TITLE
Optimize `new ArrayList()` allocations whenever possible

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpInboundChannelAdapter.java
@@ -491,7 +491,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 			else {
 				converted = convertPayloads(messages, channel);
 				if (BatchMode.EXTRACT_PAYLOADS_WITH_HEADERS.equals(AmqpInboundChannelAdapter.this.batchMode)) {
-					List<Map<String, @Nullable Object>> listHeaders = new ArrayList<>();
+					List<Map<String, @Nullable Object>> listHeaders = new ArrayList<>(messages.size());
 					messages.forEach(msg -> listHeaders.add(AmqpInboundChannelAdapter.this.headerMapper
 							.toHeadersFromRequest(msg.getMessageProperties())));
 					headers = listHeaders;
@@ -553,7 +553,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 		private @Nullable List<org.springframework.messaging.Message<?>> convertMessages(List<Message> messages,
 				@Nullable Channel channel) {
 
-			List<org.springframework.messaging.Message<?>> converted = new ArrayList<>();
+			List<org.springframework.messaging.Message<?>> converted = new ArrayList<>(messages.size());
 			try {
 				messages.forEach(message -> converted.add(createMessageFromAmqp(message, channel)));
 				return converted;
@@ -574,7 +574,7 @@ public class AmqpInboundChannelAdapter extends MessageProducerSupport implements
 		}
 
 		private @Nullable List<?> convertPayloads(List<Message> messages, @Nullable Channel channel) {
-			List<Object> converted = new ArrayList<>();
+			List<Object> converted = new ArrayList<>(messages.size());
 			try {
 				messages.forEach(message -> converted.add(this.converter.fromMessage(message)));
 				return converted;

--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/support/DefaultAmqpHeaderMapper.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.amqp.support;
 
-import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -62,36 +61,33 @@ import org.springframework.util.StringUtils;
  */
 public class DefaultAmqpHeaderMapper extends AbstractHeaderMapper<MessageProperties> implements AmqpHeaderMapper {
 
-	private static final List<String> STANDARD_HEADER_NAMES = new ArrayList<>();
-
-	static {
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.APP_ID);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.CLUSTER_ID);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.CONTENT_ENCODING);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.CONTENT_LENGTH);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.CONTENT_TYPE);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.CORRELATION_ID);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.DELAY);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.DELIVERY_MODE);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.DELIVERY_TAG);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.EXPIRATION);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.MESSAGE_COUNT);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.MESSAGE_ID);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.RECEIVED_DELAY);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.RECEIVED_DELIVERY_MODE);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.RECEIVED_EXCHANGE);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.RECEIVED_ROUTING_KEY);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.REDELIVERED);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.REPLY_TO);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.TIMESTAMP);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.TYPE);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.USER_ID);
-		STANDARD_HEADER_NAMES.add(JsonHeaders.TYPE_ID);
-		STANDARD_HEADER_NAMES.add(JsonHeaders.CONTENT_TYPE_ID);
-		STANDARD_HEADER_NAMES.add(JsonHeaders.KEY_TYPE_ID);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.SPRING_REPLY_CORRELATION);
-		STANDARD_HEADER_NAMES.add(AmqpHeaders.SPRING_REPLY_TO_STACK);
-	}
+	private static final List<String> STANDARD_HEADER_NAMES =
+			List.of(AmqpHeaders.APP_ID,
+					AmqpHeaders.CLUSTER_ID,
+					AmqpHeaders.CONTENT_ENCODING,
+					AmqpHeaders.CONTENT_LENGTH,
+					AmqpHeaders.CONTENT_TYPE,
+					AmqpHeaders.CORRELATION_ID,
+					AmqpHeaders.DELAY,
+					AmqpHeaders.DELIVERY_MODE,
+					AmqpHeaders.DELIVERY_TAG,
+					AmqpHeaders.EXPIRATION,
+					AmqpHeaders.MESSAGE_COUNT,
+					AmqpHeaders.MESSAGE_ID,
+					AmqpHeaders.RECEIVED_DELAY,
+					AmqpHeaders.RECEIVED_DELIVERY_MODE,
+					AmqpHeaders.RECEIVED_EXCHANGE,
+					AmqpHeaders.RECEIVED_ROUTING_KEY,
+					AmqpHeaders.REDELIVERED,
+					AmqpHeaders.REPLY_TO,
+					AmqpHeaders.TIMESTAMP,
+					AmqpHeaders.TYPE,
+					AmqpHeaders.USER_ID,
+					JsonHeaders.TYPE_ID,
+					JsonHeaders.CONTENT_TYPE_ID,
+					JsonHeaders.KEY_TYPE_ID,
+					AmqpHeaders.SPRING_REPLY_CORRELATION,
+					AmqpHeaders.SPRING_REPLY_TO_STACK);
 
 	@SuppressWarnings("this-escape")
 	protected DefaultAmqpHeaderMapper(String @Nullable [] requestHeaderNames, String @Nullable [] replyHeaderNames) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageGroupProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/ResequencingMessageGroupProcessor.java
@@ -49,7 +49,7 @@ public class ResequencingMessageGroupProcessor implements MessageGroupProcessor 
 		if (!messages.isEmpty()) {
 			List<Message<?>> sorted = new ArrayList<>(messages);
 			sorted.sort(this.comparator);
-			ArrayList<Message<?>> partialSequence = new ArrayList<>();
+			ArrayList<Message<?>> partialSequence = new ArrayList<>(messages.size());
 			int previousSequence = extractSequenceNumber(sorted.get(0));
 			int currentSequence = previousSequence;
 			for (Message<?> message : sorted) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/QueueChannel.java
@@ -207,8 +207,8 @@ public class QueueChannel extends AbstractPollableChannel implements QueueChanne
 		if (selector == null) {
 			return this.clear();
 		}
-		List<Message<?>> purgedMessages = new ArrayList<>();
 		Object[] array = this.queue.toArray();
+		List<Message<?>> purgedMessages = new ArrayList<>(array.length);
 		for (Object o : array) {
 			Message<?> message = (Message<?>) o;
 			if (!selector.accept(message) && this.queue.remove(message)) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/CompositeKryoRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/CompositeKryoRegistrar.java
@@ -29,6 +29,8 @@ import org.springframework.util.CollectionUtils;
  * A {@link KryoRegistrar} that delegates and validates registrations across all components.
  *
  * @author David Turanski
+ * @author Artem Bilan
+ *
  * @since 4.2
  */
 public class CompositeKryoRegistrar extends AbstractKryoRegistrar {
@@ -36,7 +38,7 @@ public class CompositeKryoRegistrar extends AbstractKryoRegistrar {
 	private final List<KryoRegistrar> delegates;
 
 	public CompositeKryoRegistrar(List<KryoRegistrar> delegates) {
-		this.delegates = new ArrayList<KryoRegistrar>(delegates);
+		this.delegates = new ArrayList<>(delegates);
 
 		if (!CollectionUtils.isEmpty(this.delegates)) {
 			validateRegistrations();
@@ -52,7 +54,7 @@ public class CompositeKryoRegistrar extends AbstractKryoRegistrar {
 
 	@Override
 	public final List<Registration> getRegistrations() {
-		List<Registration> registrations = new ArrayList<Registration>();
+		List<Registration> registrations = new ArrayList<>();
 		for (KryoRegistrar registrar : this.delegates) {
 			registrations.addAll(registrar.getRegistrations());
 		}
@@ -60,10 +62,11 @@ public class CompositeKryoRegistrar extends AbstractKryoRegistrar {
 	}
 
 	private void validateRegistrations() {
-		List<Integer> ids = new ArrayList<Integer>();
-		List<Class<?>> types = new ArrayList<Class<?>>();
+		List<Registration> registrations = getRegistrations();
+		List<Integer> ids = new ArrayList<>(registrations.size());
+		List<Class<?>> types = new ArrayList<>(registrations.size());
 
-		for (Registration registration : getRegistrations()) {
+		for (Registration registration : registrations) {
 			Assert.isTrue(registration.getId() >= MIN_REGISTRATION_VALUE,
 					"registration ID must be >= " + MIN_REGISTRATION_VALUE);
 			if (ids.contains(registration.getId())) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/KryoClassListRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/KryoClassListRegistrar.java
@@ -64,17 +64,18 @@ public class KryoClassListRegistrar extends AbstractKryoRegistrar {
 	 * @param initialValue the initial value
 	 */
 	public void setInitialValue(int initialValue) {
-		Assert.isTrue(initialValue >= MIN_REGISTRATION_VALUE, "'initialValue' must be >= " + MIN_REGISTRATION_VALUE);
+		Assert.isTrue(initialValue >= MIN_REGISTRATION_VALUE,
+				() -> "'initialValue' must be >= " + MIN_REGISTRATION_VALUE);
 		this.initialValue = initialValue;
 	}
 
 	@Override
 	public List<Registration> getRegistrations() {
-		List<Registration> registrations = new ArrayList<>();
+		List<Registration> registrations = new ArrayList<>(this.registeredClasses.size());
 		if (!CollectionUtils.isEmpty(this.registeredClasses)) {
 			for (int i = 0; i < this.registeredClasses.size(); i++) {
-				registrations.add(new Registration(this.registeredClasses.get(i),
-						KRYO.getSerializer(this.registeredClasses.get(i)), i + this.initialValue));
+				Class<?> type = this.registeredClasses.get(i);
+				registrations.add(new Registration(type, KRYO.getSerializer(type), i + this.initialValue));
 			}
 		}
 		return registrations;

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/KryoClassMapRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/KryoClassMapRegistrar.java
@@ -30,6 +30,8 @@ import org.springframework.util.CollectionUtils;
  * used to explicitly set the registration ID for each class.
  *
  * @author David Turanski
+ * @author Artem Bilan
+ *
  * @since 4.2
  */
 public class KryoClassMapRegistrar extends AbstractKryoRegistrar {
@@ -37,16 +39,16 @@ public class KryoClassMapRegistrar extends AbstractKryoRegistrar {
 	private final Map<Integer, Class<?>> registeredClasses;
 
 	public KryoClassMapRegistrar(Map<Integer, Class<?>> kryoRegisteredClasses) {
-		this.registeredClasses = new HashMap<Integer, Class<?>>(kryoRegisteredClasses);
+		this.registeredClasses = new HashMap<>(kryoRegisteredClasses);
 	}
 
 	@Override
 	public List<Registration> getRegistrations() {
-		List<Registration> registrations = new ArrayList<Registration>();
+		List<Registration> registrations = new ArrayList<>(this.registeredClasses.size());
 		if (!CollectionUtils.isEmpty(this.registeredClasses)) {
 			for (Map.Entry<Integer, Class<?>> entry : this.registeredClasses.entrySet()) {
-				registrations.add(
-						new Registration(entry.getValue(), KRYO.getSerializer(entry.getValue()), entry.getKey()));
+				Class<?> type = entry.getValue();
+				registrations.add(new Registration(type, KRYO.getSerializer(type), entry.getKey()));
 			}
 		}
 		return registrations;

--- a/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/KryoRegistrationRegistrar.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/codec/kryo/KryoRegistrationRegistrar.java
@@ -25,6 +25,8 @@ import com.esotericsoftware.kryo.Registration;
  * A {@link KryoRegistrar} implementation backed by a List of {@link Registration}.
  *
  * @author David Turanski
+ * @author Artem Bilan
+ *
  * @since 4.2
  */
 public class KryoRegistrationRegistrar extends AbstractKryoRegistrar {
@@ -32,9 +34,7 @@ public class KryoRegistrationRegistrar extends AbstractKryoRegistrar {
 	private final List<Registration> registrations;
 
 	public KryoRegistrationRegistrar(List<Registration> registrations) {
-		this.registrations = registrations != null
-				? new ArrayList<Registration>(registrations)
-				: new ArrayList<Registration>();
+		this.registrations = new ArrayList<>(registrations);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/GlobalChannelInterceptorProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/GlobalChannelInterceptorProcessor.java
@@ -120,7 +120,7 @@ public final class GlobalChannelInterceptorProcessor
 			LOGGER.debug("Applying global interceptors on channel '" + beanName + "'");
 		}
 
-		List<GlobalChannelInterceptorWrapper> tempInterceptors = new ArrayList<>();
+		List<GlobalChannelInterceptorWrapper> tempInterceptors = new ArrayList<>(this.positiveOrderInterceptors.size());
 
 		this.positiveOrderInterceptors
 				.forEach(interceptorWrapper ->

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationBeanPostProcessor.java
@@ -63,7 +63,7 @@ public class MessagingAnnotationBeanPostProcessor
 
 	private final Map<Class<? extends Annotation>, MethodAnnotationPostProcessor<?>> postProcessors;
 
-	private final List<Runnable> methodsToPostProcessAfterContextInitialization = new ArrayList<>();
+	private final List<Runnable> methodsToPostProcessAfterContextInitialization;
 
 	@SuppressWarnings("NullAway.Init")
 	private ConfigurableListableBeanFactory beanFactory;
@@ -74,6 +74,7 @@ public class MessagingAnnotationBeanPostProcessor
 			Map<Class<? extends Annotation>, MethodAnnotationPostProcessor<?>> postProcessors) {
 
 		this.postProcessors = postProcessors;
+		this.methodsToPostProcessAfterContextInitialization = new ArrayList<>(this.postProcessors.size());
 	}
 
 	@Override
@@ -217,7 +218,7 @@ public class MessagingAnnotationBeanPostProcessor
 	protected static List<MessagingMetaAnnotation> obtainMessagingAnnotations(
 			Set<Class<? extends Annotation>> postProcessors, MergedAnnotations annotations, String identified) {
 
-		List<MessagingMetaAnnotation> messagingAnnotations = new ArrayList<>();
+		List<MessagingMetaAnnotation> messagingAnnotations = new ArrayList<>(postProcessors.size());
 
 		for (Class<? extends Annotation> annotationType : postProcessors) {
 			annotations.stream()

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
@@ -58,9 +58,9 @@ import org.springframework.util.ErrorHandler;
  */
 public class PartitionedDispatcher extends AbstractDispatcher {
 
-	private final List<UnicastingDispatcher> partitions = new ArrayList<>();
+	private final List<UnicastingDispatcher> partitions;
 
-	private final List<ExecutorService> executors = new ArrayList<>();
+	private final List<ExecutorService> executors;
 
 	private final int partitionCount;
 
@@ -79,7 +79,7 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 	private final Lock lock = new ReentrantLock();
 
 	/**
-	 * Instantiate based on a provided number of partitions and function for partition key against
+	 * Instantiate based on a provided number of partitions and function for a partition key against
 	 * the message to dispatch.
 	 * @param partitionCount the number of partitions in this channel.
 	 * @param partitionKeyFunction the function to resolve a partition key against the message
@@ -90,6 +90,8 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 		Assert.notNull(partitionKeyFunction, "'partitionKeyFunction' must not be null");
 		this.partitionKeyFunction = partitionKeyFunction;
 		this.partitionCount = partitionCount;
+		this.partitions = new ArrayList<>(partitionCount);
+		this.executors = new ArrayList<>(partitionCount);
 	}
 
 	/**
@@ -143,7 +145,7 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 
 	/**
 	 * Set a {@link MessageHandlingTaskDecorator} to wrap a message handling task into some
-	 * addition logic, e.g. message channel may provide an interception for its operations.
+	 * addition logic, e.g., a message channel may provide an interception for its operations.
 	 * @param messageHandlingTaskDecorator the {@link MessageHandlingTaskDecorator} to use.
 	 */
 	public void setMessageHandlingTaskDecorator(MessageHandlingTaskDecorator messageHandlingTaskDecorator) {
@@ -153,7 +155,7 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 
 	/**
 	 * Shutdown this dispatcher on application close.
-	 * The partition executors are shutdown and internal state of this instance is cleared.
+	 * The partition executors are shutdown and the internal state of this instance is cleared.
 	 */
 	public void shutdown() {
 		this.executors.forEach(ExecutorService::shutdown);

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
@@ -167,7 +167,7 @@ public class UnicastingDispatcher extends AbstractDispatcher {
 						IntegrationUtils.wrapInDeliveryExceptionIfNecessary(message,
 								() -> "Dispatcher failed to deliver Message", ex);
 				if (exceptions == null) {
-					exceptions = new ArrayList<>();
+					exceptions = new ArrayList<>(getHandlerCount());
 				}
 				exceptions.add(runtimeException);
 				boolean isLast = !handlerIterator.hasNext();

--- a/spring-integration-core/src/main/java/org/springframework/integration/expression/ReloadableResourceBundleExpressionSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/expression/ReloadableResourceBundleExpressionSource.java
@@ -371,7 +371,7 @@ public class ReloadableResourceBundleExpressionSource implements ExpressionSourc
 	 * @return the List of filenames to check
 	 */
 	private List<String> calculateFilenamesForLocale(String basename, Locale locale) {
-		List<String> result = new ArrayList<>();
+		List<String> result = new ArrayList<>(3);
 		String language = locale.getLanguage();
 		String country = locale.getCountry();
 		String variant = locale.getVariant();

--- a/spring-integration-core/src/main/java/org/springframework/integration/graph/CompositeMessageHandlerNode.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/graph/CompositeMessageHandlerNode.java
@@ -34,13 +34,13 @@ import org.springframework.messaging.MessageHandler;
  */
 public class CompositeMessageHandlerNode extends MessageHandlerNode {
 
-	private final List<InnerHandler> handlers = new ArrayList<>();
+	private final List<InnerHandler> handlers;
 
 	public CompositeMessageHandlerNode(int nodeId, String name, MessageHandler handler, String input,
 			@Nullable String output, List<InnerHandler> handlers) {
 
 		super(nodeId, name, handler, input, output);
-		this.handlers.addAll(handlers);
+		this.handlers = new ArrayList<>(handlers);
 	}
 
 	public List<InnerHandler> getHandlers() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/CacheRequestHandlerAdvice.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/CacheRequestHandlerAdvice.java
@@ -91,7 +91,7 @@ public class CacheRequestHandlerAdvice extends AbstractRequestHandlerAdvice
 
 	private final String @Nullable [] cacheNames;
 
-	private final List<CacheOperation> cacheOperations = new ArrayList<>();
+	private final List<CacheOperation> cacheOperations = new ArrayList<>(3);
 
 	private Expression keyExpression = new FunctionExpression<Message<?>>(Message::getPayload);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationMessageHandlerMethodFactory.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/IntegrationMessageHandlerMethodFactory.java
@@ -93,7 +93,7 @@ public class IntegrationMessageHandlerMethodFactory extends DefaultMessageHandle
 	}
 
 	private List<HandlerMethodArgumentResolver> buildArgumentResolvers(boolean listCapable) {
-		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
+		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>(6);
 		resolvers.add(new PayloadExpressionArgumentResolver());
 		resolvers.add(new NullAwarePayloadArgumentResolver(this.messageConverter));
 		resolvers.add(new PayloadsArgumentResolver());

--- a/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/mapping/AbstractHeaderMapper.java
@@ -74,9 +74,9 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	public static final String NON_STANDARD_HEADER_NAME_PATTERN = "NON_STANDARD_HEADERS";
 
 	private static final Collection<String> TRANSIENT_HEADER_NAMES =
-			Arrays.asList(MessageHeaders.ID, MessageHeaders.TIMESTAMP);
+			List.of(MessageHeaders.ID, MessageHeaders.TIMESTAMP);
 
-	protected final Log logger = LogFactory.getLog(getClass()); // NOSONAR final
+	protected final Log logger = LogFactory.getLog(getClass());
 
 	private final String standardHeaderPrefix;
 
@@ -92,7 +92,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 
 	/**
 	 * Create a new instance.
-	 * @param standardHeaderPrefix the header prefix that identifies standard header. Such prefix helps to
+	 * @param standardHeaderPrefix the header prefix that identifies the standard header. Such a prefix helps to
 	 * differentiate user-defined headers from standard headers. If set, user-defined headers are also
 	 * mapped by default
 	 * @param requestHeaderNames the header names that should be mapped from a request to {@link MessageHeaders}
@@ -158,36 +158,35 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	 * <p>Special patterns are also recognized: {@link #STANDARD_REQUEST_HEADER_NAME_PATTERN},
 	 * {@link #STANDARD_REQUEST_HEADER_NAME_PATTERN} and {@link #NON_STANDARD_HEADER_NAME_PATTERN}.
 	 * @param patterns the patterns to apply
-	 * @return a header mapper that match if any of the specified patters match
+	 * @return a header mapper that matches if any of the specified patters match
 	 */
 	protected HeaderMatcher createHeaderMatcher(Collection<String> patterns) {
-		List<HeaderMatcher> matchers = new ArrayList<>();
+		List<HeaderMatcher> matchers = new ArrayList<>(patterns.size());
 		for (String pattern : patterns) {
-			if (STANDARD_REQUEST_HEADER_NAME_PATTERN.equals(pattern)) {
-				matchers.add(new ContentBasedHeaderMatcher(true, this.requestHeaderNames));
-			}
-			else if (STANDARD_REPLY_HEADER_NAME_PATTERN.equals(pattern)) {
-				matchers.add(new ContentBasedHeaderMatcher(true, this.replyHeaderNames));
-			}
-			else if (NON_STANDARD_HEADER_NAME_PATTERN.equals(pattern)) {
-				matchers.add(new PrefixBasedMatcher(false, this.standardHeaderPrefix));
-			}
-			else {
-				String thePattern = pattern;
-				boolean negate = false;
-				if (pattern.startsWith("!")) {
-					thePattern = pattern.substring(1);
-					negate = true;
-				}
-				else if (pattern.startsWith("\\!")) {
-					thePattern = pattern.substring(1);
-				}
-				if (negate) {
-					// negative matchers get priority
-					matchers.add(0, new SinglePatternBasedHeaderMatcher(thePattern, negate));
-				}
-				else {
-					matchers.add(new SinglePatternBasedHeaderMatcher(thePattern, negate));
+			switch (pattern) {
+				case STANDARD_REQUEST_HEADER_NAME_PATTERN ->
+						matchers.add(new ContentBasedHeaderMatcher(true, this.requestHeaderNames));
+				case STANDARD_REPLY_HEADER_NAME_PATTERN ->
+						matchers.add(new ContentBasedHeaderMatcher(true, this.replyHeaderNames));
+				case NON_STANDARD_HEADER_NAME_PATTERN ->
+						matchers.add(new PrefixBasedMatcher(false, this.standardHeaderPrefix));
+				default -> {
+					String thePattern = pattern;
+					boolean negate = false;
+					if (pattern.startsWith("!")) {
+						thePattern = pattern.substring(1);
+						negate = true;
+					}
+					else if (pattern.startsWith("\\!")) {
+						thePattern = pattern.substring(1);
+					}
+					if (negate) {
+						// negative matchers get priority
+						matchers.add(0, new SinglePatternBasedHeaderMatcher(thePattern, negate));
+					}
+					else {
+						matchers.add(new SinglePatternBasedHeaderMatcher(thePattern, negate));
+					}
 				}
 			}
 		}
@@ -485,16 +484,14 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	 */
 	protected static class PatternBasedHeaderMatcher implements HeaderMatcher {
 
-		private static final Log LOGGER = LogFactory.getLog(HeaderMatcher.class);
+		private static final Log LOGGER = LogFactory.getLog(PatternBasedHeaderMatcher.class);
 
-		private final Collection<String> patterns = new ArrayList<>();
+		private final Collection<String> patterns;
 
 		public PatternBasedHeaderMatcher(Collection<String> patterns) {
 			Assert.notNull(patterns, "Patterns must no be null");
 			Assert.notEmpty(patterns, "At least one pattern must be specified");
-			for (String pattern : patterns) {
-				this.patterns.add(pattern.toLowerCase(Locale.ROOT));
-			}
+			this.patterns = patterns.stream().map((pattern) -> pattern.toLowerCase(Locale.ROOT)).toList();
 		}
 
 		@Override
@@ -525,7 +522,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	 */
 	protected static class SinglePatternBasedHeaderMatcher implements HeaderMatcher {
 
-		private static final Log LOGGER = LogFactory.getLog(HeaderMatcher.class);
+		private static final Log LOGGER = LogFactory.getLog(SinglePatternBasedHeaderMatcher.class);
 
 		private final String pattern;
 
@@ -569,7 +566,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	 */
 	protected static class PrefixBasedMatcher implements HeaderMatcher {
 
-		private static final Log LOGGER = LogFactory.getLog(HeaderMatcher.class);
+		private static final Log LOGGER = LogFactory.getLog(PrefixBasedMatcher.class);
 
 		private final boolean match;
 
@@ -604,7 +601,7 @@ public abstract class AbstractHeaderMapper<T> implements RequestReplyHeaderMappe
 	 */
 	protected static class CompositeHeaderMatcher implements HeaderMatcher {
 
-		private static final Log LOGGER = LogFactory.getLog(HeaderMatcher.class);
+		private static final Log LOGGER = LogFactory.getLog(CompositeHeaderMatcher.class);
 
 		private final Collection<HeaderMatcher> matchers;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMappingMessageRouter.java
@@ -264,10 +264,15 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 
 	@Override
 	protected Collection<MessageChannel> determineTargetChannels(Message<?> message) {
-		Collection<MessageChannel> channels = new ArrayList<>();
-		Collection<Object> channelKeys = getChannelKeys(message);
-		addToCollection(channels, channelKeys, message);
-		return channels;
+		Collection<@Nullable Object> channelKeys = getChannelKeys(message);
+		if (channelKeys != null) {
+			Collection<MessageChannel> channels = new ArrayList<>(channelKeys.size());
+			addToCollection(channels, channelKeys, message);
+			return channels;
+		}
+		else {
+			return Collections.emptyList();
+		}
 	}
 
 	/**
@@ -277,7 +282,7 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 	 * @param message The message.
 	 * @return The channel keys.
 	 */
-	protected abstract @Nullable List<Object> getChannelKeys(Message<?> message);
+	protected abstract @Nullable List<@Nullable Object> getChannelKeys(Message<?> message);
 
 	/**
 	 * Convenience method allowing conversion of a list
@@ -362,10 +367,7 @@ public abstract class AbstractMappingMessageRouter extends AbstractMessageRouter
 		}
 	}
 
-	private void addToCollection(Collection<MessageChannel> channels, @Nullable Collection<?> channelKeys, Message<?> message) {
-		if (channelKeys == null) {
-			return;
-		}
+	private void addToCollection(Collection<MessageChannel> channels, Collection<?> channelKeys, Message<?> message) {
 		for (Object channelKey : channelKeys) {
 			if (channelKey != null) {
 				addChannelKeyToCollection(channels, message, channelKey);

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/AbstractMessageProcessingRouter.java
@@ -19,6 +19,8 @@ package org.springframework.integration.router;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.context.Lifecycle;
 import org.springframework.core.convert.ConversionService;
@@ -80,7 +82,7 @@ class AbstractMessageProcessingRouter extends AbstractMappingMessageRouter
 	}
 
 	@Override
-	protected List<Object> getChannelKeys(Message<?> message) {
+	protected List<@Nullable Object> getChannelKeys(Message<?> message) {
 		Object result = this.messageProcessor.processMessage(message);
 		return Collections.singletonList(result);
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/ErrorMessageExceptionTypeRouter.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.jmx.export.annotation.ManagedOperation;
 import org.springframework.messaging.Message;
@@ -112,11 +114,10 @@ public class ErrorMessageExceptionTypeRouter extends AbstractMappingMessageRoute
 	}
 
 	@Override
-	protected List<Object> getChannelKeys(Message<?> message) {
+	protected List<@Nullable Object> getChannelKeys(Message<?> message) {
 		String mostSpecificCause = null;
 		Object payload = message.getPayload();
-		if (payload instanceof Throwable) {
-			Throwable cause = (Throwable) payload;
+		if (payload instanceof Throwable cause) {
 			while (cause != null) {
 				for (Map.Entry<String, Class<?>> entry : this.classNameMappings.entrySet()) {
 					String channelKey = entry.getKey();

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/HeaderValueRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/HeaderValueRouter.java
@@ -19,6 +19,8 @@ package org.springframework.integration.router;
 import java.util.Collections;
 import java.util.List;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -45,7 +47,7 @@ public class HeaderValueRouter extends AbstractMappingMessageRouter {
 	}
 
 	@Override
-	protected List<Object> getChannelKeys(Message<?> message) {
+	protected List<@Nullable Object> getChannelKeys(Message<?> message) {
 		Object value = message.getHeaders().get(this.headerName);
 		if (value instanceof String && ((String) value).indexOf(',') != -1) {
 			value = StringUtils.tokenizeToStringArray((String) value, ",");

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/PayloadTypeRouter.java
@@ -42,14 +42,14 @@ public class PayloadTypeRouter extends AbstractMappingMessageRouter {
 	/**
 	 * Selects the most appropriate channel name matching channel identifiers which are the
 	 * fully qualified class names encountered while traversing the payload type hierarchy.
-	 * To resolve ties and conflicts (e.g., Serializable and String) it will match:
+	 * To resolve ties and conflicts (e.g., Serializable and String), it will match:
 	 * 1. Type name to channel identifier else...
 	 * 2. Name of the subclass of the type to channel identifier else...
 	 * 3. Name of the Interface of the type to channel identifier while also
-	 *    preferring direct interface over indirect subclass
+	 *    preferring direct interface to indirect subclass
 	 */
 	@Override
-	protected @Nullable List<Object> getChannelKeys(Message<?> message) {
+	protected @Nullable List<@Nullable Object> getChannelKeys(Message<?> message) {
 		if (CollectionUtils.isEmpty(getChannelMappings())) {
 			return null;
 		}
@@ -59,7 +59,7 @@ public class PayloadTypeRouter extends AbstractMappingMessageRouter {
 			type = type.getComponentType();
 		}
 		String closestMatch = findClosestMatch(type, isArray);
-		return (closestMatch != null) ? Collections.singletonList(closestMatch) : null;
+		return (closestMatch != null) ? Collections.<@Nullable Object>singletonList(closestMatch) : null;
 	}
 
 	private @Nullable String findClosestMatch(Class<?> type, boolean isArray) { // NOSONAR

--- a/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/router/RecipientListRouter.java
@@ -257,7 +257,7 @@ public class RecipientListRouter extends AbstractMessageRouter implements Recipi
 
 	@Override
 	protected Collection<MessageChannel> determineTargetChannels(Message<?> message) {
-		List<MessageChannel> result = new ArrayList<>();
+		List<MessageChannel> result = new ArrayList<>(this.recipients.size());
 		for (Recipient recipient : this.recipients) {
 			if (recipient.accept(message)) {
 				result.add(recipient.getChannel());
@@ -276,7 +276,8 @@ public class RecipientListRouter extends AbstractMessageRouter implements Recipi
 
 		private final @Nullable MessageSelector selector;
 
-		private @Nullable MessageChannel channel;
+		@SuppressWarnings("NullAway.Init")
+		private MessageChannel channel;
 
 		private @Nullable String channelName;
 
@@ -308,7 +309,6 @@ public class RecipientListRouter extends AbstractMessageRouter implements Recipi
 			return this.selector;
 		}
 
-		@Nullable
 		public MessageChannel getChannel() {
 			if (this.channel == null) {
 				String channelNameForInitialization = this.channelName;

--- a/spring-integration-core/src/main/java/org/springframework/integration/selector/PayloadTypeSelector.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/selector/PayloadTypeSelector.java
@@ -16,7 +16,7 @@
 
 package org.springframework.integration.selector;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.integration.core.MessageSelector;
@@ -29,10 +29,11 @@ import org.springframework.util.Assert;
  * of the selector's accepted types.
  *
  * @author Mark Fisher
+ * @author Artem Bilan
  */
 public class PayloadTypeSelector implements MessageSelector {
 
-	private final List<Class<?>> acceptedTypes = new ArrayList<Class<?>>();
+	private final List<Class<?>> acceptedTypes;
 
 	/**
 	 * Create a selector for the provided types. At least one is required.
@@ -41,9 +42,7 @@ public class PayloadTypeSelector implements MessageSelector {
 	 */
 	public PayloadTypeSelector(Class<?>... types) {
 		Assert.notEmpty(types, "at least one type is required");
-		for (Class<?> type : types) {
-			this.acceptedTypes.add(type);
-		}
+		this.acceptedTypes = Arrays.asList(types);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/AbstractKeyValueMessageStore.java
@@ -243,7 +243,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 			Assert.isInstanceOf(MessageGroupMetadata.class, mgm);
 			MessageGroupMetadata messageGroupMetadata = (MessageGroupMetadata) mgm;
 
-			List<UUID> ids = new ArrayList<>();
+			List<UUID> ids = new ArrayList<>(messages.size());
 			for (Message<?> messageToRemove : messages) {
 				UUID id = messageToRemove.getHeaders().getId();
 				Assert.state(id != null, () -> "Message 'id' must not be null: " + messageToRemove);
@@ -252,7 +252,7 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 
 			messageGroupMetadata.removeAll(ids);
 
-			List<Object> messageIds = new ArrayList<>();
+			List<Object> messageIds = new ArrayList<>(ids.size());
 			for (UUID id : ids) {
 				messageIds.add(this.messagePrefix + groupId + '_' + id);
 			}
@@ -391,14 +391,15 @@ public abstract class AbstractKeyValueMessageStore extends AbstractMessageGroupS
 	@Override
 	public Collection<Message<?>> getMessagesForGroup(Object groupId) {
 		MessageGroupMetadata groupMetadata = getGroupMetadata(groupId);
-		ArrayList<Message<?>> messages = new ArrayList<>();
 		if (groupMetadata != null) {
+			ArrayList<Message<?>> messages = new ArrayList<>(groupMetadata.size());
 			Iterator<UUID> messageIds = groupMetadata.messageIdIterator();
 			while (messageIds.hasNext()) {
 				messages.add(getMessageFromGroup(messageIds.next(), groupId));
 			}
+			return messages;
 		}
-		return messages;
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupQueue.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageGroupQueue.java
@@ -229,7 +229,7 @@ public class MessageGroupQueue extends AbstractQueue<Message<?>> implements Bloc
 	@Override
 	public int drainTo(Collection<? super Message<?>> collection, int maxElements) {
 		int originalSize = collection.size();
-		ArrayList<Message<?>> list = new ArrayList<>();
+		ArrayList<Message<?>> list = new ArrayList<>(maxElements);
 		final Lock lock = this.storeLock;
 		try {
 			lock.lockInterruptibly();

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/AbstractIntegrationMessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/AbstractIntegrationMessageBuilder.java
@@ -70,7 +70,7 @@ public abstract class AbstractIntegrationMessageBuilder<T> {
 		List<List<Object>> incomingSequenceDetails = getSequenceDetails();
 		if (incomingCorrelationId != null) {
 			if (incomingSequenceDetails == null) {
-				incomingSequenceDetails = new ArrayList<>();
+				incomingSequenceDetails = new ArrayList<>(1);
 			}
 			else {
 				incomingSequenceDetails = new ArrayList<>(incomingSequenceDetails);

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageBuilder.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/MutableMessageBuilder.java
@@ -82,7 +82,7 @@ public final class MutableMessageBuilder<T> extends AbstractIntegrationMessageBu
 
 	@SuppressWarnings("unchecked")
 	@Override
-	public 	@Nullable <V> V getHeader(String key, Class<V> type) {
+	public @Nullable <V> V getHeader(String key, Class<V> type) {
 		Object value = this.headers.get(key);
 		if (value == null) {
 			return null;
@@ -179,12 +179,10 @@ public final class MutableMessageBuilder<T> extends AbstractIntegrationMessageBu
 	}
 
 	private List<String> getMatchingHeaderNames(String pattern, Map<String, Object> headers) {
-		List<String> matchingHeaderNames = new ArrayList<>();
-		if (headers != null) {
-			for (Map.Entry<String, Object> header : headers.entrySet()) {
-				if (PatternMatchUtils.simpleMatch(pattern, header.getKey())) {
-					matchingHeaderNames.add(header.getKey());
-				}
+		List<String> matchingHeaderNames = new ArrayList<>(headers.size());
+		for (Map.Entry<String, Object> header : headers.entrySet()) {
+			if (PatternMatchUtils.simpleMatch(pattern, header.getKey())) {
+				matchingHeaderNames.add(header.getKey());
 			}
 		}
 		return matchingHeaderNames;

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/AcceptOnceCollectionFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/AcceptOnceCollectionFilter.java
@@ -43,7 +43,7 @@ public class AcceptOnceCollectionFilter<T> implements CollectionFilter<T> {
 	public Collection<T> filter(Collection<T> unfilteredElements) {
 		this.lock.lock();
 		try {
-			List<T> filteredElements = new ArrayList<>();
+			List<T> filteredElements = new ArrayList<>(unfilteredElements.size());
 			for (T element : unfilteredElements) {
 				if (!this.lastSeenElements.contains(element)) {
 					filteredElements.add(element);

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/AnnotatedMethodFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/AnnotatedMethodFilter.java
@@ -56,8 +56,8 @@ public class AnnotatedMethodFilter implements MethodFilter {
 	}
 
 	public List<Method> filter(List<Method> methods) {
-		List<Method> annotatedCandidates = new ArrayList<>();
-		List<Method> fallbackCandidates = new ArrayList<>();
+		List<Method> annotatedCandidates = new ArrayList<>(methods.size());
+		List<Method> fallbackCandidates = new ArrayList<>(methods.size());
 		for (Method method : methods) {
 			if (method.isBridge()) {
 				continue;

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/UniqueMethodFilter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/UniqueMethodFilter.java
@@ -27,14 +27,16 @@ import org.springframework.util.ReflectionUtils.MethodFilter;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Ngoc Nhan
+ *
  * @since 2.0
  */
 public class UniqueMethodFilter implements MethodFilter {
 
-	private final List<Method> uniqueMethods = new ArrayList<>();
+	private final List<Method> uniqueMethods;
 
 	public UniqueMethodFilter(Class<?> targetClass) {
 		Method[] allMethods = ReflectionUtils.getAllDeclaredMethods(targetClass);
+		this.uniqueMethods = new ArrayList<>(allMethods.length);
 		for (Method method : allMethods) {
 			this.uniqueMethods.add(org.springframework.util.ClassUtils.getMostSpecificMethod(method, targetClass));
 		}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileListFilterFactoryBean.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/config/FileListFilterFactoryBean.java
@@ -130,9 +130,9 @@ public class FileListFilterFactoryBean implements FactoryBean<FileListFilter<Fil
 	private FileListFilter<File> initializeFileListFilter() {
 		validate();
 
-		final List<FileListFilter<File>> filtersNeeded = new ArrayList<>();
+		final List<FileListFilter<File>> filtersNeeded = new ArrayList<>(3);
 
-		if (!Boolean.FALSE.equals(this.ignoreHidden)) {
+		if (this.ignoreHidden) {
 			filtersNeeded.add(new IgnoreHiddenFileListFilter());
 		}
 

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractFileListFilter.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.file.filters;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -38,15 +39,16 @@ public abstract class AbstractFileListFilter<F> implements FileListFilter<F> {
 
 	@Override
 	public final List<F> filterFiles(F @Nullable [] files) {
-		List<F> accepted = new ArrayList<>();
 		if (files != null) {
+			List<F> accepted = new ArrayList<>(files.length);
 			for (F file : files) {
-				if (this.accept(file)) {
+				if (accept(file)) {
 					accepted.add(file);
 				}
 			}
+			return accepted;
 		}
-		return accepted;
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractLastModifiedFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractLastModifiedFileListFilter.java
@@ -19,6 +19,7 @@ package org.springframework.integration.file.filters;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -83,8 +84,8 @@ public abstract class AbstractLastModifiedFileListFilter<F> implements DiscardAw
 
 	@Override
 	public List<F> filterFiles(F @Nullable [] files) {
-		List<F> list = new ArrayList<>();
 		if (files != null) {
+			List<F> list = new ArrayList<>(files.length);
 			Instant now = Instant.now();
 			for (F file : files) {
 				if (fileIsAged(file, now)) {
@@ -94,9 +95,10 @@ public abstract class AbstractLastModifiedFileListFilter<F> implements DiscardAw
 					this.discardCallback.accept(file);
 				}
 			}
+			return list;
 		}
 
-		return list;
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractMarkerFilePresentFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractMarkerFilePresentFileListFilter.java
@@ -126,7 +126,7 @@ public abstract class AbstractMarkerFilePresentFileListFilter<F> implements File
 		final Set<String> candidates = Arrays.stream(files)
 				.map(this::getFilename)
 				.collect(Collectors.toSet());
-		List<F> results = new ArrayList<>();
+		List<F> results = new ArrayList<>(files.length);
 		for (F file : files) {
 			boolean anyMatch = this.filtersAndFunctions.entrySet().stream().anyMatch(entry -> {
 				F[] fileToCheck = (F[]) Array.newInstance(file.getClass(), 1);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractRecentFileListFilter.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/filters/AbstractRecentFileListFilter.java
@@ -19,6 +19,7 @@ package org.springframework.integration.file.filters;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -41,7 +42,7 @@ public abstract class AbstractRecentFileListFilter<F> implements FileListFilter<
 	private final Duration age;
 
 	/**
-	 * Construct an instance with default age as 1 day.
+	 * Construct an instance with the default age as 1 day.
 	 */
 	public AbstractRecentFileListFilter() {
 		this(Duration.ofDays(1));
@@ -58,17 +59,18 @@ public abstract class AbstractRecentFileListFilter<F> implements FileListFilter<
 
 	@Override
 	public List<F> filterFiles(F @Nullable [] files) {
-		List<F> list = new ArrayList<>();
 		if (files != null) {
+			List<F> list = new ArrayList<>(files.length);
 			Instant now = Instant.now();
 			for (F file : files) {
 				if (!fileIsAged(file, now)) {
 					list.add(file);
 				}
 			}
+			return list;
 		}
 
-		return list;
+		return Collections.emptyList();
 	}
 
 	@Override

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/AbstractRemoteFileStreamingMessageSource.java
@@ -265,7 +265,7 @@ public abstract class AbstractRemoteFileStreamingMessageSource<F>
 		catch (RuntimeException ex) {
 			if (this.strictOrder) {
 				// If we could not fetch the file content, then it is fatal.
-				// Clear local queue to be refreshed on the next 'receive()' call.
+				// Clear the local queue to be refreshed on the next 'receive()' call.
 				List<AbstractFileInfo<F>> filesToReset = new ArrayList<>();
 				filesToReset.add(file);
 				this.toBeReceived.drainTo(filesToReset);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/aop/StandardRotationPolicy.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/aop/StandardRotationPolicy.java
@@ -54,7 +54,7 @@ public class StandardRotationPolicy implements RotationPolicy {
 
 	private final DelegatingSessionFactory<?> factory;
 
-	private final List<KeyDirectory> keyDirectories = new ArrayList<>();
+	private final List<KeyDirectory> keyDirectories;
 
 	private final boolean fair;
 
@@ -69,10 +69,9 @@ public class StandardRotationPolicy implements RotationPolicy {
 			boolean fair) {
 
 		Assert.notNull(factory, "factory cannot be null");
-		Assert.notNull(keyDirectories, "keyDirectories cannot be null");
-		Assert.isTrue(!keyDirectories.isEmpty(), "At least one KeyDirectory is required");
+		Assert.notEmpty(keyDirectories, "keyDirectories must not be empty");
 		this.factory = factory;
-		this.keyDirectories.addAll(keyDirectories);
+		this.keyDirectories = new ArrayList<>(keyDirectories);
 		this.fair = fair;
 		this.iterator = this.keyDirectories.iterator();
 	}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -967,7 +967,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 
 	private List<String> putLocalDirectory(Message<?> requestMessage, File file, @Nullable String subDirectory) {
 		List<File> filteredFiles = filterMputFiles(file.listFiles());
-		List<String> replies = new ArrayList<>();
+		List<String> replies = new ArrayList<>(filteredFiles.size());
 		try {
 			for (File filteredFile : filteredFiles) {
 				if (!filteredFile.isDirectory()) {
@@ -1027,7 +1027,7 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 			purgeDots(lsFiles);
 		}
 		if (this.options.contains(Option.NAME_ONLY)) {
-			List<String> results = new ArrayList<>();
+			List<String> results = new ArrayList<>(lsFiles.size());
 			for (F file : lsFiles) {
 				results.add(getFilename(file));
 			}
@@ -1051,7 +1051,6 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	private List<F> listFilesInRemoteDir(Session<F> session, @Nullable String directory, String subDirectory)
 			throws IOException {
 
-		List<F> lsFiles = new ArrayList<>();
 		String remoteDirectory = buildRemotePath(directory, subDirectory);
 
 		F[] list = session.list(remoteDirectory);
@@ -1063,11 +1062,13 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 			files = Arrays.asList(list);
 		}
 		if (!ObjectUtils.isEmpty(files)) {
+			List<F> lsFiles = new ArrayList<>(files.size());
 			for (F file : files) {
 				processFile(session, directory, subDirectory, lsFiles, this.options.contains(Option.RECURSIVE), file);
 			}
+			return lsFiles;
 		}
-		return lsFiles;
+		return Collections.emptyList();
 	}
 
 	private String buildRemotePath(@Nullable String parent, String child) {
@@ -1269,10 +1270,10 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	private List<File> mGetWithoutRecursion(Message<?> message, Session<F> session, String remoteDirectory,
 			String remoteFilename) throws IOException {
 
-		List<File> files = new ArrayList<>();
 		String remotePath = buildRemotePath(remoteDirectory, remoteFilename);
 		List<AbstractFileInfo<F>> remoteFiles = lsRemoteFilesForMget(message, session, remoteDirectory,
 				remoteFilename, remotePath);
+		List<File> files = new ArrayList<>(remoteFiles.size());
 		try {
 			for (AbstractFileInfo<F> lsEntry : remoteFiles) {
 				if (lsEntry.isDirectory()) {
@@ -1313,9 +1314,9 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 	private List<File> mGetWithRecursion(Message<?> message, Session<F> session, String remoteDirectory,
 			String remoteFilename) throws IOException {
 
-		List<File> files = new ArrayList<>();
 		List<AbstractFileInfo<F>> fileNames = lsRemoteFilesForMget(message, session, remoteDirectory,
 				remoteFilename, remoteDirectory);
+		List<File> files = new ArrayList<>(fileNames.size());
 		try {
 			for (AbstractFileInfo<F> lsEntry : fileNames) {
 				File file = getRemoteFileForMget(message, session, remoteDirectory, lsEntry);

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/synchronizer/AbstractInboundFileSynchronizer.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -399,7 +400,7 @@ public abstract class AbstractInboundFileSynchronizer<F>
 			List<F> sliceToTransfer = remoteFiles;
 			List<F> remoteFilesToCache = null;
 			if (!CollectionUtils.isEmpty(remoteFiles) && maxFetchSize > 0) {
-				remoteFilesToCache = remoteFiles;
+				remoteFilesToCache = new ArrayList<>(remoteFiles);
 				sliceToTransfer = remoteFiles.stream().limit(maxFetchSize).toList();
 				remoteFilesToCache.removeAll(sliceToTransfer);
 			}
@@ -477,8 +478,7 @@ public abstract class AbstractInboundFileSynchronizer<F>
 				}
 			}
 			else {
-				filteredFiles = new ArrayList<>();
-				Collections.addAll(filteredFiles, files);
+				filteredFiles = Arrays.asList(files);
 			}
 
 			return filteredFiles;

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSource.java
@@ -70,7 +70,7 @@ public class FtpStreamingMessageSource extends AbstractRemoteFileStreamingMessag
 
 	@Override
 	protected List<AbstractFileInfo<FTPFile>> asFileInfoList(Collection<FTPFile> files) {
-		List<AbstractFileInfo<FTPFile>> canonicalFiles = new ArrayList<>();
+		List<AbstractFileInfo<FTPFile>> canonicalFiles = new ArrayList<>(files.size());
 		for (FTPFile file : files) {
 			canonicalFiles.add(new FtpFileInfo(file));
 		}

--- a/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/outbound/FtpOutboundGateway.java
+++ b/spring-integration-ftp/src/main/java/org/springframework/integration/ftp/outbound/FtpOutboundGateway.java
@@ -187,7 +187,7 @@ public class FtpOutboundGateway extends AbstractRemoteFileOutboundGateway<FTPFil
 
 	@Override
 	protected List<AbstractFileInfo<FTPFile>> asFileInfoList(Collection<FTPFile> files) {
-		List<AbstractFileInfo<FTPFile>> canonicalFiles = new ArrayList<>();
+		List<AbstractFileInfo<FTPFile>> canonicalFiles = new ArrayList<>(files.size());
 		for (FTPFile file : files) {
 			canonicalFiles.add(new FtpFileInfo(file));
 		}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/inbound/HttpRequestHandlingEndpointSupport.java
@@ -113,9 +113,9 @@ import org.springframework.web.servlet.HandlerMapping;
  */
 public abstract class HttpRequestHandlingEndpointSupport extends BaseHttpInboundEndpoint {
 
-	private final List<HttpMessageConverter<?>> defaultMessageConverters = new ArrayList<>();
+	private final List<HttpMessageConverter<?>> defaultMessageConverters = new ArrayList<>(10);
 
-	private List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
+	private List<HttpMessageConverter<?>> messageConverters = new ArrayList<>(10);
 
 	private boolean convertersMerged;
 
@@ -136,7 +136,7 @@ public abstract class HttpRequestHandlingEndpointSupport extends BaseHttpInbound
 	}
 
 	/**
-	 * Construct a gateway. If 'expectReply' is true it will wait for the
+	 * Construct a gateway. If 'expectReply' is {@code true} it will wait for the
 	 * {@link #setReplyTimeout(long) replyTimeout} for a reply; if the timeout is exceeded
 	 * a '500 Internal Server Error' status code is returned. This can be modified using
 	 * the {@link #setStatusCodeExpression statusCodeExpression}.

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/support/DefaultHttpHeaderMapper.java
@@ -450,7 +450,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	private void setAccept(HttpHeaders target, Object value) {
 		Collection<?> valuesToAccept = valueToCollection(value);
 		if (!CollectionUtils.isEmpty(valuesToAccept)) {
-			List<MediaType> acceptableMediaTypes = new ArrayList<>();
+			List<MediaType> acceptableMediaTypes = new ArrayList<>(valuesToAccept.size());
 			for (Object type : valuesToAccept) {
 				if (type instanceof MimeType) {
 					acceptableMediaTypes.add(MediaType.asMediaType((MimeType) type));
@@ -472,7 +472,7 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 	private void setAcceptCharset(HttpHeaders target, Object value) {
 		Collection<?> valuesToConvert = valueToCollection(value);
 		if (!CollectionUtils.isEmpty(valuesToConvert)) {
-			List<Charset> acceptableCharsets = new ArrayList<>();
+			List<Charset> acceptableCharsets = new ArrayList<>(valuesToConvert.size());
 			for (Object charset : valuesToConvert) {
 				if (charset instanceof Charset) {
 					acceptableCharsets.add((Charset) charset);
@@ -665,11 +665,11 @@ public class DefaultHttpHeaderMapper implements HeaderMapper<HttpHeaders>, BeanF
 
 	private void setIfNoneMatch(HttpHeaders target, Object value) {
 		Collection<?> valuesToAccept = valueToCollection(value);
-		List<String> ifNoneMatchList = new ArrayList<>();
+		List<String> ifNoneMatchList = new ArrayList<>(valuesToAccept.size());
 
 		for (Object match : valuesToAccept) {
-			if (match instanceof String) {
-				ifNoneMatchList.add((String) match);
+			if (match instanceof String stringValue) {
+				ifNoneMatchList.add(stringValue);
 			}
 			else {
 				throwIllegalArgumentForUnexpectedValue(

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/IntegrationMBeanExportConfiguration.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/config/IntegrationMBeanExportConfiguration.java
@@ -143,8 +143,8 @@ public class IntegrationMBeanExportConfiguration implements ImportAware, Environ
 	}
 
 	private void setupComponentNamePatterns(IntegrationMBeanExporter exporter) {
-		List<String> patterns = new ArrayList<>();
 		String[] managedComponents = this.attributes.getStringArray("managedComponents");
+		List<String> patterns = new ArrayList<>(managedComponents.length);
 		for (String managedComponent : managedComponents) {
 			String pattern = this.environment.resolvePlaceholders(managedComponent);
 			patterns.addAll(Arrays.asList(StringUtils.commaDelimitedListToStringArray(pattern)));

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/inbound/DefaultMBeanObjectConverter.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/inbound/DefaultMBeanObjectConverter.java
@@ -132,8 +132,8 @@ public class DefaultMBeanObjectConverter implements MBeanObjectConverter {
 
 	private @Nullable Object convertFromArray(Object input) {
 		if (CompositeData.class.isAssignableFrom(input.getClass().getComponentType())) {
-			List<@Nullable Object> converted = new ArrayList<>();
 			int length = Array.getLength(input);
+			List<@Nullable Object> converted = new ArrayList<>(length);
 			for (int i = 0; i < length; i++) {
 				Object value = checkAndConvert(Array.get(input, i));
 				converted.add(value);

--- a/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/inbound/NotificationListeningMessageProducer.java
+++ b/spring-integration-jmx/src/main/java/org/springframework/integration/jmx/inbound/NotificationListeningMessageProducer.java
@@ -202,7 +202,7 @@ public class NotificationListeningMessageProducer extends MessageProducerSupport
 	 * @return the collection of {@link ObjectName} ofr provided {@link #mBeanObjectNames}.
 	 */
 	protected Collection<ObjectName> retrieveMBeanNames() {
-		List<ObjectName> objectNames = new ArrayList<>();
+		List<ObjectName> objectNames = new ArrayList<>(this.mBeanObjectNames.length);
 		for (ObjectName pattern : this.mBeanObjectNames) {
 			Set<ObjectInstance> mBeanInfos;
 			try {

--- a/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/BeanPropertyParameterSource.java
+++ b/spring-integration-jpa/src/main/java/org/springframework/integration/jpa/support/parametersource/BeanPropertyParameterSource.java
@@ -73,8 +73,8 @@ public class BeanPropertyParameterSource implements ParameterSource {
 	 */
 	public String[] getReadablePropertyNames() {
 		if (this.propertyNames == null) {
-			final List<String> names = new ArrayList<>();
 			PropertyDescriptor[] props = this.beanWrapper.getPropertyDescriptors();
+			final List<String> names = new ArrayList<>(props.length);
 			for (PropertyDescriptor pd : props) {
 				if (this.beanWrapper.isReadableProperty(pd.getName())) {
 					names.add(pd.getName());

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageSource.java
@@ -897,7 +897,7 @@ public class KafkaMessageSource<K, V> extends AbstractMessageSource<Object>
 				synchronized (candidates) {
 					if (candidates.iterator().next().equals(this.ackInfo)) {
 						// see if there are any pending acks for higher offsets
-						List<KafkaAckInfo<K, V>> toCommit = new ArrayList<>();
+						List<KafkaAckInfo<K, V>> toCommit = new ArrayList<>(candidates.size());
 						for (KafkaAckInfo<K, V> info : candidates) {
 							if (!this.ackInfo.equals(info)) {
 								if (info.isAckDeferred()) {

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/AbstractConfigurableMongoDbMessageStore.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.mongodb.store;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -152,9 +151,7 @@ public abstract class AbstractConfigurableMongoDbMessageStore extends AbstractMe
 				this.mappingMongoConverter = new MappingMongoConverter(new DefaultDbRefResolver(this.mongoDbFactory),
 						new MongoMappingContext());
 				this.mappingMongoConverter.setApplicationContext(this.applicationContext);
-				List<Object> customConverters = new ArrayList<>();
-				customConverters.add(new MessageToBinaryConverter());
-				customConverters.add(new BinaryToMessageConverter());
+				List<Object> customConverters = List.of(new MessageToBinaryConverter(), new BinaryToMessageConverter());
 				this.mappingMongoConverter.setCustomConversions(new MongoCustomConversions(customConverters));
 				this.mappingMongoConverter.afterPropertiesSet();
 			}

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/ConfigurableMongoDbMessageStore.java
@@ -178,7 +178,7 @@ public class ConfigurableMongoDbMessageStore extends AbstractConfigurableMongoDb
 
 	@Override
 	protected void doRemoveMessagesFromGroup(Object groupId, Collection<Message<?>> messages) {
-		Collection<UUID> ids = new ArrayList<>();
+		Collection<UUID> ids = new ArrayList<>(messages.size());
 		for (Message<?> messageToRemove : messages) {
 			ids.add(Objects.requireNonNull(messageToRemove.getHeaders().getId()));
 			if (ids.size() >= getRemoveBatchSize()) {

--- a/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
+++ b/spring-integration-mongodb/src/main/java/org/springframework/integration/mongodb/store/MongoDbMessageStore.java
@@ -322,7 +322,7 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 
 	@Override
 	protected void doRemoveMessagesFromGroup(Object groupId, Collection<Message<?>> messages) {
-		Collection<UUID> ids = new ArrayList<>();
+		Collection<UUID> ids = new ArrayList<>(messages.size());
 		for (Message<?> messageToRemove : messages) {
 			UUID id = messageToRemove.getHeaders().getId();
 			Assert.state(id != null, () -> "The message 'id' must notbe null:" + messageToRemove);
@@ -552,7 +552,8 @@ public class MongoDbMessageStore extends AbstractMessageGroupStore
 
 		@Override
 		public void afterPropertiesSet() {
-			List<Object> converters = new ArrayList<>();
+			List<Object> converters =
+					new ArrayList<>(7 + (this.customConverters != null ? this.customConverters.length : 0));
 			converters.add(new MessageHistoryToDocumentConverter());
 			converters.add(new DocumentToMessageHistoryConverter());
 			converters.add(new DocumentToGenericMessageConverter());

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -121,7 +121,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 	 */
 	public Mqttv5PahoMessageDrivenChannelAdapter(String url, String clientId, MqttSubscription... mqttSubscriptions) {
 		this(url, clientId, Arrays.stream(mqttSubscriptions).map(MqttSubscription::getTopic).toArray(String[]::new));
-		this.subscriptions = new ArrayList<>();
+		this.subscriptions = new ArrayList<>(mqttSubscriptions.length);
 		Collections.addAll(this.subscriptions, mqttSubscriptions);
 	}
 
@@ -145,7 +145,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 
 		this(connectionOptions, clientId,
 				Arrays.stream(mqttSubscriptions).map(MqttSubscription::getTopic).toArray(String[]::new));
-		this.subscriptions = new ArrayList<>();
+		this.subscriptions = new ArrayList<>(mqttSubscriptions.length);
 		Collections.addAll(this.subscriptions, mqttSubscriptions);
 	}
 
@@ -171,7 +171,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 			MqttSubscription... mqttSubscriptions) {
 
 		this(clientManager, Arrays.stream(mqttSubscriptions).map(MqttSubscription::getTopic).toArray(String[]::new));
-		this.subscriptions = new ArrayList<>();
+		this.subscriptions = new ArrayList<>(mqttSubscriptions.length);
 		Collections.addAll(this.subscriptions, mqttSubscriptions);
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapter.java
@@ -126,7 +126,7 @@ public class RedisInboundChannelAdapter extends MessageProducerSupport {
 		MessageListenerDelegate delegate = new MessageListenerDelegate();
 		MessageListenerAdapter adapter = new MessageListenerAdapter(delegate);
 		adapter.setSerializer(this.serializer);
-		List<Topic> topicList = new ArrayList<>();
+		List<Topic> topicList = new ArrayList<>(hasTopics ? this.topics.length : this.topicPatterns.length);
 		if (hasTopics) {
 			for (String topic : this.topics) {
 				topicList.add(new ChannelTopic(topic));

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/ExpressionArgumentsStrategy.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/outbound/ExpressionArgumentsStrategy.java
@@ -85,7 +85,7 @@ public class ExpressionArgumentsStrategy implements ArgumentsStrategy, BeanFacto
 			evaluationContextToUse = IntegrationContextUtils.getEvaluationContext(this.beanFactory);
 			evaluationContextToUse.setVariable("cmd", command);
 		}
-		List<Object> arguments = new ArrayList<>();
+		List<Object> arguments = new ArrayList<>(this.argumentExpressions.length);
 		for (Expression argumentExpression : this.argumentExpressions) {
 			Object argument = argumentExpression.getValue(evaluationContextToUse, message);
 			if (argument != null) {

--- a/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/IntegrationRSocketMessageHandler.java
+++ b/spring-integration-rsocket/src/main/java/org/springframework/integration/rsocket/IntegrationRSocketMessageHandler.java
@@ -128,9 +128,10 @@ class IntegrationRSocketMessageHandler extends RSocketMessageHandler {
 				new IntegrationRSocketPayloadReturnValueHandler((List<Encoder<?>>) getEncoders(),
 						getReactiveAdapterRegistry());
 		if (this.messageMappingCompatible) {
-			List<HandlerMethodReturnValueHandler> handlers = new ArrayList<>();
+			List<HandlerMethodReturnValueHandler> customHandlers = getReturnValueHandlerConfigurer().getCustomHandlers();
+			List<HandlerMethodReturnValueHandler> handlers = new ArrayList<>(customHandlers.size() + 1);
 			handlers.add(integrationRSocketPayloadReturnValueHandler);
-			handlers.addAll(getReturnValueHandlerConfigurer().getCustomHandlers());
+			handlers.addAll(customHandlers);
 			return handlers;
 		}
 		else {

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/inbound/SftpStreamingMessageSource.java
@@ -72,7 +72,7 @@ public class SftpStreamingMessageSource extends AbstractRemoteFileStreamingMessa
 
 	@Override
 	protected List<AbstractFileInfo<SftpClient.DirEntry>> asFileInfoList(Collection<SftpClient.DirEntry> files) {
-		List<AbstractFileInfo<SftpClient.DirEntry>> canonicalFiles = new ArrayList<>();
+		List<AbstractFileInfo<SftpClient.DirEntry>> canonicalFiles = new ArrayList<>(files.size());
 		for (SftpClient.DirEntry file : files) {
 			canonicalFiles.add(new SftpFileInfo(file));
 		}

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/ResourceKnownHostsServerKeyVerifier.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/ResourceKnownHostsServerKeyVerifier.java
@@ -121,7 +121,7 @@ public class ResourceKnownHostsServerKeyVerifier implements ServerKeyVerifier {
 			return Collections.emptyList();
 		}
 
-		List<KnownHostsServerKeyVerifier.HostEntryPair> matches = new ArrayList<>();
+		List<KnownHostsServerKeyVerifier.HostEntryPair> matches = new ArrayList<>(knownHosts.size());
 		for (KnownHostsServerKeyVerifier.HostEntryPair match : knownHosts) {
 			KnownHostEntry entry = match.getHostEntry();
 			for (SshdSocketAddress host : candidates) {

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbStreamingMessageSource.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/inbound/SmbStreamingMessageSource.java
@@ -72,7 +72,7 @@ public class SmbStreamingMessageSource extends AbstractRemoteFileStreamingMessag
 
 	@Override
 	protected List<AbstractFileInfo<SmbFile>> asFileInfoList(Collection<SmbFile> files) {
-		List<AbstractFileInfo<SmbFile>> canonicalFiles = new ArrayList<>();
+		List<AbstractFileInfo<SmbFile>> canonicalFiles = new ArrayList<>(files.size());
 		for (SmbFile file : files) {
 			canonicalFiles.add(new SmbFileInfo(file));
 		}

--- a/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbOutboundGateway.java
+++ b/spring-integration-smb/src/main/java/org/springframework/integration/smb/outbound/SmbOutboundGateway.java
@@ -163,7 +163,7 @@ public class SmbOutboundGateway extends AbstractRemoteFileOutboundGateway<SmbFil
 
 	@Override
 	protected List<AbstractFileInfo<SmbFile>> asFileInfoList(Collection<SmbFile> files) {
-		List<AbstractFileInfo<SmbFile>> canonicalFiles = new ArrayList<>();
+		List<AbstractFileInfo<SmbFile>> canonicalFiles = new ArrayList<>(files.size());
 		for (SmbFile file : files) {
 			canonicalFiles.add(new SmbFileInfo(file));
 		}

--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/support/PassThruSubProtocolHandler.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/support/PassThruSubProtocolHandler.java
@@ -19,6 +19,7 @@ package org.springframework.integration.websocket.support;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -52,7 +53,7 @@ public class PassThruSubProtocolHandler implements SubProtocolHandler {
 
 	public void setSupportedProtocols(String... supportedProtocols) {
 		Assert.noNullElements(supportedProtocols, "'supportedProtocols' must not be empty");
-		this.supportedProtocols.addAll(Arrays.asList(supportedProtocols));
+		Collections.addAll(this.supportedProtocols, supportedProtocols);
 	}
 
 	@Override

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/DefaultSoapHeaderMapper.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.ws;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -62,13 +61,9 @@ import org.springframework.xml.transform.TransformerHelper;
  */
 public class DefaultSoapHeaderMapper extends AbstractHeaderMapper<SoapMessage> implements SoapHeaderMapper {
 
-	protected static final List<String> STANDARD_HEADER_NAMES = new ArrayList<>();
+	protected static final List<String> STANDARD_HEADER_NAMES = List.of(WebServiceHeaders.SOAP_ACTION);
 
-	static {
-		STANDARD_HEADER_NAMES.add(WebServiceHeaders.SOAP_ACTION);
-	}
-
-	protected final TransformerHelper transformerHelper = new TransformerHelper(); // NOSONAR final
+	protected final TransformerHelper transformerHelper = new TransformerHelper();
 
 	public DefaultSoapHeaderMapper() {
 		super(WebServiceHeaders.PREFIX, STANDARD_HEADER_NAMES, Collections.emptyList());

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/router/XPathRouter.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/router/XPathRouter.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.jspecify.annotations.Nullable;
 import org.w3c.dom.DOMException;
@@ -114,13 +113,13 @@ public class XPathRouter extends AbstractMappingMessageRouter {
 	}
 
 	@Override
-	protected List<Object> getChannelKeys(Message<?> message) {
+	protected List<@Nullable Object> getChannelKeys(Message<?> message) {
 		Node node = this.converter.convertToNode(message.getPayload());
 		if (this.evaluateAsString) {
-			return Collections.singletonList(Objects.requireNonNull(this.xPathExpression.evaluateAsString(node)));
+			return Collections.<@Nullable Object>singletonList(this.xPathExpression.evaluateAsString(node));
 		}
 		else {
-			return this.xPathExpression.evaluate(node, this.nodeMapper);
+			return (List<@Nullable Object>) this.xPathExpression.evaluate(node, this.nodeMapper);
 		}
 	}
 

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/support/DefaultXmppHeaderMapper.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.xmpp.support;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,15 +46,12 @@ import org.springframework.util.StringUtils;
  */
 public class DefaultXmppHeaderMapper extends AbstractHeaderMapper<MessageBuilder> implements XmppHeaderMapper {
 
-	private static final List<String> STANDARD_HEADER_NAMES = new ArrayList<>();
-
-	static {
-		STANDARD_HEADER_NAMES.add(XmppHeaders.FROM);
-		STANDARD_HEADER_NAMES.add(XmppHeaders.SUBJECT);
-		STANDARD_HEADER_NAMES.add(XmppHeaders.THREAD);
-		STANDARD_HEADER_NAMES.add(XmppHeaders.TO);
-		STANDARD_HEADER_NAMES.add(XmppHeaders.TYPE);
-	}
+	private static final List<String> STANDARD_HEADER_NAMES =
+			List.of(XmppHeaders.FROM,
+					XmppHeaders.SUBJECT,
+					XmppHeaders.THREAD,
+					XmppHeaders.TO,
+					XmppHeaders.TYPE);
 
 	public DefaultXmppHeaderMapper() {
 		super(XmppHeaders.PREFIX, STANDARD_HEADER_NAMES, STANDARD_HEADER_NAMES);


### PR DESCRIPTION
To avoid resizing at runtime, it is better to use `ArrayList` with a predefined size. In some cases it is possible from the context of the list we are creating

* Fix typos in Javadocs of the affected classes according to IDE suggestions
* Use diamond operators for modern Java in the affected classes
* pattern matching expressions for `if` where IDE suggested
* Use `switch` in one place instead of `if..else`. Again: good suggestion from IDE
* Fix Nullability for the router hierarchy
* Have to add "redundant" cast in the `XPathRouter` to make NullAway happy

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
