### PR TITLE
GH-10574: Rely on `WebServiceTemplate.defaultUri`

### DIFF
--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParser.java
@@ -58,7 +58,7 @@ public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayPars
 		String uri = element.getAttribute("uri");
 		String destinationProvider = element.getAttribute("destination-provider");
 		List<Element> uriVariableElements = DomUtils.getChildElementsByTagName(element, "uri-variable");
-		if (StringUtils.hasText(destinationProvider) == StringUtils.hasText(uri)) {
+		if (StringUtils.hasText(destinationProvider) && StringUtils.hasText(uri)) {
 			parserContext.getReaderContext().error(
 					"Exactly one of 'uri' or 'destination-provider' is required.", element);
 		}
@@ -140,7 +140,9 @@ public class WebServiceOutboundGatewayParser extends AbstractOutboundGatewayPars
 		}
 	}
 
-	private void parseMarshallerAttribute(BeanDefinitionBuilder builder, Element element, ParserContext parserContext) {
+	private static void parseMarshallerAttribute(BeanDefinitionBuilder builder, Element element,
+			ParserContext parserContext) {
+
 		String marshallerRef = element.getAttribute("marshaller");
 		String unmarshallerRef = element.getAttribute("unmarshaller");
 		if (StringUtils.hasText(marshallerRef)) {

--- a/spring-integration-ws/src/main/java/org/springframework/integration/ws/outbound/SimpleWebServiceOutboundGateway.java
+++ b/spring-integration-ws/src/main/java/org/springframework/integration/ws/outbound/SimpleWebServiceOutboundGateway.java
@@ -35,6 +35,7 @@ import org.springframework.ws.WebServiceMessage;
 import org.springframework.ws.WebServiceMessageFactory;
 import org.springframework.ws.client.core.SourceExtractor;
 import org.springframework.ws.client.core.WebServiceMessageCallback;
+import org.springframework.ws.client.core.WebServiceTemplate;
 import org.springframework.ws.client.support.destination.DestinationProvider;
 import org.springframework.ws.mime.Attachment;
 import org.springframework.ws.mime.MimeMessage;
@@ -88,6 +89,28 @@ public class SimpleWebServiceOutboundGateway extends AbstractWebServiceOutboundG
 			@Nullable WebServiceMessageFactory messageFactory) {
 
 		super(uri, messageFactory);
+		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();
+	}
+
+	/**
+	 * Create an instance based on the predefined {@link WebServiceTemplate}
+	 * as an alternative to fine-grained configuration.
+	 * @param template the {@link WebServiceTemplate} to use.
+	 * @since 7.1
+	 */
+	public SimpleWebServiceOutboundGateway(WebServiceTemplate template) {
+		this(template, null);
+	}
+
+	/**
+	 * Create an instance based on the predefined {@link WebServiceTemplate}
+	 * as an alternative to fine-grained configuration.
+	 * @param template the {@link WebServiceTemplate} to use.
+	 * @param sourceExtractor the {@link SourceExtractor} to use.
+	 * @since 7.1
+	 */
+	public SimpleWebServiceOutboundGateway(WebServiceTemplate template, @Nullable SourceExtractor<?> sourceExtractor) {
+		super(template);
 		this.sourceExtractor = (sourceExtractor != null) ? sourceExtractor : new DefaultSourceExtractor();
 	}
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests-context.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests-context.xml
@@ -23,11 +23,12 @@
 		<si:queue capacity="10"/>
 	</si:channel>
 
-	<bean id="webServiceTemplate" class="org.springframework.ws.client.core.WebServiceTemplate"/>
+	<bean id="webServiceTemplate" class="org.springframework.ws.client.core.WebServiceTemplate">
+		<property name="defaultUri" value="https://example.org" />
+	</bean>
 
 	<ws:outbound-gateway id="gatewayWithReplyChannel"
 	                     request-channel="inputChannel"
-	                     uri="https://example.org"
 	                     reply-channel="outputChannel"
 	                     reply-timeout="777"
 	                     web-service-template="webServiceTemplate"

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
 import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
@@ -444,10 +445,12 @@ public class WebServiceOutboundGatewayParserTests {
 
 	@Test
 	public void invalidGatewayWithNeitherUriNorDestinationProvider() {
-		assertThatExceptionOfType(BeanDefinitionParsingException.class)
+		assertThatExceptionOfType(BeanCreationException.class)
 				.isThrownBy(() ->
 						new ClassPathXmlApplicationContext("invalidGatewayWithNeitherUriNorDestinationProvider.xml",
-								getClass()));
+								getClass()))
+				.withMessageContaining("'destinationProvider' or 'uri' must be provided, " +
+						"or 'defaultUri' must be set on the 'WebServiceTemplate'");
 	}
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/invalidGatewayWithNeitherUriNorDestinationProvider.xml
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/invalidGatewayWithNeitherUriNorDestinationProvider.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:si="http://www.springframework.org/schema/integration"
-	xmlns:ws="http://www.springframework.org/schema/integration/ws"
-	xmlns:util='http://www.springframework.org/schema/util'
-	xsi:schemaLocation="http://www.springframework.org/schema/beans
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:si="http://www.springframework.org/schema/integration"
+	   xmlns:ws="http://www.springframework.org/schema/integration/ws"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
 			https://www.springframework.org/schema/beans/spring-beans.xsd
 			http://www.springframework.org/schema/integration
 			https://www.springframework.org/schema/integration/spring-integration.xsd
 			http://www.springframework.org/schema/integration/ws
-			https://www.springframework.org/schema/integration/ws/spring-integration-ws.xsd
-			http://www.springframework.org/schema/util
-			https://www.springframework.org/schema/util/spring-util.xsd">
+			https://www.springframework.org/schema/integration/ws/spring-integration-ws.xsd">
 
 	<si:channel id="inputChannel"/>
 
@@ -19,9 +16,6 @@
 		<si:queue capacity="10"/>
 	</si:channel>
 
-	<ws:outbound-gateway id="gatewayWithBothUriAndDestinationProvider"
-	                     request-channel="inputChannel"/>
-
-	<bean id="destinationProvider" class="org.springframework.integration.ws.config.StubDestinationProvider"/>
+	<ws:outbound-gateway id="gatewayWithoutNeitherUriNorDestinationProvider" request-channel="inputChannel"/>
 
 </beans>

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
@@ -175,9 +175,10 @@ public class WsDslTests {
 		WebServiceMessageCallback requestCallback = msg -> {
 		};
 		Map<String, Expression> uriVariableExpressions = new HashMap<>();
-		uriVariableExpressions.put("foo", new LiteralExpression("bar"));
-		WebServiceTemplate template = mock();
-		String uri = "foo";
+		uriVariableExpressions.put("testVariable", new LiteralExpression("testValue"));
+		WebServiceTemplate template = new WebServiceTemplate();
+		String uri = "testUri";
+		template.setDefaultUri(uri);
 		MarshallingWebServiceOutboundGateway gateway =
 				Ws.marshallingOutboundGateway(template)
 						.uri(uri)
@@ -202,13 +203,12 @@ public class WsDslTests {
 		WebServiceMessageCallback requestCallback = msg -> {
 		};
 		Map<String, Expression> uriVariableExpressions = new HashMap<>();
-		uriVariableExpressions.put("foo", new LiteralExpression("bar"));
+		uriVariableExpressions.put("testVariable", new LiteralExpression("testValue"));
 		SourceExtractor<?> sourceExtractor = mock();
-		WebServiceTemplate template = mock();
-		String uri = "foo";
+		WebServiceTemplate template = new WebServiceTemplate();
+		template.setDefaultUri("testUri");
 		SimpleWebServiceOutboundGateway gateway =
 				Ws.simpleOutboundGateway(template)
-						.uri(uri)
 						.sourceExtractor(sourceExtractor)
 						.encodingMode(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY)
 						.headerMapper(headerMapper)

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -14,3 +14,8 @@ For more details, see the https://github.com/spring-projects/spring-integration/
 In general, the project has been moved to the latest dependency versions.
 Java 17 is still the baseline, but Java 25 is supported.
 
+[[x7.0-web-services-changes]]
+=== Web Services Support Changes
+
+The Web Services Outbound Gateway now can rely on the provided `WebServiceTemplate.defaultUri`.
+See xref:ws.adoc[] for more information.

--- a/src/reference/antora/modules/ROOT/pages/ws.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ws.adoc
@@ -40,6 +40,7 @@ To invoke a web service when you send a message to a channel, you have two optio
 The former accepts either a `String` or `javax.xml.transform.Source` as the message payload.
 The latter supports any implementation of the `Marshaller` and `Unmarshaller` interfaces.
 Both require a Spring Web Services `DestinationProvider`, to determine the URI of the web service to be called.
+Or explicit uri directly, or via `WebServiceTemplate.defaultUri` (since version 7.1).
 The following example shows both options for invoking a web service:
 
 [source,java]

--- a/src/reference/antora/modules/ROOT/pages/ws.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ws.adoc
@@ -39,8 +39,7 @@ compile "org.springframework.integration:spring-integration-ws:{project-version}
 To invoke a web service when you send a message to a channel, you have two options, both of which build upon the https://projects.spring.io/spring-ws/[Spring Web Services] project: `SimpleWebServiceOutboundGateway` and `MarshallingWebServiceOutboundGateway`.
 The former accepts either a `String` or `javax.xml.transform.Source` as the message payload.
 The latter supports any implementation of the `Marshaller` and `Unmarshaller` interfaces.
-Both require a Spring Web Services `DestinationProvider`, to determine the URI of the web service to be called.
-Or explicit uri directly, or via `WebServiceTemplate.defaultUri` (since version 7.1).
+Both require a Spring Web Services `DestinationProvider` to determine the URI of the web service to be called, or an explicit URI can be provided directly or via `WebServiceTemplate.defaultUri` (since version 7.1).
 The following example shows both options for invoking a web service:
 
 [source,java]


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10574

* Change the logic of the `AbstractWebServiceOutboundGateway` to take into account a `WebServiceTemplate.defaultUri` option as an alternative to the explicit `uri` or `destinationProvider`
* Expose `WebServiceTemplate`-based ctor in the `SimpleWebServiceOutboundGateway` (The `MarshallingWebServiceOutboundGateway` already has one)
* Adjust tests and XML parser to cover a new logic
* Mention the change in docs

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
