### PR TITLE
Update Gradle dependencies to use `implementation`

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/amqp.adoc
+++ b/src/reference/antora/modules/ROOT/pages/amqp.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-amqp:{project-version}"
+implementation "org.springframework.integration:spring-integration-amqp:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/camel.adoc
+++ b/src/reference/antora/modules/ROOT/pages/camel.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-camel:{project-version}"
+implementation "org.springframework.integration:spring-integration-camel:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/cassandra.adoc
+++ b/src/reference/antora/modules/ROOT/pages/cassandra.adoc
@@ -23,7 +23,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-cassandra:{project-version}"
+implementation "org.springframework.integration:spring-integration-cassandra:{project-version}"
 ----
 ======
 
@@ -81,7 +81,7 @@ public MessageHandler cassandraMessageHandler() {
     Map<String, Expression> params = new HashMap<>();
     params.put("author", PARSER.parseExpression("payload"));
     params.put("size", PARSER.parseExpression("headers.limit"));
-    
+
     cassandraMessageHandler.setParameterExpressions(params);
 
     cassandraMessageHandler.setOutputChannel(resultChannel());

--- a/src/reference/antora/modules/ROOT/pages/cloudevents.adoc
+++ b/src/reference/antora/modules/ROOT/pages/cloudevents.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-cloudevents:{project-version}"
+implementation "org.springframework.integration:spring-integration-cloudevents:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/debezium.adoc
+++ b/src/reference/antora/modules/ROOT/pages/debezium.adoc
@@ -23,7 +23,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-debezium:{project-version}"
+implementation "org.springframework.integration:spring-integration-debezium:{project-version}"
 ----
 ======
 
@@ -48,7 +48,7 @@ Gradle::
 +
 [source, groovy, role="secondary"]
 ----
-compile "io.debezium:debezium-connector-postgres:{debezium-version}"
+implementation "io.debezium:debezium-connector-postgres:{debezium-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/event.adoc
+++ b/src/reference/antora/modules/ROOT/pages/event.adoc
@@ -23,7 +23,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-event:{project-version}"
+implementation "org.springframework.integration:spring-integration-event:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/feed.adoc
+++ b/src/reference/antora/modules/ROOT/pages/feed.adoc
@@ -23,7 +23,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-feed:{project-version}"
+implementation "org.springframework.integration:spring-integration-feed:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/file.adoc
+++ b/src/reference/antora/modules/ROOT/pages/file.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-file:{project-version}"
+implementation "org.springframework.integration:spring-integration-file:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/ftp.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ftp.adoc
@@ -25,7 +25,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-ftp:{project-version}"
+implementation "org.springframework.integration:spring-integration-ftp:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/graphql.adoc
+++ b/src/reference/antora/modules/ROOT/pages/graphql.adoc
@@ -23,7 +23,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-graphql:{project-version}"
+implementation "org.springframework.integration:spring-integration-graphql:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/groovy.adoc
+++ b/src/reference/antora/modules/ROOT/pages/groovy.adoc
@@ -23,7 +23,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-groovy:{project-version}"
+implementation "org.springframework.integration:spring-integration-groovy:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/grpc.adoc
+++ b/src/reference/antora/modules/ROOT/pages/grpc.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-grpc:{project-version}"
+implementation "org.springframework.integration:spring-integration-grpc:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/hazelcast.adoc
+++ b/src/reference/antora/modules/ROOT/pages/hazelcast.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-hazelcast:{project-version}"
+implementation "org.springframework.integration:spring-integration-hazelcast:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/http.adoc
+++ b/src/reference/antora/modules/ROOT/pages/http.adoc
@@ -24,7 +24,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-http:{project-version}"
+implementation "org.springframework.integration:spring-integration-http:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/ip.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ip.adoc
@@ -26,7 +26,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-ip:{project-version}"
+implementation "org.springframework.integration:spring-integration-ip:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/jdbc.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jdbc.adoc
@@ -23,7 +23,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-jdbc:{project-version}"
+implementation "org.springframework.integration:spring-integration-jdbc:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/jms.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jms.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-jms:{project-version}"
+implementation "org.springframework.integration:spring-integration-jms:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/jmx.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jmx.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-jmx:{project-version}"
+implementation "org.springframework.integration:spring-integration-jmx:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/jpa.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jpa.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-jpa:{project-version}"
+implementation "org.springframework.integration:spring-integration-jpa:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/kafka.adoc
+++ b/src/reference/antora/modules/ROOT/pages/kafka.adoc
@@ -25,7 +25,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-kafka:{project-version}"
+implementation "org.springframework.integration:spring-integration-kafka:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/mail.adoc
+++ b/src/reference/antora/modules/ROOT/pages/mail.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-mail:{project-version}"
+implementation "org.springframework.integration:spring-integration-mail:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/mongodb.adoc
+++ b/src/reference/antora/modules/ROOT/pages/mongodb.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-mongodb:{project-version}"
+implementation "org.springframework.integration:spring-integration-mongodb:{project-version}"
 ----
 ======
 
@@ -53,7 +53,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.mongodb:mongodb-driver-reactivestreams"
+implementation "org.mongodb:mongodb-driver-reactivestreams"
 ----
 ======
 
@@ -76,7 +76,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.mongodb:mongodb-driver-sync"
+implementation "org.mongodb:mongodb-driver-sync"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/mqtt.adoc
+++ b/src/reference/antora/modules/ROOT/pages/mqtt.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-mqtt:{project-version}"
+implementation "org.springframework.integration:spring-integration-mqtt:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/r2dbc.adoc
+++ b/src/reference/antora/modules/ROOT/pages/r2dbc.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-r2dbc:{project-version}"
+implementation "org.springframework.integration:spring-integration-r2dbc:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/redis.adoc
+++ b/src/reference/antora/modules/ROOT/pages/redis.adoc
@@ -23,7 +23,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-redis:{project-version}"
+implementation "org.springframework.integration:spring-integration-redis:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/rsocket.adoc
+++ b/src/reference/antora/modules/ROOT/pages/rsocket.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-rsocket:{project-version}"
+implementation "org.springframework.integration:spring-integration-rsocket:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/scripting.adoc
+++ b/src/reference/antora/modules/ROOT/pages/scripting.adoc
@@ -24,7 +24,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-scripting:{project-version}"
+implementation "org.springframework.integration:spring-integration-scripting:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/sftp.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sftp.adoc
@@ -35,7 +35,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-sftp:{project-version}"
+implementation "org.springframework.integration:spring-integration-sftp:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/smb.adoc
+++ b/src/reference/antora/modules/ROOT/pages/smb.adoc
@@ -24,7 +24,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-smb:{project-version}"
+implementation "org.springframework.integration:spring-integration-smb:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/stomp.adoc
+++ b/src/reference/antora/modules/ROOT/pages/stomp.adoc
@@ -25,7 +25,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-stomp:{project-version}"
+implementation "org.springframework.integration:spring-integration-stomp:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/stream.adoc
+++ b/src/reference/antora/modules/ROOT/pages/stream.adoc
@@ -24,7 +24,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-stream:{project-version}"
+implementation "org.springframework.integration:spring-integration-stream:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/syslog.adoc
+++ b/src/reference/antora/modules/ROOT/pages/syslog.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-syslog:{project-version}"
+implementation "org.springframework.integration:spring-integration-syslog:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/web-sockets.adoc
+++ b/src/reference/antora/modules/ROOT/pages/web-sockets.adoc
@@ -25,7 +25,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-websocket:{project-version}"
+implementation "org.springframework.integration:spring-integration-websocket:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/webflux.adoc
+++ b/src/reference/antora/modules/ROOT/pages/webflux.adoc
@@ -22,7 +22,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-webflux:{project-version}"
+implementation "org.springframework.integration:spring-integration-webflux:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/ws.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ws.adoc
@@ -29,7 +29,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-ws:{project-version}"
+implementation "org.springframework.integration:spring-integration-ws:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/xml.adoc
+++ b/src/reference/antora/modules/ROOT/pages/xml.adoc
@@ -33,7 +33,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-xml:{project-version}"
+implementation "org.springframework.integration:spring-integration-xml:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/xmpp.adoc
+++ b/src/reference/antora/modules/ROOT/pages/xmpp.adoc
@@ -34,7 +34,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-xmpp:{project-version}"
+implementation "org.springframework.integration:spring-integration-xmpp:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/zeromq.adoc
+++ b/src/reference/antora/modules/ROOT/pages/zeromq.adoc
@@ -24,7 +24,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-zeromq:{project-version}"
+implementation "org.springframework.integration:spring-integration-zeromq:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/zip.adoc
+++ b/src/reference/antora/modules/ROOT/pages/zip.adoc
@@ -28,7 +28,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-zip:{project-version}"
+implementation "org.springframework.integration:spring-integration-zip:{project-version}"
 ----
 ======
 

--- a/src/reference/antora/modules/ROOT/pages/zookeeper.adoc
+++ b/src/reference/antora/modules/ROOT/pages/zookeeper.adoc
@@ -26,7 +26,7 @@ Gradle::
 +
 [source, groovy, subs="normal", role="secondary"]
 ----
-compile "org.springframework.integration:spring-integration-zookeeper:{project-version}"
+implementation "org.springframework.integration:spring-integration-zookeeper:{project-version}"
 ----
 ======
 


### PR DESCRIPTION
Replace deprecated `compile` configuration with `implementation` across all Spring Integration reference documentation. The `compile` configuration was deprecated in Gradle 4.0 and removed in Gradle 7.0. This update ensures documentation examples use current Gradle best practices.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
