### PR TITLE
GH-10666: TcpNio: Restore RejectedExecutionException propagation

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioConnection.java
@@ -224,7 +224,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	}
 
 	/**
-	 * Subclasses can override this, for example to wrap the input stream.
+	 * Subclasses can override this, for example, to wrap the input stream.
 	 * @return the input stream.
 	 * @since 5.0
 	 */
@@ -235,7 +235,6 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	/**
 	 * Allocate a ByteBuffer of the requested length using normal or
 	 * direct buffers, depending on the usingDirectBuffers field.
-	 *
 	 * @param length The buffer length.
 	 * @return The buffer.
 	 */
@@ -248,7 +247,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	 * When there is a listener, this method assembles
 	 * data into messages by invoking convertAndSend whenever there is
 	 * data in the input Stream. Method exits when a message is complete
-	 * and there is no more data; thus freeing the thread to work on other
+	 * and there is no more data, thus freeing the thread to work on other
 	 * sockets.
 	 */
 	@Override
@@ -540,6 +539,9 @@ public class TcpNioConnection extends TcpConnectionSupport {
 			}
 			closeConnection(true);
 		}
+		catch (RejectedExecutionException ree) {
+			throw ree;
+		}
 		catch (Exception e) {
 			logger.error("Exception on Read " + getConnectionId() + " " + e.getMessage(), e);
 			closeConnection(true);
@@ -568,7 +570,7 @@ public class TcpNioConnection extends TcpConnectionSupport {
 	}
 
 	/**
-	 * If true, connection will attempt to use direct buffers where possible.
+	 * If true, the connection will attempt to use direct buffers where possible.
 	 * @param usingDirectBuffers the usingDirectBuffers to set.
 	 */
 	public void setUsingDirectBuffers(boolean usingDirectBuffers) {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -38,11 +38,14 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -852,6 +855,40 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 		connection.close();
 
 		cleanupCompositeExecutor(compositeExec);
+	}
+
+	@Test
+	public void delayedReadsDueToRejectedExecutionException() throws InterruptedException {
+		CountDownLatch delayReadLatch = new CountDownLatch(1);
+		TcpNioClientConnectionFactory factory = new TcpNioClientConnectionFactory("localhost", 0) {
+
+			@Override
+			protected void delayRead(Selector selector, long now, SelectionKey key) {
+				// Means RejectedExecutionException was propagated from the TcpNioConnection.readPacket()
+				delayReadLatch.countDown();
+			}
+
+		};
+
+		ThreadPoolExecutor threadPoolExecutor =
+				new ThreadPoolExecutor(1, 1, 0, TimeUnit.MILLISECONDS, new SynchronousQueue<>());
+		factory.setTaskExecutor(threadPoolExecutor);
+		factory.start();
+		SocketChannel chan1 = mock();
+		TcpNioConnection conn1 = mock();
+		Map<SocketChannel, TcpNioConnection> connections = Map.of(chan1, conn1);
+		willReturn(true).given(chan1).isOpen();
+		SelectionKey key1 = mock();
+		willReturn(true).given(key1).isReadable();
+		willReturn(true).given(key1).isValid();
+		willReturn(conn1).given(key1).attachment();
+		Set<SelectionKey> keys = new HashSet<>();
+		keys.add(key1);
+		Selector selector = mock();
+		when(selector.selectedKeys()).thenReturn(keys);
+		factory.processNioSelections(1, selector, null, connections);
+		assertThat(delayReadLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		threadPoolExecutor.shutdown();
 	}
 
 	private static void testMulti(boolean multiAccept) throws InterruptedException, IOException {


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10666

After some refactoring in the past, the `TcpNioConnection.readPacket()` does not re-throw a `RejectedExecutionException` when no sufficient resource to handle a new task in the `Executor`.
This leads to connection closing instead of delaying reads as it is suggested by the `AbstractConnectionFactory`.
Note: the `AbstractConnectionFactory.keyReadable()` still handles a thrown from the task `RejectedExecutionException` but this is a dead code since `TcpNioConnection.readPacket()` does not propagate one.

* Fix `TcpNioConnection.readPacket()` to catch and re-throw `RejectedExecutionException` as it was before the mentioned refactoring instead of falling down to a common `catch` block when this connection is closed.
* Add a mock `TcpNioConnectionTests.delayedReadsDueToRejectedExecutionException()` to ensure that `AbstractConnectionFactory.delayRead()` is called when not enough resources in the provided `Executor`.

**Auto-cherry-pick to `7.0.x` & `6.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
