### PR TITLE
Simplify Kotlin DSL for MessageSource integration flows

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/kotlin-dsl.adoc
+++ b/src/reference/antora/modules/ROOT/pages/kotlin-dsl.adoc
@@ -65,7 +65,7 @@ fun functionFlow() =
 
 @Bean
 fun messageSourceFlow() =
-        integrationFlow(MessageProcessorMessageSource { "testSource" },
+        integrationFlow({ "testSource" },
                 { poller { it.fixedDelay(10).maxMessagesPerPoll(1) } }) {
             channel { queue("fromSupplierQueue") }
         }


### PR DESCRIPTION
Remove explicit MessageProcessorMessageSource wrapper in favor of direct lambda usage in integrationFlow() calls. This makes the Kotlin DSL more idiomatic by leveraging Kotlin's function type inference, aligning with the language's conventions for functional interfaces.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
