### PR TITLE
GH-10682: Fix MQTT for shared subscription on `ClientManager`

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/AbstractMqttClientManager.java
@@ -55,6 +55,8 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 
 	private final Set<ConnectCallback> connectCallbacks = Collections.synchronizedSet(new HashSet<>());
 
+	private final Set<DefaultMessageHandler<?>> defaultMessageHandlers = Collections.synchronizedSet(new HashSet<>());
+
 	private final String clientId;
 
 	private int phase = DEFAULT_MANAGER_PHASE;
@@ -115,6 +117,11 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 
 	protected Set<ConnectCallback> getCallbacks() {
 		return this.connectCallbacks;
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	protected <M> Set<DefaultMessageHandler<M>> getDefaultMessageHandlers() {
+		return (Set<DefaultMessageHandler<M>>) (Set) this.defaultMessageHandlers;
 	}
 
 	/**
@@ -212,6 +219,16 @@ public abstract class AbstractMqttClientManager<T, C> implements ClientManager<T
 	@Override
 	public boolean removeCallback(ConnectCallback connectCallback) {
 		return this.connectCallbacks.remove(connectCallback);
+	}
+
+	@Override
+	public <M> void addDefaultMessageHandler(DefaultMessageHandler<M> defaultMessageHandler) {
+		this.defaultMessageHandlers.add(defaultMessageHandler);
+	}
+
+	@Override
+	public <M> boolean removeDefaultMessageHandler(DefaultMessageHandler<M> defaultMessageHandler) {
+		return this.defaultMessageHandlers.remove(defaultMessageHandler);
 	}
 
 	public boolean isRunning() {

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/ClientManager.java
@@ -89,6 +89,21 @@ public interface ClientManager<T, C> extends SmartLifecycle, MqttComponent<C> {
 	boolean removeCallback(ConnectCallback connectCallback);
 
 	/**
+	 * Register a callback for the {@code messageArrived} event from the client.
+	 * @param defaultMessageHandler a {@link DefaultMessageHandler} to register.
+	 * @since 6.5.6
+	 */
+	<M> void addDefaultMessageHandler(DefaultMessageHandler<M> defaultMessageHandler);
+
+	/**
+	 * Remove the callback from registration.
+	 * @param defaultMessageHandler a {@link DefaultMessageHandler} to unregister.
+	 * @return true if callback was removed.
+	 * @since 6.5.6
+	 */
+	<M> boolean removeDefaultMessageHandler(DefaultMessageHandler<M> defaultMessageHandler);
+
+	/**
 	 * Return the managed clients isConnected.
 	 * @return the managed clients isConnected.
 	 * @since 6.4
@@ -106,9 +121,32 @@ public interface ClientManager<T, C> extends SmartLifecycle, MqttComponent<C> {
 
 		/**
 		 * Called when the connection to the server is completed successfully.
-		 * @param isReconnect if true, the connection was the result of automatic reconnect.
+		 * @param isReconnect if true, the connection was the result of automatic reconnecting.
 		 */
 		void connectComplete(boolean isReconnect);
+
+	}
+
+	/**
+	 * A contract for a default message handler on the {@code messageArrived} event from the client.
+	 *
+	 * @param <M> the message type from the specific client implementation.
+	 *
+	 * @since 6.5.6
+	 *
+	 * @see org.eclipse.paho.mqttv5.client.MqttCallback#messageArrived(String, org.eclipse.paho.mqttv5.common.MqttMessage)
+	 * @see org.eclipse.paho.client.mqttv3.MqttCallback#messageArrived(String, org.eclipse.paho.client.mqttv3.MqttMessage)
+	 */
+	@FunctionalInterface
+	interface DefaultMessageHandler<M> {
+
+		/**
+		 * Called when the {@code messageArrived} is called from the client as a fallback message listener.
+		 * @param topic the topic from which the message was received.
+		 *              Could be used in the target implementation to filter messages by topic.
+		 * @param message the received and unrouted MQTT message.
+		 */
+		void messageArrived(String topic, M message);
 
 	}
 

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv3ClientManager.java
@@ -188,7 +188,8 @@ public class Mqttv3ClientManager
 
 	@Override
 	public void messageArrived(String topic, MqttMessage message) {
-		// not this manager concern
+		getDefaultMessageHandlers()
+				.forEach((defaultMessageHandler) -> defaultMessageHandler.messageArrived(topic, message));
 	}
 
 	@Override

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/core/Mqttv5ClientManager.java
@@ -176,7 +176,8 @@ public class Mqttv5ClientManager
 
 	@Override
 	public void messageArrived(String topic, MqttMessage message) {
-		// not this manager concern
+		getDefaultMessageHandlers()
+				.forEach((defaultMessageHandler) -> defaultMessageHandler.messageArrived(topic, message));
 	}
 
 	@Override
@@ -186,7 +187,7 @@ public class Mqttv5ClientManager
 
 	@Override
 	public void connectComplete(boolean reconnect, String serverURI) {
-		getCallbacks().forEach(callback -> callback.connectComplete(reconnect));
+		getCallbacks().forEach((callback) -> callback.connectComplete(reconnect));
 	}
 
 	@Override


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10682

The Paho MQTT misses the logic to check for shared subscriptions when messages are received via listener.
The regular `MqttCallback` is called as a fallback for those unrouted messages.

* Expose `ClientManager.addDefaultMessageHandler()` option to let `AbstractMqttMessageDrivenChannelAdapter` implementations to provide the hook for those unrouted messages

Related to: https://github.com/eclipse-paho/paho.mqtt.java/issues/827

**Auto-cherry-pick to `7.0.x` & `6.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
