### PR TITLE
Fix writingLatch lifecycle in TcpNioConnection

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -483,6 +483,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 		finally {
 			this.writingToPipe = false;
 			writingLatchToUse.countDown();
+			this.writingLatch = null;
 		}
 	}
 
@@ -828,7 +829,6 @@ public class TcpNioConnection extends TcpConnectionSupport {
 					Thread.currentThread().interrupt();
 					throw new IOException("Interrupted while waiting for buffer space", e);
 				}
-				TcpNioConnection.this.writingLatch = new CountDownLatch(1);
 			}
 		}
 


### PR DESCRIPTION
This PR fixes a lost-notify race in TcpNioConnection where writingLatch could be replaced from
ChannelInputStream.write(), causing the assembler to wait on a stale latch under concurrency.

Changes:
- Do not replace writingLatch from the pipe write path
- Clear writingLatch at the end of the doRead() cycle
- Add a regression test proving the latch is not replaced during pipe write and is cleared after read

Fixes #10671
