### PR TITLE
Add `nullChannel()` to Kotlin DSL

### DIFF
--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
@@ -64,6 +64,7 @@ import java.util.function.Consumer
  * @property delegate the [IntegrationFlowDefinition] this instance is delegating to.
  *
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.3
  */
@@ -173,6 +174,17 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 */
 	fun channel(messageChannelName: String) {
 		this.delegate.channel(messageChannelName)
+	}
+
+	/**
+	 * Populate a [org.springframework.integration.channel.NullChannel] instance
+	 * at the current [IntegrationFlow] chain position.
+	 * The nullChannel acts like "/dev/null".
+	 * @since 7.0.1
+	 * @see org.springframework.integration.channel.NullChannel
+	 */
+	fun nullChannel() {
+		this.delegate.nullChannel()
 	}
 
 	/**

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
@@ -368,7 +368,7 @@ class KotlinDslTests : TestApplicationContextAware {
 				transform<String> { it.uppercase() }
 			}
 
-		
+
 		/*
 		A Java variant for the flow below
 		@Bean

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
@@ -367,6 +367,8 @@ class KotlinDslTests : TestApplicationContextAware {
 				}
 				transform<String> { it.uppercase() }
 			}
+
+		
 		/*
 		A Java variant for the flow below
 		@Bean
@@ -386,7 +388,6 @@ class KotlinDslTests : TestApplicationContextAware {
 							scatterGather -> scatterGather
 								.gatherTimeout(10_000));
 		}*/
-
 		@Bean
 		fun scatterGatherFlow() =
 			integrationFlow {

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
@@ -372,20 +372,21 @@ class KotlinDslTests : TestApplicationContextAware {
 		@Bean
 		public IntegrationFlow scatterGatherFlow() {
 			return f -> f
-			.scatterGather(scatterer -> scatterer
-			.applySequence(true)
-				.recipientFlow(m -> true, sf -> sf.handle((p, h) -> Math.random() * 10))
-			.recipientFlow(m -> true, sf -> sf.handle((p, h) -> Math.random() * 10))
-			.recipientFlow(m -> true, sf -> sf.handle((p, h) -> Math.random() * 10)),
-			gatherer -> gatherer
-			.releaseStrategy(group ->
-			group.size() == 3 ||
-					group.getMessages()
-						.stream()
-						.anyMatch(m -> (Double) m.getPayload() > 5)),
-			scatterGather -> scatterGather
-			.gatherTimeout(10_000));
+				.scatterGather(scatterer -> scatterer
+								.applySequence(true)
+								.recipientFlow(m -> true, sf -> sf.handle((p, h) -> Math.random() * 10))
+								.recipientFlow(m -> true, sf -> sf.handle((p, h) -> Math.random() * 10))
+								.recipientFlow(m -> true, sf -> sf.handle((p, h) -> Math.random() * 10)),
+							gatherer -> gatherer
+								.releaseStrategy(group ->
+											group.size() == 3 ||
+													group.getMessages()
+														.stream()
+														.anyMatch(m -> (Double) m.getPayload() > 5)),
+							scatterGather -> scatterGather
+								.gatherTimeout(10_000));
 		}*/
+
 		@Bean
 		fun scatterGatherFlow() =
 			integrationFlow {


### PR DESCRIPTION
This commit adds support for `nullChannel()` in the Kotlin DSL, mirroring the functionality recently added to the Groovy DSL. The `nullChannel()` method populates a NullChannel instance at the current IntegrationFlow chain position, acting like "/dev/null" to discard messages.

Two test cases verify the functionality:
- Messages sent to a flow ending with `nullChannel()` are discarded
- Transform operations can precede `nullChannel()` in a flow

This enhancement provides feature parity between the Kotlin and Groovy DSLs for null channel support.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
