### PR TITLE
Add nullChannel DSL element to Groovy DSL

### DIFF
--- a/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
+++ b/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
@@ -108,6 +108,7 @@ class GroovyIntegrationFlowDefinition {
 	 * at the current {@link IntegrationFlow} chain position.
 	 * The nullChannel acts like "/dev/null".
 	 * @see org.springframework.integration.channel.NullChannel
+	 * @since 7.0.1
 	 */
 	GroovyIntegrationFlowDefinition nullChannel() {
 		this.delegate.nullChannel()

--- a/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
+++ b/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
@@ -107,8 +107,8 @@ class GroovyIntegrationFlowDefinition {
 	 * Populate a {@link org.springframework.integration.channel.NullChannel} instance
 	 * at the current {@link IntegrationFlow} chain position.
 	 * The nullChannel acts like "/dev/null".
-	 * @see org.springframework.integration.channel.NullChannel
 	 * @since 7.0.1
+	 * @see org.springframework.integration.channel.NullChannel
 	 */
 	GroovyIntegrationFlowDefinition nullChannel() {
 		this.delegate.nullChannel()

--- a/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
+++ b/spring-integration-groovy/src/main/groovy/org/springframework/integration/groovy/dsl/GroovyIntegrationFlowDefinition.groovy
@@ -104,6 +104,17 @@ class GroovyIntegrationFlowDefinition {
 	}
 
 	/**
+	 * Populate a {@link org.springframework.integration.channel.NullChannel} instance
+	 * at the current {@link IntegrationFlow} chain position.
+	 * The nullChannel acts like "/dev/null".
+	 * @see org.springframework.integration.channel.NullChannel
+	 */
+	GroovyIntegrationFlowDefinition nullChannel() {
+		this.delegate.nullChannel()
+		this
+	}
+
+	/**
 	 * Populate a {@link org.springframework.integration.dsl.support.MessageChannelReference} instance
 	 * at the current {@link IntegrationFlow} chain position.
 	 * The provided {@code messageChannelName} is used for the bean registration


### PR DESCRIPTION
The Groovy DSL was missing support for the nullChannel, which is a special channel that discards messages (acts like /dev/null). This prevents users from using nullChannel in their Groovy integration flows.

Add unit tests to verify:
- nullChannel can be used at the end of a flow
- nullChannel can be used after transform operations
- Messages are properly discarded without exceptions

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
