### PR TITLE
Disable `requiresReply` for Transformer

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/TransformerFactoryBean.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/TransformerFactoryBean.java
@@ -39,20 +39,15 @@ import org.springframework.util.StringUtils;
  */
 public class TransformerFactoryBean extends AbstractStandardMessageHandlerFactoryBean {
 
-	@SuppressWarnings("this-escape")
-	public TransformerFactoryBean() {
-		setRequiresReply(true);
-	}
-
 	@Override
 	protected MessageHandler createMethodInvokingHandler(Object targetObject, @Nullable String targetMethodName) {
 		Assert.notNull(targetObject, "targetObject must not be null");
-		Transformer transformer = null;
+		Transformer transformer;
 		if (targetObject instanceof Transformer castTransformer) {
 			transformer = castTransformer;
 		}
 		else {
-			this.checkForIllegalTarget(targetObject, targetMethodName);
+			checkForIllegalTarget(targetObject, targetMethodName);
 			if (StringUtils.hasText(targetMethodName)) {
 				transformer = new MethodInvokingTransformer(targetObject, targetMethodName);
 			}
@@ -60,20 +55,20 @@ public class TransformerFactoryBean extends AbstractStandardMessageHandlerFactor
 				transformer = new MethodInvokingTransformer(targetObject);
 			}
 		}
-		return this.createHandler(transformer);
+		return createHandler(transformer);
 	}
 
 	@Override
 	protected MessageHandler createExpressionEvaluatingHandler(Expression expression) {
 		Transformer transformer = new ExpressionEvaluatingTransformer(expression);
-		MessageTransformingHandler handler = this.createHandler(transformer);
+		MessageTransformingHandler handler = createHandler(transformer);
 		handler.setPrimaryExpression(expression);
 		return handler;
 	}
 
 	protected MessageTransformingHandler createHandler(Transformer transformer) {
 		MessageTransformingHandler handler = new MessageTransformingHandler(transformer);
-		this.postProcessReplyProducer(handler);
+		postProcessReplyProducer(handler);
 		return handler;
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
@@ -52,7 +52,7 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 	 */
 	@SuppressWarnings("this-escape")
 	public MessageTransformingHandler() {
-		setRequiresReply(true);
+		super.setRequiresReply(true);
 	}
 
 	/**
@@ -74,6 +74,16 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 	public void setTransformer(Transformer transformer) {
 		Assert.notNull(transformer, "transformer must not be null");
 		this.transformer = transformer;
+	}
+
+	/**
+	 * Overridden to throw an {@link UnsupportedOperationException} since transformer must never return null
+	 * and {@code requiresReply == true} by default.
+	 * @param requiresReply never used.
+	 */
+	@Override
+	public void setRequiresReply(boolean requiresReply) {
+		throw new UnsupportedOperationException("Transformer always requires a non-null reply payload.");
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/transformer/MessageTransformingHandler.java
@@ -80,6 +80,7 @@ public class MessageTransformingHandler extends AbstractReplyProducingMessageHan
 	 * Overridden to throw an {@link UnsupportedOperationException} since transformer must never return null
 	 * and {@code requiresReply == true} by default.
 	 * @param requiresReply never used.
+	 * @since 7.1
 	 */
 	@Override
 	public void setRequiresReply(boolean requiresReply) {

--- a/src/reference/antora/modules/ROOT/pages/transformer.adoc
+++ b/src/reference/antora/modules/ROOT/pages/transformer.adoc
@@ -124,7 +124,8 @@ As of Spring Integration 2.0, a message transformer's transformation method can 
 Returning `null` results in an exception (a `MessageTransformationException` to be precise), because a message transformer should always be expected to transform each source message into a valid target message.
 In other words, a message transformer should not be used as a message filter, because there is a dedicated `<filter>` option for that.
 However, if you do need this type of behavior (where a component might return `null` and that should not be considered an error), you could use a service activator.
-Its `requires-reply` value is `false` by default, but that can be set to `true` in order to have exceptions thrown for `null` return values, as with the transformer.
+Its `requiresReply` value is `false` by default, but that can be set to `true` in order to have exceptions thrown for `null` return values, as with the transformer.
+The transformer's `requiresReply` property cannot be modified: it is always `true` since the transformer pattern definition does not allow nulls for replies.
 
 [[transformers-and-spring-expression-language-spel]]
 == Transformers and Spring Expression Language (SpEL)

--- a/src/reference/antora/modules/ROOT/pages/transformer.adoc
+++ b/src/reference/antora/modules/ROOT/pages/transformer.adoc
@@ -124,7 +124,7 @@ As of Spring Integration 2.0, a message transformer's transformation method can 
 Returning `null` results in an exception (a `MessageTransformationException` to be precise), because a message transformer should always be expected to transform each source message into a valid target message.
 In other words, a message transformer should not be used as a message filter, because there is a dedicated `<filter>` option for that.
 However, if you do need this type of behavior (where a component might return `null` and that should not be considered an error), you could use a service activator.
-Its `requiresReply` value is `false` by default, but that can be set to `true` in order to have exceptions thrown for `null` return values, as with the transformer.
+The service activator's `requiresReply` value is `false` by default, but that can be set to `true` in order to have exceptions thrown for `null` return values, as with the transformer.
 The transformer's `requiresReply` property cannot be modified: it is always `true` since the transformer pattern definition does not allow nulls for replies.
 
 [[transformers-and-spring-expression-language-spel]]

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -14,7 +14,13 @@ For more details, see the https://github.com/spring-projects/spring-integration/
 In general, the project has been moved to the latest dependency versions.
 Java 17 is still the baseline, but Java 25 is supported.
 
-[[x7.0-web-services-changes]]
+[[x7.1-general-changes]]
+=== General Changes
+
+The `MessageTransformingHandler.requiresReply` flag cannot be modified: an `UnsupportedOperationException` is thrown from the overridden `setRequiresReply()` method to indicate the transformer pattern cannot produce nulls for replies.
+See xref:transformer.adoc[] for more information.
+
+[[x7.1-web-services-changes]]
 === Web Services Support Changes
 
 The Web Services Outbound Gateway now can rely on the provided `WebServiceTemplate.defaultUri`.


### PR DESCRIPTION
The Transformer pattern was never about letting the null result pass down into a reply message. Or perform filter-like logic via transformation.
The service activator was always advertised for a logic to deal with a null result. Plus, after adopting NullAway, the `AbstractMessageProcessingTransformer` now throws `MessageTransformationException` when the processing result is null.

* Fix `MessageTransformingHandler` to disallow changing `requiresReply` to avoid a false impression that a null result could lead to something but an exception.

More info in: https://stackoverflow.com/questions/79871975/best-practices-for-error-handling-in-synchronous-spring-integration-flows

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
