### PR TITLE
GH-10624: PartitionedChannel: customize worker queue size

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
@@ -36,7 +36,7 @@ import org.springframework.util.Assert;
  * The {@code partitionKeyFunction} is used to determine to which partition the message
  * has to be dispatched.
  * By default, the {@link IntegrationMessageHeaderAccessor#CORRELATION_ID} message header is used
- * for partition key.
+ * for a partition key.
  * <p>
  * The actual dispatching and threading logic is implemented in the {@link PartitionedDispatcher}.
  * <p>
@@ -71,7 +71,7 @@ public class PartitionedChannel extends AbstractExecutorChannel {
 	}
 
 	/**
-	 * Instantiate based on a provided number of partitions and function for partition key against
+	 * Instantiate based on a provided number of partitions and function for a partition key against
 	 * the message.
 	 * @param partitionCount the number of partitions in this channel.
 	 * @param partitionKeyFunction the function to resolve a partition key against the message
@@ -121,6 +121,16 @@ public class PartitionedChannel extends AbstractExecutorChannel {
 	 */
 	public void setLoadBalancingStrategy(@Nullable LoadBalancingStrategy loadBalancingStrategy) {
 		getDispatcher().setLoadBalancingStrategy(loadBalancingStrategy);
+	}
+
+	/**
+	 * Provide a size of the queue in the partition executor's worker.
+	 * Default to zero.
+	 * @param workerQueueSize the size of the partition executor's worker queue.
+	 * @since 6.4.10
+	 */
+	public void setWorkerQueueSize(int workerQueueSize) {
+		getDispatcher().setWorkerQueueSize(workerQueueSize);
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/PartitionedChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/PartitionedChannelSpec.java
@@ -39,6 +39,8 @@ public class PartitionedChannelSpec extends LoadBalancingChannelSpec<Partitioned
 
 	private @Nullable ThreadFactory threadFactory;
 
+	private int workerQueueSize;
+
 	protected PartitionedChannelSpec(int partitionCount) {
 		this.partitionCount = partitionCount;
 	}
@@ -53,6 +55,18 @@ public class PartitionedChannelSpec extends LoadBalancingChannelSpec<Partitioned
 		return this;
 	}
 
+	/**
+	 * Provide a size of the queue in the partition executor's worker.
+	 * Default to zero.
+	 * @param workerQueueSize the size of the partition executor's worker queue.
+	 * @return the spec.
+	 * @since 6.4.10
+	 */
+	public PartitionedChannelSpec workerQueueSize(int workerQueueSize) {
+		this.workerQueueSize = workerQueueSize;
+		return this;
+	}
+
 	@Override
 	protected PartitionedChannel doGet() {
 		if (this.partitionKeyFunction != null) {
@@ -62,6 +76,7 @@ public class PartitionedChannelSpec extends LoadBalancingChannelSpec<Partitioned
 			this.channel = new PartitionedChannel(this.partitionCount);
 		}
 		this.channel.setLoadBalancingStrategy(this.loadBalancingStrategy);
+		this.channel.setWorkerQueueSize(this.workerQueueSize);
 		if (this.failoverStrategy != null) {
 			this.channel.setFailoverStrategy(this.failoverStrategy);
 		}


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10624

* Expose `workerQueueSize` from the `PartitionedDispatcher` and respective delegates from the `PartitionedChannel` and `PartitionedChannelSpec`

**Auto-cherry-pick to `6.5.x` & `6.4.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
