### PR TITLE
GH-10760: Support topic filters in messages arrived callback

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -189,7 +189,6 @@ public class MqttPahoMessageDrivenChannelAdapter
 		}
 	}
 
-	@SuppressWarnings("deprecation")
 	private void connect() throws MqttException {
 		this.lock.lock();
 		try {

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/MqttPahoMessageDrivenChannelAdapter.java
@@ -29,6 +29,7 @@ import org.eclipse.paho.client.mqttv3.MqttCallbackExtended;
 import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.eclipse.paho.client.mqttv3.MqttTopic;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.context.ApplicationEventPublisher;
@@ -74,7 +75,7 @@ public class MqttPahoMessageDrivenChannelAdapter
 	 * Never invoked because MQTT v3 does not support shared subscriptions.
 	 * But it is here for consistency with the {@link ClientManager} requirements
 	 */
-	private final ClientManager.DefaultMessageHandler<MqttMessage> defaultMessageHandler = this::messageArrived;
+	private final ClientManager.DefaultMessageHandler<MqttMessage> defaultMessageHandler = this::messageArrivedIfMatched;
 
 	private final MqttPahoClientFactory clientFactory;
 
@@ -368,14 +369,6 @@ public class MqttPahoMessageDrivenChannelAdapter
 
 	@Override
 	public void messageArrived(String topic, MqttMessage mqttMessage) {
-		// Just simple check since MQTT v3 does not support shared subscriptions.
-		boolean subscribed = Arrays.asList(getTopic()).contains(topic);
-		if (!subscribed) {
-			logger.trace(() ->
-					"Arrived message on topic '" + topic + "' this channel adapter is not subscribed to. Ignoring...");
-			return;
-		}
-
 		AbstractIntegrationMessageBuilder<?> builder = toMessageBuilder(topic, mqttMessage);
 		if (builder != null) {
 			if (isManualAcks()) {
@@ -444,6 +437,17 @@ public class MqttPahoMessageDrivenChannelAdapter
 		else {
 			this.readyToSubscribeOnStart = true;
 		}
+	}
+
+	private void messageArrivedIfMatched(String topic, MqttMessage mqttMessage) {
+		for (String subscribedTopic : getTopic()) {
+			if (MqttTopic.isMatched(subscribedTopic, topic)) {
+				messageArrived(topic, mqttMessage);
+				return;
+			}
+		}
+		logger.trace(() ->
+				"Arrived message on topic '" + topic + "' this channel adapter is not subscribed to. Ignoring...");
 	}
 
 	/**

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
@@ -144,7 +144,7 @@ public class Mqttv5BackToBackTests implements MosquittoContainerTest {
 
 	@Test
 	public void testSharedTopicMqttv5Interaction() {
-		this.mqttv5MessageDrivenChannelAdapter.addTopic("$share/group/testTopic");
+		this.mqttv5MessageDrivenChannelAdapter.addTopic("$share/group/#");
 
 		String testPayload = "shared topic payload";
 		this.mqttOutFlowInput.send(


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10760

The previous fix with protection against subscribed topics did not include the logic about wildcard support in MQTT subscriptions

* Fix `MqttPahoMessageDrivenChannelAdapter` extracting `messageArrivedIfMatched()` which would be called as a fallback common callback. Delegate matching logic to the `MqttTopic.isMatched()` utility
* Fix `Mqttv5PahoMessageDrivenChannelAdapter` extracting `messageArrivedIfMatched()` which would be called as a fallback common callback. Delegate matching logic to the `MqttTopicValidator.isMatched()` utility. However, before that check for the `$share/` prefix and strip two subscription parts. Exactly the logic missed in Paho Client
* Modify `Mqttv5BackToBackTests.testSharedTopicMqttv5Interaction()` for wildcard to be sure new matching logic works as expected

**Auto-cherry-pick to `7.0.x` & `6.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
