### PR TITLE
Add TestUtils.propertyValue() based on generics

### DIFF
--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpChannelParserTests.java
@@ -41,6 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 2.1
  */
 @SpringJUnitConfig
@@ -62,34 +64,36 @@ public class AmqpChannelParserTests {
 	@Test
 	public void interceptor() {
 		MessageChannel channel = context.getBean("channelWithInterceptor", MessageChannel.class);
-		List<?> interceptorList = TestUtils.getPropertyValue(channel, "interceptors.interceptors", List.class);
-		assertThat(interceptorList.size()).isEqualTo(1);
+		List<?> interceptorList = TestUtils.getPropertyValue(channel, "interceptors.interceptors");
+		assertThat(interceptorList).hasSize(1);
 		assertThat(interceptorList.get(0).getClass()).isEqualTo(TestInterceptor.class);
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue())
+		assertThat(TestUtils.<Integer>getPropertyValue(
+				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers").intValue())
 				.isEqualTo(Integer.MAX_VALUE);
 		channel = context.getBean("pubSub", MessageChannel.class);
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertThat(TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"))
+		assertThat(TestUtils.<Object>getPropertyValue(channel, "container.messageListener.messageBuilderFactory"))
 				.isSameAs(mbf);
-		assertThat(TestUtils.getPropertyValue(channel, "container.missingQueuesFatal", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(channel, "container.transactional", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(channel, "amqpTemplate.transactional", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(channel, "container")).isInstanceOf(SimpleMessageListenerContainer.class);
+		assertThat(TestUtils.<Boolean>getPropertyValue(channel, "container.missingQueuesFatal")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(channel, "container.transactional")).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(channel, "amqpTemplate.transactional")).isFalse();
+		assertThat(TestUtils.<SimpleMessageListenerContainer>getPropertyValue(channel, "container"))
+				.isInstanceOf(SimpleMessageListenerContainer.class);
 	}
 
 	@Test
 	public void subscriberLimit() {
 		MessageChannel channel = context.getBean("channelWithSubscriberLimit", MessageChannel.class);
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue())
+		assertThat(TestUtils.<Integer>getPropertyValue(
+				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers").intValue())
 				.isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(channel, "container.missingQueuesFatal", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(channel, "container.transactional", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(channel, "amqpTemplate.transactional", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(channel, "extractPayload", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(channel, "container")).isInstanceOf(DirectMessageListenerContainer.class);
-		assertThat(TestUtils.getPropertyValue(channel, "container.consumersPerQueue")).isEqualTo(2);
+		assertThat(TestUtils.<Boolean>getPropertyValue(channel, "container.missingQueuesFatal")).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(channel, "container.transactional")).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(channel, "amqpTemplate.transactional")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(channel, "extractPayload")).isFalse();
+		assertThat(TestUtils.<DirectMessageListenerContainer>getPropertyValue(channel, "container"))
+				.isInstanceOf(DirectMessageListenerContainer.class);
+		assertThat(TestUtils.<Integer>getPropertyValue(channel, "container.consumersPerQueue")).isEqualTo(2);
 	}
 
 	@Test
@@ -97,11 +101,11 @@ public class AmqpChannelParserTests {
 		checkExtract(this.pollableWithEP);
 		checkExtract(this.withEP);
 		checkExtract(this.pubSubWithEP);
-		assertThat(TestUtils.getPropertyValue(this.withEP, "defaultDeliveryMode"))
+		assertThat(TestUtils.<MessageDeliveryMode>getPropertyValue(this.withEP, "defaultDeliveryMode"))
 				.isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
-		assertThat(TestUtils.getPropertyValue(this.withEP, "headersMappedLast", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.pollableWithEP, "defaultDeliveryMode")).isNull();
-		assertThat(TestUtils.getPropertyValue(this.pollableWithEP, "headersMappedLast", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.withEP, "headersMappedLast")).isFalse();
+		assertThat(TestUtils.<Object>getPropertyValue(this.pollableWithEP, "defaultDeliveryMode")).isNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.pollableWithEP, "headersMappedLast")).isTrue();
 	}
 
 	private void checkExtract(AbstractAmqpChannel channel) {
@@ -109,7 +113,7 @@ public class AmqpChannelParserTests {
 				.contains("Mock for AmqpHeaderMapper");
 		assertThat(TestUtils.getPropertyValue(channel, "inboundHeaderMapper").toString())
 				.contains("Mock for AmqpHeaderMapper");
-		assertThat(TestUtils.getPropertyValue(channel, "extractPayload", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(channel, "extractPayload")).isTrue();
 	}
 
 	private static class TestInterceptor implements ChannelInterceptor {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundChannelAdapterParserTests.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.mock;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -62,15 +63,15 @@ public class AmqpInboundChannelAdapterParserTests {
 		Object adapter = context.getBean("rabbitInbound.adapter");
 		assertThat(channel.getClass()).isEqualTo(DirectChannel.class);
 		assertThat(adapter.getClass()).isEqualTo(AmqpInboundChannelAdapter.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.TRUE);
-		assertThat(TestUtils.getPropertyValue(adapter, "phase")).isEqualTo(Integer.MAX_VALUE / 2);
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.TRUE);
+		assertThat(TestUtils.<Integer>getPropertyValue(adapter, "phase")).isEqualTo(Integer.MAX_VALUE / 2);
+		assertThat(TestUtils.<Boolean>getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal"))
 				.isTrue();
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer"))
+		assertThat(TestUtils.<SimpleMessageListenerContainer>getPropertyValue(adapter, "messageListenerContainer"))
 				.isInstanceOf(SimpleMessageListenerContainer.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "batchMode", BatchMode.class))
+		assertThat(TestUtils.<BatchMode>getPropertyValue(adapter, "batchMode"))
 				.isEqualTo(BatchMode.EXTRACT_PAYLOADS);
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.batchSize", Integer.class))
+		assertThat(TestUtils.<Integer>getPropertyValue(adapter, "messageListenerContainer.batchSize"))
 				.isEqualTo(2);
 	}
 
@@ -78,25 +79,25 @@ public class AmqpInboundChannelAdapterParserTests {
 	public void verifyDMCC() {
 		Object adapter = context.getBean("dmlc.adapter");
 		assertThat(adapter.getClass()).isEqualTo(AmqpInboundChannelAdapter.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal"))
 				.isFalse();
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer"))
+		assertThat(TestUtils.<DirectMessageListenerContainer>getPropertyValue(adapter, "messageListenerContainer"))
 				.isInstanceOf(DirectMessageListenerContainer.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.consumersPerQueue")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(adapter, "batchMode", BatchMode.class))
+		assertThat(TestUtils.<Integer>getPropertyValue(adapter, "messageListenerContainer.consumersPerQueue")).isEqualTo(2);
+		assertThat(TestUtils.<BatchMode>getPropertyValue(adapter, "batchMode"))
 				.isEqualTo(BatchMode.MESSAGES);
 	}
 
 	@Test
 	public void verifyLifeCycle() {
 		Object adapter = context.getBean("autoStartFalse.adapter");
-		assertThat(TestUtils.getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.FALSE);
-		assertThat(TestUtils.getPropertyValue(adapter, "phase")).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.acknowledgeMode"))
+		assertThat(TestUtils.<Boolean>getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.FALSE);
+		assertThat(TestUtils.<Integer>getPropertyValue(adapter, "phase")).isEqualTo(123);
+		assertThat(TestUtils.<AcknowledgeMode>getPropertyValue(adapter, "messageListenerContainer.acknowledgeMode"))
 				.isEqualTo(AcknowledgeMode.NONE);
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(adapter, "messageListenerContainer.missingQueuesFatal"))
 				.isFalse();
-		assertThat(TestUtils.getPropertyValue(adapter, "messageListenerContainer.batchSize", Integer.class))
+		assertThat(TestUtils.<Integer>getPropertyValue(adapter, "messageListenerContainer.batchSize"))
 				.isEqualTo(3);
 	}
 
@@ -106,9 +107,8 @@ public class AmqpInboundChannelAdapterParserTests {
 				AmqpInboundChannelAdapter.class);
 
 		AbstractMessageListenerContainer mlc =
-				TestUtils.getPropertyValue(adapter, "messageListenerContainer", AbstractMessageListenerContainer.class);
-		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener",
-				ChannelAwareMessageListener.class);
+				TestUtils.<AbstractMessageListenerContainer>getPropertyValue(adapter, "messageListenerContainer");
+		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener");
 		MessageProperties amqpProperties = new MessageProperties();
 		amqpProperties.setAppId("test.appId");
 		amqpProperties.setClusterId("test.clusterId");
@@ -135,9 +135,8 @@ public class AmqpInboundChannelAdapterParserTests {
 				AmqpInboundChannelAdapter.class);
 
 		AbstractMessageListenerContainer mlc =
-				TestUtils.getPropertyValue(adapter, "messageListenerContainer", AbstractMessageListenerContainer.class);
-		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener",
-				ChannelAwareMessageListener.class);
+				TestUtils.<AbstractMessageListenerContainer>getPropertyValue(adapter, "messageListenerContainer");
+		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener");
 		MessageProperties amqpProperties = new MessageProperties();
 		amqpProperties.setAppId("test.appId");
 		amqpProperties.setClusterId("test.clusterId");
@@ -164,9 +163,8 @@ public class AmqpInboundChannelAdapterParserTests {
 				AmqpInboundChannelAdapter.class);
 
 		AbstractMessageListenerContainer mlc =
-				TestUtils.getPropertyValue(adapter, "messageListenerContainer", AbstractMessageListenerContainer.class);
-		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener",
-				ChannelAwareMessageListener.class);
+				TestUtils.<AbstractMessageListenerContainer>getPropertyValue(adapter, "messageListenerContainer");
+		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener");
 		MessageProperties amqpProperties = new MessageProperties();
 		amqpProperties.setAppId("test.appId");
 		amqpProperties.setClusterId("test.clusterId");
@@ -194,9 +192,8 @@ public class AmqpInboundChannelAdapterParserTests {
 				AmqpInboundChannelAdapter.class);
 
 		AbstractMessageListenerContainer mlc =
-				TestUtils.getPropertyValue(adapter, "messageListenerContainer", AbstractMessageListenerContainer.class);
-		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener",
-				ChannelAwareMessageListener.class);
+				TestUtils.<AbstractMessageListenerContainer>getPropertyValue(adapter, "messageListenerContainer");
+		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener");
 		MessageProperties amqpProperties = new MessageProperties();
 		amqpProperties.setAppId("test.appId");
 		amqpProperties.setClusterId("test.clusterId");

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpInboundGatewayParserTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import org.springframework.amqp.core.Address;
+import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -52,6 +53,7 @@ import static org.mockito.Mockito.mock;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -66,29 +68,29 @@ public class AmqpInboundGatewayParserTests {
 	public void customMessageConverter() {
 		Object gateway = context.getBean("gateway");
 		MessageConverter gatewayConverter =
-				TestUtils.getPropertyValue(gateway, "amqpMessageConverter", MessageConverter.class);
+				TestUtils.<MessageConverter>getPropertyValue(gateway, "amqpMessageConverter");
 		MessageConverter templateConverter =
-				TestUtils.getPropertyValue(gateway, "amqpTemplate.messageConverter", MessageConverter.class);
+				TestUtils.<MessageConverter>getPropertyValue(gateway, "amqpTemplate.messageConverter");
 		TestConverter testConverter = context.getBean("testConverter", TestConverter.class);
 		assertThat(gatewayConverter).isSameAs(testConverter);
 		assertThat(templateConverter).isSameAs(testConverter);
-		assertThat(TestUtils.getPropertyValue(gateway, "autoStartup")).isEqualTo(Boolean.TRUE);
-		assertThat(TestUtils.getPropertyValue(gateway, "phase")).isEqualTo(0);
-		assertThat(TestUtils.getPropertyValue(gateway, "messagingTemplate.receiveTimeout")).isEqualTo(1234L);
-		assertThat(TestUtils.getPropertyValue(gateway, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "autoStartup")).isEqualTo(Boolean.TRUE);
+		assertThat(TestUtils.<Integer>getPropertyValue(gateway, "phase")).isEqualTo(0);
+		assertThat(TestUtils.<Long>getPropertyValue(gateway, "messagingTemplate.receiveTimeout")).isEqualTo(1234L);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "messageListenerContainer.missingQueuesFatal"))
 				.isTrue();
 	}
 
 	@Test
 	public void verifyLifeCycle() {
 		Object gateway = context.getBean("autoStartFalseGateway");
-		assertThat(TestUtils.getPropertyValue(gateway, "autoStartup")).isEqualTo(Boolean.FALSE);
-		assertThat(TestUtils.getPropertyValue(gateway, "phase")).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(gateway, "messageListenerContainer.missingQueuesFatal", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "autoStartup")).isEqualTo(Boolean.FALSE);
+		assertThat(TestUtils.<Integer>getPropertyValue(gateway, "phase")).isEqualTo(123);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "messageListenerContainer.missingQueuesFatal"))
 				.isFalse();
 		Object amqpTemplate = context.getBean("amqpTemplate");
-		assertThat(TestUtils.getPropertyValue(gateway, "amqpTemplate")).isSameAs(amqpTemplate);
-		Address defaultReplyTo = TestUtils.getPropertyValue(gateway, "defaultReplyTo", Address.class);
+		assertThat(TestUtils.<AmqpTemplate>getPropertyValue(gateway, "amqpTemplate")).isSameAs(amqpTemplate);
+		Address defaultReplyTo = TestUtils.getPropertyValue(gateway, "defaultReplyTo");
 		Address expected = new Address("fooExchange/barRoutingKey");
 		assertThat(defaultReplyTo.getExchangeName()).isEqualTo(expected.getExchangeName());
 		assertThat(defaultReplyTo.getRoutingKey()).isEqualTo(expected.getRoutingKey());
@@ -106,10 +108,10 @@ public class AmqpInboundGatewayParserTests {
 		});
 
 		final AmqpInboundGateway gateway = context.getBean("withHeaderMapper", AmqpInboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "replyHeadersMappedLast", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "replyHeadersMappedLast")).isTrue();
 		Field amqpTemplateField = ReflectionUtils.findField(AmqpInboundGateway.class, "amqpTemplate");
 		amqpTemplateField.setAccessible(true);
-		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(gateway, "amqpTemplate", RabbitTemplate.class);
+		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(gateway, "amqpTemplate");
 		amqpTemplate = Mockito.spy(amqpTemplate);
 
 		Mockito.doAnswer(invocation -> {
@@ -123,9 +125,8 @@ public class AmqpInboundGatewayParserTests {
 		ReflectionUtils.setField(amqpTemplateField, gateway, amqpTemplate);
 
 		AbstractMessageListenerContainer mlc =
-				TestUtils.getPropertyValue(gateway, "messageListenerContainer", AbstractMessageListenerContainer.class);
-		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener",
-				ChannelAwareMessageListener.class);
+				TestUtils.<AbstractMessageListenerContainer>getPropertyValue(gateway, "messageListenerContainer");
+		ChannelAwareMessageListener listener = TestUtils.getPropertyValue(mlc, "messageListener");
 		MessageProperties amqpProperties = new MessageProperties();
 		amqpProperties.setAppId("test.appId");
 		amqpProperties.setClusterId("test.clusterId");

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -50,6 +50,7 @@ import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
+import org.springframework.integration.support.ErrorMessageStrategy;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.support.context.NamedComponent;
 import org.springframework.integration.test.util.TestUtils;
@@ -80,6 +81,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -102,30 +104,28 @@ public class AmqpOutboundChannelAdapterParserTests {
 		Object adapter = context.getBean("rabbitOutbound.adapter");
 		assertThat(channel.getClass()).isEqualTo(DirectChannel.class);
 		assertThat(adapter.getClass()).isEqualTo(EventDrivenConsumer.class);
-		MessageHandler handler = TestUtils.getPropertyValue(adapter, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(adapter, "handler");
 		assertThat(handler instanceof NamedComponent).isTrue();
 		assertThat(((NamedComponent) handler).getComponentType()).isEqualTo("amqp:outbound-channel-adapter");
 		handler.handleMessage(new GenericMessage<String>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(handler, "lazyConnect", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "lazyConnect")).isTrue();
 	}
 
 	@Test
 	public void withHeaderMapperCustomHeaders() {
 		Object eventDrivenConsumer = context.getBean("withHeaderMapperCustomHeaders");
 
-		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivenConsumer, "handler",
-				AmqpOutboundEndpoint.class);
-		assertThat(TestUtils.getPropertyValue(endpoint, "defaultDeliveryMode")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(endpoint, "lazyConnect", Boolean.class)).isFalse();
-		assertThat(TestUtils
-				.getPropertyValue(endpoint, "delayExpression", org.springframework.expression.Expression.class)
+		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivenConsumer, "handler");
+		assertThat(TestUtils.<Object>getPropertyValue(endpoint, "defaultDeliveryMode")).isNotNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "lazyConnect")).isFalse();
+		assertThat(TestUtils.<org.springframework.expression.Expression>getPropertyValue(endpoint, "delayExpression")
 				.getExpressionString()).isEqualTo("42");
-		assertThat(TestUtils.getPropertyValue(endpoint, "headersMappedLast", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "headersMappedLast")).isFalse();
 
 		Field amqpTemplateField = ReflectionUtils.findField(AmqpOutboundEndpoint.class, "rabbitTemplate");
 		amqpTemplateField.setAccessible(true);
-		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(endpoint, "rabbitTemplate", RabbitTemplate.class);
+		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(endpoint, "rabbitTemplate");
 		amqpTemplate = Mockito.spy(amqpTemplate);
 		final AtomicBoolean shouldBePersistent = new AtomicBoolean();
 
@@ -168,43 +168,42 @@ public class AmqpOutboundChannelAdapterParserTests {
 	@Test
 	public void parseWithPublisherConfirms() {
 		Object eventDrivenConsumer = context.getBean("withPublisherConfirms");
-		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivenConsumer, "handler",
-				AmqpOutboundEndpoint.class);
+		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivenConsumer, "handler");
 		NullChannel nullChannel = context.getBean(NullChannel.class);
 		MessageChannel ackChannel = context.getBean("ackChannel", MessageChannel.class);
-		assertThat(TestUtils.getPropertyValue(endpoint, "confirmAckChannel")).isSameAs(ackChannel);
-		assertThat(TestUtils.getPropertyValue(endpoint, "confirmNackChannel")).isSameAs(nullChannel);
-		assertThat(TestUtils.getPropertyValue(endpoint, "errorMessageStrategy")).isSameAs(context.getBean("ems"));
-		assertThat(TestUtils.getPropertyValue(endpoint, "waitForConfirm", Boolean.class)).isFalse();
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(endpoint, "confirmAckChannel")).isSameAs(ackChannel);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(endpoint, "confirmNackChannel")).isSameAs(nullChannel);
+		assertThat(TestUtils.<ErrorMessageStrategy>getPropertyValue(endpoint, "errorMessageStrategy"))
+				.isSameAs(context.getBean("ems"));
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "waitForConfirm")).isFalse();
 	}
 
 	@Test
 	public void parseWithPublisherConfirms2() {
 		Object eventDrivenConsumer = context.getBean("withPublisherConfirms2");
-		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivenConsumer, "handler",
-				AmqpOutboundEndpoint.class);
+		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivenConsumer, "handler");
 		MessageChannel nackChannel = context.getBean("nackChannel", MessageChannel.class);
 		MessageChannel ackChannel = context.getBean("ackChannel", MessageChannel.class);
-		assertThat(TestUtils.getPropertyValue(endpoint, "confirmAckChannel")).isSameAs(ackChannel);
-		assertThat(TestUtils.getPropertyValue(endpoint, "confirmNackChannel")).isSameAs(nackChannel);
-		assertThat(TestUtils.getPropertyValue(endpoint, "confirmTimeout")).isEqualTo(Duration.ofMillis(2000));
-		assertThat(TestUtils.getPropertyValue(endpoint, "errorMessageStrategy")).isSameAs(context.getBean("ems"));
-		assertThat(TestUtils.getPropertyValue(endpoint, "waitForConfirm", Boolean.class)).isTrue();
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(endpoint, "confirmAckChannel")).isSameAs(ackChannel);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(endpoint, "confirmNackChannel")).isSameAs(nackChannel);
+		assertThat(TestUtils.<Duration>getPropertyValue(endpoint, "confirmTimeout")).isEqualTo(Duration.ofMillis(2000));
+		assertThat(TestUtils.<ErrorMessageStrategy>getPropertyValue(endpoint, "errorMessageStrategy"))
+				.isSameAs(context.getBean("ems"));
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "waitForConfirm")).isTrue();
 	}
 
-	@SuppressWarnings("rawtypes")
 	@Test
 	public void amqpOutboundChannelAdapterWithinChain() {
 		Object eventDrivenConsumer = context.getBean("chainWithRabbitOutbound");
 
-		List chainHandlers = TestUtils.getPropertyValue(eventDrivenConsumer, "handler.handlers", List.class);
+		List<?> chainHandlers = TestUtils.getPropertyValue(eventDrivenConsumer, "handler.handlers");
 
 		AmqpOutboundEndpoint endpoint = (AmqpOutboundEndpoint) chainHandlers.get(0);
-		assertThat(TestUtils.getPropertyValue(endpoint, "defaultDeliveryMode")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(endpoint, "defaultDeliveryMode")).isNull();
 
 		Field amqpTemplateField = ReflectionUtils.findField(AmqpOutboundEndpoint.class, "rabbitTemplate");
 		amqpTemplateField.setAccessible(true);
-		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(endpoint, "rabbitTemplate", RabbitTemplate.class);
+		RabbitTemplate amqpTemplate = TestUtils.getPropertyValue(endpoint, "rabbitTemplate");
 		amqpTemplate = Mockito.spy(amqpTemplate);
 
 		Mockito.doAnswer(invocation -> {
@@ -308,11 +307,11 @@ public class AmqpOutboundChannelAdapterParserTests {
 
 	@Test
 	public void testInt2971AmqpOutboundChannelAdapterWithCustomHeaderMapper() {
-		AmqpHeaderMapper headerMapper = TestUtils.getPropertyValue(this.amqpMessageHandlerWithCustomHeaderMapper,
-				"headerMapper", AmqpHeaderMapper.class);
+		AmqpHeaderMapper headerMapper =
+				TestUtils.getPropertyValue(this.amqpMessageHandlerWithCustomHeaderMapper, "headerMapper");
 		assertThat(headerMapper).isSameAs(this.context.getBean("customHeaderMapper"));
-		assertThat(TestUtils.getPropertyValue(this.amqpMessageHandlerWithCustomHeaderMapper,
-				"headersMappedLast", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.amqpMessageHandlerWithCustomHeaderMapper, "headersMappedLast"))
+				.isTrue();
 	}
 
 	@Test
@@ -323,7 +322,7 @@ public class AmqpOutboundChannelAdapterParserTests {
 		doThrow(toBeThrown).when(connectionFactory).createConnection();
 		when(amqpTemplate.getConnectionFactory()).thenReturn(connectionFactory);
 		AmqpOutboundEndpoint handler = new AmqpOutboundEndpoint(amqpTemplate);
-		LogAccessor logger = spy(TestUtils.getPropertyValue(handler, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(handler, "logger"));
 		new DirectFieldAccessor(handler).setPropertyValue("logger", logger);
 		doNothing().when(logger).error(toBeThrown, "Failed to eagerly establish the connection.");
 		ApplicationContext context = mock(ApplicationContext.class);

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/OutboundGatewayTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/OutboundGatewayTests.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.when;
  * @author Dave Syer
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -79,7 +80,6 @@ public class OutboundGatewayTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testExpressionsBeanResolver() {
 		ApplicationContext context = mock(ApplicationContext.class);
 		doAnswer(invocation -> invocation.getArguments()[0] + "bar").when(context).getBean(anyString());
@@ -102,12 +102,12 @@ public class OutboundGatewayTests {
 		endpoint.setConfirmCorrelationExpressionString("@baz");
 		endpoint.setBeanFactory(context);
 		endpoint.afterPropertiesSet();
-		Message<?> message = new GenericMessage<String>("Hello, world!");
-		assertThat(TestUtils.getPropertyValue(endpoint, "routingKeyGenerator", MessageProcessor.class)
+		Message<?> message = new GenericMessage<>("Hello, world!");
+		assertThat(TestUtils.<MessageProcessor<?>>getPropertyValue(endpoint, "routingKeyGenerator")
 				.processMessage(message)).isEqualTo("foobar");
-		assertThat(TestUtils.getPropertyValue(endpoint, "exchangeNameGenerator", MessageProcessor.class)
+		assertThat(TestUtils.<MessageProcessor<?>>getPropertyValue(endpoint, "exchangeNameGenerator")
 				.processMessage(message)).isEqualTo("barbar");
-		assertThat(TestUtils.getPropertyValue(endpoint, "correlationDataGenerator", MessageProcessor.class)
+		assertThat(TestUtils.<MessageProcessor<?>>getPropertyValue(endpoint, "correlationDataGenerator")
 				.processMessage(message)).isEqualTo("bazbar");
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpTests.java
@@ -89,6 +89,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -166,7 +167,8 @@ public class AmqpTests implements RabbitTestContainer {
 	@Test
 	public void testAmqpInboundGatewayFlow() {
 		assertThat(this.amqpInboundGatewayContainer).isNotNull();
-		assertThat(TestUtils.getPropertyValue(this.amqpInboundGateway, "amqpTemplate")).isSameAs(this.amqpTemplate);
+		assertThat(TestUtils.<AmqpTemplate>getPropertyValue(this.amqpInboundGateway, "amqpTemplate"))
+				.isSameAs(this.amqpTemplate);
 
 		Object result = this.amqpTemplate.convertSendAndReceive(this.amqpQueue.getName(), "world");
 		assertThat(result).isEqualTo("HELLO WORLD");
@@ -210,8 +212,7 @@ public class AmqpTests implements RabbitTestContainer {
 						this.rabbitConnectionFactory)
 				.autoStartup(false)
 				.templateChannelTransacted(true));
-		assertThat(TestUtils.getPropertyValue(flow, "currentMessageChannel.amqpTemplate.transactional",
-				Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(flow, "currentMessageChannel.amqpTemplate.transactional")).isTrue();
 	}
 
 	@Autowired
@@ -269,11 +270,13 @@ public class AmqpTests implements RabbitTestContainer {
 
 	@Test
 	void unitTestChannel() {
-		assertThat(TestUtils.getPropertyValue(this.unitChannel, "defaultDeliveryMode"))
+		assertThat(TestUtils.<MessageDeliveryMode>getPropertyValue(this.unitChannel, "defaultDeliveryMode"))
 				.isEqualTo(MessageDeliveryMode.NON_PERSISTENT);
-		assertThat(TestUtils.getPropertyValue(this.unitChannel, "inboundHeaderMapper")).isSameAs(this.mapperIn);
-		assertThat(TestUtils.getPropertyValue(this.unitChannel, "outboundHeaderMapper")).isSameAs(this.mapperOut);
-		assertThat(TestUtils.getPropertyValue(this.unitChannel, "extractPayload", Boolean.class)).isTrue();
+		assertThat(TestUtils.<AmqpHeaderMapper>getPropertyValue(this.unitChannel, "inboundHeaderMapper"))
+				.isSameAs(this.mapperIn);
+		assertThat(TestUtils.<AmqpHeaderMapper>getPropertyValue(this.unitChannel, "outboundHeaderMapper"))
+				.isSameAs(this.mapperOut);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.unitChannel, "extractPayload")).isTrue();
 	}
 
 	@Test

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpClientMessageProducerTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpClientMessageProducerTests.java
@@ -57,6 +57,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 7.0
  */
@@ -137,8 +138,7 @@ public class AmqpClientMessageProducerTests implements RabbitTestContainer {
 	@Test
 	void failureAfterReceiving() {
 		RabbitAmqpListenerContainer listenerContainer =
-				TestUtils.getPropertyValue(this.failureAmqpClientMessageProducer, "listenerContainer",
-						RabbitAmqpListenerContainer.class);
+				TestUtils.getPropertyValue(this.failureAmqpClientMessageProducer, "listenerContainer");
 
 		AtomicReference<Throwable> listenerError = new AtomicReference<>();
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AmqpOutboundEndpointTests.java
@@ -31,7 +31,6 @@ import org.springframework.amqp.rabbit.connection.CorrelationData;
 import org.springframework.amqp.rabbit.connection.CorrelationData.Confirm;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.support.AmqpHeaders;
-import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -41,6 +40,7 @@ import org.springframework.integration.amqp.support.ReturnedAmqpMessageException
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.mapping.support.JsonHeaders;
 import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.PollableChannel;
@@ -64,6 +64,7 @@ import static org.mockito.Mockito.verify;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Glenn Renfro
  *
  * @since 2.1
  *
@@ -202,7 +203,7 @@ public class AmqpOutboundEndpointTests implements RabbitTestContainer {
 		verify(template).send(isNull(), isNull(), any(), correlationCaptor.capture());
 		CorrelationData correlation = correlationCaptor.getValue();
 		correlationList.add(correlation);
-		assertThat(TestUtils.getPropertyValue(correlation, "message", Message.class)).isSameAs(message);
+		assertThat(TestUtils.<Object>getPropertyValue(correlation, "message")).isSameAs(message);
 		Message<?> nack = nacks.receive(10_000);
 		assertThat(nack).isNotNull();
 		assertThat(nack.getPayload()).isInstanceOf(NackedAmqpMessageException.class);

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AsyncAmqpGatewayTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/outbound/AsyncAmqpGatewayTests.java
@@ -39,7 +39,6 @@ import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.amqp.rabbit.listener.adapter.ReplyingMessageListener;
 import org.springframework.amqp.support.AmqpHeaders;
-import org.springframework.amqp.utils.test.TestUtils;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.core.log.LogAccessor;
@@ -51,6 +50,7 @@ import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.support.TestApplicationContextAware;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.ErrorMessage;
@@ -67,6 +67,7 @@ import static org.mockito.Mockito.spy;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.3
  *
@@ -125,7 +126,7 @@ class AsyncAmqpGatewayTests implements RabbitTestContainer, TestApplicationConte
 		receiver.start();
 
 		AsyncAmqpOutboundGateway gateway = new AsyncAmqpOutboundGateway(asyncTemplate);
-		LogAccessor logger = spy(TestUtils.getPropertyValue(gateway, "logger", LogAccessor.class));
+		LogAccessor logger = spy((LogAccessor) TestUtils.getPropertyValue(gateway, "logger"));
 		given(logger.isDebugEnabled()).willReturn(true);
 		final CountDownLatch replyTimeoutLatch = new CountDownLatch(1);
 		willAnswer(invocation -> {

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/BoundRabbitChannelAdviceIntegrationTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/support/BoundRabbitChannelAdviceIntegrationTests.java
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.spy;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.1
  *
@@ -79,7 +80,7 @@ public class BoundRabbitChannelAdviceIntegrationTests implements RabbitTestConta
 	@Test
 	void testAdvice() throws Exception {
 		BoundRabbitChannelAdvice advice = this.config.advice(this.config.template());
-		Log logger = spy(TestUtils.getPropertyValue(advice, "logger", Log.class));
+		Log logger = spy(TestUtils.<Log>getPropertyValue(advice, "logger"));
 		new DirectFieldAccessor(advice).setPropertyValue("logger", logger);
 		willReturn(true).given(logger).isDebugEnabled();
 		final CountDownLatch latch = new CountDownLatch(1);

--- a/spring-integration-cassandra/src/test/java/org/springframework/integration/cassandra/config/CassandraOutboundAdapterParserTests.java
+++ b/spring-integration-cassandra/src/test/java/org/springframework/integration/cassandra/config/CassandraOutboundAdapterParserTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Filippo Balicchia
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 6.0
  */
@@ -43,51 +44,54 @@ class CassandraOutboundAdapterParserTests {
 	@Test
 	void minimalConfig() {
 		CassandraMessageHandler handler =
-				TestUtils.getPropertyValue(this.context.getBean("outbound1.adapter"), "handler",
-						CassandraMessageHandler.class);
+				TestUtils.<CassandraMessageHandler>getPropertyValue(this.context.getBean("outbound1.adapter"), "handler");
 
-		assertThat(TestUtils.getPropertyValue(handler, "componentName")).isEqualTo("outbound1.adapter");
-		assertThat(TestUtils.getPropertyValue(handler, "mode")).isEqualTo(CassandraMessageHandler.Type.INSERT);
-		assertThat(TestUtils.getPropertyValue(handler, "cassandraOperations"))
+		assertThat(TestUtils.<String>getPropertyValue(handler, "componentName")).isEqualTo("outbound1.adapter");
+		assertThat(TestUtils.<CassandraMessageHandler.Type>getPropertyValue(handler, "mode"))
+				.isEqualTo(CassandraMessageHandler.Type.INSERT);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "cassandraOperations"))
 				.isSameAs(this.context.getBean("cassandraTemplate"));
-		assertThat(TestUtils.getPropertyValue(handler, "writeOptions")).isSameAs(this.context.getBean("writeOptions"));
-		assertThat(TestUtils.getPropertyValue(handler, "async", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "writeOptions"))
+				.isSameAs(this.context.getBean("writeOptions"));
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "async")).isFalse();
 	}
 
 	@Test
 	void ingestConfig() {
 		CassandraMessageHandler handler =
-				TestUtils.getPropertyValue(this.context.getBean("outbound2"), "handler",
-						CassandraMessageHandler.class);
+				TestUtils.<CassandraMessageHandler>getPropertyValue(this.context.getBean("outbound2"), "handler");
 
-		assertThat(TestUtils.getPropertyValue(handler, "ingestQuery"))
+		assertThat(TestUtils.<String>getPropertyValue(handler, "ingestQuery"))
 				.isEqualTo("insert into book (isbn, title, author, pages, saleDate, isInStock) " +
 						"values (?, ?, ?, ?, ?, ?)");
-		assertThat(TestUtils.getPropertyValue(handler, "producesReply", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "producesReply")).isFalse();
 	}
 
 	@Test
 	void fullConfig() {
 		CassandraMessageHandler handler =
-				TestUtils.getPropertyValue(this.context.getBean("outgateway"), "handler",
-						CassandraMessageHandler.class);
+				TestUtils.<CassandraMessageHandler>getPropertyValue(this.context.getBean("outgateway"), "handler");
 
-		assertThat(TestUtils.getPropertyValue(handler, "producesReply", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(handler, "mode")).isEqualTo(CassandraMessageHandler.Type.STATEMENT);
-		assertThat(TestUtils.getPropertyValue(handler, "writeOptions")).isSameAs(this.context.getBean("writeOptions"));
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "producesReply")).isTrue();
+		assertThat(TestUtils.<CassandraMessageHandler.Type>getPropertyValue(handler, "mode"))
+				.isEqualTo(CassandraMessageHandler.Type.STATEMENT);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "writeOptions"))
+				.isSameAs(this.context.getBean("writeOptions"));
 	}
 
 	@Test
 	void statementConfig() {
 		CassandraMessageHandler handler =
-				TestUtils.getPropertyValue(this.context.getBean("outbound4.adapter"), "handler",
-						CassandraMessageHandler.class);
+				TestUtils.getPropertyValue(this.context.getBean("outbound4.adapter"), "handler");
 
-		assertThat(TestUtils.getPropertyValue(handler, "componentName")).isEqualTo("outbound4.adapter");
-		assertThat(TestUtils.getPropertyValue(handler, "mode")).isEqualTo(CassandraMessageHandler.Type.STATEMENT);
-		assertThat(TestUtils.getPropertyValue(handler, "cassandraOperations"))
+		assertThat(TestUtils.<String>getPropertyValue(handler, "componentName"))
+				.isEqualTo("outbound4.adapter");
+		assertThat(TestUtils.<CassandraMessageHandler.Type>getPropertyValue(handler, "mode"))
+				.isEqualTo(CassandraMessageHandler.Type.STATEMENT);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "cassandraOperations"))
 				.isSameAs(this.context.getBean("cassandraTemplate"));
-		assertThat(TestUtils.getPropertyValue(handler, "writeOptions")).isSameAs(this.context.getBean("writeOptions"));
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "writeOptions"))
+				.isSameAs(this.context.getBean("writeOptions"));
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandlerTests.java
@@ -57,6 +57,7 @@ import static org.mockito.Mockito.verify;
  * @author Artem Bilan
  * @author Meherzad Lahewala
  * @author Youbin Wu
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -175,10 +176,10 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 
 		assertThat(outputMessages.size()).isEqualTo(1);
 
-		assertThat(TestUtils.getPropertyValue(handler, "messageStore.groupIdToMessageGroup", Map.class).size())
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "messageStore.groupIdToMessageGroup").size())
 				.isEqualTo(1);
 		groupStore.expireMessageGroups(0);
-		assertThat(TestUtils.getPropertyValue(handler, "messageStore.groupIdToMessageGroup", Map.class).size())
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "messageStore.groupIdToMessageGroup").size())
 				.isEqualTo(0);
 	}
 
@@ -206,10 +207,10 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 
 		assertThat(outputMessages.size()).isEqualTo(1);
 
-		assertThat(TestUtils.getPropertyValue(handler, "messageStore.groupIdToMessageGroup", Map.class).size())
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "messageStore.groupIdToMessageGroup").size())
 				.isEqualTo(1);
 		groupStore.expireMessageGroups(0);
-		assertThat(TestUtils.getPropertyValue(handler, "messageStore.groupIdToMessageGroup", Map.class).size())
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "messageStore.groupIdToMessageGroup").size())
 				.isEqualTo(1);
 
 		handler.setMinimumTimeoutForEmptyGroups(10);
@@ -218,7 +219,7 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 
 		while (n++ < 200) {
 			groupStore.expireMessageGroups(0);
-			if (TestUtils.getPropertyValue(handler, "messageStore.groupIdToMessageGroup", Map.class).size() > 0) {
+			if (!TestUtils.<Map<?, ?>>getPropertyValue(handler, "messageStore.groupIdToMessageGroup").isEmpty()) {
 				Thread.sleep(50);
 			}
 			else {
@@ -227,7 +228,7 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 		}
 
 		assertThat(n < 200).isTrue();
-		assertThat(TestUtils.getPropertyValue(handler, "messageStore.groupIdToMessageGroup", Map.class).size())
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "messageStore.groupIdToMessageGroup").size())
 				.isEqualTo(0);
 	}
 
@@ -238,7 +239,7 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 		handler.setReleaseStrategy(group -> true);
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
-		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
+		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore");
 		Method forceComplete =
 				AbstractCorrelatingMessageHandler.class.getDeclaredMethod("forceComplete", MessageGroup.class);
 		forceComplete.setAccessible(true);
@@ -264,7 +265,7 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 		handler.setReleaseStrategy(group -> true);
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
-		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
+		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore");
 		mgs.addMessagesToGroup("foo", new GenericMessage<>("foo"));
 		mgs.completeGroup("foo");
 		mgs = spy(mgs);
@@ -272,7 +273,7 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 		Method forceComplete =
 				AbstractCorrelatingMessageHandler.class.getDeclaredMethod("forceComplete", MessageGroup.class);
 		forceComplete.setAccessible(true);
-		MessageGroup group = (MessageGroup) TestUtils.getPropertyValue(mgs, "groupIdToMessageGroup", Map.class)
+		MessageGroup group = (MessageGroup) TestUtils.<Map<?, ?>>getPropertyValue(mgs, "groupIdToMessageGroup")
 				.get("foo");
 		assertThat(group.isComplete()).isTrue();
 		forceComplete.invoke(handler, group);
@@ -290,7 +291,7 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 		handler.setReleaseStrategy(group -> true);
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
-		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
+		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore");
 		mgs.addMessagesToGroup("foo", new GenericMessage<>("foo"));
 		MessageGroup group = new SimpleMessageGroup(mgs.getMessageGroup("foo"));
 		mgs.completeGroup("foo");
@@ -299,7 +300,7 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 		Method forceComplete =
 				AbstractCorrelatingMessageHandler.class.getDeclaredMethod("forceComplete", MessageGroup.class);
 		forceComplete.setAccessible(true);
-		MessageGroup groupInStore = (MessageGroup) TestUtils.getPropertyValue(mgs, "groupIdToMessageGroup", Map.class)
+		MessageGroup groupInStore = (MessageGroup) TestUtils.<Map<?, ?>>getPropertyValue(mgs, "groupIdToMessageGroup")
 				.get("foo");
 		assertThat(groupInStore.isComplete()).isTrue();
 		assertThat(group.isComplete()).isFalse();
@@ -319,7 +320,7 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 		handler.setReleaseStrategy(group -> true);
 		QueueChannel outputChannel = new QueueChannel();
 		handler.setOutputChannel(outputChannel);
-		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
+		MessageGroupStore mgs = TestUtils.getPropertyValue(handler, "messageStore");
 		mgs.addMessagesToGroup("foo", new GenericMessage<>("foo"));
 		MessageGroup group = new SimpleMessageGroup(mgs.getMessageGroup("foo"));
 		mgs = spy(mgs);
@@ -327,7 +328,7 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 		Method forceComplete =
 				AbstractCorrelatingMessageHandler.class.getDeclaredMethod("forceComplete", MessageGroup.class);
 		forceComplete.setAccessible(true);
-		MessageGroup groupInStore = (MessageGroup) TestUtils.getPropertyValue(mgs, "groupIdToMessageGroup", Map.class)
+		MessageGroup groupInStore = (MessageGroup) TestUtils.<Map<?, ?>>getPropertyValue(mgs, "groupIdToMessageGroup")
 				.get("foo");
 		assertThat(groupInStore.isComplete()).isFalse();
 		assertThat(group.isComplete()).isFalse();
@@ -418,20 +419,20 @@ public class AbstractCorrelatingMessageHandlerTests implements TestApplicationCo
 
 		assertThat(outputMessages.size()).isEqualTo(1);
 
-		assertThat(TestUtils.getPropertyValue(handler, "messageStore.groupIdToMessageGroup", Map.class).size())
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "messageStore.groupIdToMessageGroup").size())
 				.isEqualTo(1);
 
 		Thread.sleep(100);
 
 		int n = 0;
 
-		while (TestUtils.getPropertyValue(handler, "messageStore.groupIdToMessageGroup", Map.class).size() > 0
+		while (!TestUtils.<Map<?, ?>>getPropertyValue(handler, "messageStore.groupIdToMessageGroup").isEmpty()
 				&& n++ < 200) {
 			Thread.sleep(50);
 		}
 
 		assertThat(n < 200).isTrue();
-		assertThat(TestUtils.getPropertyValue(handler, "messageStore.groupIdToMessageGroup", Map.class).size())
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "messageStore.groupIdToMessageGroup").size())
 				.isEqualTo(0);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/AggregatorTests.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Iwein Fuld
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class AggregatorTests  implements TestApplicationContextAware {
 
@@ -557,7 +558,7 @@ public class AggregatorTests  implements TestApplicationContextAware {
 	}
 
 	private void checkLock(AbstractCorrelatingMessageHandler handler, String group, boolean expectedHeld) {
-		ReentrantLock lock = (ReentrantLock) TestUtils.getPropertyValue(handler, "lockRegistry", LockRegistry.class)
+		ReentrantLock lock = (ReentrantLock) TestUtils.<LockRegistry<?>>getPropertyValue(handler, "lockRegistry")
 				.obtain(UUIDConverter.getUUID(group).toString());
 		assertThat(lock.isHeldByCurrentThread()).isEqualTo(expectedHeld);
 	}
@@ -570,7 +571,7 @@ public class AggregatorTests  implements TestApplicationContextAware {
 
 		@Override
 		public Object processMessageGroup(MessageGroup group) {
-			Integer product = 1;
+			int product = 1;
 			for (Message<?> message : group.getMessages()) {
 				product *= (Integer) message.getPayload();
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/AggregatorIntegrationTests.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -145,8 +146,7 @@ public class AggregatorIntegrationTests {
 			this.groupTimeoutAggregatorInput.send(new GenericMessage<>(i, headers));
 
 			//Wait until 'group-timeout' does its stuff.
-			MessageGroupStore mgs = TestUtils.getPropertyValue(this.context.getBean("gta.handler"), "messageStore",
-					MessageGroupStore.class);
+			MessageGroupStore mgs = TestUtils.getPropertyValue(this.context.getBean("gta.handler"), "messageStore");
 			int n = 0;
 			while (n++ < 100 && mgs.getMessageGroupCount() > 0) {
 				Thread.sleep(100);
@@ -167,13 +167,12 @@ public class AggregatorIntegrationTests {
 		this.groupTimeoutAggregatorInput.send(new GenericMessage<>(1, headers));
 
 		//Wait until 'group-timeout' does its stuff.
-		MessageGroupStore mgs = TestUtils.getPropertyValue(this.context.getBean("gta.handler"), "messageStore",
-				MessageGroupStore.class);
+		MessageGroupStore mgs = TestUtils.getPropertyValue(this.context.getBean("gta.handler"), "messageStore");
 		int n = 0;
 		while (n++ < 100 && mgs.getMessageGroupCount() > 0) {
 			Thread.sleep(100);
 			if (n == 10) {
-				TestUtils.getPropertyValue(this.output, "queue", Queue.class).clear();
+				TestUtils.<Queue<?>>getPropertyValue(this.output, "queue").clear();
 			}
 		}
 		assertThat(n < 100).as("Group did not complete").isTrue();

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/ResequencerIntegrationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/integration/ResequencerIntegrationTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author David Liu
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -51,8 +52,8 @@ public class ResequencerIntegrationTests {
 		MessageChannel inputChannel = context.getBean("resequencerLightInput", MessageChannel.class);
 		QueueChannel outputChannel = context.getBean("outputChannel", QueueChannel.class);
 		EventDrivenConsumer edc = context.getBean("resequencerLight", EventDrivenConsumer.class);
-		ResequencingMessageHandler handler = TestUtils.getPropertyValue(edc, "handler", ResequencingMessageHandler.class);
-		MessageGroupStore store = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
+		ResequencingMessageHandler handler = TestUtils.getPropertyValue(edc, "handler");
+		MessageGroupStore store = TestUtils.getPropertyValue(handler, "messageStore");
 
 		Message<?> message1 = MessageBuilder.withPayload("1").setCorrelationId("A").setSequenceNumber(1).build();
 		Message<?> message2 = MessageBuilder.withPayload("2").setCorrelationId("A").setSequenceNumber(2)
@@ -116,8 +117,8 @@ public class ResequencerIntegrationTests {
 		MessageChannel inputChannel = context.getBean("resequencerDeepInput", MessageChannel.class);
 		QueueChannel outputChannel = context.getBean("outputChannel", QueueChannel.class);
 		EventDrivenConsumer edc = context.getBean("resequencerDeep", EventDrivenConsumer.class);
-		ResequencingMessageHandler handler = TestUtils.getPropertyValue(edc, "handler", ResequencingMessageHandler.class);
-		MessageGroupStore store = TestUtils.getPropertyValue(handler, "messageStore", MessageGroupStore.class);
+		ResequencingMessageHandler handler = TestUtils.getPropertyValue(edc, "handler");
+		MessageGroupStore store = TestUtils.getPropertyValue(handler, "messageStore");
 
 		Message<?> message1 = MessageBuilder.withPayload("1").setCorrelationId("A").setSequenceNumber(1).build();
 		Message<?> message2 = MessageBuilder.withPayload("2").setCorrelationId("A").setSequenceNumber(2).build();

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/DatatypeChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/DatatypeChannelTests.java
@@ -52,6 +52,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 2.0
  */
 public class DatatypeChannelTests {
@@ -135,7 +137,7 @@ public class DatatypeChannelTests {
 		context.refresh();
 
 		QueueChannel channel = context.getBean("testChannel", QueueChannel.class);
-		assertThat(TestUtils.getPropertyValue(channel, "messageConverter.conversionService"))
+		assertThat(TestUtils.<Object>getPropertyValue(channel, "messageConverter.conversionService"))
 				.isSameAs(context.getBean(ConversionService.class));
 		assertThat(channel.send(new GenericMessage<Boolean>(Boolean.TRUE))).isTrue();
 		assertThat(channel.receive().getPayload()).isEqualTo(1);

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/DirectChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/DirectChannelTests.java
@@ -50,13 +50,14 @@ import static org.mockito.Mockito.when;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 class DirectChannelTests {
 
 	@Test
 	void testSend() {
 		DirectChannel channel = new DirectChannel();
-		LogAccessor logger = spy(TestUtils.getPropertyValue(channel, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(channel, "logger"));
 		when(logger.isDebugEnabled()).thenReturn(true);
 		new DirectFieldAccessor(channel).setPropertyValue("logger", logger);
 		ThreadNameExtractingTestTarget target = new ThreadNameExtractingTestTarget();
@@ -179,26 +180,35 @@ class DirectChannelTests {
 		assertThat(context.containsBean("channelC")).isTrue();
 		assertThat(context.containsBean("channelD")).isTrue();
 		EventDrivenConsumer consumerA = context.getBean("serviceA", EventDrivenConsumer.class);
-		assertThat(TestUtils.getPropertyValue(consumerA, "inputChannel")).isEqualTo(context.getBean("channelA"));
-		assertThat(TestUtils.getPropertyValue(consumerA, "handler.outputChannelName")).isEqualTo("channelB");
+		assertThat(TestUtils.<Object>getPropertyValue(consumerA, "inputChannel"))
+				.isEqualTo(context.getBean("channelA"));
+		assertThat(TestUtils.<String>getPropertyValue(consumerA, "handler.outputChannelName"))
+				.isEqualTo("channelB");
 
 		EventDrivenConsumer consumerB = context.getBean("serviceB", EventDrivenConsumer.class);
-		assertThat(TestUtils.getPropertyValue(consumerB, "inputChannel")).isEqualTo(context.getBean("channelB"));
-		assertThat(TestUtils.getPropertyValue(consumerB, "handler.outputChannelName")).isEqualTo("channelC");
+		assertThat(TestUtils.<Object>getPropertyValue(consumerB, "inputChannel"))
+				.isEqualTo(context.getBean("channelB"));
+		assertThat(TestUtils.<String>getPropertyValue(consumerB, "handler.outputChannelName"))
+				.isEqualTo("channelC");
 
 		EventDrivenConsumer consumerC = context.getBean("serviceC", EventDrivenConsumer.class);
-		assertThat(TestUtils.getPropertyValue(consumerC, "inputChannel")).isEqualTo(context.getBean("channelC"));
-		assertThat(TestUtils.getPropertyValue(consumerC, "handler.outputChannelName")).isEqualTo("channelD");
+		assertThat(TestUtils.<Object>getPropertyValue(consumerC, "inputChannel"))
+				.isEqualTo(context.getBean("channelC"));
+		assertThat(TestUtils.<String>getPropertyValue(consumerC, "handler.outputChannelName"))
+				.isEqualTo("channelD");
 
 		EventDrivenConsumer consumerD = context.getBean("serviceD", EventDrivenConsumer.class);
-		assertThat(TestUtils.getPropertyValue(consumerD, "inputChannel")).isEqualTo(parentChannelA);
-		assertThat(TestUtils.getPropertyValue(consumerD, "handler.outputChannelName")).isEqualTo("parentChannelB");
+		assertThat(TestUtils.<Object>getPropertyValue(consumerD, "inputChannel"))
+				.isEqualTo(parentChannelA);
+		assertThat(TestUtils.<String>getPropertyValue(consumerD, "handler.outputChannelName"))
+				.isEqualTo("parentChannelB");
 
 		EventDrivenConsumer consumerE = context.getBean("serviceE", EventDrivenConsumer.class);
-		assertThat(TestUtils.getPropertyValue(consumerE, "inputChannel")).isEqualTo(parentChannelB);
+		assertThat(TestUtils.<Object>getPropertyValue(consumerE, "inputChannel"))
+				.isEqualTo(parentChannelB);
 
 		EventDrivenConsumer consumerF = context.getBean("serviceF", EventDrivenConsumer.class);
-		assertThat(TestUtils.getPropertyValue(consumerF, "inputChannel")).isEqualTo(channelEarly);
+		assertThat(TestUtils.<Object>getPropertyValue(consumerF, "inputChannel")).isEqualTo(channelEarly);
 
 		context.close();
 		parentContext.close();

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/PartitionedChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/PartitionedChannelTests.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 6.1
  */
@@ -135,7 +136,7 @@ public class PartitionedChannelTests {
 		String partitionForLastMessage = partitionedMessages.keySet().iterator().next();
 		assertThat(partitionForLastMessage).isIn(allocatedPartitions);
 
-		List<?> partitionExecutors = TestUtils.getPropertyValue(partitionedChannel, "dispatcher.executors", List.class);
+		List<?> partitionExecutors = TestUtils.getPropertyValue(partitionedChannel, "dispatcher.executors");
 		BlockingQueue<?> workQueue = ((ThreadPoolExecutor) partitionExecutors.get(0)).getQueue();
 
 		assertThat(workQueue).isInstanceOf(SynchronousQueue.class);
@@ -169,7 +170,7 @@ public class PartitionedChannelTests {
 		assertThat(strings).hasSize(1)
 				.allMatch(value -> value.startsWith("testChannel-partition-thread-"));
 
-		List<?> partitionExecutors = TestUtils.getPropertyValue(this.testChannel, "dispatcher.executors", List.class);
+		List<?> partitionExecutors = TestUtils.<List>getPropertyValue(this.testChannel, "dispatcher.executors");
 		BlockingQueue<?> workQueue = ((ThreadPoolExecutor) partitionExecutors.get(0)).getQueue();
 
 		assertThat(workQueue)

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/ChannelParserTests.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @see ChannelWithCustomQueueParserTests
  */
@@ -101,8 +102,9 @@ public class ChannelParserTests {
 	public void testExecutorChannel() {
 		MessageChannel channel = context.getBean("executorChannel", MessageChannel.class);
 		assertThat(channel).isInstanceOf(ExecutorChannel.class);
-		assertThat(TestUtils.getPropertyValue(channel, "messageConverter")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(channel, "messageConverter.conversionService")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(channel, "messageConverter")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(channel, "messageConverter.conversionService"))
+				.isNotNull();
 	}
 
 	@Test
@@ -111,8 +113,9 @@ public class ChannelParserTests {
 				"ChannelParserTests-no-converter-context.xml", this.getClass());
 		MessageChannel channel = context.getBean("executorChannel", MessageChannel.class);
 		assertThat(channel).isInstanceOf(ExecutorChannel.class);
-		assertThat(TestUtils.getPropertyValue(channel, "messageConverter")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(channel, "messageConverter.conversionService")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(channel, "messageConverter")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(channel, "messageConverter.conversionService"))
+				.isNotNull();
 		context.close();
 	}
 
@@ -185,9 +188,10 @@ public class ChannelParserTests {
 		assertThat(channel.send(new GenericMessage<>(123))).isTrue();
 		assertThat(channel.send(new GenericMessage<>(123.45))).isTrue();
 		assertThat(channel.send(new GenericMessage<>(Boolean.TRUE))).isTrue();
-		assertThat(TestUtils.getPropertyValue(channel, "messageConverter"))
+		assertThat(TestUtils.<Object>getPropertyValue(channel, "messageConverter"))
 				.isInstanceOf(DefaultDatatypeChannelMessageConverter.class);
-		assertThat(TestUtils.getPropertyValue(channel, "messageConverter.conversionService")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(channel, "messageConverter.conversionService"))
+				.isNotNull();
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/config/DispatchingChannelParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/config/DispatchingChannelParserTests.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.mock;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -140,8 +141,7 @@ public class DispatchingChannelParserTests {
 	@Test
 	public void loadBalancerRef() {
 		MessageChannel channel = channels.get("lbRefChannel");
-		LoadBalancingStrategy lbStrategy = TestUtils.getPropertyValue(channel, "dispatcher.loadBalancingStrategy",
-				LoadBalancingStrategy.class);
+		LoadBalancingStrategy lbStrategy = TestUtils.getPropertyValue(channel, "dispatcher.loadBalancingStrategy");
 		assertThat(lbStrategy).isInstanceOf(SampleLoadBalancingStrategy.class);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/FluxMessageChannelTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/FluxMessageChannelTests.java
@@ -57,6 +57,7 @@ import static org.awaitility.Awaitility.await;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -145,7 +146,7 @@ public class FluxMessageChannelTests {
 
 		await()
 				.atMost(Duration.ofSeconds(30))
-				.until(() -> TestUtils.getPropertyValue(flux, "sink.sink.done", Boolean.class));
+				.until(() -> TestUtils.<Boolean>getPropertyValue(flux, "sink.sink.done"));
 	}
 
 	@Test
@@ -163,7 +164,7 @@ public class FluxMessageChannelTests {
 		stepVerifier.verify();
 
 		Disposable.Composite upstreamSubscriptions =
-				TestUtils.getPropertyValue(messageChannel, "upstreamSubscriptions", Disposable.Composite.class);
+				TestUtils.<Disposable.Composite>getPropertyValue(messageChannel, "upstreamSubscriptions");
 		await().untilAsserted(() -> assertThat(upstreamSubscriptions.size()).isEqualTo(0));
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/registry/HeaderChannelRegistryTests.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0
  *
@@ -93,9 +94,9 @@ public class HeaderChannelRegistryTests implements TestApplicationContextAware {
 		assertThat(reply).isNotNull();
 		assertThat(reply.getPayload()).isEqualTo("echo:foo");
 		String stringReplyChannel = reply.getHeaders().get("stringReplyChannel", String.class);
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(registry, "channels", Map.class)
-						.get(stringReplyChannel), "expireAt", Long.class) - System.currentTimeMillis())
+		assertThat(TestUtils.<Long>getPropertyValue(
+				TestUtils.<Map<?, ?>>getPropertyValue(registry, "channels")
+						.get(stringReplyChannel), "expireAt") - System.currentTimeMillis())
 				.isLessThan(61000L);
 	}
 
@@ -108,9 +109,9 @@ public class HeaderChannelRegistryTests implements TestApplicationContextAware {
 		assertThat(reply).isNotNull();
 		assertThat(reply.getPayload()).isEqualTo("echo:ttl");
 		String stringReplyChannel = reply.getHeaders().get("stringReplyChannel", String.class);
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(registry, "channels", Map.class)
-						.get(stringReplyChannel), "expireAt", Long.class) - System.currentTimeMillis())
+		assertThat(TestUtils.<Long>getPropertyValue(
+				TestUtils.<Map<?, ?>>getPropertyValue(registry, "channels")
+						.get(stringReplyChannel), "expireAt") - System.currentTimeMillis())
 				.isGreaterThan(100000L);
 	}
 
@@ -126,18 +127,18 @@ public class HeaderChannelRegistryTests implements TestApplicationContextAware {
 		assertThat(reply).isNotNull();
 		assertThat(reply.getPayload()).isEqualTo("echo:ttl");
 		String stringReplyChannel = reply.getHeaders().get("stringReplyChannel", String.class);
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(registry, "channels", Map.class)
-						.get(stringReplyChannel), "expireAt", Long.class) - System.currentTimeMillis())
+		assertThat(TestUtils.<Long>getPropertyValue(
+				TestUtils.<Map<?, ?>>getPropertyValue(registry, "channels")
+						.get(stringReplyChannel), "expireAt") - System.currentTimeMillis())
 				.isGreaterThan(160000L).isLessThan(181000L);
 		// Now for Elvis...
 		reply = template.sendAndReceive(new GenericMessage<>("ttl"));
 		assertThat(reply).isNotNull();
 		assertThat(reply.getPayload()).isEqualTo("echo:ttl");
 		stringReplyChannel = reply.getHeaders().get("stringReplyChannel", String.class);
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(registry, "channels", Map.class)
-						.get(stringReplyChannel), "expireAt", Long.class) - System.currentTimeMillis())
+		assertThat(TestUtils.<Long>getPropertyValue(
+				TestUtils.<Map<?, ?>>getPropertyValue(registry, "channels")
+						.get(stringReplyChannel), "expireAt") - System.currentTimeMillis())
 				.isGreaterThan(220000L);
 	}
 
@@ -235,7 +236,7 @@ public class HeaderChannelRegistryTests implements TestApplicationContextAware {
 		registry.setTaskScheduler(new SimpleAsyncTaskScheduler());
 		MessageChannel channel = new DirectChannel();
 		String foo = (String) registry.channelToChannelName(channel);
-		Map<?, ?> map = TestUtils.getPropertyValue(registry, "channels", Map.class);
+		Map<?, ?> map = TestUtils.getPropertyValue(registry, "channels");
 		assertThat(map).hasSize(1);
 		assertThat(registry.channelNameToChannel(foo)).isSameAs(channel);
 		assertThat(map).hasSize(1);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/AggregatorParserTests.java
@@ -65,6 +65,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Artem Bilan
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -91,8 +92,8 @@ public class AggregatorParserTests {
 				.isEqualTo("123456789");
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		Object handler = context.getBean("aggregatorWithReference.handler");
-		assertThat(TestUtils.getPropertyValue(handler, "outputProcessor.messageBuilderFactory")).isSameAs(mbf);
-		assertThat(TestUtils.getPropertyValue(handler, "releaseLockBeforeSend", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "outputProcessor.messageBuilderFactory")).isSameAs(mbf);
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "releaseLockBeforeSend")).isTrue();
 	}
 
 	@Test
@@ -109,8 +110,8 @@ public class AggregatorParserTests {
 
 		assertThat(output.getQueueSize()).isEqualTo(3);
 		output.purge(null);
-		assertThat(TestUtils.getPropertyValue(context.getBean("aggregatorWithMGPReference.handler"),
-				"releaseLockBeforeSend", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(context.getBean("aggregatorWithMGPReference.handler"),
+				"releaseLockBeforeSend")).isFalse();
 	}
 
 	@Test
@@ -146,8 +147,8 @@ public class AggregatorParserTests {
 				.toString()).as("The aggregated message payload is not correct").isEqualTo("[123]");
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		Object handler = context.getBean("aggregatorWithExpressions.handler");
-		assertThat(TestUtils.getPropertyValue(handler, "outputProcessor.messageBuilderFactory")).isSameAs(mbf);
-		assertThat(TestUtils.getPropertyValue(handler, "expireGroupsUponTimeout", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "outputProcessor.messageBuilderFactory")).isSameAs(mbf);
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "expireGroupsUponTimeout")).isTrue();
 	}
 
 	@Test
@@ -178,26 +179,27 @@ public class AggregatorParserTests {
 		assertThat(accessor.getPropertyValue("discardChannelName"))
 				.as("The AggregatorEndpoint is not injected with the appropriate discard channel")
 				.isEqualTo("discardChannel");
-		assertThat(TestUtils.getPropertyValue(consumer, "messagingTemplate.sendTimeout"))
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "messagingTemplate.sendTimeout"))
 				.as("The AggregatorEndpoint is not set with the appropriate timeout value").isEqualTo(86420000L);
 		assertThat(accessor.getPropertyValue("sendPartialResultOnExpiry"))
 				.as("The AggregatorEndpoint is not configured with the appropriate 'send partial results on timeout' " +
 						"flag")
 				.isEqualTo(true);
-		assertThat(TestUtils.getPropertyValue(consumer, "expireGroupsUponTimeout", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(consumer, "expireGroupsUponCompletion", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(consumer, "minimumTimeoutForEmptyGroups")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(consumer, "groupTimeoutExpression", Expression.class)
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "expireGroupsUponTimeout")).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "expireGroupsUponCompletion")).isTrue();
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "minimumTimeoutForEmptyGroups")).isEqualTo(123L);
+		assertThat(TestUtils.<Expression>getPropertyValue(consumer, "groupTimeoutExpression")
 				.getExpressionString()).isEqualTo("456");
-		assertThat(TestUtils.getPropertyValue(consumer, "lockRegistry"))
+		assertThat(TestUtils.<Object>getPropertyValue(consumer, "lockRegistry"))
 				.isSameAs(this.context.getBean(LockRegistry.class));
-		assertThat(TestUtils.getPropertyValue(consumer, "taskScheduler")).isSameAs(this.context.getBean("scheduler"));
-		assertThat(TestUtils.getPropertyValue(consumer, "messageStore")).isSameAs(this.context.getBean("store"));
-		assertThat(TestUtils.getPropertyValue(consumer, "order")).isEqualTo(5);
-		assertThat(TestUtils.getPropertyValue(consumer, "forceReleaseAdviceChain")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(consumer, "popSequence", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(consumer, "expireTimeout")).isEqualTo(250L);
-		assertThat(TestUtils.getPropertyValue(consumer, "expireDuration", Duration.class))
+		assertThat(TestUtils.<Object>getPropertyValue(consumer, "taskScheduler"))
+				.isSameAs(this.context.getBean("scheduler"));
+		assertThat(TestUtils.<Object>getPropertyValue(consumer, "messageStore")).isSameAs(this.context.getBean("store"));
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "order")).isEqualTo(5);
+		assertThat(TestUtils.<Object>getPropertyValue(consumer, "forceReleaseAdviceChain")).isNotNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "popSequence")).isFalse();
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "expireTimeout")).isEqualTo(250L);
+		assertThat(TestUtils.<Duration>getPropertyValue(consumer, "expireDuration"))
 				.isEqualTo(Duration.ofSeconds(10));
 	}
 
@@ -214,7 +216,8 @@ public class AggregatorParserTests {
 		assertThat(response.getPayload()).isEqualTo(6L);
 		Object mbf = context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
 		Object handler = context.getBean("aggregatorWithReferenceAndMethod.handler");
-		assertThat(TestUtils.getPropertyValue(handler, "outputProcessor.messageBuilderFactory")).isSameAs(mbf);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "outputProcessor.messageBuilderFactory"))
+				.isSameAs(mbf);
 	}
 
 	@Test
@@ -235,12 +238,12 @@ public class AggregatorParserTests {
 	@Test
 	public void testAggregatorWithPojoReleaseStrategy() {
 		MessageChannel input = this.context.getBean("aggregatorWithPojoReleaseStrategyInput", MessageChannel.class);
-		EventDrivenConsumer endpoint = this.context.getBean("aggregatorWithPojoReleaseStrategy", EventDrivenConsumer.class);
-		ReleaseStrategy releaseStrategy =
-				TestUtils.getPropertyValue(endpoint, "handler.releaseStrategy", ReleaseStrategy.class);
+		EventDrivenConsumer endpoint =
+				this.context.getBean("aggregatorWithPojoReleaseStrategy", EventDrivenConsumer.class);
+		ReleaseStrategy releaseStrategy = TestUtils.getPropertyValue(endpoint, "handler.releaseStrategy");
 		assertThat(releaseStrategy instanceof MethodInvokingReleaseStrategy).isTrue();
 		MessagingMethodInvokerHelper methodInvokerHelper =
-				TestUtils.getPropertyValue(releaseStrategy, "adapter.delegate", MessagingMethodInvokerHelper.class);
+				TestUtils.getPropertyValue(releaseStrategy, "adapter.delegate");
 		Object handlerMethods = TestUtils.getPropertyValue(methodInvokerHelper, "handlerMethods");
 		assertThat(handlerMethods).isNotNull();
 		Object handlerMethod = TestUtils.getPropertyValue(methodInvokerHelper, "handlerMethod");
@@ -260,12 +263,14 @@ public class AggregatorParserTests {
 	@Test // see INT-2011
 	public void testAggregatorWithPojoReleaseStrategyAsCollection() {
 		MessageChannel input = (MessageChannel) context.getBean("aggregatorWithPojoReleaseStrategyInputAsCollection");
-		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("aggregatorWithPojoReleaseStrategyAsCollection");
+		EventDrivenConsumer endpoint = (EventDrivenConsumer)
+				context.getBean("aggregatorWithPojoReleaseStrategyAsCollection");
 		ReleaseStrategy releaseStrategy = (ReleaseStrategy) new DirectFieldAccessor(new DirectFieldAccessor(endpoint)
 				.getPropertyValue("handler")).getPropertyValue("releaseStrategy");
 		assertThat(releaseStrategy instanceof MethodInvokingReleaseStrategy).isTrue();
-		DirectFieldAccessor releaseStrategyAccessor = new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(releaseStrategy)
-				.getPropertyValue("adapter")).getPropertyValue("delegate"));
+		DirectFieldAccessor releaseStrategyAccessor =
+				new DirectFieldAccessor(new DirectFieldAccessor(new DirectFieldAccessor(releaseStrategy)
+						.getPropertyValue("adapter")).getPropertyValue("delegate"));
 		Object handlerMethods = releaseStrategyAccessor.getPropertyValue("handlerMethods");
 		assertThat(handlerMethods).isNotNull();
 		Object handlerMethod = releaseStrategyAccessor.getPropertyValue("handlerMethod");
@@ -291,16 +296,20 @@ public class AggregatorParserTests {
 
 	@Test
 	public void testAggregationWithExpressionsAndPojoAggregator() {
-		EventDrivenConsumer aggregatorConsumer = (EventDrivenConsumer) context.getBean("aggregatorWithExpressionsAndPojoAggregator");
-		AggregatingMessageHandler aggregatingMessageHandler = (AggregatingMessageHandler) TestUtils.getPropertyValue(aggregatorConsumer, "handler");
-		MethodInvokingMessageGroupProcessor messageGroupProcessor = (MethodInvokingMessageGroupProcessor) TestUtils.getPropertyValue(aggregatingMessageHandler, "outputProcessor");
+		EventDrivenConsumer aggregatorConsumer = context.getBean("aggregatorWithExpressionsAndPojoAggregator",
+				EventDrivenConsumer.class);
+		AggregatingMessageHandler aggregatingMessageHandler =
+				TestUtils.getPropertyValue(aggregatorConsumer, "handler");
+		MethodInvokingMessageGroupProcessor messageGroupProcessor =
+				TestUtils.getPropertyValue(aggregatingMessageHandler, "outputProcessor");
 		Object messageGroupProcessorTargetObject = TestUtils.getPropertyValue(messageGroupProcessor, "processor" +
 				".delegate.targetObject");
 		assertThat(messageGroupProcessorTargetObject).isSameAs(context.getBean("aggregatorBean"));
-		ReleaseStrategy releaseStrategy = (ReleaseStrategy) TestUtils.getPropertyValue(aggregatingMessageHandler, "releaseStrategy");
-		CorrelationStrategy correlationStrategy = (CorrelationStrategy) TestUtils.getPropertyValue(aggregatingMessageHandler, "correlationStrategy");
-		Long minimumTimeoutForEmptyGroups = TestUtils.getPropertyValue(aggregatingMessageHandler,
-				"minimumTimeoutForEmptyGroups", Long.class);
+		ReleaseStrategy releaseStrategy = TestUtils.getPropertyValue(aggregatingMessageHandler, "releaseStrategy");
+		CorrelationStrategy correlationStrategy =
+				TestUtils.getPropertyValue(aggregatingMessageHandler, "correlationStrategy");
+		Long minimumTimeoutForEmptyGroups =
+				TestUtils.getPropertyValue(aggregatingMessageHandler, "minimumTimeoutForEmptyGroups");
 
 		assertThat(ExpressionEvaluatingReleaseStrategy.class.equals(releaseStrategy.getClass())).isTrue();
 		assertThat(ExpressionEvaluatingCorrelationStrategy.class.equals(correlationStrategy.getClass())).isTrue();

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelAdapterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelAdapterParserTests.java
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -223,7 +224,7 @@ public class ChannelAdapterParserTests {
 		SourcePollingChannelAdapter adapter =
 				this.applicationContext.getBean("methodInvokingSourceWithTimeout", SourcePollingChannelAdapter.class);
 		assertThat(adapter).isNotNull();
-		long sendTimeout = TestUtils.getPropertyValue(adapter, "messagingTemplate.sendTimeout", Long.class);
+		long sendTimeout = TestUtils.<Long>getPropertyValue(adapter, "messagingTemplate.sendTimeout");
 		assertThat(sendTimeout).isEqualTo(999);
 	}
 
@@ -262,7 +263,7 @@ public class ChannelAdapterParserTests {
 		MessageSource<?> testMessageSource = this.applicationContext.getBean("testMessageSource", MessageSource.class);
 		SourcePollingChannelAdapter adapterWithMessageSourceRef =
 				this.applicationContext.getBean("adapterWithMessageSourceRef", SourcePollingChannelAdapter.class);
-		MessageSource<?> source = TestUtils.getPropertyValue(adapterWithMessageSourceRef, "source", MessageSource.class);
+		MessageSource<?> source = TestUtils.getPropertyValue(adapterWithMessageSourceRef, "source");
 		assertThat(source).isSameAs(testMessageSource);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelWithMessageStoreParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ChannelWithMessageStoreParserTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Dave Syer
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -86,7 +87,7 @@ public class ChannelWithMessageStoreParserTests {
 
 	@Test
 	public void testPriorityMessageStore() {
-		assertThat(TestUtils.getPropertyValue(this.priorityChannel, "queue.messageGroupStore"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.priorityChannel, "queue.messageGroupStore"))
 				.isSameAs(this.priorityMessageStore);
 		assertThat(this.priorityChannel).isInstanceOf(PriorityChannel.class);
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/FilterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/FilterParserTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -93,8 +94,8 @@ public class FilterParserTests {
 
 	@Test
 	public void adviseDiscard() {
-		assertThat(TestUtils.getPropertyValue(this.advised, "postProcessWithinAdvice", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.notAdvised, "postProcessWithinAdvice", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.advised, "postProcessWithinAdvice")).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.notAdvised, "postProcessWithinAdvice")).isTrue();
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/IdGeneratorConfigurerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/IdGeneratorConfigurerTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0
  *
@@ -59,7 +60,7 @@ public class IdGeneratorConfigurerTests {
 		UUID id = headers.getId();
 		assertThat(id.getMostSignificantBits()).isNotEqualTo(1);
 		assertThat(id.getLeastSignificantBits()).isNotEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(headers, "idGenerator")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(headers, "idGenerator")).isNull();
 	}
 
 	@Test
@@ -73,7 +74,7 @@ public class IdGeneratorConfigurerTests {
 
 			// multiple beans are ignored with warning
 			MessageHeaders headers = new MessageHeaders(null);
-			assertThat(TestUtils.getPropertyValue(headers, "idGenerator")).isNull();
+			assertThat(TestUtils.<Object>getPropertyValue(headers, "idGenerator")).isNull();
 		}
 	}
 
@@ -85,7 +86,7 @@ public class IdGeneratorConfigurerTests {
 			context.refresh();
 
 			MessageHeaders headers = new MessageHeaders(null);
-			assertThat(TestUtils.getPropertyValue(headers, "idGenerator")).isNull();
+			assertThat(TestUtils.<Object>getPropertyValue(headers, "idGenerator")).isNull();
 		}
 	}
 
@@ -115,7 +116,7 @@ public class IdGeneratorConfigurerTests {
 		assertThat(id.getMostSignificantBits()).isNotEqualTo(1);
 		assertThat(id.getLeastSignificantBits()).isNotEqualTo(2);
 
-		assertThat(TestUtils.getPropertyValue(headers, "idGenerator")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(headers, "idGenerator")).isNull();
 	}
 
 	@Test
@@ -150,7 +151,7 @@ public class IdGeneratorConfigurerTests {
 		assertThat(id.getMostSignificantBits()).isNotEqualTo(1);
 		assertThat(id.getLeastSignificantBits()).isNotEqualTo(2);
 
-		assertThat(TestUtils.getPropertyValue(headers, "idGenerator")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(headers, "idGenerator")).isNull();
 	}
 
 	@Test
@@ -183,7 +184,8 @@ public class IdGeneratorConfigurerTests {
 			context.registerBeanDefinition("foo", new RootBeanDefinition(JdkIdGenerator.class));
 			context.refresh();
 			MessageHeaders headers = new MessageHeaders(null);
-			assertThat(TestUtils.getPropertyValue(headers, "idGenerator")).isSameAs(context.getBean(IdGenerator.class));
+			assertThat(TestUtils.<Object>getPropertyValue(headers, "idGenerator"))
+					.isSameAs(context.getBean(IdGenerator.class));
 		}
 	}
 
@@ -201,7 +203,7 @@ public class IdGeneratorConfigurerTests {
 			headers = new MessageHeaders(null);
 			assertThat(headers.getId().getMostSignificantBits()).isEqualTo(0);
 			assertThat(headers.getId().getLeastSignificantBits()).isEqualTo(2);
-			AtomicLong bottomBits = TestUtils.getPropertyValue(idGenerator, "bottomBits", AtomicLong.class);
+			AtomicLong bottomBits = TestUtils.getPropertyValue(idGenerator, "bottomBits");
 			bottomBits.set(0xffffffff);
 			headers = new MessageHeaders(null);
 			assertThat(headers.getId().getMostSignificantBits()).isEqualTo(1);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ReleaseStrategyFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ReleaseStrategyFactoryBeanTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.fail;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0.2
  */
@@ -57,27 +58,29 @@ public class ReleaseStrategyFactoryBeanTests {
 
 	@Test
 	public void testRefWithMethodWithDifferentAnnotatedMethod() throws Exception {
-		Bar bar = new Bar();
+		ReleaseStrategyTest bar = new ReleaseStrategyTest();
 		ReleaseStrategyFactoryBean factory = new ReleaseStrategyFactoryBean();
 		factory.setTarget(bar);
 		factory.setMethodName("doRelease2");
 		factory.afterPropertiesSet();
 		ReleaseStrategy delegate = factory.getObject();
 		assertThat(delegate).isInstanceOf(MethodInvokingReleaseStrategy.class);
-		assertThat(TestUtils.getPropertyValue(delegate, "adapter.delegate.targetObject", Bar.class)).isEqualTo(bar);
-		assertThat(TestUtils.getPropertyValue(delegate, "adapter.delegate.handlerMethod.expressionString"))
+		assertThat(TestUtils.<ReleaseStrategyTest>getPropertyValue(delegate, "adapter.delegate.targetObject"))
+				.isEqualTo(bar);
+		assertThat(TestUtils.<String>getPropertyValue(delegate, "adapter.delegate.handlerMethod.expressionString"))
 				.isEqualTo("#target.doRelease2(messages)");
 	}
 
 	@Test
 	public void testRefWithNoMethodWithAnnotation() throws Exception {
-		Bar bar = new Bar();
+		ReleaseStrategyTest bar = new ReleaseStrategyTest();
 		ReleaseStrategyFactoryBean factory = new ReleaseStrategyFactoryBean();
 		factory.setTarget(bar);
 		factory.afterPropertiesSet();
 		ReleaseStrategy delegate = factory.getObject();
 		assertThat(delegate).isInstanceOf(MethodInvokingReleaseStrategy.class);
-		assertThat(TestUtils.getPropertyValue(delegate, "adapter.delegate.targetObject", Bar.class)).isEqualTo(bar);
+		assertThat(TestUtils.<ReleaseStrategyTest>getPropertyValue(delegate, "adapter.delegate.targetObject"))
+				.isEqualTo(bar);
 	}
 
 	@Test
@@ -117,8 +120,8 @@ public class ReleaseStrategyFactoryBeanTests {
 		factory.afterPropertiesSet();
 		ReleaseStrategy delegate = factory.getObject();
 		assertThat(delegate).isInstanceOf(MethodInvokingReleaseStrategy.class);
-		assertThat(TestUtils.getPropertyValue(delegate, "adapter.delegate.targetObject", Baz.class)).isEqualTo(baz);
-		assertThat(TestUtils.getPropertyValue(delegate, "adapter.delegate.handlerMethod.expressionString"))
+		assertThat(TestUtils.<Baz>getPropertyValue(delegate, "adapter.delegate.targetObject")).isEqualTo(baz);
+		assertThat(TestUtils.<String>getPropertyValue(delegate, "adapter.delegate.handlerMethod.expressionString"))
 				.isEqualTo("#target.doRelease2(messages)");
 	}
 
@@ -130,7 +133,7 @@ public class ReleaseStrategyFactoryBeanTests {
 
 	}
 
-	public class Bar {
+	public class ReleaseStrategyTest {
 
 		@org.springframework.integration.annotation.ReleaseStrategy
 		public boolean doRelease(Collection<?> bar) {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/RouterFactoryBeanDelegationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/RouterFactoryBeanDelegationTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -56,7 +57,7 @@ public class RouterFactoryBeanDelegationTests {
 
 	@Test
 	public void checkResolutionRequiredConfiguredOnTargetRouter() {
-		boolean resolutionRequired = TestUtils.getPropertyValue(router, "resolutionRequired", Boolean.class);
+		boolean resolutionRequired = TestUtils.<Boolean>getPropertyValue(router, "resolutionRequired");
 		assertThat(resolutionRequired).as("The 'resolutionRequired' property should be 'true'").isTrue();
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/SelectorChainParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/SelectorChainParserTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -93,13 +94,12 @@ public class SelectorChainParserTests {
 		assertThat(chain4.accept(new GenericMessage<>("test4"))).isTrue();
 	}
 
-	@SuppressWarnings("unchecked")
 	private List<MessageSelector> getSelectors(MessageSelectorChain chain) {
-		return (List<MessageSelector>) TestUtils.getPropertyValue(chain, "selectors", List.class);
+		return TestUtils.getPropertyValue(chain, "selectors");
 	}
 
 	private VotingStrategy getStrategy(MessageSelectorChain chain) {
-		return TestUtils.getPropertyValue(chain, "votingStrategy", VotingStrategy.class);
+		return TestUtils.getPropertyValue(chain, "votingStrategy");
 	}
 
 	public static class StubPojoSelector {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBeanTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/SourcePollingChannelAdapterFactoryBeanTests.java
@@ -67,6 +67,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class SourcePollingChannelAdapterFactoryBeanTests {
 
@@ -166,7 +167,7 @@ public class SourcePollingChannelAdapterFactoryBeanTests {
 		pollingChannelAdapter.setTaskScheduler(taskScheduler);
 
 		MessagePublishingErrorHandler errorHandler = new MessagePublishingErrorHandler();
-		Log errorHandlerLogger = TestUtils.getPropertyValue(errorHandler, "logger", Log.class);
+		Log errorHandlerLogger = TestUtils.getPropertyValue(errorHandler, "logger");
 		errorHandlerLogger = spy(errorHandlerLogger);
 		DirectFieldAccessor dfa = new DirectFieldAccessor(errorHandler);
 		dfa.setPropertyValue("logger", errorHandlerLogger);
@@ -177,7 +178,7 @@ public class SourcePollingChannelAdapterFactoryBeanTests {
 		pollingChannelAdapter.setBeanFactory(mock(BeanFactory.class));
 		pollingChannelAdapter.afterPropertiesSet();
 
-		LogAccessor adapterLogger = TestUtils.getPropertyValue(pollingChannelAdapter, "logger", LogAccessor.class);
+		LogAccessor adapterLogger = TestUtils.getPropertyValue(pollingChannelAdapter, "logger");
 		adapterLogger = spy(adapterLogger);
 		when(adapterLogger.isDebugEnabled()).thenReturn(true);
 
@@ -239,7 +240,7 @@ public class SourcePollingChannelAdapterFactoryBeanTests {
 		pollingChannelAdapter.setOutputChannel(outputChannel);
 		pollingChannelAdapter.setBeanFactory(mock(BeanFactory.class));
 
-		LogAccessor logger = spy(TestUtils.getPropertyValue(pollingChannelAdapter, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(pollingChannelAdapter, "logger"));
 		new DirectFieldAccessor(pollingChannelAdapter).setPropertyValue("logger", logger);
 
 		CountDownLatch logCalledLatch = new CountDownLatch(1);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/WireTapParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/WireTapParserTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -76,7 +77,8 @@ public class WireTapParserTests {
 
 	@Test
 	public void simpleWireTapWithIdAndSelectorExpression() {
-		assertThat(TestUtils.getPropertyValue(wireTap, "selector")).isInstanceOf(ExpressionEvaluatingSelector.class);
+		assertThat(TestUtils.<Object>getPropertyValue(wireTap, "selector"))
+				.isInstanceOf(ExpressionEvaluatingSelector.class);
 		Message<?> original = new GenericMessage<>("test");
 		withId.send(original);
 		Message<?> intercepted = wireTapChannel.receive(0);
@@ -109,7 +111,7 @@ public class WireTapParserTests {
 		int expectedTimeoutCount = 0;
 		int otherTimeoutCount = 0;
 		for (WireTap wireTap : wireTaps) {
-			long timeout = TestUtils.getPropertyValue(wireTap, "timeout", Long.class);
+			long timeout = TestUtils.<Long>getPropertyValue(wireTap, "timeout");
 			if (timeout == 0) {
 				defaultTimeoutCount++;
 			}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AggregatorAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/AggregatorAnnotationTests.java
@@ -32,13 +32,13 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageHandler;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.integration.test.util.TestUtils.getPropertyValue;
 
 /**
  * @author Marius Bogoevici
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 public class AggregatorAnnotationTests {
 
@@ -48,11 +48,11 @@ public class AggregatorAnnotationTests {
 				new String[] {"classpath:/org/springframework/integration/config/annotation/testAnnotatedAggregator.xml"});
 		final String endpointName = "endpointWithDefaultAnnotation";
 		MessageHandler aggregator = this.getAggregator(context, endpointName);
-		assertThat(getPropertyValue(aggregator, "releaseStrategy") instanceof SimpleSequenceSizeReleaseStrategy)
-				.isTrue();
-		assertThat(getPropertyValue(aggregator, "outputChannel")).isNull();
-		assertThat(getPropertyValue(aggregator, "messagingTemplate.sendTimeout")).isEqualTo(45000L);
-		assertThat(getPropertyValue(aggregator, "sendPartialResultOnExpiry")).isEqualTo(false);
+		assertThat(TestUtils.<SimpleSequenceSizeReleaseStrategy>getPropertyValue(aggregator,
+				"releaseStrategy")).isInstanceOf(SimpleSequenceSizeReleaseStrategy.class);
+		assertThat(TestUtils.<Object>getPropertyValue(aggregator, "outputChannel")).isNull();
+		assertThat(TestUtils.<Long>getPropertyValue(aggregator, "messagingTemplate.sendTimeout")).isEqualTo(45000L);
+		assertThat(TestUtils.<Boolean>getPropertyValue(aggregator, "sendPartialResultOnExpiry")).isEqualTo(false);
 		context.close();
 	}
 
@@ -62,12 +62,12 @@ public class AggregatorAnnotationTests {
 				new String[] {"classpath:/org/springframework/integration/config/annotation/testAnnotatedAggregator.xml"});
 		final String endpointName = "endpointWithCustomizedAnnotation";
 		MessageHandler aggregator = this.getAggregator(context, endpointName);
-		assertThat(getPropertyValue(aggregator, "releaseStrategy") instanceof SimpleSequenceSizeReleaseStrategy)
-				.isTrue();
-		assertThat(getPropertyValue(aggregator, "outputChannelName")).isEqualTo("outputChannel");
-		assertThat(getPropertyValue(aggregator, "discardChannelName")).isEqualTo("discardChannel");
-		assertThat(getPropertyValue(aggregator, "messagingTemplate.sendTimeout")).isEqualTo(98765432L);
-		assertThat(getPropertyValue(aggregator, "sendPartialResultOnExpiry")).isEqualTo(true);
+		assertThat(TestUtils.<SimpleSequenceSizeReleaseStrategy>getPropertyValue(aggregator, "releaseStrategy"))
+				.isInstanceOf(SimpleSequenceSizeReleaseStrategy.class);
+		assertThat(TestUtils.<String>getPropertyValue(aggregator, "outputChannelName")).isEqualTo("outputChannel");
+		assertThat(TestUtils.<String>getPropertyValue(aggregator, "discardChannelName")).isEqualTo("discardChannel");
+		assertThat(TestUtils.<Long>getPropertyValue(aggregator, "messagingTemplate.sendTimeout")).isEqualTo(98765432L);
+		assertThat(TestUtils.<Boolean>getPropertyValue(aggregator, "sendPartialResultOnExpiry")).isEqualTo(true);
 		context.close();
 	}
 
@@ -77,7 +77,7 @@ public class AggregatorAnnotationTests {
 				new String[] {"classpath:/org/springframework/integration/config/annotation/testAnnotatedAggregator.xml"});
 		final String endpointName = "endpointWithDefaultAnnotationAndCustomReleaseStrategy";
 		MessageHandler aggregator = this.getAggregator(context, endpointName);
-		Object releaseStrategy = getPropertyValue(aggregator, "releaseStrategy");
+		Object releaseStrategy = TestUtils.getPropertyValue(aggregator, "releaseStrategy");
 		assertThat(releaseStrategy instanceof MethodInvokingReleaseStrategy).isTrue();
 		MethodInvokingReleaseStrategy releaseStrategyAdapter = (MethodInvokingReleaseStrategy) releaseStrategy;
 		Object handlerMethods = new DirectFieldAccessor(releaseStrategyAdapter)
@@ -95,7 +95,7 @@ public class AggregatorAnnotationTests {
 				new String[] {"classpath:/org/springframework/integration/config/annotation/testAnnotatedAggregator.xml"});
 		final String endpointName = "endpointWithCorrelationStrategy";
 		MessageHandler aggregator = this.getAggregator(context, endpointName);
-		Object correlationStrategy = getPropertyValue(aggregator, "correlationStrategy");
+		Object correlationStrategy = TestUtils.getPropertyValue(aggregator, "correlationStrategy");
 		assertThat(correlationStrategy instanceof MethodInvokingCorrelationStrategy).isTrue();
 		MethodInvokingCorrelationStrategy releaseStrategyAdapter = (MethodInvokingCorrelationStrategy) correlationStrategy;
 		DirectFieldAccessor processorAccessor =
@@ -114,7 +114,7 @@ public class AggregatorAnnotationTests {
 	private MessageHandler getAggregator(ApplicationContext context, final String endpointName) {
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean(endpointName
 				+ ".aggregatingMethod.aggregator");
-		return TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class);
+		return TestUtils.<MessageHandler>getPropertyValue(endpoint, "handler");
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/CustomMessagingAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/CustomMessagingAnnotationTests.java
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.verify;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.3.8
  */
@@ -78,7 +79,7 @@ public class CustomMessagingAnnotationTests {
 	public void testLogAnnotation() {
 		assertThat(this.loggingHandler).isNotNull();
 
-		LogAccessor log = spy(TestUtils.getPropertyValue(this.loggingHandler, "messageLogger", LogAccessor.class));
+		LogAccessor log = spy(TestUtils.<LogAccessor>getPropertyValue(this.loggingHandler, "messageLogger"));
 
 		given(log.isWarnEnabled())
 				.willReturn(true);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.mock;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -78,12 +79,11 @@ public class FilterAnnotationPostProcessorTests {
 		TestUtils.registerBean("adviceChain", advice, this.context);
 		testValidFilter(new TestFilterWithAdviceDiscardWithin());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class).get(0)).isSameAs(advice);
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.postProcessWithinAdvice", Boolean.class)).isTrue();
+		assertThat(TestUtils.<List<?>>getPropertyValue(endpoint, "handler.adviceChain").get(0)).isSameAs(advice);
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "handler.postProcessWithinAdvice")).isTrue();
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void filterAnnotationWithAdviceDiscardWithinTwice() {
 		TestAdvice advice1 = new TestAdvice();
 		TestAdvice advice2 = new TestAdvice();
@@ -91,10 +91,10 @@ public class FilterAnnotationPostProcessorTests {
 		TestUtils.registerBean("adviceChain2", advice2, this.context);
 		testValidFilter(new TestFilterWithAdviceDiscardWithinTwice());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
-		List<TestAdvice> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class);
+		List<TestAdvice> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain");
 		assertThat(adviceList).hasSize(2)
 				.containsExactly(advice1, advice2);
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.postProcessWithinAdvice", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "handler.postProcessWithinAdvice")).isTrue();
 	}
 
 	@Test
@@ -103,8 +103,8 @@ public class FilterAnnotationPostProcessorTests {
 		TestUtils.registerBean("adviceChain", advice, this.context);
 		testValidFilter(new TestFilterWithAdviceDiscardWithout());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class).get(0)).isSameAs(advice);
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.postProcessWithinAdvice", Boolean.class)).isFalse();
+		assertThat(TestUtils.<List<?>>getPropertyValue(endpoint, "handler.adviceChain").get(0)).isSameAs(advice);
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "handler.postProcessWithinAdvice")).isFalse();
 	}
 
 	@Test
@@ -113,12 +113,11 @@ public class FilterAnnotationPostProcessorTests {
 		TestUtils.registerBean("adviceChain", new TestAdvice[] {advice}, this.context);
 		testValidFilter(new TestFilterWithAdviceDiscardWithin());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class).get(0)).isSameAs(advice);
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.postProcessWithinAdvice", Boolean.class)).isTrue();
+		assertThat(TestUtils.<List<?>>getPropertyValue(endpoint, "handler.adviceChain").get(0)).isSameAs(advice);
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "handler.postProcessWithinAdvice")).isTrue();
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void filterAnnotationWithAdviceArrayTwice() {
 		TestAdvice advice1 = new TestAdvice();
 		TestAdvice advice2 = new TestAdvice();
@@ -128,10 +127,10 @@ public class FilterAnnotationPostProcessorTests {
 		TestUtils.registerBean("adviceChain2", new TestAdvice[] {advice3, advice4}, this.context);
 		testValidFilter(new TestFilterWithAdviceDiscardWithinTwice());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
-		List<TestAdvice> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class);
+		List<TestAdvice> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain");
 		assertThat(adviceList).hasSize(4)
 				.containsExactly(advice1, advice2, advice3, advice4);
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.postProcessWithinAdvice", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "handler.postProcessWithinAdvice")).isTrue();
 	}
 
 	@Test
@@ -140,12 +139,11 @@ public class FilterAnnotationPostProcessorTests {
 		TestUtils.registerBean("adviceChain", Collections.singletonList(advice), this.context);
 		testValidFilter(new TestFilterWithAdviceDiscardWithin());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class).get(0)).isSameAs(advice);
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.postProcessWithinAdvice", Boolean.class)).isTrue();
+		assertThat(TestUtils.<List<?>>getPropertyValue(endpoint, "handler.adviceChain").get(0)).isSameAs(advice);
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "handler.postProcessWithinAdvice")).isTrue();
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void filterAnnotationWithAdviceCollectionTwice() {
 		TestAdvice advice1 = new TestAdvice();
 		TestAdvice advice2 = new TestAdvice();
@@ -155,10 +153,10 @@ public class FilterAnnotationPostProcessorTests {
 		TestUtils.registerBean("adviceChain2", new TestAdvice[] {advice3, advice4}, this.context);
 		testValidFilter(new TestFilterWithAdviceDiscardWithinTwice());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("testFilter.filter.filter");
-		List<TestAdvice> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain", List.class);
+		List<TestAdvice> adviceList = TestUtils.getPropertyValue(endpoint, "handler.adviceChain");
 		assertThat(adviceList).hasSize(4)
 				.containsExactly(advice1, advice2, advice3, advice4);
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.postProcessWithinAdvice", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "handler.postProcessWithinAdvice")).isTrue();
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationsWithBeanAnnotationTests.java
@@ -97,6 +97,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Oleg Zhurakousky
+ * @author Glenn Renfro
  *
  * @since 4.0
  */
@@ -186,7 +187,8 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 			assertThat(messageHistory).isNotNull();
 			String messageHistoryString = messageHistory.toString();
 			assertThat(messageHistoryString)
-					.contains("routerChannel", "filterChannel", "aggregatorChannel", "splitterChannel", "serviceChannel")
+					.contains("routerChannel", "filterChannel", "aggregatorChannel",
+							"splitterChannel", "serviceChannel")
 					.doesNotContain("discardChannel");
 		}
 
@@ -262,10 +264,10 @@ public class MessagingAnnotationsWithBeanAnnotationTests {
 
 	@Test
 	public void outputChannelIsLazyLoaded() {
-		assertThat(TestUtils.getPropertyValue(this.objectToMapTransformerHandler, "outputChannelName"))
+		assertThat(TestUtils.<String>getPropertyValue(this.objectToMapTransformerHandler, "outputChannelName"))
 				.isEqualTo("lazilyCreatedChannel");
 
-		assertThat(TestUtils.getPropertyValue(this.objectToMapTransformerHandler, "outputChannel")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(this.objectToMapTransformerHandler, "outputChannel")).isNull();
 
 		assertThat(this.objectToMapTransformerHandler.getOutputChannel())
 				.isInstanceOf(DirectChannel.class)

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/BarrierParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/BarrierParserTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.2
  *
@@ -79,16 +80,16 @@ public class BarrierParserTests {
 
 	@Test
 	public void parserFieldPopulationTests() {
-		BarrierMessageHandler handler = TestUtils.getPropertyValue(this.barrier1, "handler",
-				BarrierMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "requestTimeout")).isEqualTo(10000L);
-		assertThat(TestUtils.getPropertyValue(handler, "triggerTimeout")).isEqualTo(5000L);
-		assertThat(TestUtils.getPropertyValue(handler, "requiresReply", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.barrier2, "handler.correlationStrategy"))
+		BarrierMessageHandler handler = TestUtils.getPropertyValue(this.barrier1, "handler");
+		assertThat(TestUtils.<Long>getPropertyValue(handler, "requestTimeout")).isEqualTo(10000L);
+		assertThat(TestUtils.<Long>getPropertyValue(handler, "triggerTimeout")).isEqualTo(5000L);
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "requiresReply")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(this.barrier2, "handler.correlationStrategy"))
 				.isInstanceOf(HeaderAttributeCorrelationStrategy.class);
-		assertThat(TestUtils.getPropertyValue(this.barrier3, "handler.messageGroupProcessor"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.barrier3, "handler.messageGroupProcessor"))
 				.isInstanceOf(TestMGP.class);
-		assertThat(TestUtils.getPropertyValue(this.barrier3, "handler.correlationStrategy")).isInstanceOf(TestCS.class);
+		assertThat(TestUtils.<Object>getPropertyValue(this.barrier3, "handler.correlationStrategy"))
+				.isInstanceOf(TestCS.class);
 		assertThat(this.discards).isSameAs(handler.getDiscardChannel());
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/BridgeParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/BridgeParserTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -105,7 +106,8 @@ public class BridgeParserTests {
 
 	@Test
 	public void bridgeWithSendTimeout() {
-		assertThat(TestUtils.getPropertyValue(bridgeWithSendTimeout, "handler.messagingTemplate.sendTimeout"))
+		assertThat(TestUtils.<Long>getPropertyValue(bridgeWithSendTimeout,
+				"handler.messagingTemplate.sendTimeout"))
 				.isEqualTo(1234L);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/CronTriggerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/CronTriggerParserTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -47,7 +48,7 @@ public class CronTriggerParserTests {
 		PollerMetadata metadata = (PollerMetadata) poller;
 		Trigger trigger = metadata.getTrigger();
 		assertThat(trigger.getClass()).isEqualTo(CronTrigger.class);
-		String expression = TestUtils.getPropertyValue(trigger, "expression.expression", String.class);
+		String expression = TestUtils.getPropertyValue(trigger, "expression.expression");
 		assertThat(expression).isEqualTo("*/10 * 9-17 * * MON-FRI");
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DefaultConfiguringBeanFactoryPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DefaultConfiguringBeanFactoryPostProcessorTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -66,14 +67,13 @@ public class DefaultConfiguringBeanFactoryPostProcessorTests {
 	public void taskSchedulerRegistered() {
 		Object taskScheduler = context.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME);
 		assertThat(taskScheduler.getClass()).isEqualTo(ThreadPoolTaskScheduler.class);
-		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler", ErrorHandler.class);
+		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler");
 		assertThat(errorHandler.getClass()).isEqualTo(MessagePublishingErrorHandler.class);
-		MessageChannel defaultErrorChannel = TestUtils.getPropertyValue(errorHandler,
-				"messagingTemplate.defaultDestination", MessageChannel.class);
+		MessageChannel defaultErrorChannel =
+				TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNull();
 		errorHandler.handleError(new Throwable());
-		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination",
-				MessageChannel.class);
+		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNotNull();
 		assertThat(defaultErrorChannel).isEqualTo(context.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME));
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DefaultOutboundChannelAdapterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DefaultOutboundChannelAdapterParserTests.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -63,17 +64,17 @@ public class DefaultOutboundChannelAdapterParserTests {
 	@Test
 	public void checkConfig() {
 		Object adapter = context.getBean("adapter");
-		assertThat(TestUtils.getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.FALSE);
+		assertThat(TestUtils.<Boolean>getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.FALSE);
 		Object handler = TestUtils.getPropertyValue(adapter, "handler");
 		assertThat(handler.getClass()).isEqualTo(MethodInvokingMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "order")).isEqualTo(99);
+		assertThat(TestUtils.<Integer>getPropertyValue(handler, "order")).isEqualTo(99);
 	}
 
 	@Test
 	public void checkConfigWithInnerBeanAndPoller() {
 		Object adapter = context.getBean("adapterB");
-		assertThat(TestUtils.getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.FALSE);
-		MessageHandler handler = TestUtils.getPropertyValue(adapter, "handler", MessageHandler.class);
+		assertThat(TestUtils.<Boolean>getPropertyValue(adapter, "autoStartup")).isEqualTo(Boolean.FALSE);
+		MessageHandler handler = TestUtils.getPropertyValue(adapter, "handler");
 		assertThat(AopUtils.isAopProxy(handler)).isTrue();
 		assertThat(((Advised) handler).getAdvisors()[0].getAdvice()).isInstanceOf(RequestHandlerRetryAdvice.class);
 
@@ -91,7 +92,7 @@ public class DefaultOutboundChannelAdapterParserTests {
 		Object adapter = context.getBean("adapterC");
 		Object handler = TestUtils.getPropertyValue(adapter, "handler");
 		assertThat(handler.getClass()).isEqualTo(MethodInvokingMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "order")).isEqualTo(99);
+		assertThat(TestUtils.<Integer>getPropertyValue(handler, "order")).isEqualTo(99);
 		Object targetObject = TestUtils.getPropertyValue(handler, "processor.delegate.targetObject");
 		assertThat(targetObject.getClass()).isEqualTo(TestConsumer.class);
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelayerParserTests.java
@@ -47,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -62,14 +63,14 @@ public class DelayerParserTests {
 		DelayHandler delayHandler = context.getBean("delayerWithDefaultScheduler.handler", DelayHandler.class);
 		assertThat(delayHandler.getOrder()).isEqualTo(99);
 		assertThat(delayHandler.getOutputChannel()).isSameAs(this.context.getBean("output"));
-		assertThat(TestUtils.getPropertyValue(delayHandler, "defaultDelay", Long.class)).isEqualTo(1234L);
+		assertThat(TestUtils.<Long>getPropertyValue(delayHandler, "defaultDelay")).isEqualTo(1234L);
 		//INT-2243
-		assertThat(TestUtils.getPropertyValue(delayHandler, "delayExpression")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(delayHandler, "delayExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Object>getPropertyValue(delayHandler, "delayExpression")).isNotNull();
+		assertThat(TestUtils.<Expression>getPropertyValue(delayHandler, "delayExpression").getExpressionString())
 				.isEqualTo("headers.foo");
-		assertThat(TestUtils.getPropertyValue(delayHandler, "messagingTemplate.sendTimeout", Long.class))
+		assertThat(TestUtils.<Long>getPropertyValue(delayHandler, "messagingTemplate.sendTimeout"))
 				.isEqualTo(987L);
-		assertThat(TestUtils.getPropertyValue(delayHandler, "taskScheduler")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(delayHandler, "taskScheduler")).isNotNull();
 	}
 
 	@Test
@@ -104,8 +105,8 @@ public class DelayerParserTests {
 	@Test //INT-2649
 	public void transactionalSubElement() throws Exception {
 		Object endpoint = context.getBean("delayerWithTransactional");
-		DelayHandler delayHandler = TestUtils.getPropertyValue(endpoint, "handler", DelayHandler.class);
-		List<?> adviceChain = TestUtils.getPropertyValue(delayHandler, "delayedAdviceChain", List.class);
+		DelayHandler delayHandler = TestUtils.getPropertyValue(endpoint, "handler");
+		List<?> adviceChain = TestUtils.getPropertyValue(delayHandler, "delayedAdviceChain");
 		assertThat(adviceChain.size()).isEqualTo(1);
 		Object advice = adviceChain.get(0);
 		assertThat(advice instanceof TransactionInterceptor).isTrue();
@@ -123,8 +124,8 @@ public class DelayerParserTests {
 	@Test //INT-2649
 	public void adviceChainSubElement() {
 		Object endpoint = context.getBean("delayerWithAdviceChain");
-		DelayHandler delayHandler = TestUtils.getPropertyValue(endpoint, "handler", DelayHandler.class);
-		List<?> adviceChain = TestUtils.getPropertyValue(delayHandler, "delayedAdviceChain", List.class);
+		DelayHandler delayHandler = TestUtils.getPropertyValue(endpoint, "handler");
+		List<?> adviceChain = TestUtils.getPropertyValue(delayHandler, "delayedAdviceChain");
 		assertThat(adviceChain.size()).isEqualTo(2);
 		assertThat(adviceChain.get(0)).isSameAs(context.getBean("testAdviceBean"));
 
@@ -133,22 +134,22 @@ public class DelayerParserTests {
 		TransactionAttributeSource transactionAttributeSource =
 				((TransactionInterceptor) txAdvice).getTransactionAttributeSource();
 		assertThat(transactionAttributeSource.getClass()).isEqualTo(NameMatchTransactionAttributeSource.class);
-		HashMap<?, ?> nameMap = TestUtils.getPropertyValue(transactionAttributeSource, "nameMap", HashMap.class);
+		HashMap<?, ?> nameMap = TestUtils.getPropertyValue(transactionAttributeSource, "nameMap");
 		assertThat(nameMap.toString()).isEqualTo("{*=PROPAGATION_REQUIRES_NEW,ISOLATION_DEFAULT,readOnly}");
 	}
 
 	@Test
 	public void testInt2243Expression() {
 		DelayHandler delayHandler = context.getBean("delayerWithExpression.handler", DelayHandler.class);
-		assertThat(TestUtils.getPropertyValue(delayHandler, "delayExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(delayHandler, "delayExpression").getExpressionString())
 				.isEqualTo("100");
-		assertThat(TestUtils.getPropertyValue(delayHandler, "ignoreExpressionFailures", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(delayHandler, "ignoreExpressionFailures")).isFalse();
 	}
 
 	@Test
 	public void testInt2243ExpressionSubElement() {
 		DelayHandler delayHandler = context.getBean("delayerWithExpressionSubElement.handler", DelayHandler.class);
-		assertThat(TestUtils.getPropertyValue(delayHandler, "delayExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(delayHandler, "delayExpression").getExpressionString())
 				.isEqualTo("headers.timestamp + 1000");
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelegatingConsumerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DelegatingConsumerParserTests.java
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0
  *
@@ -171,7 +172,7 @@ public class DelegatingConsumerParserTests {
 		assertThat(splitterWithARPMH).isInstanceOf(MySplitterThatIsAnARPMH.class);
 		testHandler(splitterWithARPMH);
 		assertThat(splitterWithARPMHWithAtts).isInstanceOf(MySplitterThatIsAnARPMH.class);
-		assertThat(TestUtils.getPropertyValue(splitterWithARPMHWithAtts, "messagingTemplate.sendTimeout", Long.class))
+		assertThat(TestUtils.<Long>getPropertyValue(splitterWithARPMHWithAtts, "messagingTemplate.sendTimeout"))
 				.isEqualTo(Long.valueOf(123));
 		testHandler(splitterWithARPMHWithAtts);
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DispatcherMaxSubscribersTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/DispatcherMaxSubscribersTests.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -61,30 +62,30 @@ public abstract class DispatcherMaxSubscribersTests {
 
 	protected void doTestUnicast(int val1, int val2, int val3, int val4, int val5) {
 		Integer autoCreateMax =
-				TestUtils.getPropertyValue(autoCreateChannel, "dispatcher.maxSubscribers", Integer.class);
+				TestUtils.<Integer>getPropertyValue(autoCreateChannel, "dispatcher.maxSubscribers");
 		assertThat(autoCreateMax).isEqualTo(val1);
-		Integer defaultMax = TestUtils.getPropertyValue(defaultChannel, "dispatcher.maxSubscribers", Integer.class);
+		Integer defaultMax = TestUtils.getPropertyValue(defaultChannel, "dispatcher.maxSubscribers");
 		assertThat(defaultMax.intValue()).isEqualTo(val1);
-		Integer defaultMax2 = TestUtils.getPropertyValue(defaultChannel2, "dispatcher.maxSubscribers", Integer.class);
+		Integer defaultMax2 = TestUtils.getPropertyValue(defaultChannel2, "dispatcher.maxSubscribers");
 		assertThat(defaultMax2.intValue()).isEqualTo(val2);
-		Integer explicitMax = TestUtils.getPropertyValue(explicitChannel, "dispatcher.maxSubscribers", Integer.class);
+		Integer explicitMax = TestUtils.getPropertyValue(explicitChannel, "dispatcher.maxSubscribers");
 		assertThat(explicitMax.intValue()).isEqualTo(val3);
-		Integer execMax = TestUtils.getPropertyValue(executorChannel, "dispatcher.maxSubscribers", Integer.class);
+		Integer execMax = TestUtils.getPropertyValue(executorChannel, "dispatcher.maxSubscribers");
 		assertThat(execMax.intValue()).isEqualTo(val4);
 		Integer explicitExecMax =
-				TestUtils.getPropertyValue(explicitExecutorChannel, "dispatcher.maxSubscribers", Integer.class);
+				TestUtils.<Integer>getPropertyValue(explicitExecutorChannel, "dispatcher.maxSubscribers");
 		assertThat(explicitExecMax.intValue()).isEqualTo(val5);
 	}
 
 	protected void doTestMulticast(int val1, int val2) {
 		Integer defaultMax = TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(pubSubDefaultChannel, "dispatcher"), "maxSubscribers", Integer.class);
+				TestUtils.getPropertyValue(pubSubDefaultChannel, "dispatcher"), "maxSubscribers");
 		assertThat(defaultMax.intValue()).isEqualTo(val1);
 		Integer explicitMax = TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(pubSubExplicitChannel, "dispatcher"), "maxSubscribers", Integer.class);
+				TestUtils.getPropertyValue(pubSubExplicitChannel, "dispatcher"), "maxSubscribers");
 		assertThat(explicitMax.intValue()).isEqualTo(val2);
 		Integer explicitMin =
-				TestUtils.getPropertyValue(pubSubExplicitChannel, "dispatcher.minSubscribers", Integer.class);
+				TestUtils.<Integer>getPropertyValue(pubSubExplicitChannel, "dispatcher.minSubscribers");
 		assertThat(explicitMin.intValue()).isEqualTo(1);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParser2Tests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParser2Tests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -44,7 +45,7 @@ public class EnricherParser2Tests {
 	public void configurationCheckRequiresReply() {
 		Object endpoint = context.getBean("enricher");
 
-		boolean requiresReply = TestUtils.getPropertyValue(endpoint, "handler.requiresReply", Boolean.class);
+		boolean requiresReply = TestUtils.<Boolean>getPropertyValue(endpoint, "handler.requiresReply");
 
 		assertThat(requiresReply).as("Was expecting requiresReply to be 'false'").isFalse();
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/EnricherParserTests.java
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -70,7 +71,7 @@ public class EnricherParserTests {
 		assertThat(accessor.getPropertyValue("outputChannelName")).isEqualTo("output");
 		assertThat(accessor.getPropertyValue("shouldClonePayload")).isEqualTo(true);
 		assertThat(accessor.getPropertyValue("requestPayloadExpression")).isNull();
-		assertThat(TestUtils.getPropertyValue(enricher, "gateway.beanFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(enricher, "gateway.beanFactory")).isNotNull();
 
 		Map<Expression, Expression> propertyExpressions =
 				(Map<Expression, Expression>) accessor.getPropertyValue("propertyExpressions");
@@ -99,8 +100,8 @@ public class EnricherParserTests {
 	public void configurationCheckTimeoutParameters() {
 		Object endpoint = context.getBean("enricher");
 
-		Long requestTimeout = TestUtils.getPropertyValue(endpoint, "handler.requestTimeout", Long.class);
-		Long replyTimeout = TestUtils.getPropertyValue(endpoint, "handler.replyTimeout", Long.class);
+		Long requestTimeout = TestUtils.getPropertyValue(endpoint, "handler.requestTimeout");
+		Long replyTimeout = TestUtils.getPropertyValue(endpoint, "handler.replyTimeout");
 
 		assertThat(requestTimeout).isEqualTo(Long.valueOf(1234L));
 		assertThat(replyTimeout).isEqualTo(Long.valueOf(9876L));
@@ -110,7 +111,7 @@ public class EnricherParserTests {
 	public void configurationCheckRequiresReply() {
 		Object endpoint = context.getBean("enricher");
 
-		boolean requiresReply = TestUtils.getPropertyValue(endpoint, "handler.requiresReply", Boolean.class);
+		boolean requiresReply = TestUtils.<Boolean>getPropertyValue(endpoint, "handler.requiresReply");
 
 		assertThat(requiresReply).as("Was expecting requiresReply to be 'false'").isTrue();
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ErrorChannelAutoCreationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ErrorChannelAutoCreationTests.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -46,14 +47,14 @@ public class ErrorChannelAutoCreationTests {
 	@Test
 	public void testErrorChannelIsPubSub() {
 		assertThat(this.errorChannel).isInstanceOf(PublishSubscribeChannel.class);
-		assertThat(TestUtils.getPropertyValue(this.errorChannel, "dispatcher.requireSubscribers", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.errorChannel, "dispatcher.requireSubscribers"))
 				.isTrue();
-		assertThat(TestUtils.getPropertyValue(this.errorChannel, "dispatcher.ignoreFailures", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.errorChannel, "dispatcher.ignoreFailures"))
 				.isTrue();
 
 		@SuppressWarnings("unchecked")
 		Set<MessageHandler> handlers =
-				TestUtils.getPropertyValue(this.errorChannel, "dispatcher.handlers", Set.class);
+				TestUtils.getPropertyValue(this.errorChannel, "dispatcher.handlers");
 
 		assertThat(handlers).first()
 				.isInstanceOf(LoggingHandler.class)

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/HeaderEnricherParserTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -49,46 +50,42 @@ class HeaderEnricherParserTests {
 	@Test
 	void sendTimeoutDefault() {
 		Object endpoint = context.getBean("headerEnricherWithDefaults");
-		long sendTimeout = TestUtils.getPropertyValue(endpoint, "handler.messagingTemplate.sendTimeout", Long.class);
+		long sendTimeout = TestUtils.getPropertyValue(endpoint, "handler.messagingTemplate.sendTimeout");
 		assertThat(sendTimeout).isEqualTo(45000L);
 	}
 
 	@Test
 	void sendTimeoutConfigured() {
 		Object endpoint = context.getBean("headerEnricherWithSendTimeout");
-		long sendTimeout = TestUtils.getPropertyValue(endpoint, "handler.messagingTemplate.sendTimeout", Long.class);
+		long sendTimeout = TestUtils.getPropertyValue(endpoint, "handler.messagingTemplate.sendTimeout");
 		assertThat(sendTimeout).isEqualTo(1234L);
 	}
 
 	@Test
 	void shouldSkipNullsDefault() {
 		Object endpoint = context.getBean("headerEnricherWithDefaults");
-		Boolean shouldSkipNulls = TestUtils
-				.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls", Boolean.class);
+		Boolean shouldSkipNulls = TestUtils.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls");
 		assertThat(shouldSkipNulls).isEqualTo(Boolean.TRUE);
 	}
 
 	@Test
 	void shouldSkipNullsFalseConfigured() {
 		Object endpoint = context.getBean("headerEnricherWithShouldSkipNullsFalse");
-		Boolean shouldSkipNulls = TestUtils
-				.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls", Boolean.class);
+		Boolean shouldSkipNulls = TestUtils.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls");
 		assertThat(shouldSkipNulls).isEqualTo(Boolean.FALSE);
 	}
 
 	@Test
 	void shouldSkipNullsTrueConfigured() {
 		Object endpoint = context.getBean("headerEnricherWithShouldSkipNullsTrue");
-		Boolean shouldSkipNulls = TestUtils
-				.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls", Boolean.class);
+		Boolean shouldSkipNulls = TestUtils.getPropertyValue(endpoint, "handler.transformer.shouldSkipNulls");
 		assertThat(shouldSkipNulls).isEqualTo(Boolean.TRUE);
 	}
 
 	@Test
 	void testStringPriorityHeader() {
 		MessageHandler messageHandler =
-				TestUtils.getPropertyValue(this.context.getBean("headerEnricherWithPriorityAsString"),
-						"handler", MessageHandler.class);
+				TestUtils.getPropertyValue(this.context.getBean("headerEnricherWithPriorityAsString"), "handler");
 		Message<?> message = new GenericMessage<>("hello");
 		assertThatExceptionOfType(MessageTransformationException.class)
 				.isThrownBy(() -> messageHandler.handleMessage(message))
@@ -100,8 +97,7 @@ class HeaderEnricherParserTests {
 	@Test
 	void testStringPriorityHeaderWithType() {
 		MessageHandler messageHandler =
-				TestUtils.getPropertyValue(context.getBean("headerEnricherWithPriorityAsStringAndType"),
-						"handler", MessageHandler.class);
+				TestUtils.getPropertyValue(context.getBean("headerEnricherWithPriorityAsStringAndType"), "handler");
 		QueueChannel replyChannel = new QueueChannel();
 		Message<?> message = MessageBuilder.withPayload("foo").setReplyChannel(replyChannel).build();
 		messageHandler.handleMessage(message);

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/IdempotentReceiverParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/IdempotentReceiverParserTests.java
@@ -40,6 +40,7 @@ import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.handler.advice.IdempotentReceiverInterceptor;
 import org.springframework.integration.metadata.MetadataStore;
 import org.springframework.integration.selector.MetadataStoreSelector;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -51,6 +52,7 @@ import static org.springframework.integration.test.util.TestUtils.getPropertyVal
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.1
  */
@@ -92,13 +94,13 @@ public class IdempotentReceiverParserTests {
 
 	@Test
 	public void testSelectorInterceptor() {
-		assertThat(getPropertyValue(this.selectorInterceptor, "messageSelector")).isSameAs(this.selector);
-		assertThat(getPropertyValue(this.selectorInterceptor, "discardChannel")).isNull();
-		assertThat(getPropertyValue(this.selectorInterceptor, "throwExceptionOnRejection", Boolean.class)).isFalse();
-		@SuppressWarnings("unchecked")
+		assertThat(TestUtils.<Object>getPropertyValue(this.selectorInterceptor, "messageSelector")).
+				isSameAs(this.selector);
+		assertThat(TestUtils.<Object>getPropertyValue(this.selectorInterceptor, "discardChannel")).isNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.selectorInterceptor, "throwExceptionOnRejection"))
+				.isFalse();
 		Map<String, List<String>> idempotentEndpoints =
-				getPropertyValue(this.idempotentReceiverAutoProxyCreator,
-						"idempotentEndpoints", Map.class);
+				TestUtils.getPropertyValue(this.idempotentReceiverAutoProxyCreator, "idempotentEndpoints");
 		List<String> endpoints = idempotentEndpoints.get("selectorInterceptor");
 		assertThat(endpoints).isNotNull();
 		assertThat(endpoints.isEmpty()).isFalse();
@@ -107,17 +109,19 @@ public class IdempotentReceiverParserTests {
 
 	@Test
 	public void testStrategyInterceptor() {
-		assertThat(getPropertyValue(this.strategyInterceptor, "discardChannel")).isSameAs(this.nullChannel);
-		assertThat(getPropertyValue(this.strategyInterceptor, "throwExceptionOnRejection", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(this.strategyInterceptor, "discardChannel"))
+				.isSameAs(this.nullChannel);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.strategyInterceptor, "throwExceptionOnRejection")).isTrue();
 		Object messageSelector = getPropertyValue(this.strategyInterceptor, "messageSelector");
 		assertThat(messageSelector).isInstanceOf(MetadataStoreSelector.class);
-		assertThat(getPropertyValue(messageSelector, "keyStrategy")).isSameAs(this.keyStrategy);
-		assertThat(getPropertyValue(messageSelector, "valueStrategy")).isSameAs(this.valueStrategy);
-		assertThat(getPropertyValue(messageSelector, "compareValues")).isSameAs(this.alwaysAccept);
-		@SuppressWarnings("unchecked")
+		assertThat(TestUtils.<Object>getPropertyValue(messageSelector, "keyStrategy"))
+				.isSameAs(this.keyStrategy);
+		assertThat(TestUtils.<Object>getPropertyValue(messageSelector, "valueStrategy"))
+				.isSameAs(this.valueStrategy);
+		assertThat(TestUtils.<Object>getPropertyValue(messageSelector, "compareValues"))
+				.isSameAs(this.alwaysAccept);
 		Map<String, List<String>> idempotentEndpoints =
-				getPropertyValue(this.idempotentReceiverAutoProxyCreator,
-						"idempotentEndpoints", Map.class);
+				TestUtils.getPropertyValue(this.idempotentReceiverAutoProxyCreator, "idempotentEndpoints");
 		List<String> endpoints = idempotentEndpoints.get("strategyInterceptor");
 		assertThat(endpoints).isNotNull();
 		assertThat(endpoints.isEmpty()).isFalse();
@@ -128,14 +132,14 @@ public class IdempotentReceiverParserTests {
 	public void testExpressionInterceptor() {
 		Object messageSelector = getPropertyValue(this.expressionInterceptor, "messageSelector");
 		assertThat(messageSelector).isInstanceOf(MetadataStoreSelector.class);
-		assertThat(getPropertyValue(messageSelector, "metadataStore")).isSameAs(this.store);
+		assertThat(TestUtils.<Object>getPropertyValue(messageSelector, "metadataStore"))
+				.isSameAs(this.store);
 		Object keyStrategy = getPropertyValue(messageSelector, "keyStrategy");
 		assertThat(keyStrategy).isInstanceOf(ExpressionEvaluatingMessageProcessor.class);
 		assertThat(keyStrategy.toString()).contains("headers.foo");
 		@SuppressWarnings("unchecked")
-		Map<String, List<String>> idempotentEndpoints =
-				getPropertyValue(this.idempotentReceiverAutoProxyCreator,
-						"idempotentEndpoints", Map.class);
+		Map<String, List<String>> idempotentEndpoints = TestUtils.getPropertyValue(
+				this.idempotentReceiverAutoProxyCreator, "idempotentEndpoints");
 		List<String> endpoints = idempotentEndpoints.get("expressionInterceptor");
 		assertThat(endpoints).isNotNull();
 		assertThat(endpoints.isEmpty()).isFalse();

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InboundChannelAdapterExpressionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InboundChannelAdapterExpressionTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -54,14 +55,14 @@ public class InboundChannelAdapterExpressionTests {
 				this.context.getBean("fixedDelayProducer", SourcePollingChannelAdapter.class);
 		assertThat(adapter.isAutoStartup()).isFalse();
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(adapter);
-		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger", Trigger.class);
+		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger");
 		assertThat(trigger.getClass()).isEqualTo(PeriodicTrigger.class);
 		DirectFieldAccessor triggerAccessor = new DirectFieldAccessor(trigger);
 		assertThat(triggerAccessor.getPropertyValue("period")).isEqualTo(Duration.ofMillis(1234));
 		assertThat(triggerAccessor.getPropertyValue("fixedRate")).isEqualTo(Boolean.FALSE);
 		assertThat(adapterAccessor.getPropertyValue("outputChannel"))
 				.isEqualTo(this.context.getBean("fixedDelayChannel"));
-		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression", Expression.class);
+		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression");
 		assertThat(expression.getExpressionString()).isEqualTo("'fixedDelayTest'");
 	}
 
@@ -71,14 +72,14 @@ public class InboundChannelAdapterExpressionTests {
 				this.context.getBean("fixedRateProducer", SourcePollingChannelAdapter.class);
 		assertThat(adapter.isAutoStartup()).isFalse();
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(adapter);
-		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger", Trigger.class);
+		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger");
 		assertThat(trigger.getClass()).isEqualTo(PeriodicTrigger.class);
 		DirectFieldAccessor triggerAccessor = new DirectFieldAccessor(trigger);
 		assertThat(triggerAccessor.getPropertyValue("period")).isEqualTo(Duration.ofMillis(5678));
 		assertThat(triggerAccessor.getPropertyValue("fixedRate")).isEqualTo(Boolean.TRUE);
 		assertThat(adapterAccessor.getPropertyValue("outputChannel"))
 				.isEqualTo(this.context.getBean("fixedRateChannel"));
-		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression", Expression.class);
+		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression");
 		assertThat(expression.getExpressionString()).isEqualTo("'fixedRateTest'");
 	}
 
@@ -88,12 +89,12 @@ public class InboundChannelAdapterExpressionTests {
 				this.context.getBean("cronProducer", SourcePollingChannelAdapter.class);
 		assertThat(adapter.isAutoStartup()).isFalse();
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(adapter);
-		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger", Trigger.class);
+		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger");
 		assertThat(trigger.getClass()).isEqualTo(CronTrigger.class);
-		assertThat(TestUtils.getPropertyValue(trigger, "expression.expression"))
+		assertThat(TestUtils.<String>getPropertyValue(trigger, "expression.expression"))
 				.isEqualTo("7 6 5 4 3 ?");
 		assertThat(adapterAccessor.getPropertyValue("outputChannel")).isEqualTo(this.context.getBean("cronChannel"));
-		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression", Expression.class);
+		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression");
 		assertThat(expression.getExpressionString()).isEqualTo("'cronTest'");
 	}
 
@@ -103,22 +104,21 @@ public class InboundChannelAdapterExpressionTests {
 				this.context.getBean("triggerRefProducer", SourcePollingChannelAdapter.class);
 		assertThat(adapter.isAutoStartup()).isTrue();
 		DirectFieldAccessor adapterAccessor = new DirectFieldAccessor(adapter);
-		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger", Trigger.class);
+		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger");
 		assertThat(trigger).isEqualTo(this.context.getBean("customTrigger"));
 		assertThat(adapterAccessor.getPropertyValue("outputChannel"))
 				.isEqualTo(this.context.getBean("triggerRefChannel"));
-		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression", Expression.class);
+		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression");
 		assertThat(expression.getExpressionString()).isEqualTo("'triggerRefTest'");
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void headerExpressions() {
 		SourcePollingChannelAdapter adapter =
 				this.context.getBean("headerExpressionsProducer", SourcePollingChannelAdapter.class);
 		assertThat(adapter.isAutoStartup()).isFalse();
 		Map<String, Expression> headerExpressions =
-				TestUtils.getPropertyValue(adapter, "source.headerExpressions", Map.class);
+				TestUtils.getPropertyValue(adapter, "source.headerExpressions");
 		assertThat(headerExpressions.size()).isEqualTo(2);
 		assertThat(headerExpressions.get("foo").getExpressionString()).isEqualTo("6 * 7");
 		assertThat(headerExpressions.get("bar").getExpressionString()).isEqualTo("x");
@@ -130,7 +130,7 @@ public class InboundChannelAdapterExpressionTests {
 	public void testInt2867InnerExpression() {
 		SourcePollingChannelAdapter adapter =
 				this.context.getBean("expressionElement", SourcePollingChannelAdapter.class);
-		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression", Expression.class);
+		Expression expression = TestUtils.getPropertyValue(adapter, "source.expression");
 		assertThat(expression.getExpressionString()).isEqualTo("'Hello World!'");
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InboundChannelAdapterWithDefaultPollerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/InboundChannelAdapterWithDefaultPollerTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 public class InboundChannelAdapterWithDefaultPollerTests {
@@ -41,7 +42,7 @@ public class InboundChannelAdapterWithDefaultPollerTests {
 
 	@Test
 	public void verifyDefaultPollerInUse() {
-		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger", Trigger.class);
+		Trigger trigger = TestUtils.getPropertyValue(adapter, "trigger");
 		assertThat(trigger).isInstanceOf(PeriodicTrigger.class);
 		PeriodicTrigger periodicTrigger = (PeriodicTrigger) trigger;
 		assertThat(periodicTrigger.getPeriodDuration()).isEqualTo(Duration.ofMillis(12345));

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/LoggingChannelAdapterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/LoggingChannelAdapterParserTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -52,24 +53,29 @@ public class LoggingChannelAdapterParserTests {
 
 	@Test
 	public void verifyConfig() {
-		LoggingHandler loggingHandler = TestUtils.getPropertyValue(loggerConsumer, "handler", LoggingHandler.class);
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "messageLogger.log.logger.name"))
+		LoggingHandler loggingHandler = TestUtils.getPropertyValue(loggerConsumer, "handler");
+		assertThat(TestUtils.<String>getPropertyValue(loggingHandler, "messageLogger.log.logger.name"))
 				.isEqualTo("org.springframework.integration.test.logger");
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "order")).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "level")).isEqualTo(LoggingHandler.Level.WARN);
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "expression")).isInstanceOf(FunctionExpression.class);
+		assertThat(TestUtils.<Integer>getPropertyValue(loggingHandler, "order")).isEqualTo(1);
+		assertThat(TestUtils.<LoggingHandler.Level>getPropertyValue(loggingHandler, "level"))
+				.isEqualTo(LoggingHandler.Level.WARN);
+		assertThat(TestUtils.<Object>getPropertyValue(loggingHandler, "expression"))
+				.isInstanceOf(FunctionExpression.class);
 	}
 
 	@Test
 	public void verifyExpressionAndOtherDefaultConfig() {
 		LoggingHandler loggingHandler =
-				TestUtils.getPropertyValue(loggerWithExpression, "handler", LoggingHandler.class);
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "messageLogger.log.logger.name"))
+				TestUtils.<LoggingHandler>getPropertyValue(loggerWithExpression, "handler");
+		assertThat(TestUtils.<String>getPropertyValue(loggingHandler, "messageLogger.log.logger.name"))
 				.isEqualTo("org.springframework.integration.handler.LoggingHandler");
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "order")).isEqualTo(Ordered.LOWEST_PRECEDENCE);
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "level")).isEqualTo(LoggingHandler.Level.INFO);
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "expression.expression")).isEqualTo("payload.foo");
-		assertThat(TestUtils.getPropertyValue(loggingHandler, "evaluationContext.beanResolver")).isNotNull();
+		assertThat(TestUtils.<Integer>getPropertyValue(loggingHandler, "order"))
+				.isEqualTo(Ordered.LOWEST_PRECEDENCE);
+		assertThat(TestUtils.<LoggingHandler.Level>getPropertyValue(loggingHandler, "level"))
+				.isEqualTo(LoggingHandler.Level.INFO);
+		assertThat(TestUtils.<String>getPropertyValue(loggingHandler, "expression.expression"))
+				.isEqualTo("payload.foo");
+		assertThat(TestUtils.<Object>getPropertyValue(loggingHandler, "evaluationContext.beanResolver")).isNotNull();
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ObjectToStringTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/ObjectToStringTransformerParserTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -88,7 +89,8 @@ public class ObjectToStringTransformerParserTests {
 
 	@Test
 	public void charset() {
-		assertThat(TestUtils.getPropertyValue(this.withCharset, "handler.transformer.charset")).isEqualTo("FOO");
+		assertThat(TestUtils.<String>getPropertyValue(this.withCharset, "handler.transformer.charset"))
+				.isEqualTo("FOO");
 	}
 
 	private static class TestBean {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PNamespaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PNamespaceTests.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -99,8 +100,7 @@ public class PNamespaceTests {
 	}
 
 	private TestBean prepare(EventDrivenConsumer edc) {
-		return TestUtils.getPropertyValue(serviceActivator,
-				"handler.processor.delegate.targetObject", TestBean.class);
+		return TestUtils.<TestBean>getPropertyValue(serviceActivator, "handler.processor.delegate.targetObject");
 	}
 
 	public interface InboundGateway {

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PayloadDeserializingTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PayloadDeserializingTransformerParserTests.java
@@ -47,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -77,7 +78,7 @@ public class PayloadDeserializingTransformerParserTests {
 		assertThat(result.getPayload() instanceof String).isTrue();
 		assertThat(result.getPayload()).isEqualTo("foo");
 		Set<?> patterns =
-				TestUtils.getPropertyValue(this.handler, "transformer.converter.allowedPatterns", Set.class);
+				TestUtils.getPropertyValue(this.handler, "transformer.converter.allowedPatterns");
 		assertThat(patterns.size()).isEqualTo(1);
 		assertThat(patterns.iterator().next()).isEqualTo("*");
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PollerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/PollerParserTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class PollerParserTests {
 
@@ -96,7 +97,7 @@ public class PollerParserTests {
 				((TransactionInterceptor) txAdvice).getTransactionAttributeSource();
 		assertThat(transactionAttributeSource).isInstanceOf(NameMatchTransactionAttributeSource.class);
 		@SuppressWarnings("rawtypes")
-		HashMap nameMap = TestUtils.getPropertyValue(transactionAttributeSource, "nameMap", HashMap.class);
+		HashMap nameMap = TestUtils.getPropertyValue(transactionAttributeSource, "nameMap");
 		assertThat(nameMap.size()).isEqualTo(1);
 		assertThat(nameMap.toString()).isEqualTo("{*=PROPAGATION_REQUIRES_NEW,ISOLATION_DEFAULT,readOnly}");
 		context.close();

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests-context.xml
@@ -25,23 +25,23 @@
 		<int:exponential-back-off initial="1000" multiplier="3.0" maximum="10000" jitter="6"/>
 	</int:handler-retry-advice>
 
-	<int:handler-retry-advice id="a7" recovery-channel="foo" send-timeout="4567" />
+	<int:handler-retry-advice id="a7" recovery-channel="inputChannel" send-timeout="4567" />
 
-	<int:channel id="foo" />
+	<int:channel id="inputChannel" />
 
-	<int:service-activator id="sa1" input-channel="foo" expression="'foo'">
+	<int:service-activator id="sa1" input-channel="inputChannel" expression="'expression'">
 		<int:request-handler-advice-chain>
 			<ref bean="a1"/>
 		</int:request-handler-advice-chain>
 	</int:service-activator>
 
-	<int:service-activator id="sa2" input-channel="foo" expression="'foo'">
+	<int:service-activator id="sa2" input-channel="inputChannel" expression="'expression'">
 		<int:request-handler-advice-chain>
 			<int:retry-advice max-retries="9" />
 		</int:request-handler-advice-chain>
 	</int:service-activator>
 
-	<int:service-activator id="saDefaultRetry" input-channel="foo" expression="'foo'">
+	<int:service-activator id="saDefaultRetry" input-channel="inputChannel" expression="'expression'">
 		<int:request-handler-advice-chain>
 			<int:retry-advice />
 		</int:request-handler-advice-chain>

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/RetryAdviceParserTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.0
  *
@@ -75,44 +76,51 @@ public class RetryAdviceParserTests {
 	private MessageHandler defaultRetryHandler;
 
 	@Autowired
-	private MessageChannel foo;
+	private MessageChannel inputChannel;
 
 	@Test
 	public void testAll() {
-		assertThat(TestUtils.getPropertyValue(a1, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(3L);
-		assertThat(TestUtils.getPropertyValue(a2, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(4L);
-		assertThat(TestUtils.getPropertyValue(a3, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(5L);
-		assertThat(TestUtils.getPropertyValue(a4, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(6L);
-		assertThat(TestUtils.getPropertyValue(a5, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(7L);
-		assertThat(TestUtils.getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(8L);
-		assertThat(TestUtils.getPropertyValue(a7, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(3L);
+		assertThat(TestUtils.<Long>getPropertyValue(a1, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(3L);
+		assertThat(TestUtils.<Long>getPropertyValue(a2, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(4L);
+		assertThat(TestUtils.<Long>getPropertyValue(a3, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(5L);
+		assertThat(TestUtils.<Long>getPropertyValue(a4, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(6L);
+		assertThat(TestUtils.<Long>getPropertyValue(a5, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(7L);
+		assertThat(TestUtils.<Long>getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(8L);
+		assertThat(TestUtils.<Long>getPropertyValue(a7, "retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(3L);
 
 		assertThat(
-				TestUtils.getPropertyValue(a3, "retryTemplate.retryPolicy.backOff", FixedBackOff.class).getInterval())
+				TestUtils.<FixedBackOff>getPropertyValue(a3, "retryTemplate.retryPolicy.backOff").getInterval())
 				.isEqualTo(1000L);
 		assertThat(
-				TestUtils.getPropertyValue(a4, "retryTemplate.retryPolicy.backOff", FixedBackOff.class).getInterval())
+				TestUtils.<FixedBackOff>getPropertyValue(a4, "retryTemplate.retryPolicy.backOff").getInterval())
 				.isEqualTo(1234L);
 
-		assertThat(TestUtils.getPropertyValue(a5, "retryTemplate.retryPolicy.backOff.initialInterval")).isEqualTo(100L);
-		assertThat(TestUtils.getPropertyValue(a5, "retryTemplate.retryPolicy.backOff.multiplier")).isEqualTo(2.0);
-		assertThat(TestUtils.getPropertyValue(a5, "retryTemplate.retryPolicy.backOff.maxInterval")).isEqualTo(30000L);
-		assertThat(TestUtils.getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.initialInterval")).isEqualTo(1000L);
-		assertThat(TestUtils.getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.multiplier")).isEqualTo(3.0);
-		assertThat(TestUtils.getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.maxInterval")).isEqualTo(10000L);
-		assertThat(TestUtils.getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.jitter")).isEqualTo(6L);
+		assertThat(TestUtils.<Long>getPropertyValue(a5, "retryTemplate.retryPolicy.backOff.initialInterval"))
+				.isEqualTo(100L);
+		assertThat(TestUtils.<Double>getPropertyValue(a5, "retryTemplate.retryPolicy.backOff.multiplier"))
+				.isEqualTo(2.0);
+		assertThat(TestUtils.<Long>getPropertyValue(a5, "retryTemplate.retryPolicy.backOff.maxInterval"))
+				.isEqualTo(30000L);
+		assertThat(TestUtils.<Long>getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.initialInterval"))
+				.isEqualTo(1000L);
+		assertThat(TestUtils.<Double>getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.multiplier"))
+				.isEqualTo(3.0);
+		assertThat(TestUtils.<Long>getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.maxInterval"))
+				.isEqualTo(10000L);
+		assertThat(TestUtils.<Long>getPropertyValue(a6, "retryTemplate.retryPolicy.backOff.jitter")).isEqualTo(6L);
 
-		assertThat(TestUtils.getPropertyValue(a1, "recoveryCallback")).isNull();
-		assertThat(TestUtils.getPropertyValue(a7, "recoveryCallback")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(a7, "recoveryCallback.channel")).isSameAs(this.foo);
-		assertThat(TestUtils.getPropertyValue(a7, "recoveryCallback.messagingTemplate.sendTimeout")).isEqualTo(4567L);
+		assertThat(TestUtils.<Object>getPropertyValue(a1, "recoveryCallback")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(a7, "recoveryCallback")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(a7, "recoveryCallback.channel")).isSameAs(this.inputChannel);
+		assertThat(TestUtils.<Long>getPropertyValue(a7, "recoveryCallback.messagingTemplate.sendTimeout"))
+				.isEqualTo(4567L);
 
-		assertThat(TestUtils.getPropertyValue(this.handler1, "adviceChain", List.class).get(0)).isSameAs(this.a1);
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(this.handler2, "adviceChain", List.class).get(0),
+		assertThat(TestUtils.<List<?>>getPropertyValue(this.handler1, "adviceChain").get(0)).isSameAs(this.a1);
+		assertThat(TestUtils.<Long>getPropertyValue(
+				TestUtils.<List<?>>getPropertyValue(this.handler2, "adviceChain").get(0),
 				"retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(9L);
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(this.defaultRetryHandler, "adviceChain", List.class).get(0),
+		assertThat(TestUtils.<Long>getPropertyValue(
+				TestUtils.<List<?>>getPropertyValue(this.defaultRetryHandler, "adviceChain").get(0),
 				"retryTemplate.retryPolicy.backOff.maxAttempts")).isEqualTo(3L);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/xml/TransactionSynchronizationFactoryParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/xml/TransactionSynchronizationFactoryParserTests.java
@@ -23,7 +23,6 @@ import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpression;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.transaction.DefaultTransactionSynchronizationFactory;
-import org.springframework.integration.transaction.ExpressionEvaluatingTransactionSynchronizationProcessor;
 import org.springframework.integration.transaction.TransactionSynchronizationProcessor;
 import org.springframework.messaging.MessageChannel;
 
@@ -32,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 public class TransactionSynchronizationFactoryParserTests {
 
@@ -49,32 +49,26 @@ public class TransactionSynchronizationFactoryParserTests {
 		DefaultTransactionSynchronizationFactory syncFactory = context.getBean("syncFactoryComplete",
 				DefaultTransactionSynchronizationFactory.class);
 		assertThat(syncFactory).isNotNull();
-		TransactionSynchronizationProcessor processor = TestUtils.getPropertyValue(syncFactory, "processor",
-				ExpressionEvaluatingTransactionSynchronizationProcessor.class);
+		TransactionSynchronizationProcessor processor = TestUtils.getPropertyValue(syncFactory, "processor");
 		assertThat(processor).isNotNull();
 
-		MessageChannel beforeCommitResultChannel = TestUtils.getPropertyValue(processor, "beforeCommitChannel",
-				MessageChannel.class);
+		MessageChannel beforeCommitResultChannel = TestUtils.getPropertyValue(processor, "beforeCommitChannel");
 		assertThat(beforeCommitResultChannel).isNotNull();
 		assertThat(context.getBean("beforeCommitChannel")).isEqualTo(beforeCommitResultChannel);
 		Object beforeCommitExpression = TestUtils.getPropertyValue(processor, "beforeCommitExpression");
 		assertThat(beforeCommitExpression).isNull();
 
-		MessageChannel afterCommitResultChannel = TestUtils.getPropertyValue(processor, "afterCommitChannel",
-				MessageChannel.class);
+		MessageChannel afterCommitResultChannel = TestUtils.getPropertyValue(processor, "afterCommitChannel");
 		assertThat(afterCommitResultChannel).isNotNull();
 		assertThat(context.getBean("nullChannel")).isEqualTo(afterCommitResultChannel);
-		Expression afterCommitExpression = TestUtils.getPropertyValue(processor, "afterCommitExpression",
-				Expression.class);
+		Expression afterCommitExpression = TestUtils.getPropertyValue(processor, "afterCommitExpression");
 		assertThat(afterCommitExpression).isNotNull();
 		assertThat(((SpelExpression) afterCommitExpression).getExpressionString()).isEqualTo("'afterCommit'");
 
-		MessageChannel afterRollbackResultChannel = TestUtils.getPropertyValue(processor, "afterRollbackChannel",
-				MessageChannel.class);
+		MessageChannel afterRollbackResultChannel = TestUtils.getPropertyValue(processor, "afterRollbackChannel");
 		assertThat(afterRollbackResultChannel).isNotNull();
 		assertThat(context.getBean("afterRollbackChannel")).isEqualTo(afterRollbackResultChannel);
-		Expression afterRollbackExpression = TestUtils.getPropertyValue(processor, "afterRollbackExpression",
-				Expression.class);
+		Expression afterRollbackExpression = TestUtils.getPropertyValue(processor, "afterRollbackExpression");
 		assertThat(afterRollbackExpression).isNotNull();
 		assertThat(((SpelExpression) afterRollbackExpression).getExpressionString()).isEqualTo("'afterRollback'");
 		context.close();

--- a/spring-integration-core/src/test/java/org/springframework/integration/context/IntegrationContextTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/context/IntegrationContextTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0
  */
@@ -57,7 +58,8 @@ public class IntegrationContextTests {
 		assertThat(this.integrationProperties.isMessagingTemplateThrowExceptionOnLateReply()).isTrue();
 		assertThat(this.integrationProperties.getTaskSchedulerPoolSize()).isEqualTo(20);
 		assertThat(this.serviceActivator.getIntegrationProperties()).isSameAs(this.integrationProperties);
-		assertThat(TestUtils.getPropertyValue(this.taskScheduler, "poolSize")).isEqualTo(20);
+		assertThat(TestUtils.<Integer>getPropertyValue(this.taskScheduler, "poolSize"))
+				.isEqualTo(20);
 		assertThat(this.serviceActivator.isAutoStartup()).isFalse();
 		assertThat(this.serviceActivator.isRunning()).isFalse();
 		assertThat(this.serviceActivatorExplicit.isAutoStartup()).isTrue();

--- a/spring-integration-core/src/test/java/org/springframework/integration/core/MessageIdGenerationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/core/MessageIdGenerationTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.verify;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class MessageIdGenerationTests {
 
@@ -138,7 +139,7 @@ public class MessageIdGenerationTests {
 	}
 
 	private void assertDestroy() {
-		assertThat(TestUtils.getPropertyValue(new MessageHeaders(null), "idGenerator")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(new MessageHeaders(null), "idGenerator")).isNull();
 	}
 
 	public static class SampleIdGenerator implements IdGenerator {

--- a/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/PollingTransactionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/PollingTransactionTests.java
@@ -52,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Andreas Baer
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class PollingTransactionTests {
 
@@ -75,16 +76,15 @@ public class PollingTransactionTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void transactionWithCommitAndAdvices() throws InterruptedException {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"transactionTests.xml", this.getClass());
 		PollingConsumer advisedPoller = context.getBean("advisedSa", PollingConsumer.class);
 
-		List<Advice> adviceChain = TestUtils.getPropertyValue(advisedPoller, "adviceChain", List.class);
+		List<Advice> adviceChain = TestUtils.getPropertyValue(advisedPoller, "adviceChain");
 		assertThat(adviceChain.size()).isEqualTo(4);
 		advisedPoller.start();
-		Callable<?> pollingTask = TestUtils.getPropertyValue(advisedPoller, "pollingTask", Callable.class);
+		Callable<?> pollingTask = TestUtils.getPropertyValue(advisedPoller, "pollingTask");
 		assertThat(pollingTask instanceof Advised).as("Poller is not Advised").isTrue();
 		Advisor[] advisors = ((Advised) pollingTask).getAdvisors();
 		assertThat(advisors.length).isEqualTo(4);

--- a/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/RoundRobinDispatcherTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dispatcher/RoundRobinDispatcherTests.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.verify;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class RoundRobinDispatcherTests {
 
@@ -94,7 +95,7 @@ public class RoundRobinDispatcherTests {
 	public void currentHandlerIndexOverFlow() {
 		this.dispatcher.addHandler(this.handler);
 		this.dispatcher.addHandler(this.differentHandler);
-		TestUtils.getPropertyValue(this.dispatcher, "loadBalancingStrategy.currentHandlerIndex", AtomicInteger.class)
+		TestUtils.<AtomicInteger>getPropertyValue(this.dispatcher, "loadBalancingStrategy.currentHandlerIndex")
 				.set(Integer.MAX_VALUE - 5);
 		for (int i = 0; i < 40; i++) {
 			this.dispatcher.dispatch(this.message);

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
@@ -116,6 +116,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gary Russell
  * @author Oleg Zhurakousky
  * @author Tim Feuerbach
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -203,7 +204,7 @@ public class IntegrationFlowTests {
 	public void testWithSupplierMessageSourceImpliedPoller() {
 		assertThat(this.stringSupplierEndpoint.isAutoStartup()).isFalse();
 		assertThat(this.stringSupplierEndpoint.isRunning()).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.stringSupplierEndpoint, "taskScheduler"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.stringSupplierEndpoint, "taskScheduler"))
 				.isSameAs(this.customScheduler);
 		this.stringSupplierEndpoint.start();
 		assertThat(this.suppliedChannel.receive(10000).getPayload()).isEqualTo("FOO");
@@ -274,7 +275,8 @@ public class IntegrationFlowTests {
 		assertThat(reply.getPayload()).isEqualTo("test");
 		assertThat(this.delayedAdvice.getInvoked()).isTrue();
 
-		assertThat(TestUtils.getPropertyValue(this.delayHandler, "taskScheduler")).isSameAs(this.customScheduler);
+		assertThat(TestUtils.<Object>getPropertyValue(this.delayHandler, "taskScheduler"))
+				.isSameAs(this.customScheduler);
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/gateway/GatewayDslTests.java
@@ -56,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.1.3
  */
@@ -147,7 +148,7 @@ public class GatewayDslTests {
 
 		MessagingGatewaySupport methodGateway = gateways.values().iterator().next();
 		MessagingTemplate messagingTemplate =
-				TestUtils.getPropertyValue(methodGateway, "messagingTemplate", MessagingTemplate.class);
+				TestUtils.<MessagingTemplate>getPropertyValue(methodGateway, "messagingTemplate");
 
 		assertThat(messagingTemplate.getReceiveTimeout()).isEqualTo(10);
 		assertThat(messagingTemplate.getSendTimeout()).isEqualTo(20);

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
@@ -93,6 +93,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -139,7 +140,7 @@ public class ManualFlowTests {
 		assertThat(started.get()).isTrue();
 
 		Set<MessageProducer> replyProducers =
-				TestUtils.getPropertyValue(flowBuilder, "REFERENCED_REPLY_PRODUCERS", Set.class);
+				TestUtils.getPropertyValue(flowBuilder, "REFERENCED_REPLY_PRODUCERS");
 
 		assertThat(replyProducers.contains(bridgeHandler)).isTrue();
 
@@ -491,7 +492,7 @@ public class ManualFlowTests {
 	@Test
 	public void testBeanDefinitionInfoInTheException() {
 		Map<?, ?> mergedBeanDefinitions =
-				TestUtils.getPropertyValue(this.beanFactory, "mergedBeanDefinitions", Map.class);
+				TestUtils.getPropertyValue(this.beanFactory, "mergedBeanDefinitions");
 
 		int mergedBeanDefinitionsSizeBeforeRandomFlow = mergedBeanDefinitions.size();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/reactivestreams/ReactiveStreamsTests.java
@@ -67,6 +67,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -126,7 +127,8 @@ public class ReactiveStreamsTests {
 
 		disposable.dispose();
 		assertThat(this.messageSource.isRunning()).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.messageSource, "messagingTemplate.sendTimeout")).isEqualTo(256L);
+		assertThat(TestUtils.<Long>getPropertyValue(this.messageSource, "messagingTemplate.sendTimeout"))
+				.isEqualTo(256L);
 	}
 
 	@RetryingTest(10)

--- a/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/endpoint/PollerAdviceTests.java
@@ -76,6 +76,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.1
  *
@@ -378,7 +379,7 @@ public class PollerAdviceTests {
 		Source source = ctx.getBean(Source.class);
 		adapter.start();
 		assertThat(source.latch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(TestUtils.getPropertyValue(adapter, "trigger.override")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "trigger.override")).isNotNull();
 		adapter.stop();
 		OtherAdvice sourceAdvice = ctx.getBean(OtherAdvice.class);
 		int count = sourceAdvice.calls;

--- a/spring-integration-core/src/test/java/org/springframework/integration/expression/ExpressionUtilsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/expression/ExpressionUtilsTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0
  */
@@ -55,7 +56,8 @@ public class ExpressionUtilsTests {
 		IntegrationEvaluationContextFactoryBean factory =
 				context.getBean("&" + IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME,
 						IntegrationEvaluationContextFactoryBean.class);
-		assertThat(TestUtils.getPropertyValue(factory, "typeConverter")).isSameAs(evalContext.getTypeConverter());
+		assertThat(TestUtils.<Object>getPropertyValue(factory, "typeConverter"))
+				.isSameAs(evalContext.getTypeConverter());
 	}
 
 	@Test
@@ -68,7 +70,7 @@ public class ExpressionUtilsTests {
 		assertThat(evalContext.getBeanResolver()).isNotNull();
 		TypeConverter typeConverter = evalContext.getTypeConverter();
 		assertThat(typeConverter).isNotNull();
-		assertThat(TestUtils.getPropertyValue(typeConverter, "conversionService", Supplier.class).get())
+		assertThat(TestUtils.<Supplier<?>>getPropertyValue(typeConverter, "conversionService").get())
 				.isSameAs(DefaultConversionService.getSharedInstance());
 	}
 
@@ -90,7 +92,7 @@ public class ExpressionUtilsTests {
 		assertThat(evalContext.getBeanResolver()).isNull();
 		TypeConverter typeConverter = evalContext.getTypeConverter();
 		assertThat(typeConverter).isNotNull();
-		assertThat(TestUtils.getPropertyValue(typeConverter, "conversionService", Supplier.class).get())
+		assertThat(TestUtils.<Supplier<?>>getPropertyValue(typeConverter, "conversionService").get())
 				.isSameAs(DefaultConversionService.getSharedInstance());
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/expression/ParentContextTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/expression/ParentContextTests.java
@@ -56,6 +56,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * @author Gary Russell
  * @author Artem Bilan
  * @author Pierre Lakreb
+ * @author Glenn Renfro
  *
  * @since 3.0
  */
@@ -83,8 +84,7 @@ public class ParentContextTests {
 				this.getClass());
 
 		Object parentEvaluationContextFactoryBean = parent.getBean(IntegrationEvaluationContextFactoryBean.class);
-		Map<?, ?> parentFunctions = TestUtils.getPropertyValue(parentEvaluationContextFactoryBean, "functions",
-				Map.class);
+		Map<?, ?> parentFunctions = TestUtils.getPropertyValue(parentEvaluationContextFactoryBean, "functions");
 		assertThat(parentFunctions.size()).isEqualTo(4);
 		Object jsonPath = parentFunctions.get("jsonPath");
 		assertThat(jsonPath).isNotNull();
@@ -95,8 +95,7 @@ public class ParentContextTests {
 		child.refresh();
 
 		Object childEvaluationContextFactoryBean = child.getBean(IntegrationEvaluationContextFactoryBean.class);
-		Map<?, ?> childFunctions = TestUtils.getPropertyValue(childEvaluationContextFactoryBean, "functions",
-				Map.class);
+		Map<?, ?> childFunctions = TestUtils.getPropertyValue(childEvaluationContextFactoryBean, "functions");
 		assertThat(childFunctions.size()).isEqualTo(5);
 		assertThat(childFunctions.containsKey("barParent")).isTrue();
 		assertThat(childFunctions.containsKey("fooFunc")).isTrue();

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayInterfaceTests.java
@@ -109,6 +109,7 @@ import static org.mockito.Mockito.verify;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig(classes = GatewayInterfaceTests.TestConfig.class)
 @DirtiesContext
@@ -189,7 +190,7 @@ public class GatewayInterfaceTests {
 		Bar bar = ac.getBean(Bar.class);
 		bar.foo("hello");
 		assertThat(called.get()).isTrue();
-		Map<?, ?> gateways = TestUtils.getPropertyValue(ac.getBean("&sampleGateway"), "gatewayMap", Map.class);
+		Map<?, ?> gateways = TestUtils.getPropertyValue(ac.getBean("&sampleGateway"), "gatewayMap");
 		assertThat(gateways.size()).isEqualTo(5);
 		ac.close();
 	}
@@ -343,7 +344,8 @@ public class GatewayInterfaceTests {
 		bf.registerSingleton("requestChannelBaz", channel);
 		bf.registerSingleton("requestChannelFoo", channel);
 		bf.registerSingleton("taskScheduler", mock(TaskScheduler.class));
-		bf.registerSingleton(IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME, new StandardEvaluationContext());
+		bf.registerSingleton(IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME,
+				new StandardEvaluationContext());
 		fb.setBeanFactory(bf);
 		fb.afterPropertiesSet();
 		assertThat(fb.getObject()).isNotSameAs(bar);
@@ -424,8 +426,8 @@ public class GatewayInterfaceTests {
 	@Test
 	@SuppressWarnings("deprecation")
 	public void testExecs() throws Exception {
-		assertThat(TestUtils.getPropertyValue(execGatewayFB, "asyncExecutor")).isSameAs(exec);
-		assertThat(TestUtils.getPropertyValue(noExecGatewayFB, "asyncExecutor")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(execGatewayFB, "asyncExecutor")).isSameAs(exec);
+		assertThat(TestUtils.<Object>getPropertyValue(noExecGatewayFB, "asyncExecutor")).isNull();
 
 		Future<Thread> result = this.int2634Gateway.test3(Thread.currentThread());
 		assertThat(result.get()).isNotEqualTo(Thread.currentThread());
@@ -468,10 +470,10 @@ public class GatewayInterfaceTests {
 		assertThat(this.notActivatedByProfileGateway).isNull();
 
 		assertThat(this.annotationGatewayProxyFactoryBean.getAsyncExecutor()).isSameAs(this.exec);
-		assertThat(TestUtils.getPropertyValue(this.annotationGatewayProxyFactoryBean,
-				"defaultRequestTimeout", Expression.class).getValue()).isEqualTo(1111L);
-		assertThat(TestUtils.getPropertyValue(this.annotationGatewayProxyFactoryBean,
-				"defaultReplyTimeout", Expression.class).getValue()).isEqualTo(0L);
+		assertThat(TestUtils.<Expression>getPropertyValue(this.annotationGatewayProxyFactoryBean,
+				"defaultRequestTimeout").getValue()).isEqualTo(1111L);
+		assertThat(TestUtils.<Expression>getPropertyValue(this.annotationGatewayProxyFactoryBean,
+				"defaultReplyTimeout").getValue()).isEqualTo(0L);
 
 		Collection<MessagingGatewaySupport> messagingGateways =
 				this.annotationGatewayProxyFactoryBean.getGateways().values();
@@ -483,9 +485,10 @@ public class GatewayInterfaceTests {
 		assertThat(gateway.getErrorChannel()).isSameAs(this.errorChannel);
 		Object requestMapper = TestUtils.getPropertyValue(gateway, "requestMapper");
 
-		assertThat(TestUtils.getPropertyValue(requestMapper, "payloadExpression.expression")).isEqualTo("args[0]");
+		assertThat(TestUtils.<String>getPropertyValue(requestMapper, "payloadExpression.expression"))
+				.isEqualTo("args[0]");
 
-		Map globalHeaderExpressions = TestUtils.getPropertyValue(requestMapper, "globalHeaderExpressions", Map.class);
+		Map globalHeaderExpressions = TestUtils.getPropertyValue(requestMapper, "globalHeaderExpressions");
 		assertThat(globalHeaderExpressions.size()).isEqualTo(1);
 
 		Object barHeaderExpression = globalHeaderExpressions.get("bar");

--- a/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayXmlAndAnnotationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/gateway/GatewayXmlAndAnnotationTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -50,31 +51,30 @@ public class GatewayXmlAndAnnotationTests {
 
 	@Test
 	public void test() {
-		assertThat(TestUtils.getPropertyValue(gatewayProxyFactoryBean, "defaultReplyTimeout", Expression.class)
+		assertThat(TestUtils.<Expression>getPropertyValue(gatewayProxyFactoryBean, "defaultReplyTimeout")
 				.getValue()).isEqualTo(123L);
-		@SuppressWarnings("unchecked")
-		Map<Method, MessagingGatewaySupport> gatewayMap = TestUtils.getPropertyValue(gatewayProxyFactoryBean,
-				"gatewayMap", Map.class);
+		Map<Method, MessagingGatewaySupport> gatewayMap =
+				TestUtils.getPropertyValue(gatewayProxyFactoryBean, "gatewayMap");
 		int assertions = 0;
 		for (Entry<Method, MessagingGatewaySupport> entry : gatewayMap.entrySet()) {
 			switch (entry.getKey().getName()) {
 				case "annotationShouldNotOverrideDefault" -> {
-					assertThat(TestUtils.getPropertyValue(entry.getValue(),
+					assertThat(TestUtils.<Long>getPropertyValue(entry.getValue(),
 							"messagingTemplate.receiveTimeout")).isEqualTo(123L);
 					assertions++;
 				}
 				case "annotationShouldOverrideDefault" -> {
-					assertThat(TestUtils.getPropertyValue(entry.getValue(),
+					assertThat(TestUtils.<Long>getPropertyValue(entry.getValue(),
 							"messagingTemplate.receiveTimeout")).isEqualTo(234L);
 					assertions++;
 				}
 				case "annotationShouldOverrideDefaultToInfinity" -> {
-					assertThat(TestUtils.getPropertyValue(entry.getValue(),
+					assertThat(TestUtils.<Long>getPropertyValue(entry.getValue(),
 							"messagingTemplate.receiveTimeout")).isEqualTo(-1L);
 					assertions++;
 				}
 				case "explicitTimeoutShouldOverrideDefault" -> {
-					assertThat(TestUtils.getPropertyValue(entry.getValue(),
+					assertThat(TestUtils.<Long>getPropertyValue(entry.getValue(),
 							"messagingTemplate.receiveTimeout")).isEqualTo(456L);
 					assertions++;
 				}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/AsyncHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/AsyncHandlerTests.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.spy;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.3
  *
@@ -104,7 +105,7 @@ public class AsyncHandlerTests implements TestApplicationContextAware {
 		this.handler.setOutputChannel(this.output);
 		this.handler.setBeanFactory(mock(BeanFactory.class));
 		this.latch = new CountDownLatch(1);
-		LogAccessor logAccessor = TestUtils.getPropertyValue(this.handler, "logger", LogAccessor.class);
+		LogAccessor logAccessor = TestUtils.getPropertyValue(this.handler, "logger");
 		Log log = spy(logAccessor.getLog());
 		new DirectFieldAccessor(logAccessor).setPropertyValue("log", log);
 		doAnswer(invocation -> {

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/ExpressionEvaluatingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/ExpressionEvaluatingMessageProcessorTests.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -83,7 +84,7 @@ public class ExpressionEvaluatingMessageProcessorTests implements TestApplicatio
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		processor.afterPropertiesSet();
 		EvaluationContext evaluationContext =
-				TestUtils.getPropertyValue(processor, "evaluationContext", EvaluationContext.class);
+				TestUtils.<EvaluationContext>getPropertyValue(processor, "evaluationContext");
 		evaluationContext.setVariable("target", new TestTarget());
 		assertThat(processor.processMessage(new GenericMessage<>("2"))).isEqualTo("2");
 	}
@@ -104,7 +105,7 @@ public class ExpressionEvaluatingMessageProcessorTests implements TestApplicatio
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		processor.afterPropertiesSet();
 		EvaluationContext evaluationContext =
-				TestUtils.getPropertyValue(processor, "evaluationContext", EvaluationContext.class);
+				TestUtils.<EvaluationContext>getPropertyValue(processor, "evaluationContext");
 		evaluationContext.setVariable("target", new TestTarget());
 		assertThat(processor.processMessage(new GenericMessage<>("2"))).isEqualTo(null);
 	}
@@ -134,7 +135,7 @@ public class ExpressionEvaluatingMessageProcessorTests implements TestApplicatio
 
 		processor.afterPropertiesSet();
 		EvaluationContext evaluationContext =
-				TestUtils.getPropertyValue(processor, "evaluationContext", EvaluationContext.class);
+				TestUtils.<EvaluationContext>getPropertyValue(processor, "evaluationContext");
 		evaluationContext.setVariable("target", new TestTarget());
 		String result = processor.processMessage(new GenericMessage<>("classpath*:*-test.xml"));
 		assertThat(result).contains("log4j2-test.xml");

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/LoggingHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/LoggingHandlerTests.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.when;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Andriy Kryvtsun
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -103,11 +104,11 @@ public class LoggingHandlerTests implements TestApplicationContextAware {
 		loggingHandler.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		loggingHandler.afterPropertiesSet();
 
-		LogAccessor logAccessor = TestUtils.getPropertyValue(loggingHandler, "messageLogger", LogAccessor.class);
+		LogAccessor logAccessor = TestUtils.getPropertyValue(loggingHandler, "messageLogger");
 		Log log = spy(logAccessor.getLog());
 		when(log.isInfoEnabled()).thenReturn(false, true);
 		new DirectFieldAccessor(logAccessor).setPropertyValue("log", log);
-		Expression expression = spy(TestUtils.getPropertyValue(loggingHandler, "expression", Expression.class));
+		Expression expression = spy(TestUtils.<Expression>getPropertyValue(loggingHandler, "expression"));
 		loggingHandler.setLogExpression(expression);
 		loggingHandler.handleMessage(new GenericMessage<>("foo"));
 		verify(expression, never()).getValue(any(EvaluationContext.class), any(Message.class));

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -104,15 +104,17 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
+@SuppressWarnings("unchecked")
 public class MethodInvokingMessageProcessorTests implements TestApplicationContextAware {
 
 	private static final Log logger = LogFactory.getLog(MethodInvokingMessageProcessorTests.class);
 
 	@Test
 	public void testMessageHandlerMethodFactoryOverride() {
-		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(MyConfiguration.class)) {
+		try (AnnotationConfigApplicationContext context =
+				new AnnotationConfigApplicationContext(MyConfiguration.class)) {
 			MessageChannel channel = context.getBean("foo", MessageChannel.class);
 			channel.send(MessageBuilder.withPayload("Bob Smith").build());
 			PollableChannel out = context.getBean("out", PollableChannel.class);
@@ -192,7 +194,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 		}
 
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new B(), "myMethod");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new B(), "myMethod");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> message = (Message<?>) processor.processMessage(new GenericMessage<>(""));
 		assertThat(message.getHeaders().get("A")).isEqualTo("A");
@@ -223,7 +225,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 		}
 
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new B(), "myMethod");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new B(), "myMethod");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> message = (Message<?>) processor.processMessage(new GenericMessage<>(""));
 		assertThat(message.getHeaders().get("B")).isEqualTo("B");
@@ -258,7 +260,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 		}
 
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new C(), "myMethod");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new C(), "myMethod");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> message = (Message<?>) processor.processMessage(new GenericMessage<>(""));
 		assertThat(message.getHeaders().get("C")).isEqualTo("C");
@@ -288,7 +290,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 		}
 
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new C(), "myMethod");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new C(), "myMethod");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> message = (Message<?>) processor.processMessage(new GenericMessage<>(""));
 		assertThat(message.getHeaders().get("C")).isEqualTo("C");
@@ -296,7 +298,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	public void payloadAsMethodParameterAndObjectAsReturnValue() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new TestBean(),
 				"acceptPayloadAndReturnObject");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Object result = processor.processMessage(new GenericMessage<>("testing"));
@@ -305,7 +307,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	public void testPayloadCoercedToString() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new TestBean(),
 				"acceptPayloadAndReturnObject");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Object result = processor.processMessage(new GenericMessage<>(123456789));
@@ -314,7 +316,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	public void payloadAsMethodParameterAndMessageAsReturnValue() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new TestBean(),
 				"acceptPayloadAndReturnMessage");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> result = (Message<?>) processor.processMessage(new GenericMessage<>("testing"));
@@ -323,7 +325,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	public void messageAsMethodParameterAndObjectAsReturnValue() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new TestBean(),
 				"acceptMessageAndReturnObject");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Object result = processor.processMessage(new GenericMessage<>("testing"));
@@ -332,7 +334,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	public void messageAsMethodParameterAndMessageAsReturnValue() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new TestBean(),
 				"acceptMessageAndReturnMessage");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> result = (Message<?>) processor.processMessage(new GenericMessage<>("testing"));
@@ -341,7 +343,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	public void messageSubclassAsMethodParameterAndMessageAsReturnValue() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new TestBean(),
 				"acceptMessageSubclassAndReturnMessage");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> result = (Message<?>) processor.processMessage(new GenericMessage<>("testing"));
@@ -350,7 +352,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	public void messageSubclassAsMethodParameterAndMessageSubclassAsReturnValue() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new TestBean(),
 				"acceptMessageSubclassAndReturnMessageSubclass");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> result = (Message<?>) processor.processMessage(new GenericMessage<>("testing"));
@@ -359,7 +361,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	public void payloadAndHeaderAnnotationMethodParametersAndObjectAsReturnValue() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new TestBean(),
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new TestBean(),
 				"acceptPayloadAndHeaderAndReturnObject");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> request = MessageBuilder.withPayload("testing").setHeader("number", 123).build();
@@ -369,8 +371,8 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	public void testVoidMethodsIncludedByDefault() {
-		MethodInvokingMessageProcessor processor =
-				new MethodInvokingMessageProcessor(new TestBean(), "testVoidReturningMethods");
+		MethodInvokingMessageProcessor<?> processor =
+				new MethodInvokingMessageProcessor<>(new TestBean(), "testVoidReturningMethods");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		assertThat(processor.processMessage(MessageBuilder.withPayload("Something").build())).isNull();
 		assertThat(processor.processMessage(MessageBuilder.withPayload(12).build())).isEqualTo(12);
@@ -380,7 +382,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void messageOnlyWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("messageOnly", Message.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Object result = processor.processMessage(new GenericMessage<>("foo"));
 		assertThat(result).isEqualTo("foo");
@@ -390,7 +392,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void payloadWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("integerMethod", Integer.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Object result = processor.processMessage(new GenericMessage<>(123));
 		assertThat(result).isEqualTo(123);
@@ -400,7 +402,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void convertedPayloadWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("integerMethod", Integer.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Object result = processor.processMessage(new GenericMessage<>("456"));
 		assertThat(result).isEqualTo(456);
@@ -410,7 +412,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void conversionFailureWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("integerMethod", Integer.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		assertThatExceptionOfType(MessageConversionException.class)
 				.isThrownBy(() -> processor.processMessage(new GenericMessage<>("foo")));
@@ -419,7 +421,8 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	@Test
 	public void filterSelectsAnnotationMethodsOnly() {
 		OverloadedMethodBean bean = new OverloadedMethodBean();
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, ServiceActivator.class);
+		MethodInvokingMessageProcessor<?> processor =
+				new MethodInvokingMessageProcessor<>(bean, ServiceActivator.class);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		processor.processMessage(MessageBuilder.withPayload(123).build());
 		assertThat(bean.lastArg).isNotNull();
@@ -431,7 +434,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void testProcessMessageBadExpression() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("integerMethod", Integer.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		assertThatExceptionOfType(MessageConversionException.class)
 				.isThrownBy(() -> processor.processMessage(new GenericMessage<>("foo")))
@@ -442,7 +445,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void testProcessMessageRuntimeException() throws Exception {
 		TestErrorService service = new TestErrorService();
 		Method method = service.getClass().getMethod("error", String.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		assertThatExceptionOfType(MessageHandlingException.class)
 				.isThrownBy(() -> processor.processMessage(new GenericMessage<>("foo")))
@@ -453,7 +456,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void testProcessMessageCheckedException() throws Exception {
 		TestErrorService service = new TestErrorService();
 		Method method = service.getClass().getMethod("checked", String.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		assertThatExceptionOfType(MessageHandlingException.class)
 				.isThrownBy(() -> processor.processMessage(new GenericMessage<>("foo")))
@@ -465,7 +468,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void testProcessMessageMethodNotFound() throws Exception {
 		TestDifferentErrorService service = new TestDifferentErrorService();
 		Method method = TestErrorService.class.getMethod("checked", String.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setUseSpelInvoker(true);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		assertThatExceptionOfType(MessageHandlingException.class)
@@ -477,7 +480,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void messageAndHeaderWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("messageAndHeader", Message.class, Integer.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<String> message = MessageBuilder.withPayload("foo").setHeader("number", 42).build();
 		Object result = processor.processMessage(message);
@@ -488,7 +491,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void multipleHeadersWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("twoHeaders", String.class, Integer.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<String> message =
 				MessageBuilder.withPayload("foo")
@@ -503,7 +506,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void optionalAndRequiredWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("optionalAndRequiredHeader", String.class, Integer.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setUseSpelInvoker(true);
 		optionalAndRequiredWithAnnotatedMethodGuts(processor);
 	}
@@ -512,16 +515,17 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	public void compiledOptionalAndRequiredWithAnnotatedMethod() throws Exception {
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("optionalAndRequiredHeader", String.class, Integer.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setUseSpelInvoker(true);
 		DirectFieldAccessor compilerConfigAccessor = compileImmediate(processor);
 		optionalAndRequiredWithAnnotatedMethodGuts(processor);
-		assertThat(TestUtils.getPropertyValue(processor, "delegate.handlerMethod.expression.compiledAst")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(processor, "delegate.handlerMethod.expression.compiledAst"))
+				.isNotNull();
 		optionalAndRequiredWithAnnotatedMethodGuts(processor);
 		compilerConfigAccessor.setPropertyValue("compilerMode", SpelCompilerMode.OFF);
 	}
 
-	private void optionalAndRequiredWithAnnotatedMethodGuts(MethodInvokingMessageProcessor processor) {
+	private void optionalAndRequiredWithAnnotatedMethodGuts(MethodInvokingMessageProcessor<?> processor) {
 
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<String> message = MessageBuilder.withPayload("foo")
@@ -550,7 +554,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("optionalAndRequiredDottedHeader", String.class, Integer.class,
 				String.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setUseSpelInvoker(true);
 		optionalAndRequiredDottedWithAnnotatedMethodGuts(processor);
 	}
@@ -560,16 +564,17 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("optionalAndRequiredDottedHeader", String.class, Integer.class,
 				String.class);
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setUseSpelInvoker(true);
 		DirectFieldAccessor compilerConfigAccessor = compileImmediate(processor);
 		optionalAndRequiredDottedWithAnnotatedMethodGuts(processor);
-		assertThat(TestUtils.getPropertyValue(processor, "delegate.handlerMethod.expression.compiledAst")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(processor,
+				"delegate.handlerMethod.expression.compiledAst")).isNotNull();
 		optionalAndRequiredDottedWithAnnotatedMethodGuts(processor);
 		compilerConfigAccessor.setPropertyValue("compilerMode", SpelCompilerMode.OFF);
 	}
 
-	private void optionalAndRequiredDottedWithAnnotatedMethodGuts(MethodInvokingMessageProcessor processor) {
+	private void optionalAndRequiredDottedWithAnnotatedMethodGuts(MethodInvokingMessageProcessor<?> processor) {
 
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<String> message = MessageBuilder.withPayload("hello")
@@ -599,7 +604,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	@Test
 	public void testOverloadedNonVoidReturningMethodsWithExactMatchForType() {
 		AmbiguousMethodBean bean = new AmbiguousMethodBean();
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, "foo");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(bean, "foo");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		processor.processMessage(MessageBuilder.withPayload("true").build());
 		assertThat(bean.lastArg).isNotNull();
@@ -771,7 +776,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 	@Test
 	public void testIneligible() {
 		IneligibleMethodBean bean = new IneligibleMethodBean();
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(bean, "foo");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(bean, "foo");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		processor.processMessage(MessageBuilder.withPayload("true").build());
 		assertThat(bean.lastArg).isNotNull();
@@ -835,7 +840,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 		AnnotatedTestService service = new AnnotatedTestService();
 		Method method = service.getClass().getMethod("integerMethod", Integer.class);
 
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, method);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setUseSpelInvoker(true);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 
@@ -851,7 +856,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 		}
 		stopWatch.stop();
 
-		processor = new MethodInvokingMessageProcessor(service, method);
+		processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 
 		stopWatch.start("Invocable");
@@ -862,7 +867,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 		DirectFieldAccessor compilerConfigAccessor = compileImmediate(processor);
 
-		processor = new MethodInvokingMessageProcessor(service, method);
+		processor = new MethodInvokingMessageProcessor<>(service, method);
 		processor.setUseSpelInvoker(true);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 
@@ -887,7 +892,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 		}
 
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new A(), "myMethod");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new A(), "myMethod");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		try {
 			processor.processMessage(new GenericMessage<>("foo"));
@@ -897,7 +902,8 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 			assertThat(e.getCause().getStackTrace()[0].getClassName()).isEqualTo(A.class.getName());
 		}
 
-		assertThat(TestUtils.getPropertyValue(processor, "delegate.handlerMethod.failedAttempts")).isEqualTo(0);
+		assertThat(TestUtils.<Integer>getPropertyValue(processor, "delegate.handlerMethod.failedAttempts"))
+				.isEqualTo(0);
 
 	}
 
@@ -923,7 +929,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 		});
 		service = (MessageHandler) proxyFactory.getProxy(getClass().getClassLoader());
 
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, "handleMessage");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, "handleMessage");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 
 		processor.processMessage(new GenericMessage<>("foo"));
@@ -958,7 +964,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 		GenericMessage<String> testMessage = new GenericMessage<>("foo");
 
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(service, "handle");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(service, "handle");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 
 		processor.processMessage(testMessage);
@@ -977,28 +983,32 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 		helper.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Message<?> message = new GenericMessage<>("Test");
 		helper.process(message);
-		assertThat(TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"))
+		assertThat(TestUtils.<SpelCompilerMode>getPropertyValue(helper, "handlerMethod.expression.configuration" +
+				".compilerMode"))
 				.isEqualTo(SpelCompilerMode.OFF);
 
 		helper = new MessagingMethodInvokerHelper(bean,
 				UseSpelInvokerBean.class.getDeclaredMethod("bar", String.class), false);
 		helper.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		helper.process(message);
-		assertThat(TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"))
+		assertThat(TestUtils.<SpelCompilerMode>getPropertyValue(helper, "handlerMethod.expression.configuration" +
+				".compilerMode"))
 				.isEqualTo(SpelCompilerMode.IMMEDIATE);
 
 		helper = new MessagingMethodInvokerHelper(bean,
 				UseSpelInvokerBean.class.getDeclaredMethod("baz", String.class), false);
 		helper.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		helper.process(message);
-		assertThat(TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"))
+		assertThat(TestUtils.<SpelCompilerMode>getPropertyValue(helper, "handlerMethod.expression.configuration" +
+				".compilerMode"))
 				.isEqualTo(SpelCompilerMode.MIXED);
 
 		helper = new MessagingMethodInvokerHelper(bean,
 				UseSpelInvokerBean.class.getDeclaredMethod("qux", String.class), false);
 		helper.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		helper.process(message);
-		assertThat(TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"))
+		assertThat(TestUtils.<SpelCompilerMode>getPropertyValue(helper, "handlerMethod.expression.configuration" +
+				".compilerMode"))
 				.isEqualTo(SpelCompilerMode.OFF);
 
 		helper = new MessagingMethodInvokerHelper(bean,
@@ -1035,13 +1045,15 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 		helper = new MessagingMethodInvokerHelper(bean, "bar", false);
 		helper.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		helper.process(message);
-		assertThat(TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"))
+		assertThat(TestUtils.<SpelCompilerMode>getPropertyValue(helper, "handlerMethod.expression.configuration" +
+				".compilerMode"))
 				.isEqualTo(SpelCompilerMode.IMMEDIATE);
 
 		helper = new MessagingMethodInvokerHelper(bean, ServiceActivator.class, false);
 		helper.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		helper.process(message);
-		assertThat(TestUtils.getPropertyValue(helper, "handlerMethod.expression.configuration.compilerMode"))
+		assertThat(TestUtils.<SpelCompilerMode>getPropertyValue(helper, "handlerMethod.expression.configuration" +
+				".compilerMode"))
 				.isEqualTo(SpelCompilerMode.MIXED);
 	}
 
@@ -1138,13 +1150,13 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 		ApplicationContext applicationContext = new AnnotationConfigApplicationContext(TestConfiguration.class);
 
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new A(), "myMethod");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(new A(), "myMethod");
 		processor.setBeanFactory(applicationContext);
 
 		List<Employee<Person>> testData =
 				Arrays.asList(
 						new Employee<>(new Person("Foo")),
-						new Employee<>(new Person("Bar")));
+						new Employee<>(new Person("ReleaseStrategyTest")));
 
 		ObjectMapper objectMapper = new ObjectMapper();
 		byte[] value = objectMapper.writeValueAsBytes(testData);
@@ -1156,20 +1168,20 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 		String result = (String) processor.processMessage(testMessage);
 
-		assertThat(result).isEqualTo("Foo,Bar");
+		assertThat(result).isEqualTo("Foo,ReleaseStrategyTest");
 	}
 
 	@Test
 	void lifecycleOnly() {
 		assertThatIllegalStateException().isThrownBy(() ->
-						new MethodInvokingMessageProcessor(new LifecycleBean(), (String) null))
+						new MethodInvokingMessageProcessor<>(new LifecycleBean(), (String) null))
 				.withMessageContaining("no eligible methods");
 	}
 
 	@Test
 	void lifecycleOnlyExplicitMethod() {
 		LifecycleBean targetObject = new LifecycleBean();
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(targetObject, "start");
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(targetObject, "start");
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Object result = processor.processMessage(new GenericMessage<>("testing"));
 		assertThat(targetObject.startCalled).isTrue();
@@ -1177,8 +1189,8 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	@Test
 	void lifecycleWithValidStartMethod() {
-		MethodInvokingMessageProcessor processor = new MethodInvokingMessageProcessor(new LifeCycleWithCustomStart(),
-				(String) null);
+		MethodInvokingMessageProcessor<?> processor = new MethodInvokingMessageProcessor<>(
+				new LifeCycleWithCustomStart(), (String) null);
 		processor.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		Object result = processor.processMessage(new GenericMessage<>("testing"));
 		assertThat(result).isEqualTo("TESTING");
@@ -1247,10 +1259,10 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 
 	}
 
-	private DirectFieldAccessor compileImmediate(MethodInvokingMessageProcessor processor) {
+	private DirectFieldAccessor compileImmediate(MethodInvokingMessageProcessor<?> processor) {
 		// Update the parser configuration compiler mode
-		SpelParserConfiguration config = TestUtils.getPropertyValue(processor,
-				"delegate.EXPRESSION_PARSER.configuration", SpelParserConfiguration.class);
+		SpelParserConfiguration config =
+				TestUtils.getPropertyValue(processor, "delegate.EXPRESSION_PARSER.configuration");
 		DirectFieldAccessor accessor = new DirectFieldAccessor(config);
 		accessor.setPropertyValue("compilerMode", SpelCompilerMode.IMMEDIATE);
 		return accessor;
@@ -1380,7 +1392,7 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 			return properties;
 		}
 
-		public Map mapMethod(Map map) {
+		public Map<?, ?> mapMethod(Map<?, ?> map) {
 			return map;
 		}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/SendTimeoutConfigurationTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/SendTimeoutConfigurationTests.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -63,8 +64,8 @@ public class SendTimeoutConfigurationTests {
 	}
 
 	private long getTimeout(String endpointName) {
-		return TestUtils.getPropertyValue(this.context.getBean(endpointName),
-				"handler.messagingTemplate.sendTimeout", Long.class);
+		return TestUtils.<Long>getPropertyValue(
+				this.context.getBean(endpointName), "handler.messagingTemplate.sendTimeout");
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -76,6 +76,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  */
@@ -329,7 +330,6 @@ public class AdvisedMessageHandlerTests implements TestApplicationContextAware {
 	}
 
 	@Test
-	@SuppressWarnings("rawtypes")
 	public void circuitBreakerTests() {
 		final AtomicBoolean doFail = new AtomicBoolean();
 		AbstractReplyProducingMessageHandler handler = new AbstractReplyProducingMessageHandler() {
@@ -375,7 +375,7 @@ public class AdvisedMessageHandlerTests implements TestApplicationContextAware {
 				.withMessage("Circuit Breaker is Open for bean 'baz'")
 				.extracting("failedMessage").isSameAs(message);
 
-		Map metadataMap = TestUtils.getPropertyValue(advice, "metadataMap", Map.class);
+		Map<?, ?> metadataMap = TestUtils.getPropertyValue(advice, "metadataMap");
 		Object metadata = metadataMap.values().iterator().next();
 
 		DirectFieldAccessor metadataDfa = new DirectFieldAccessor(metadata);
@@ -819,9 +819,9 @@ public class AdvisedMessageHandlerTests implements TestApplicationContextAware {
 		consumer.setTaskScheduler(mock(TaskScheduler.class));
 		consumer.start();
 
-		Callable<?> pollingTask = TestUtils.getPropertyValue(consumer, "pollingTask", Callable.class);
+		Callable<?> pollingTask = TestUtils.getPropertyValue(consumer, "pollingTask");
 		assertThat(AopUtils.isAopProxy(pollingTask)).isTrue();
-		LogAccessor logger = spy(TestUtils.getPropertyValue(advice, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(advice, "logger"));
 		when(logger.isWarnEnabled()).thenReturn(Boolean.TRUE);
 		final AtomicReference<String> logMessage = new AtomicReference<>();
 		doAnswer(invocation -> {

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/IdempotentReceiverTests-context.xml
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/IdempotentReceiverTests-context.xml
@@ -7,7 +7,7 @@
 	   http://www.springframework.org/schema/integration
 	   https://www.springframework.org/schema/integration/spring-integration.xsd">
 
-	<beans:bean id="advice" class="org.springframework.integration.handler.advice.IdempotentReceiverTests$FooAdvice"/>
+	<beans:bean id="advice" class="org.springframework.integration.handler.advice.IdempotentReceiverTests$TestAdvice"/>
 
 	<beans:bean id="store" class="org.springframework.integration.metadata.SimpleMetadataStore"/>
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/JsonToObjectTransformerParserTests.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -107,7 +108,7 @@ public class JsonToObjectTransformerParserTests {
 	@Test
 	public void testInt2831CustomJsonObjectMapper() {
 		Object jsonToObjectTransformer = TestUtils.getPropertyValue(this.customJsonMapperTransformer, "transformer");
-		assertThat(TestUtils.getPropertyValue(jsonToObjectTransformer, "jsonObjectMapper", JsonObjectMapper.class))
+		assertThat(TestUtils.<JsonObjectMapper<?, ?>>getPropertyValue(jsonToObjectTransformer, "jsonObjectMapper"))
 				.isSameAs(this.jsonObjectMapper);
 
 		String jsonString = "{firstName:'John', lastName:'Doe', age:42, address:{number:123, street:'Main Street'}}";

--- a/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/json/ObjectToJsonTransformerParserTests.java
@@ -47,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -75,9 +76,9 @@ public class ObjectToJsonTransformerParserTests {
 	@Test
 	public void testContentType() {
 		ObjectToJsonTransformer transformer =
-				TestUtils.getPropertyValue(context.getBean("defaultTransformer"), "handler.transformer",
-						ObjectToJsonTransformer.class);
-		assertThat(TestUtils.getPropertyValue(transformer, "contentType")).isEqualTo("application/json");
+				TestUtils.getPropertyValue(context.getBean("defaultTransformer"), "handler.transformer");
+		assertThat(TestUtils.<String>getPropertyValue(transformer, "contentType"))
+				.isEqualTo("application/json");
 
 		assertThat(TestUtils.getPropertyValue(transformer, "jsonObjectMapper").getClass())
 				.isEqualTo(JacksonJsonObjectMapper.class);
@@ -90,10 +91,9 @@ public class ObjectToJsonTransformerParserTests {
 		// Reset readOnlyHeaders to defaults. Therefore the 'contentType' should be presented in subsequent tests
 		this.defaultMessageBuilderFactory.setReadOnlyHeaders();
 
-		transformer =
-				TestUtils.getPropertyValue(context.getBean("emptyContentTypeTransformer"), "handler.transformer",
-						ObjectToJsonTransformer.class);
-		assertThat(TestUtils.getPropertyValue(transformer, "contentType")).isEqualTo("");
+		transformer = TestUtils.<ObjectToJsonTransformer>getPropertyValue(
+				context.getBean("emptyContentTypeTransformer"), "handler.transformer");
+		assertThat(TestUtils.<String>getPropertyValue(transformer, "contentType")).isEmpty();
 
 		transformed = transformer.transform(MessageBuilder.withPayload("foo").build());
 		assertThat(transformed.getHeaders().containsKey(MessageHeaders.CONTENT_TYPE)).isFalse();
@@ -104,9 +104,9 @@ public class ObjectToJsonTransformerParserTests {
 		assertThat(transformed.getHeaders().get(MessageHeaders.CONTENT_TYPE)).isEqualTo("foo");
 
 		transformer =
-				TestUtils.getPropertyValue(context.getBean("overriddenContentTypeTransformer"), "handler.transformer",
-						ObjectToJsonTransformer.class);
-		assertThat(TestUtils.getPropertyValue(transformer, "contentType")).isEqualTo("text/xml");
+				TestUtils.getPropertyValue(context.getBean("overriddenContentTypeTransformer"), "handler.transformer");
+		assertThat(TestUtils.<String>getPropertyValue(transformer, "contentType"))
+				.isEqualTo("text/xml");
 	}
 
 	@Test

--- a/spring-integration-core/src/test/java/org/springframework/integration/resource/ResourceInboundChannelAdapterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/resource/ResourceInboundChannelAdapterParserTests.java
@@ -40,6 +40,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 2.1
  */
 public class ResourceInboundChannelAdapterParserTests {
@@ -72,14 +74,14 @@ public class ResourceInboundChannelAdapterParserTests {
 				new ClassPathXmlApplicationContext("ResourcePatternResolver-config.xml", getClass());
 		SourcePollingChannelAdapter resourceAdapter = context.getBean("resourceAdapterDefault",
 				SourcePollingChannelAdapter.class);
-		ResourceRetrievingMessageSource source = TestUtils.getPropertyValue(resourceAdapter, "source",
-				ResourceRetrievingMessageSource.class);
+		ResourceRetrievingMessageSource source = TestUtils.getPropertyValue(resourceAdapter, "source");
 		assertThat(source).isNotNull();
-		boolean autoStartup = TestUtils.getPropertyValue(resourceAdapter, "autoStartup", Boolean.class);
+		boolean autoStartup = TestUtils.<Boolean>getPropertyValue(resourceAdapter, "autoStartup");
 		assertThat(autoStartup).isFalse();
 
-		assertThat(TestUtils.getPropertyValue(source, "pattern")).isEqualTo("/**/*");
-		assertThat(TestUtils.getPropertyValue(source, "patternResolver")).isEqualTo(context);
+		assertThat(TestUtils.<String>getPropertyValue(source, "pattern")).isEqualTo("/**/*");
+		assertThat(TestUtils.<ClassPathXmlApplicationContext>getPropertyValue(source, "patternResolver"))
+				.isEqualTo(context);
 		context.close();
 	}
 
@@ -95,10 +97,10 @@ public class ResourceInboundChannelAdapterParserTests {
 				new ClassPathXmlApplicationContext("ResourcePatternResolver-config-custom.xml", getClass());
 		SourcePollingChannelAdapter resourceAdapter = context.getBean("resourceAdapterDefault",
 				SourcePollingChannelAdapter.class);
-		ResourceRetrievingMessageSource source = TestUtils.getPropertyValue(resourceAdapter, "source",
-				ResourceRetrievingMessageSource.class);
+		ResourceRetrievingMessageSource source = TestUtils.getPropertyValue(resourceAdapter, "source");
 		assertThat(source).isNotNull();
-		assertThat(TestUtils.getPropertyValue(source, "patternResolver")).isEqualTo(context.getBean("customResolver"));
+		assertThat(TestUtils.<Object>getPropertyValue(source, "patternResolver"))
+				.isEqualTo(context.getBean("customResolver"));
 		context.close();
 	}
 
@@ -136,11 +138,11 @@ public class ResourceInboundChannelAdapterParserTests {
 				"ResourcePatternResolver-config-usagerf.xml", this.getClass());
 		SourcePollingChannelAdapter resourceAdapter = context.getBean("resourceAdapterDefault",
 				SourcePollingChannelAdapter.class);
-		ResourceRetrievingMessageSource source = TestUtils.getPropertyValue(resourceAdapter, "source",
-				ResourceRetrievingMessageSource.class);
+		ResourceRetrievingMessageSource source = TestUtils.getPropertyValue(resourceAdapter, "source");
 		assertThat(source).isNotNull();
 		TestCollectionFilter customFilter = context.getBean("customFilter", TestCollectionFilter.class);
-		assertThat(TestUtils.getPropertyValue(source, "filter")).isEqualTo(customFilter);
+		assertThat(TestUtils.<TestCollectionFilter>getPropertyValue(source, "filter"))
+				.isEqualTo(customFilter);
 
 		assertThat(customFilter.invoked).isFalse();
 		resourceAdapter.start();
@@ -163,10 +165,9 @@ public class ResourceInboundChannelAdapterParserTests {
 				"ResourcePatternResolver-config-usage-emptyref.xml", this.getClass());
 		SourcePollingChannelAdapter resourceAdapter = context.getBean("resourceAdapterDefault",
 				SourcePollingChannelAdapter.class);
-		ResourceRetrievingMessageSource source = TestUtils.getPropertyValue(resourceAdapter, "source",
-				ResourceRetrievingMessageSource.class);
+		ResourceRetrievingMessageSource source = TestUtils.getPropertyValue(resourceAdapter, "source");
 		assertThat(source).isNotNull();
-		assertThat(TestUtils.getPropertyValue(source, "filter")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(source, "filter")).isNull();
 		context.close();
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/RecipientListRouterTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/RecipientListRouterTests.java
@@ -47,6 +47,7 @@ import static org.mockito.Mockito.when;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class RecipientListRouterTests {
 
@@ -429,7 +430,8 @@ public class RecipientListRouterTests {
 
 		router.handleMessage(new GenericMessage<String>("foo"));
 
-		assertThat(TestUtils.getPropertyValue(router, "defaultOutputChannel")).isSameAs(defaultChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(router, "defaultOutputChannel"))
+				.isSameAs(defaultChannel);
 		Mockito.verify(beanFactory).getBean(Mockito.eq("defaultChannel"), Mockito.eq(MessageChannel.class));
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RecipientListRouterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RecipientListRouterParserTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -74,7 +75,8 @@ public class RecipientListRouterParserTests {
 		assertThat(handler.getClass()).isEqualTo(RecipientListRouter.class);
 		RecipientListRouter router = (RecipientListRouter) handler;
 		DirectFieldAccessor accessor = new DirectFieldAccessor(router);
-		assertThat(TestUtils.getPropertyValue(router, "messagingTemplate.sendTimeout")).isEqualTo(45000L);
+		assertThat(TestUtils.<Long>getPropertyValue(router, "messagingTemplate.sendTimeout"))
+				.isEqualTo(45000L);
 		assertThat(accessor.getPropertyValue("applySequence")).isEqualTo(Boolean.FALSE);
 		assertThat(accessor.getPropertyValue("ignoreSendFailures")).isEqualTo(Boolean.FALSE);
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/router/config/RouterParserTests.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.verify;
  * @author Jonas Partner
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -175,8 +176,8 @@ public class RouterParserTests {
 	public void timeoutValueConfigured() {
 		assertThat(this.routerWithTimeout instanceof MethodInvokingRouter).isTrue();
 		MessagingTemplate template =
-				TestUtils.getPropertyValue(this.routerWithTimeout, "messagingTemplate", MessagingTemplate.class);
-		Long timeout = TestUtils.getPropertyValue(template, "sendTimeout", Long.class);
+				TestUtils.<MessagingTemplate>getPropertyValue(this.routerWithTimeout, "messagingTemplate");
+		Long timeout = TestUtils.getPropertyValue(template, "sendTimeout");
 		assertThat(timeout).isEqualTo(1234L);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/scattergather/config/ScatterGatherParserTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/scattergather/config/ScatterGatherParserTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Artem Bilan
  * @author Abdul Zaheer
+ * @author Glenn Renfro
  *
  * @since 4.1
  */
@@ -52,49 +53,53 @@ public class ScatterGatherParserTests {
 	public void testAuction() {
 		MessageHandler scatterGather = this.beanFactory.getBean("scatterGather1.handler", MessageHandler.class);
 		assertThat(scatterGather).isInstanceOf(ScatterGatherHandler.class);
-		assertThat(TestUtils.getPropertyValue(scatterGather, "scatterChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(scatterGather, "scatterChannel"))
 				.isSameAs(this.beanFactory.getBean("scatterChannel"));
 		assertThat(this.beanFactory.containsBean("scatterGather1.gatherer")).isTrue();
 		AggregatingMessageHandler gatherer =
 				this.beanFactory.getBean("scatterGather1.gatherer", AggregatingMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(scatterGather, "gatherer")).isSameAs(gatherer);
+		assertThat(TestUtils.<AggregatingMessageHandler>getPropertyValue(scatterGather, "gatherer")).isSameAs(gatherer);
 
 		Object reaper = this.beanFactory.getBean("reaper");
-		assertThat(TestUtils.getPropertyValue(reaper, "messageGroupStore")).isSameAs(gatherer.getMessageStore());
-		assertThat(TestUtils.getPropertyValue(scatterGather, "requiresReply", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(reaper, "messageGroupStore"))
+				.isSameAs(gatherer.getMessageStore());
+		assertThat(TestUtils.<Boolean>getPropertyValue(scatterGather, "requiresReply")).isTrue();
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testDistribution() {
 		MessageHandler scatterGather = this.beanFactory.getBean("scatterGather2.handler", MessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(scatterGather, "gatherChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(scatterGather, "gatherChannel"))
 				.isSameAs(this.beanFactory.getBean("gatherChannel"));
-		Lifecycle gatherEndpoint = TestUtils.getPropertyValue(scatterGather, "gatherEndpoint", Lifecycle.class);
-		assertThat(TestUtils.getPropertyValue(scatterGather, "gatherEndpoint")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(scatterGather, "gatherEndpoint")).isInstanceOf(EventDrivenConsumer.class);
-		assertThat(TestUtils.getPropertyValue(scatterGather, "gatherEndpoint.running", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(scatterGather, "gatherTimeout")).isEqualTo(100L);
+		Lifecycle gatherEndpoint = TestUtils.getPropertyValue(scatterGather, "gatherEndpoint");
+		assertThat(TestUtils.<Object>getPropertyValue(scatterGather, "gatherEndpoint")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(scatterGather, "gatherEndpoint"))
+				.isInstanceOf(EventDrivenConsumer.class);
+		assertThat(TestUtils.<Boolean>getPropertyValue(scatterGather, "gatherEndpoint.running")).isTrue();
+		assertThat(TestUtils.<Long>getPropertyValue(scatterGather, "gatherTimeout")).isEqualTo(100L);
 
 		assertThat(this.beanFactory.containsBean("myGatherer")).isTrue();
 		Object gatherer = this.beanFactory.getBean("myGatherer");
-		assertThat(TestUtils.getPropertyValue(scatterGather, "gatherer")).isSameAs(gatherer);
-		assertThat(TestUtils.getPropertyValue(gatherer, "messageStore"))
+		assertThat(TestUtils.<Object>getPropertyValue(scatterGather, "gatherer")).isSameAs(gatherer);
+		assertThat(TestUtils.<Object>getPropertyValue(gatherer, "messageStore"))
 				.isSameAs(this.beanFactory.getBean("messageStore"));
-		assertThat(TestUtils.getPropertyValue(scatterGather, "gatherEndpoint.handler")).isSameAs(gatherer);
+		assertThat(TestUtils.<Object>getPropertyValue(scatterGather, "gatherEndpoint.handler"))
+				.isSameAs(gatherer);
 
 		assertThat(this.beanFactory.containsBean("myScatterer")).isTrue();
 		Object scatterer = this.beanFactory.getBean("myScatterer");
-		assertThat(TestUtils.getPropertyValue(scatterer, "applySequence", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(scatterer, "applySequence")).isTrue();
 
-		Collection<RecipientListRouter.Recipient> recipients = TestUtils.getPropertyValue(scatterer, "recipients",
-				Collection.class);
+		Collection<RecipientListRouter.Recipient> recipients =
+				TestUtils.getPropertyValue(scatterer, "recipients");
 		assertThat(recipients.size()).isEqualTo(1);
-		assertThat(recipients.iterator().next().getChannel()).isSameAs(this.beanFactory.getBean("distributionChannel"));
+		assertThat(recipients.iterator().next().getChannel()).isSameAs(
+				this.beanFactory.getBean("distributionChannel"));
 
 		Object scatterChannel = TestUtils.getPropertyValue(scatterGather, "scatterChannel");
 		assertThat(scatterChannel).isInstanceOf(FixedSubscriberChannel.class);
-		assertThat(TestUtils.getPropertyValue(scatterChannel, "handler")).isSameAs(scatterer);
+		assertThat(TestUtils.<Object>getPropertyValue(scatterChannel, "handler")).isSameAs(scatterer);
 
 		assertThat(gatherEndpoint.isRunning()).isTrue();
 		((Lifecycle) scatterGather).stop();

--- a/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsTests.java
@@ -63,6 +63,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.0.2
  *
@@ -106,7 +107,6 @@ public class MicrometerMetricsTests {
 	@Qualifier("gatesFlow.gateway")
 	private Gate gatesFlow;
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testMicrometerMetrics() {
 		GenericMessage<String> message = new GenericMessage<>("foo");
@@ -119,7 +119,7 @@ public class MicrometerMetricsTests {
 				.isThrownBy(() -> this.channel.send(new GenericMessage<>("bar")))
 				.withStackTraceContaining("testErrorCount");
 
-		assertThat(TestUtils.getPropertyValue(this.channel, "meters", Set.class)).hasSize(2);
+		assertThat(TestUtils.<Set<?>>getPropertyValue(this.channel, "meters")).hasSize(2);
 		this.channel2.send(message);
 		this.queue.send(message);
 		this.queue.send(message);
@@ -263,7 +263,7 @@ public class MicrometerMetricsTests {
 				.withStackTraceContaining("No meter with name 'spring.integration.receive' was found");
 
 		this.channel.destroy();
-		assertThat(TestUtils.getPropertyValue(this.channel, "meters", Set.class)).hasSize(0);
+		assertThat(TestUtils.<Set<?>>getPropertyValue(this.channel, "meters")).hasSize(0);
 	}
 
 	@Configuration

--- a/spring-integration-core/src/test/java/org/springframework/integration/transformer/AvroTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/transformer/AvroTests.java
@@ -44,6 +44,8 @@ import static org.mockito.Mockito.verify;
 
 /**
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 5.2
  *
  */
@@ -56,7 +58,7 @@ public class AvroTests {
 	@LogLevels(classes = DirectChannel.class, categories = "bar", level = "DEBUG")
 	void testTransformers(@Autowired Config config) {
 		AvroTestClass1 test = new AvroTestClass1("baz", "fiz");
-		LogAccessor spied = spy(TestUtils.getPropertyValue(config.in1(), "logger", LogAccessor.class));
+		LogAccessor spied = spy(TestUtils.<LogAccessor>getPropertyValue(config.in1(), "logger"));
 		new DirectFieldAccessor(config.in1()).setPropertyValue("logger", spied);
 		config.in1().send(new GenericMessage<>(test));
 		assertThat(config.tapped().receive(0))

--- a/spring-integration-core/src/test/java/org/springframework/integration/util/SimplePoolTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/util/SimplePoolTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Gary Russell
  * @author Sergey Bogatyrev
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -140,7 +141,7 @@ public class SimplePoolTests {
 		final Set<String> strings = new HashSet<>();
 		final AtomicBoolean stale = new AtomicBoolean();
 		SimplePool<String> pool = stringPool(2, strings, stale);
-		Semaphore permits = TestUtils.getPropertyValue(pool, "permits", Semaphore.class);
+		Semaphore permits = TestUtils.getPropertyValue(pool, "permits");
 		assertThat(permits.availablePermits()).isEqualTo(2);
 		String s1 = pool.getItem();
 		assertThat(permits.availablePermits()).isEqualTo(1);

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventInboundChannelAdapterParserTests.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -73,8 +74,10 @@ public class EventInboundChannelAdapterParserTests {
 	public void validateEventParser() {
 		Object adapter = context.getBean("eventAdapterSimple");
 		assertThat(adapter).isInstanceOf(ApplicationEventListeningMessageProducer.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "outputChannel")).isEqualTo(context.getBean("input"));
-		assertThat(TestUtils.getPropertyValue(adapter, "errorChannel")).isSameAs(errorChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "outputChannel"))
+				.isEqualTo(context.getBean("input"));
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "errorChannel"))
+				.isSameAs(errorChannel);
 	}
 
 	@Test
@@ -82,14 +85,15 @@ public class EventInboundChannelAdapterParserTests {
 	public void validateEventParserWithEventTypes() {
 		Object adapter = context.getBean("eventAdapterFiltered");
 		assertThat(adapter).isInstanceOf(ApplicationEventListeningMessageProducer.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "outputChannel")).isEqualTo(context.getBean("inputFiltered"));
-		Set<ResolvableType> eventTypes = TestUtils.getPropertyValue(adapter, "eventTypes", Set.class);
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "outputChannel")).
+				isEqualTo(context.getBean("inputFiltered"));
+		Set<ResolvableType> eventTypes = TestUtils.getPropertyValue(adapter, "eventTypes");
 		assertThat(eventTypes)
 				.hasSize(3)
 				.contains(ResolvableType.forClass(SampleEvent.class),
 						ResolvableType.forClass(AnotherSampleEvent.class),
 						ResolvableType.forClass(Date.class));
-		assertThat(TestUtils.getPropertyValue(adapter, "errorChannel")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "errorChannel")).isNull();
 	}
 
 	@Test
@@ -97,12 +101,13 @@ public class EventInboundChannelAdapterParserTests {
 	public void validateEventParserWithEventTypesAndPlaceholder() {
 		Object adapter = context.getBean("eventAdapterFilteredPlaceHolder");
 		assertThat(adapter).isInstanceOf(ApplicationEventListeningMessageProducer.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "outputChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "outputChannel"))
 				.isEqualTo(context.getBean("inputFilteredPlaceHolder"));
-		Set<ResolvableType> eventTypes = TestUtils.getPropertyValue(adapter, "eventTypes", Set.class);
+		Set<ResolvableType> eventTypes = TestUtils.getPropertyValue(adapter, "eventTypes");
 		assertThat(eventTypes)
 				.hasSize(2)
-				.contains(ResolvableType.forClass(SampleEvent.class), ResolvableType.forClass(AnotherSampleEvent.class));
+				.contains(ResolvableType.forClass(SampleEvent.class),
+						ResolvableType.forClass(AnotherSampleEvent.class));
 
 	}
 
@@ -126,13 +131,13 @@ public class EventInboundChannelAdapterParserTests {
 		Object adapter = context.getBean("eventAdapterSpel");
 		assertThat(adapter).isNotNull();
 		assertThat(adapter).isInstanceOf(ApplicationEventListeningMessageProducer.class);
-		Expression expression = TestUtils.getPropertyValue(adapter, "payloadExpression", Expression.class);
+		Expression expression = TestUtils.getPropertyValue(adapter, "payloadExpression");
 		assertThat(expression.getExpressionString()).isEqualTo("source + '-test'");
 	}
 
 	@Test
 	public void testAutoCreateChannel() {
-		assertThat(TestUtils.getPropertyValue(eventListener, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(eventListener, "outputChannel")).isSameAs(autoChannel);
 	}
 
 	@SuppressWarnings("serial")

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventOutboundChannelAdapterParserTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/config/EventOutboundChannelAdapterParserTests.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Gunnar Hillert
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -79,7 +80,7 @@ public class EventOutboundChannelAdapterParserTests {
 		MessageHandler handler = (MessageHandler) adapterAccessor.getPropertyValue("handler");
 		assertThat(handler instanceof ApplicationEventPublishingMessageHandler).isTrue();
 		assertThat(adapterAccessor.getPropertyValue("inputChannel")).isEqualTo(this.context.getBean("input"));
-		assertThat(TestUtils.getPropertyValue(handler, "publishPayload", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "publishPayload")).isTrue();
 	}
 
 	@Test

--- a/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
+++ b/spring-integration-event/src/test/java/org/springframework/integration/event/inbound/ApplicationEventListeningMessageProducerTests.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class ApplicationEventListeningMessageProducerTests {
 
@@ -227,7 +228,6 @@ public class ApplicationEventListeningMessageProducerTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testInt2935CheckRetrieverCache() {
 		GenericApplicationContext ctx = TestUtils.createTestApplicationContext();
 		ConfigurableListableBeanFactory beanFactory = ctx.getBeanFactory();
@@ -247,7 +247,7 @@ public class ApplicationEventListeningMessageProducerTests {
 		ApplicationEventMulticaster multicaster =
 				ctx.getBean(AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME,
 						ApplicationEventMulticaster.class);
-		Map<?, ?> retrieverCache = TestUtils.getPropertyValue(multicaster, "retrieverCache", Map.class);
+		Map<?, ?> retrieverCache = TestUtils.getPropertyValue(multicaster, "retrieverCache");
 
 		ctx.publishEvent(new TestApplicationEvent1());
 
@@ -257,10 +257,9 @@ public class ApplicationEventListeningMessageProducerTests {
 		 */
 		assertThat(retrieverCache.size()).isEqualTo(2);
 		for (Map.Entry<?, ?> entry : retrieverCache.entrySet()) {
-			Class<? extends ApplicationEvent> event = TestUtils.getPropertyValue(entry.getKey(), "eventType.resolved",
-					Class.class);
+			Class<? extends ApplicationEvent> event = TestUtils.getPropertyValue(entry.getKey(), "eventType.resolved");
 			assertThat(event).isIn(ContextRefreshedEvent.class, TestApplicationEvent1.class);
-			Set<?> listeners = TestUtils.getPropertyValue(entry.getValue(), "applicationListeners", Set.class);
+			Set<?> listeners = TestUtils.getPropertyValue(entry.getValue(), "applicationListeners");
 			assertThat(listeners.size()).isEqualTo(1);
 			assertThat(listeners.iterator().next()).isSameAs(ctx.getBean("testListener"));
 		}
@@ -269,9 +268,9 @@ public class ApplicationEventListeningMessageProducerTests {
 		ctx.publishEvent(event2);
 		assertThat(retrieverCache.size()).isEqualTo(3);
 		for (Map.Entry<?, ?> entry : retrieverCache.entrySet()) {
-			Class<?> event = TestUtils.getPropertyValue(entry.getKey(), "eventType.resolved", Class.class);
+			Class<?> event = TestUtils.getPropertyValue(entry.getKey(), "eventType.resolved");
 			if (TestApplicationEvent2.class.isAssignableFrom(event)) {
-				Set<?> listeners = TestUtils.getPropertyValue(entry.getValue(), "applicationListeners", Set.class);
+				Set<?> listeners = TestUtils.getPropertyValue(entry.getValue(), "applicationListeners");
 				assertThat(listeners.size()).isEqualTo(2);
 				for (Object listener : listeners) {
 					assertThat(listener)
@@ -297,7 +296,8 @@ public class ApplicationEventListeningMessageProducerTests {
 	private static void populateBeanFactory(ConfigurableListableBeanFactory beanFactory) {
 		beanFactory.registerSingleton(AbstractApplicationContext.APPLICATION_EVENT_MULTICASTER_BEAN_NAME,
 				new SimpleApplicationEventMulticaster(beanFactory));
-		beanFactory.registerSingleton(IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME, new StandardEvaluationContext());
+		beanFactory.registerSingleton(IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME,
+				new StandardEvaluationContext());
 	}
 
 	@Test

--- a/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
+++ b/spring-integration-feed/src/test/java/org/springframework/integration/feed/config/FeedInboundChannelAdapterParserTests.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.verify;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -66,10 +67,12 @@ public class FeedInboundChannelAdapterParserTests {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"FeedInboundChannelAdapterParserTests-file-context.xml", this.getClass());
 		SourcePollingChannelAdapter adapter = context.getBean("feedAdapter", SourcePollingChannelAdapter.class);
-		FeedEntryMessageSource source = (FeedEntryMessageSource) TestUtils.getPropertyValue(adapter, "source");
-		assertThat(TestUtils.getPropertyValue(source, "metadataKey")).isEqualTo("feedAdapter");
-		assertThat(TestUtils.getPropertyValue(source, "metadataStore")).isSameAs(context.getBean(MetadataStore.class));
-		SyndFeedInput syndFeedInput = TestUtils.getPropertyValue(source, "syndFeedInput", SyndFeedInput.class);
+		FeedEntryMessageSource source = TestUtils.getPropertyValue(adapter, "source");
+		assertThat(TestUtils.<String>getPropertyValue(source, "metadataKey"))
+				.isEqualTo("feedAdapter");
+		assertThat(TestUtils.<Object>getPropertyValue(source, "metadataStore"))
+				.isSameAs(context.getBean(MetadataStore.class));
+		SyndFeedInput syndFeedInput = TestUtils.getPropertyValue(source, "syndFeedInput");
 		assertThat(syndFeedInput).isSameAs(context.getBean(SyndFeedInput.class));
 		assertThat(syndFeedInput.isPreserveWireFeed()).isFalse();
 		context.close();
@@ -81,7 +84,7 @@ public class FeedInboundChannelAdapterParserTests {
 				"FeedInboundChannelAdapterParserTests-http-context.xml", this.getClass());
 		SourcePollingChannelAdapter adapter = context.getBean("feedAdapter", SourcePollingChannelAdapter.class);
 		FeedEntryMessageSource source = (FeedEntryMessageSource) TestUtils.getPropertyValue(adapter, "source");
-		assertThat(TestUtils.getPropertyValue(source, "metadataStore")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(source, "metadataStore")).isNotNull();
 		context.close();
 	}
 
@@ -104,7 +107,7 @@ public class FeedInboundChannelAdapterParserTests {
 		assertThat(latch.getCount()).isEqualTo(3);
 
 		SourcePollingChannelAdapter adapter = context.getBean("feedAdapterUsage", SourcePollingChannelAdapter.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "source.syndFeedInput.preserveWireFeed", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(adapter, "source.syndFeedInput.preserveWireFeed"))
 				.isTrue();
 
 		context.close();
@@ -131,7 +134,7 @@ public class FeedInboundChannelAdapterParserTests {
 		MessageChannel autoChannel = context.getBean("autoChannel", MessageChannel.class);
 		SourcePollingChannelAdapter adapter = context.getBean("autoChannel.adapter",
 				SourcePollingChannelAdapter.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "outputChannel")).isSameAs(autoChannel);
 		context.close();
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/DefaultConfigurationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/DefaultConfigurationTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -65,14 +66,13 @@ public class DefaultConfigurationTests {
 	public void verifyTaskScheduler() {
 		Object taskScheduler = context.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME);
 		assertThat(taskScheduler.getClass()).isEqualTo(ThreadPoolTaskScheduler.class);
-		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler", ErrorHandler.class);
+		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler");
 		assertThat(errorHandler.getClass()).isEqualTo(MessagePublishingErrorHandler.class);
-		MessageChannel defaultErrorChannel = TestUtils.getPropertyValue(errorHandler,
-				"messagingTemplate.defaultDestination", MessageChannel.class);
+		MessageChannel defaultErrorChannel =
+				TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNull();
 		errorHandler.handleError(new Throwable());
-		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination",
-				MessageChannel.class);
+		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNotNull();
 		assertThat(defaultErrorChannel).isEqualTo(context.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME));
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterParserTests.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -81,8 +82,8 @@ public class FileInboundChannelAdapterParserTests {
 
 	@Test
 	public void justFilter() {
-		Iterator<?> filterIterator = TestUtils
-				.getPropertyValue(this.inboundWithJustFilterSource, "scanner.filter.fileFilters", Set.class).iterator();
+		Iterator<?> filterIterator = TestUtils.<Set<IgnoreHiddenFileListFilter>>getPropertyValue(
+				this.inboundWithJustFilterSource, "scanner.filter.fileFilters").iterator();
 		assertThat(filterIterator.next()).isInstanceOf(IgnoreHiddenFileListFilter.class);
 		assertThat(filterIterator.next()).isSameAs(this.filter);
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithClasspathInPropertiesTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithClasspathInPropertiesTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Iwein Fuld
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -65,19 +66,18 @@ public class FileInboundChannelAdapterWithClasspathInPropertiesTests {
 		File actual = (File) accessor.getPropertyValue("directoryExpression.value");
 		assertThat(actual).as("'directory' should be set").isEqualTo(expected);
 
-		FileListFilter<File> fileListFilter =
-				TestUtils.getPropertyValue(this.source, "scanner.filter", FileListFilter.class);
+		FileListFilter<File> fileListFilter = TestUtils.getPropertyValue(this.source, "scanner.filter");
 		assertThat(fileListFilter).isInstanceOf(CompositeFileListFilter.class);
-		Set<FileListFilter<File>> fileFilters =
-				TestUtils.getPropertyValue(fileListFilter, "fileFilters", Set.class);
+		Set<FileListFilter<File>> fileFilters = TestUtils.getPropertyValue(fileListFilter, "fileFilters");
 		assertThat(fileFilters).hasSize(2);
 		Iterator<FileListFilter<File>> iterator = fileFilters.iterator();
 		iterator.next();
 		FileListFilter<File> expressionFilter = iterator.next();
 		assertThat(expressionFilter).isInstanceOf(ExpressionFileListFilter.class);
-		assertThat(TestUtils.getPropertyValue(expressionFilter, "expression.expression", String.class))
+		assertThat(TestUtils.<String>getPropertyValue(expressionFilter, "expression.expression"))
 				.isEqualTo("true");
-		assertThat(TestUtils.getPropertyValue(expressionFilter, "beanFactory")).isSameAs(this.beanFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(expressionFilter, "beanFactory"))
+				.isSameAs(this.beanFactory);
 	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithPatternParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithPatternParserTests.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -72,13 +73,13 @@ public class FileInboundChannelAdapterWithPatternParserTests {
 	@Test
 	public void inputDirectory() {
 		File expected = new File(System.getProperty("java.io.tmpdir"));
-		File actual = TestUtils.getPropertyValue(this.source, "directoryExpression.value", File.class);
+		File actual = TestUtils.getPropertyValue(this.source, "directoryExpression.value");
 		assertThat(actual).isEqualTo(expected);
 	}
 
 	@Test
 	public void compositeFilterType() {
-		FileListFilter<?> filter = TestUtils.getPropertyValue(this.source, "scanner.filter", FileListFilter.class);
+		FileListFilter<?> filter = TestUtils.getPropertyValue(this.source, "scanner.filter");
 		assertThat(filter).isInstanceOf(CompositeFileListFilter.class);
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithQueueSizeTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithQueueSizeTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -62,8 +63,8 @@ public class FileInboundChannelAdapterWithQueueSizeTests {
 
 	@Test
 	public void queueSize() {
-		HeadDirectoryScanner scanner1 = TestUtils.getPropertyValue(source1, "scanner", HeadDirectoryScanner.class);
-		HeadDirectoryScanner scanner2 = TestUtils.getPropertyValue(source2, "scanner", HeadDirectoryScanner.class);
+		HeadDirectoryScanner scanner1 = TestUtils.getPropertyValue(source1, "scanner");
+		HeadDirectoryScanner scanner2 = TestUtils.getPropertyValue(source2, "scanner");
 		List<File> files = scanner1.listFiles(inputDir);
 		assertThat(files).hasSize(2);
 		files = scanner2.listFiles(inputDir);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithRegexPatternParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileInboundChannelAdapterWithRegexPatternParserTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Iwein Fuld
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @see org.springframework.integration.file.config.FileInboundChannelAdapterWithPatternParserTests
  */
@@ -53,7 +54,7 @@ public class FileInboundChannelAdapterWithRegexPatternParserTests {
 		Pattern pattern = null;
 		for (FileListFilter<?> filter : filters) {
 			if (filter instanceof RegexPatternFileListFilter) {
-				pattern = TestUtils.getPropertyValue(filter, "pattern", Pattern.class);
+				pattern = TestUtils.<Pattern>getPropertyValue(filter, "pattern");
 				break;
 			}
 		}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileListFilterFactoryBeanTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileListFilterFactoryBeanTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * @author Mark Fisher
  * @author Iwein Fuld
  * @author Gunnar Hillert
+ * @author Glenn Renfro
  */
 public class FileListFilterFactoryBeanTests {
 
@@ -116,7 +117,7 @@ public class FileListFilterFactoryBeanTests {
 		assertThat(iterator.next() instanceof AcceptOnceFileListFilter).isTrue();
 		FileListFilter<?> patternFilter = iterator.next();
 		assertThat(patternFilter).isInstanceOf(SimplePatternFileListFilter.class);
-		assertThat(TestUtils.getPropertyValue(patternFilter, "alwaysAcceptDirectories", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(patternFilter, "alwaysAcceptDirectories")).isFalse();
 	}
 
 	@Test
@@ -129,7 +130,7 @@ public class FileListFilterFactoryBeanTests {
 		FileListFilter<File> result = factory.getObject();
 		assertThat(result instanceof CompositeFileListFilter).isFalse();
 		assertThat(result).isInstanceOf(SimplePatternFileListFilter.class);
-		assertThat(TestUtils.getPropertyValue(result, "alwaysAcceptDirectories", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(result, "alwaysAcceptDirectories")).isTrue();
 	}
 
 	private static class TestFilter extends AbstractFileListFilter<File> {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundAdaptersWithClasspathInPropertiesTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundAdaptersWithClasspathInPropertiesTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -58,7 +59,7 @@ public class FileOutboundAdaptersWithClasspathInPropertiesTests {
 		File expected = new ClassPathResource("").getFile();
 
 		var destinationDirectoryExpression =
-				TestUtils.getPropertyValue(handler, "destinationDirectoryExpression", Expression.class);
+				TestUtils.<Expression>getPropertyValue(handler, "destinationDirectoryExpression");
 		File actual = new File(destinationDirectoryExpression.getExpressionString());
 
 		assertThat(actual).as("'destinationDirectory' should be set").isEqualTo(expected);
@@ -70,7 +71,7 @@ public class FileOutboundAdaptersWithClasspathInPropertiesTests {
 		File expected = new ClassPathResource("").getFile();
 
 		var destinationDirectoryExpression =
-				TestUtils.getPropertyValue(handler, "destinationDirectoryExpression", Expression.class);
+				TestUtils.<Expression>getPropertyValue(handler, "destinationDirectoryExpression");
 		File actual = new File(destinationDirectoryExpression.getExpressionString());
 
 		assertThat(actual).as("'destinationDirectory' should be set").isEqualTo(expected);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileOutboundGatewayParserTests.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Tony Falabella
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -108,11 +109,11 @@ public class FileOutboundGatewayParserTests implements TestApplicationContextAwa
 		DefaultFileNameGenerator fileNameGenerator =
 				(DefaultFileNameGenerator) handlerAccessor.getPropertyValue("fileNameGenerator");
 		assertThat(fileNameGenerator).isNotNull();
-		Expression expression = TestUtils.getPropertyValue(fileNameGenerator, "expression", Expression.class);
+		Expression expression = TestUtils.getPropertyValue(fileNameGenerator, "expression");
 		assertThat(expression).isNotNull();
 		assertThat(expression.getExpressionString()).isEqualTo("'foo.txt'");
 
-		Long sendTimeout = TestUtils.getPropertyValue(handler, "messagingTemplate.sendTimeout", Long.class);
+		Long sendTimeout = TestUtils.getPropertyValue(handler, "messagingTemplate.sendTimeout");
 		assertThat(sendTimeout).isEqualTo(Long.valueOf(777));
 
 	}
@@ -120,8 +121,8 @@ public class FileOutboundGatewayParserTests implements TestApplicationContextAwa
 	@Test
 	public void testOutboundGatewayWithDirectoryExpression() {
 		FileWritingMessageHandler handler =
-				TestUtils.getPropertyValue(gatewayWithDirectoryExpression, "handler", FileWritingMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "destinationDirectoryExpression", Expression.class)
+				TestUtils.<FileWritingMessageHandler>getPropertyValue(gatewayWithDirectoryExpression, "handler");
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "destinationDirectoryExpression")
 				.getExpressionString()).isEqualTo("temporaryFolder");
 		handler.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
@@ -252,7 +253,7 @@ public class FileOutboundGatewayParserTests implements TestApplicationContextAwa
 	 */
 	@Test
 	public void gatewayWithReplaceMode() throws Exception {
-		assertThat(TestUtils.getPropertyValue(this.gatewayWithReplaceModeHandler, "requiresReply", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.gatewayWithReplaceModeHandler, "requiresReply"))
 				.isFalse();
 
 		final MessagingTemplate messagingTemplate = new MessagingTemplate();
@@ -282,8 +283,8 @@ public class FileOutboundGatewayParserTests implements TestApplicationContextAwa
 	 */
 	@Test
 	public void gatewayWithAppendNewLine() {
-		assertThat(TestUtils.getPropertyValue(this.gatewayWithAppendNewLine, "handler.appendNewLine"))
-				.isEqualTo(Boolean.TRUE);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.gatewayWithAppendNewLine,
+				"handler.appendNewLine")).isEqualTo(Boolean.TRUE);
 	}
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileSplitterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileSplitterParserTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.2
  *
@@ -55,15 +56,19 @@ public class FileSplitterParserTests {
 
 	@Test
 	public void testComplete() {
-		assertThat(TestUtils.getPropertyValue(this.splitter, "returnIterator", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.splitter, "markers", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.splitter, "markersJson", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.splitter, "requiresReply", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.splitter, "applySequence", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.splitter, "charset")).isEqualTo(StandardCharsets.UTF_8);
-		assertThat(TestUtils.getPropertyValue(this.splitter, "messagingTemplate.sendTimeout")).isEqualTo(5L);
-		assertThat(TestUtils.getPropertyValue(this.splitter, "firstLineHeaderName")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(this.splitter, "discardChannelName")).isEqualTo("nullChannel");
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.splitter, "returnIterator")).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.splitter, "markers")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.splitter, "markersJson")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.splitter, "requiresReply")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.splitter, "applySequence")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(this.splitter, "charset"))
+				.isEqualTo(StandardCharsets.UTF_8);
+		assertThat(TestUtils.<Long>getPropertyValue(this.splitter, "messagingTemplate.sendTimeout"))
+				.isEqualTo(5L);
+		assertThat(TestUtils.<String>getPropertyValue(this.splitter, "firstLineHeaderName"))
+				.isEqualTo("foo");
+		assertThat(TestUtils.<String>getPropertyValue(this.splitter, "discardChannelName"))
+				.isEqualTo("nullChannel");
 		assertThat(this.splitter.getOutputChannel()).isSameAs(this.out);
 		assertThat(this.splitter.getOrder()).isEqualTo(2);
 		assertThat(this.fullBoat.getInputChannel()).isSameAs(this.in);

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileTailInboundChannelAdapterParserTests.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.mock;
  * @author Artem Bilan
  * @author Gavin Gray
  * @author Ali Shahbour
+ * @author Glenn Renfro
  *
  * @since 3.0
  */
@@ -73,62 +74,65 @@ public class FileTailInboundChannelAdapterParserTests {
 
 	@Test
 	public void testDefault() {
-		String fileName = TestUtils.getPropertyValue(defaultAdapter, "file", File.class).getAbsolutePath();
+		String fileName = TestUtils.<File>getPropertyValue(defaultAdapter, "file").getAbsolutePath();
 		String normalizedName = getNormalizedPath(fileName);
 		assertThat(normalizedName).isEqualTo("/tmp/baz");
-		assertThat(TestUtils.getPropertyValue(defaultAdapter, "command")).isEqualTo("tail -F -n 0 " + fileName);
-		assertThat(TestUtils.getPropertyValue(defaultAdapter, "taskExecutor")).isSameAs(exec);
-		assertThat(TestUtils.getPropertyValue(defaultAdapter, "autoStartup", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(defaultAdapter, "enableStatusReader", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(defaultAdapter, "phase")).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(defaultAdapter, "errorChannel")).isSameAs(this.tailErrorChannel);
+		assertThat(TestUtils.<String>getPropertyValue(defaultAdapter, "command")).isEqualTo("tail -F -n 0 " + fileName);
+		assertThat(TestUtils.<TaskExecutor>getPropertyValue(defaultAdapter, "taskExecutor")).isSameAs(exec);
+		assertThat(TestUtils.<Boolean>getPropertyValue(defaultAdapter, "autoStartup")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(defaultAdapter, "enableStatusReader")).isTrue();
+		assertThat(TestUtils.<Integer>getPropertyValue(defaultAdapter, "phase")).isEqualTo(123);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(defaultAdapter, "errorChannel"))
+				.isSameAs(this.tailErrorChannel);
 		this.defaultAdapter.stop();
 		this.defaultAdapter.setOptions("-F -n 6");
 		this.defaultAdapter.start();
-		assertThat(TestUtils.getPropertyValue(defaultAdapter, "command")).isEqualTo("tail -F -n 6 " + fileName);
+		assertThat(TestUtils.<String>getPropertyValue(defaultAdapter, "command")).isEqualTo("tail -F -n 6 " + fileName);
 	}
 
 	@Test
 	public void testNative() {
-		String fileName = TestUtils.getPropertyValue(nativeAdapter, "file", File.class).getAbsolutePath();
+		String fileName = TestUtils.<File>getPropertyValue(nativeAdapter, "file").getAbsolutePath();
 		String normalizedName = getNormalizedPath(fileName);
 		assertThat(normalizedName).isEqualTo("/tmp/foo");
-		assertThat(TestUtils.getPropertyValue(nativeAdapter, "command")).isEqualTo("tail -F -n 6 " + fileName);
-		assertThat(TestUtils.getPropertyValue(nativeAdapter, "taskExecutor")).isSameAs(exec);
-		assertThat(TestUtils.getPropertyValue(nativeAdapter, "taskScheduler")).isSameAs(scheduler);
-		assertThat(TestUtils.getPropertyValue(nativeAdapter, "autoStartup", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(nativeAdapter, "enableStatusReader", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(nativeAdapter, "phase")).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(nativeAdapter, "tailAttemptsDelay")).isEqualTo(456L);
+		assertThat(TestUtils.<String>getPropertyValue(nativeAdapter, "command")).isEqualTo("tail -F -n 6 " + fileName);
+		assertThat(TestUtils.<TaskExecutor>getPropertyValue(nativeAdapter, "taskExecutor")).isSameAs(exec);
+		assertThat(TestUtils.<TaskScheduler>getPropertyValue(nativeAdapter, "taskScheduler")).isSameAs(scheduler);
+		assertThat(TestUtils.<Boolean>getPropertyValue(nativeAdapter, "autoStartup")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(nativeAdapter, "enableStatusReader")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(nativeAdapter, "phase")).isEqualTo(123);
+		assertThat(TestUtils.<Long>getPropertyValue(nativeAdapter, "tailAttemptsDelay")).isEqualTo(456L);
 	}
 
 	@Test
 	public void testApacheDefault() {
-		String fileName = TestUtils.getPropertyValue(apacheDefault, "file", File.class).getAbsolutePath();
+		String fileName = TestUtils.<File>getPropertyValue(apacheDefault, "file").getAbsolutePath();
 		String normalizedName = getNormalizedPath(fileName);
 		assertThat(normalizedName).isEqualTo("/tmp/bar");
-		assertThat(TestUtils.getPropertyValue(apacheDefault, "taskExecutor")).isSameAs(exec);
-		assertThat(TestUtils.getPropertyValue(apacheDefault, "pollingDelay")).isEqualTo(Duration.ofSeconds(2));
-		assertThat(TestUtils.getPropertyValue(apacheDefault, "tailAttemptsDelay")).isEqualTo(10000L);
-		assertThat(TestUtils.getPropertyValue(apacheDefault, "idleEventInterval")).isEqualTo(10000L);
-		assertThat(TestUtils.getPropertyValue(apacheDefault, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(apacheDefault, "phase")).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(apacheDefault, "end")).isEqualTo(Boolean.TRUE);
-		assertThat(TestUtils.getPropertyValue(apacheDefault, "reopen")).isEqualTo(Boolean.FALSE);
+		assertThat(TestUtils.<TaskExecutor>getPropertyValue(apacheDefault, "taskExecutor")).isSameAs(exec);
+		assertThat(TestUtils.<Duration>getPropertyValue(apacheDefault, "pollingDelay"))
+				.isEqualTo(Duration.ofSeconds(2));
+		assertThat(TestUtils.<Long>getPropertyValue(apacheDefault, "tailAttemptsDelay")).isEqualTo(10000L);
+		assertThat(TestUtils.<Long>getPropertyValue(apacheDefault, "idleEventInterval")).isEqualTo(10000L);
+		assertThat(TestUtils.<Boolean>getPropertyValue(apacheDefault, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(apacheDefault, "phase")).isEqualTo(123);
+		assertThat(TestUtils.<Boolean>getPropertyValue(apacheDefault, "end")).isEqualTo(Boolean.TRUE);
+		assertThat(TestUtils.<Boolean>getPropertyValue(apacheDefault, "reopen")).isEqualTo(Boolean.FALSE);
 	}
 
 	@Test
 	public void testApacheEndReopen() {
-		String fileName = TestUtils.getPropertyValue(apacheEndReopen, "file", File.class).getAbsolutePath();
+		String fileName = TestUtils.<File>getPropertyValue(apacheEndReopen, "file").getAbsolutePath();
 		String normalizedName = getNormalizedPath(fileName);
 		assertThat(normalizedName).isEqualTo("/tmp/qux");
-		assertThat(TestUtils.getPropertyValue(apacheEndReopen, "taskExecutor")).isSameAs(exec);
-		assertThat(TestUtils.getPropertyValue(apacheEndReopen, "pollingDelay")).isEqualTo(Duration.ofSeconds(2));
-		assertThat(TestUtils.getPropertyValue(apacheEndReopen, "tailAttemptsDelay")).isEqualTo(10000L);
-		assertThat(TestUtils.getPropertyValue(apacheEndReopen, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(apacheEndReopen, "phase")).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(apacheEndReopen, "end")).isEqualTo(Boolean.FALSE);
-		assertThat(TestUtils.getPropertyValue(apacheEndReopen, "reopen")).isEqualTo(Boolean.TRUE);
+		assertThat(TestUtils.<TaskExecutor>getPropertyValue(apacheEndReopen, "taskExecutor")).isSameAs(exec);
+		assertThat(TestUtils.<Duration>getPropertyValue(apacheEndReopen, "pollingDelay"))
+				.isEqualTo(Duration.ofSeconds(2));
+		assertThat(TestUtils.<Long>getPropertyValue(apacheEndReopen, "tailAttemptsDelay")).isEqualTo(10000L);
+		assertThat(TestUtils.<Boolean>getPropertyValue(apacheEndReopen, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(apacheEndReopen, "phase")).isEqualTo(123);
+		assertThat(TestUtils.<Boolean>getPropertyValue(apacheEndReopen, "end")).isEqualTo(Boolean.FALSE);
+		assertThat(TestUtils.<Boolean>getPropertyValue(apacheEndReopen, "reopen")).isEqualTo(Boolean.TRUE);
 	}
 
 	/**

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileToStringTransformerParserTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/FileToStringTransformerParserTests.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -42,7 +43,7 @@ public class FileToStringTransformerParserTests {
 
 	@Test
 	public void checkDeleteFilesValue() {
-		assertThat(TestUtils.getPropertyValue(this.endpoint, "handler.transformer.deleteFiles", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.endpoint, "handler.transformer.deleteFiles")).isTrue();
 	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/config/InboundAdapterWithLockersTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/config/InboundAdapterWithLockersTests.java
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  */
 @SpringJUnitConfig
@@ -42,14 +43,14 @@ public class InboundAdapterWithLockersTests {
 
 	@Test
 	public void testAdaptersWithLockers() {
-		assertThat(TestUtils.getPropertyValue(context.getBean("inputWithLockerA"), "source.scanner.locker"))
-				.isEqualTo(context.getBean("locker"));
-		assertThat(TestUtils.getPropertyValue(context.getBean("inputWithLockerB"), "source.scanner.locker"))
-				.isEqualTo(context.getBean("locker"));
-		assertThat(TestUtils.getPropertyValue(context.getBean("inputWithLockerC"), "source.scanner.locker"))
-				.isInstanceOf(NioFileLocker.class);
-		assertThat(TestUtils.getPropertyValue(context.getBean("inputWithLockerD"), "source.scanner.locker"))
-				.isInstanceOf(NioFileLocker.class);
+		assertThat(TestUtils.<Object>getPropertyValue(context.getBean("inputWithLockerA"),
+				"source.scanner.locker")).isEqualTo(context.getBean("locker"));
+		assertThat(TestUtils.<Object>getPropertyValue(context.getBean("inputWithLockerB"),
+				"source.scanner.locker")).isEqualTo(context.getBean("locker"));
+		assertThat(TestUtils.<Object>getPropertyValue(context.getBean("inputWithLockerC"),
+				"source.scanner.locker")).isInstanceOf(NioFileLocker.class);
+		assertThat(TestUtils.<Object>getPropertyValue(context.getBean("inputWithLockerD"),
+				"source.scanner.locker")).isInstanceOf(NioFileLocker.class);
 	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/dsl/FileTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/dsl/FileTests.java
@@ -86,6 +86,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -266,7 +267,8 @@ public class FileTests {
 		assertThat(receive.getPayload()).isInstanceOf(FileSplitter.FileMarker.class); // FileMarker.Mark.END
 		assertThat(this.fileSplittingResultChannel.receive(1)).isNull();
 
-		assertThat(TestUtils.getPropertyValue(this.fileSplitter, "charset")).isEqualTo(StandardCharsets.US_ASCII);
+		assertThat(TestUtils.<Object>getPropertyValue(this.fileSplitter, "charset"))
+				.isEqualTo(StandardCharsets.US_ASCII);
 	}
 
 	@Autowired
@@ -302,7 +304,7 @@ public class FileTests {
 
 		assertThat(payloads.toArray()).isEqualTo(new String[] {"test1", "test2"});
 
-		assertThat(TestUtils.getPropertyValue(
+		assertThat(TestUtils.<RecursiveDirectoryScanner>getPropertyValue(
 				this.beanFactory.getBean("dynamicFile.adapter.source"), "scanner"))
 				.isInstanceOf(RecursiveDirectoryScanner.class);
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/filters/AcceptOnceFileListFilterTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/filters/AcceptOnceFileListFilterTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.0.4
  *
@@ -52,7 +53,6 @@ public class AcceptOnceFileListFilterTests {
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testCapacity() {
 		AcceptOnceFileListFilter<String> filter = new AcceptOnceFileListFilter<>(2);
 		assertThat(filter.accept("foo")).isTrue();
@@ -60,9 +60,9 @@ public class AcceptOnceFileListFilterTests {
 		assertThat(filter.accept("foo")).isFalse();
 		assertThat(filter.accept("baz")).isTrue();
 		assertThat(filter.accept("foo")).isTrue();
-		Queue<String> seen = TestUtils.getPropertyValue(filter, "seen", Queue.class);
+		Queue<String> seen = TestUtils.getPropertyValue(filter, "seen");
 		assertThat(seen.size()).isEqualTo(2);
-		Set<String> seenSet = TestUtils.getPropertyValue(filter, "seenSet", Set.class);
+		Set<String> seenSet = TestUtils.getPropertyValue(filter, "seenSet");
 		assertThat(seenSet.size()).isEqualTo(2);
 		assertThat(seen).containsExactly("baz", "foo");
 		assertThat(seenSet).contains("foo", "baz");
@@ -86,14 +86,14 @@ public class AcceptOnceFileListFilterTests {
 		List<String> passed = filter.filterFiles(files);
 		assertThat(Arrays.equals(files, passed.toArray())).isTrue();
 		List<String> now = filter.filterFiles(files);
-		assertThat(now.size()).isEqualTo(0);
+		assertThat(now).isEmpty();
 		filter.rollback(passed.get(1), passed);
 		now = filter.filterFiles(files);
 		assertThat(now.size()).isEqualTo(2);
 		assertThat(now.get(0)).isEqualTo("bar");
 		assertThat(now.get(1)).isEqualTo("baz");
 		now = filter.filterFiles(files);
-		assertThat(now.size()).isEqualTo(0);
+		assertThat(now).isEmpty();
 	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileInboundTransactionTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileInboundTransactionTests.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -86,7 +87,7 @@ public class FileInboundTransactionTests {
 
 		@SuppressWarnings("unchecked")
 		ResettableFileListFilter<File> fileListFilter =
-				spy(TestUtils.getPropertyValue(scanner, "filter", ResettableFileListFilter.class));
+				spy(TestUtils.<ResettableFileListFilter<File>>getPropertyValue(scanner, "filter"));
 
 		new DirectFieldAccessor(scanner).setPropertyValue("filter", fileListFilter);
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileReadingMessageSourceIntegrationTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/inbound/FileReadingMessageSourceIntegrationTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Iwein Fuld
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -66,7 +67,8 @@ public class FileReadingMessageSourceIntegrationTests {
 
 	@Test
 	public void configured() {
-		assertThat(TestUtils.getPropertyValue(this.pollableFileSource, "directoryExpression.value")).isEqualTo(inputDir);
+		assertThat(TestUtils.<File>getPropertyValue(this.pollableFileSource,
+				"directoryExpression.value")).isEqualTo(inputDir);
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileLockingNamespaceTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/FileLockingNamespaceTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Iwein Fuld
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -70,17 +71,17 @@ public class FileLockingNamespaceTests {
 
 	@Test
 	public void shouldSetCustomLockerProperly() {
-		assertThat(TestUtils.getPropertyValue(this.customLockingSource, "scanner.locker"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customLockingSource, "scanner.locker"))
 				.isInstanceOf(StubLocker.class);
-		assertThat(TestUtils.getPropertyValue(this.customLockingSource, "scanner.filter"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customLockingSource, "scanner.filter"))
 				.isInstanceOf(CompositeFileListFilter.class);
 	}
 
 	@Test
 	public void shouldSetNioLockerProperly() {
-		assertThat(TestUtils.getPropertyValue(this.nioLockingSource, "scanner.locker"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.nioLockingSource, "scanner.locker"))
 				.isInstanceOf(NioFileLocker.class);
-		assertThat(TestUtils.getPropertyValue(this.nioLockingSource, "scanner.filter"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.nioLockingSource, "scanner.filter"))
 				.isInstanceOf(CompositeFileListFilter.class);
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/locking/NioFileLockerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/locking/NioFileLockerTests.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Emmanuel Roux
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class NioFileLockerTests {
 
@@ -53,7 +54,7 @@ public class NioFileLockerTests {
 		Field channelCache = FileChannelCache.class.getDeclaredField("CHANNEL_CACHE");
 		channelCache.setAccessible(true);
 		assertThat(((Map<?, ?>) channelCache.get(null))).isEmpty();
-		assertThat(((Map<?, ?>) TestUtils.getPropertyValue(filter, "lockCache", Map.class))).isEmpty();
+		assertThat(((Map<?, ?>) TestUtils.<Map<?, ?>>getPropertyValue(filter, "lockCache"))).isEmpty();
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
@@ -80,6 +80,7 @@ import static org.mockito.Mockito.when;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Alen Turkovic
+ * @author Glenn Renfro
  */
 public class FileWritingMessageHandlerTests implements TestApplicationContextAware {
 
@@ -117,23 +118,22 @@ public class FileWritingMessageHandlerTests implements TestApplicationContextAwa
 	}
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void permissions() {
 		if (FileUtils.IS_POSIX) {
 			FileWritingMessageHandler handler = new FileWritingMessageHandler(mock(Expression.class));
 			handler.setChmod(0421);
-			Set<PosixFilePermission> permissions = TestUtils.getPropertyValue(handler, "permissions", Set.class);
+			Set<PosixFilePermission> permissions = TestUtils.getPropertyValue(handler, "permissions");
 			assertThat(permissions).hasSize(3)
 					.contains(PosixFilePermission.OWNER_READ,
 							PosixFilePermission.GROUP_WRITE,
 							PosixFilePermission.OTHERS_EXECUTE);
 			handler.setChmod(0600);
-			permissions = TestUtils.getPropertyValue(handler, "permissions", Set.class);
+			permissions = TestUtils.getPropertyValue(handler, "permissions");
 			assertThat(permissions).hasSize(2)
 					.contains(PosixFilePermission.OWNER_READ,
 							PosixFilePermission.OWNER_WRITE);
 			handler.setChmod(0777);
-			permissions = TestUtils.getPropertyValue(handler, "permissions", Set.class);
+			permissions = TestUtils.getPropertyValue(handler, "permissions");
 			assertThat(permissions).hasSize(9);
 		}
 	}
@@ -522,7 +522,7 @@ public class FileWritingMessageHandlerTests implements TestApplicationContextAwa
 		handler.handleMessage(new GenericMessage<InputStream>(new ByteArrayInputStream("buz".getBytes())));
 		handler.trigger(new GenericMessage<>(Matcher.quoteReplacement(file.getAbsolutePath())));
 		assertThat(file).hasSize(18);
-		assertThat(TestUtils.getPropertyValue(handler, "fileStates", Map.class).size()).isEqualTo(0);
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "fileStates")).isEmpty();
 
 		handler.setFlushInterval(30000);
 		final AtomicBoolean called = new AtomicBoolean();
@@ -545,7 +545,7 @@ public class FileWritingMessageHandlerTests implements TestApplicationContextAwa
 		assertThat(called.get()).isTrue();
 
 		handler.stop();
-		Log logger = spy(TestUtils.getPropertyValue(handler, "logger.log", Log.class));
+		Log logger = spy(TestUtils.<Log>getPropertyValue(handler, "logger.log"));
 		new DirectFieldAccessor(handler).setPropertyValue("logger.log", logger);
 		when(logger.isDebugEnabled()).thenReturn(true);
 		final AtomicInteger flushes = new AtomicInteger();

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/StreamingInboundTests.java
@@ -60,6 +60,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.3
  *
@@ -241,10 +242,10 @@ public class StreamingInboundTests implements TestApplicationContextAware {
 		streamer.afterPropertiesSet();
 		streamer.start();
 		assertThat(streamer.receive()).isNotNull();
-		assertThat(TestUtils.getPropertyValue(streamer, "toBeReceived", BlockingQueue.class)).hasSize(1);
+		assertThat(TestUtils.<BlockingQueue<AbstractFileInfo<?>>>getPropertyValue(streamer, "toBeReceived")).hasSize(1);
 		assertThat(streamer.metadataMap).hasSize(1);
 		streamer.stop();
-		assertThat(TestUtils.getPropertyValue(streamer, "toBeReceived", BlockingQueue.class)).hasSize(0);
+		assertThat(TestUtils.<BlockingQueue<AbstractFileInfo<?>>>getPropertyValue(streamer, "toBeReceived")).hasSize(0);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -257,12 +258,14 @@ public class StreamingInboundTests implements TestApplicationContextAware {
 		streamer.start();
 		assertThatExceptionOfType(UncheckedIOException.class)
 				.isThrownBy(streamer::receive);
-		assertThat(TestUtils.getPropertyValue(streamer, "toBeReceived", BlockingQueue.class)).hasSize(1);
+		assertThat(TestUtils.<BlockingQueue<AbstractFileInfo<?>>>getPropertyValue(streamer, "toBeReceived"))
+				.hasSize(1);
 		assertThat(streamer.metadataMap).hasSize(0);
 		streamer.setStrictOrder(true);
 		assertThatExceptionOfType(UncheckedIOException.class)
 				.isThrownBy(streamer::receive);
-		assertThat(TestUtils.getPropertyValue(streamer, "toBeReceived", BlockingQueue.class)).hasSize(0);
+		assertThat(TestUtils.<BlockingQueue<AbstractFileInfo<?>>>getPropertyValue(streamer, "toBeReceived"))
+				.hasSize(0);
 	}
 
 	public static class Streamer extends AbstractRemoteFileStreamingMessageSource<String> {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/handler/FileTransferringMessageHandlerTests.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class FileTransferringMessageHandlerTests implements TestApplicationContextAware {
 
@@ -181,10 +182,10 @@ public class FileTransferringMessageHandlerTests implements TestApplicationConte
 		verify(session1, times(1)).write(Mockito.any(InputStream.class), Mockito.anyString());
 		verify(session2, times(1)).write(Mockito.any(InputStream.class), Mockito.anyString());
 		verify(session3, times(1)).write(Mockito.any(InputStream.class), Mockito.anyString());
-		SimplePool<?> pool = TestUtils.getPropertyValue(csf, "pool", SimplePool.class);
+		SimplePool<?> pool = TestUtils.getPropertyValue(csf, "pool");
 		assertThat(pool.getAllocatedCount()).isEqualTo(1);
 		assertThat(pool.getIdleCount()).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(pool, "allocated", Set.class).iterator().next()).isSameAs(session3);
+		assertThat(TestUtils.<Set<?>>getPropertyValue(pool, "allocated").iterator().next()).isSameAs(session3);
 	}
 
 	private <F> Session<F> newSession() throws IOException {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/session/CachingSessionFactoryTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/session/CachingSessionFactoryTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0
  *
@@ -50,22 +51,26 @@ public class CachingSessionFactoryTests implements TestApplicationContextAware {
 		CachingSessionFactory<String> cache = new CachingSessionFactory<>(factory);
 		cache.setTestSession(true);
 		Session<String> sess1 = cache.getSession();
-		assertThat(TestUtils.getPropertyValue(sess1, "targetSession.id")).isEqualTo("session:1");
+		assertThat(TestUtils.<String>getPropertyValue(sess1, "targetSession.id"))
+				.isEqualTo("session:1");
 		Session<String> sess2 = cache.getSession();
-		assertThat(TestUtils.getPropertyValue(sess2, "targetSession.id")).isEqualTo("session:2");
+		assertThat(TestUtils.<String>getPropertyValue(sess2, "targetSession.id"))
+				.isEqualTo("session:2");
 		sess1.close();
 		// session back to pool; should be open and reused.
 		assertThat(sess1.isOpen()).isTrue();
 		sess1 = cache.getSession();
-		assertThat(TestUtils.getPropertyValue(sess1, "targetSession.id")).isEqualTo("session:1");
-		assertThat((TestUtils.getPropertyValue(sess1, "targetSession.testCalled", Boolean.class))).isTrue();
+		assertThat(TestUtils.<String>getPropertyValue(sess1, "targetSession.id"))
+				.isEqualTo("session:1");
+		assertThat((TestUtils.<Boolean>getPropertyValue(sess1, "targetSession.testCalled"))).isTrue();
 		sess1.close();
 		assertThat(sess1.isOpen()).isTrue();
 		// reset the cache; should close idle (sess1); sess2 should closed later
 		cache.resetCache();
 		assertThat(sess1.isOpen()).isFalse();
 		sess1 = cache.getSession();
-		assertThat(TestUtils.getPropertyValue(sess1, "targetSession.id")).isEqualTo("session:3");
+		assertThat(TestUtils.<String>getPropertyValue(sess1, "targetSession.id"))
+				.isEqualTo("session:3");
 		sess1.close();
 		assertThat(sess1.isOpen()).isTrue();
 		// session from previous epoch is closed on return

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/session/DelegatingSessionFactoryTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/session/DelegatingSessionFactoryTests.java
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.2
  *
@@ -101,7 +102,7 @@ public class DelegatingSessionFactoryTests {
 		Message<?> received = out.receive(0);
 		assertThat(received).isNotNull();
 		verify(foo.mockSession).list("foo/");
-		assertThat(TestUtils.getPropertyValue(dsf, "threadKey", ThreadLocal.class).get()).isNull();
+		assertThat(TestUtils.<ThreadLocal<Object>>getPropertyValue(dsf, "threadKey").get()).isNull();
 	}
 
 	@Configuration

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/synchronizer/AbstractRemoteFileSynchronizerTests.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.mock;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Venil Noronha
+ * @author Glenn Renfro
  *
  * @since 4.0.4
  *
@@ -123,7 +124,7 @@ public class AbstractRemoteFileSynchronizerTests implements TestApplicationConte
 		assertThat(count.get()).isEqualTo(1);
 
 		@SuppressWarnings("unchecked")
-		Map<String, List<String>> fetchCache = TestUtils.getPropertyValue(sync, "fetchCache", Map.class);
+		Map<String, List<String>> fetchCache = TestUtils.getPropertyValue(sync, "fetchCache");
 		List<String> cachedFiles = fetchCache.get("testRemoteDirectory");
 		assertThat(cachedFiles).containsExactly("testFile2", "testFile3");
 
@@ -140,7 +141,7 @@ public class AbstractRemoteFileSynchronizerTests implements TestApplicationConte
 		assertThat(cachedFiles).isNull();
 
 		StringSession stringSession =
-				TestUtils.getPropertyValue(sync, "remoteFileTemplate.sessionFactory.session", StringSession.class);
+				TestUtils.<StringSession>getPropertyValue(sync, "remoteFileTemplate.sessionFactory.session");
 		assertThat(stringSession.listCallCount).isEqualTo(1);
 
 		sync.close();

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpInboundChannelAdapterParserTests.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.ftp.config;
 
 import java.lang.reflect.Method;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Set;
@@ -62,6 +61,7 @@ import static org.mockito.Mockito.when;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Venil Noronha
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -91,37 +91,37 @@ public class FtpInboundChannelAdapterParserTests {
 
 	@Test
 	public void testFtpInboundChannelAdapterComplete() throws Exception {
-		assertThat(TestUtils.getPropertyValue(ftpInbound, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(ftpInbound, "autoStartup")).isFalse();
 		PriorityBlockingQueue<?> blockingQueue =
-				TestUtils.getPropertyValue(ftpInbound, "source.fileSource.toBeReceived", PriorityBlockingQueue.class);
+				TestUtils.getPropertyValue(ftpInbound, "source.fileSource.toBeReceived");
 		Comparator<?> comparator = blockingQueue.comparator();
 		assertThat(comparator).isNotNull();
 		assertThat(ftpInbound.getComponentName()).isEqualTo("ftpInbound");
 		assertThat(ftpInbound.getComponentType()).isEqualTo("ftp:inbound-channel-adapter");
-		assertThat(TestUtils.getPropertyValue(ftpInbound, "outputChannel")).isEqualTo(context.getBean("ftpChannel"));
-		FtpInboundFileSynchronizingMessageSource inbound =
-				(FtpInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(ftpInbound, "source");
+		assertThat(TestUtils.<Object>getPropertyValue(ftpInbound, "outputChannel"))
+				.isEqualTo(context.getBean("ftpChannel"));
+		FtpInboundFileSynchronizingMessageSource inbound = TestUtils.getPropertyValue(ftpInbound, "source");
 
-		assertThat(TestUtils.getPropertyValue(inbound, "fileSource.scanner")).isSameAs(dirScanner);
+		assertThat(TestUtils.<Object>getPropertyValue(inbound, "fileSource.scanner")).isSameAs(dirScanner);
 
-		FtpInboundFileSynchronizer fisync =
-				(FtpInboundFileSynchronizer) TestUtils.getPropertyValue(inbound, "synchronizer");
-		assertThat(TestUtils.getPropertyValue(fisync, "remoteDirectoryExpression", Expression.class)
+		FtpInboundFileSynchronizer fisync = TestUtils.getPropertyValue(inbound, "synchronizer");
+		assertThat(TestUtils.<Expression>getPropertyValue(fisync, "remoteDirectoryExpression")
 				.getExpressionString()).isEqualTo("'foo/bar'");
-		assertThat(TestUtils.getPropertyValue(fisync, "localFilenameGeneratorExpression")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(fisync, "preserveTimestamp", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(fisync, "temporaryFileSuffix", String.class)).isEqualTo(".foo");
-		assertThat(TestUtils.getPropertyValue(fisync, "remoteFileMetadataStore", MetadataStore.class))
+		assertThat(TestUtils.<Object>getPropertyValue(fisync, "localFilenameGeneratorExpression"))
+				.isNotNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(fisync, "preserveTimestamp")).isTrue();
+		assertThat(TestUtils.<String>getPropertyValue(fisync, "temporaryFileSuffix")).isEqualTo(".foo");
+		assertThat(TestUtils.<MetadataStore>getPropertyValue(fisync, "remoteFileMetadataStore"))
 				.isSameAs(this.metadataStore);
-		assertThat(TestUtils.getPropertyValue(fisync, "metadataStorePrefix", String.class)).isEqualTo("testPrefix");
+		assertThat(TestUtils.<String>getPropertyValue(fisync, "metadataStorePrefix")).isEqualTo("testPrefix");
 		String remoteFileSeparator = (String) TestUtils.getPropertyValue(fisync, "remoteFileSeparator");
 		assertThat(remoteFileSeparator).isNotNull();
 		assertThat(remoteFileSeparator).isEqualTo("");
 
-		FileListFilter<?> filter = TestUtils.getPropertyValue(fisync, "filter", FileListFilter.class);
+		FileListFilter<?> filter = TestUtils.getPropertyValue(fisync, "filter");
 		assertThat(filter).isNotNull();
 		assertThat(filter).isInstanceOf(CompositeFileListFilter.class);
-		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters", Set.class);
+		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters");
 
 		Iterator<?> filtersIterator = fileFilters.iterator();
 		assertThat(filtersIterator.next()).isInstanceOf(FtpSimplePatternFileListFilter.class);
@@ -130,8 +130,8 @@ public class FtpInboundChannelAdapterParserTests {
 		Object sessionFactory = TestUtils.getPropertyValue(fisync, "remoteFileTemplate.sessionFactory");
 		assertThat(sessionFactory).isInstanceOf(DefaultFtpSessionFactory.class);
 		FileListFilter<?> acceptAllFilter = context.getBean("acceptAllFilter", FileListFilter.class);
-		assertThat(TestUtils.getPropertyValue(inbound, "fileSource.scanner.filter.fileFilters", Collection.class)
-				.contains(acceptAllFilter)).isTrue();
+		assertThat(TestUtils.<Set<?>>getPropertyValue(inbound, "fileSource.scanner.filter.fileFilters")
+				.contains(acceptAllFilter));
 		final AtomicReference<Method> genMethod = new AtomicReference<>();
 		ReflectionUtils.doWithMethods(AbstractInboundFileSynchronizer.class, method -> {
 			method.setAccessible(true);
@@ -148,20 +148,20 @@ public class FtpInboundChannelAdapterParserTests {
 				"source.synchronizer.remoteFileTemplate.sessionFactory");
 		assertThat(sessionFactory).isInstanceOf(CachingSessionFactory.class);
 		FtpInboundFileSynchronizer fisync =
-				TestUtils.getPropertyValue(simpleAdapterWithCachedSessions, "source.synchronizer",
-						FtpInboundFileSynchronizer.class);
-		String remoteFileSeparator = (String) TestUtils.getPropertyValue(fisync, "remoteFileSeparator");
+				TestUtils.getPropertyValue(simpleAdapterWithCachedSessions, "source.synchronizer");
+		String remoteFileSeparator = TestUtils.getPropertyValue(fisync, "remoteFileSeparator");
 		assertThat(remoteFileSeparator).isNotNull();
 		assertThat(remoteFileSeparator).isEqualTo("/");
-		assertThat(TestUtils.getPropertyValue(fisync, "remoteDirectoryExpression", Expression.class)
+		assertThat(TestUtils.<Expression>getPropertyValue(fisync, "remoteDirectoryExpression")
 				.getExpressionString()).isEqualTo("foo/bar");
-		assertThat(TestUtils.getPropertyValue(simpleAdapterWithCachedSessions, "source.maxFetchSize"))
-				.isEqualTo(Integer.MIN_VALUE);
+		assertThat(TestUtils.<Integer>getPropertyValue(simpleAdapterWithCachedSessions,
+				"source.maxFetchSize")).isEqualTo(Integer.MIN_VALUE);
 	}
 
 	@Test
 	public void testAutoChannel() {
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(autoChannelAdapter, "outputChannel"))
+				.isSameAs(autoChannel);
 	}
 
 	public static class TestSessionFactoryBean implements FactoryBean<DefaultFtpSessionFactory> {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundChannelAdapterParserTests.java
@@ -53,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -88,30 +89,33 @@ public class FtpOutboundChannelAdapterParserTests {
 
 	@Test
 	public void testFtpOutboundChannelAdapterComplete() {
-		assertThat(TestUtils.getPropertyValue(ftpOutbound, "inputChannel")).isEqualTo(ftpChannel);
+		assertThat(TestUtils.<PublishSubscribeChannel>getPropertyValue(ftpOutbound, "inputChannel"))
+				.isEqualTo(ftpChannel);
 		assertThat(ftpOutbound.getComponentName()).isEqualTo("ftpOutbound");
 		FileTransferringMessageHandler<?> handler =
-				TestUtils.getPropertyValue(ftpOutbound, "handler", FileTransferringMessageHandler.class);
+				TestUtils.getPropertyValue(ftpOutbound, "handler");
 		String remoteFileSeparator = (String) TestUtils.getPropertyValue(handler,
 				"remoteFileTemplate.remoteFileSeparator");
 		assertThat(remoteFileSeparator).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.temporaryFileSuffix", String.class))
+		assertThat(TestUtils.<String>getPropertyValue(handler, "remoteFileTemplate.temporaryFileSuffix"))
 				.isEqualTo(".foo");
 		assertThat(remoteFileSeparator).isEqualTo("");
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.fileNameGenerator"))
-				.isEqualTo(this.fileNameGenerator);
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.charset")).isEqualTo(StandardCharsets.UTF_8);
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.directoryExpressionProcessor")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.temporaryDirectoryExpressionProcessor"))
-				.isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.existsMode"))
-				.isEqualTo(FtpRemoteFileTemplate.ExistsMode.NLST);
+		assertThat(TestUtils.<FileNameGenerator>getPropertyValue(handler,
+				"remoteFileTemplate.fileNameGenerator")).isEqualTo(this.fileNameGenerator);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "remoteFileTemplate.charset"))
+				.isEqualTo(StandardCharsets.UTF_8);
+		assertThat(TestUtils.<Object>getPropertyValue(handler,
+				"remoteFileTemplate.directoryExpressionProcessor")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler,
+				"remoteFileTemplate.temporaryDirectoryExpressionProcessor")).isNotNull();
+		assertThat(TestUtils.<FtpRemoteFileTemplate.ExistsMode>getPropertyValue(handler,
+				"remoteFileTemplate.existsMode")).isEqualTo(FtpRemoteFileTemplate.ExistsMode.NLST);
 		Object sfProperty = TestUtils.getPropertyValue(handler, "remoteFileTemplate.sessionFactory");
 		assertThat(sfProperty.getClass()).isEqualTo(DefaultFtpSessionFactory.class);
 		DefaultFtpSessionFactory sessionFactory = (DefaultFtpSessionFactory) sfProperty;
-		assertThat(TestUtils.getPropertyValue(sessionFactory, "host")).isEqualTo("localhost");
-		assertThat(TestUtils.getPropertyValue(sessionFactory, "port")).isEqualTo(22);
-		assertThat(TestUtils.getPropertyValue(handler, "order")).isEqualTo(23);
+		assertThat(TestUtils.<String>getPropertyValue(sessionFactory, "host")).isEqualTo("localhost");
+		assertThat(TestUtils.<Integer>getPropertyValue(sessionFactory, "port")).isEqualTo(22);
+		assertThat(TestUtils.<Integer>getPropertyValue(handler, "order")).isEqualTo(23);
 		//verify subscription order
 		Object dispatcher = TestUtils.getPropertyValue(ftpChannel, "dispatcher");
 		@SuppressWarnings("unchecked")
@@ -119,7 +123,8 @@ public class FtpOutboundChannelAdapterParserTests {
 		Iterator<MessageHandler> iterator = handlers.iterator();
 		assertThat(iterator.next()).isSameAs(TestUtils.getPropertyValue(this.ftpOutbound2, "handler"));
 		assertThat(iterator.next()).isSameAs(handler);
-		assertThat(TestUtils.getPropertyValue(ftpOutbound, "handler.mode")).isEqualTo(FileExistsMode.APPEND);
+		assertThat(TestUtils.<FileExistsMode>getPropertyValue(ftpOutbound, "handler.mode"))
+				.isEqualTo(FileExistsMode.APPEND);
 	}
 
 	@Test
@@ -136,39 +141,37 @@ public class FtpOutboundChannelAdapterParserTests {
 		assertThat(sfProperty.getClass()).isEqualTo(CachingSessionFactory.class);
 		Object innerSfProperty = TestUtils.getPropertyValue(sfProperty, "sessionFactory");
 		assertThat(innerSfProperty.getClass()).isEqualTo(DefaultFtpSessionFactory.class);
-		assertThat(TestUtils.getPropertyValue(simpleAdapter, "handler.mode")).isEqualTo(FileExistsMode.REPLACE);
+		assertThat(TestUtils.<FileExistsMode>getPropertyValue(simpleAdapter, "handler.mode"))
+				.isEqualTo(FileExistsMode.REPLACE);
 	}
 
 	@Test
 	public void adviceChain() {
-		MessageHandler handler = TestUtils.getPropertyValue(advisedAdapter, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(advisedAdapter, "handler");
 		handler.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}
 
 	@Test
 	public void testTemporaryFileSuffix() {
-		FileTransferringMessageHandler<?> handler =
-				(FileTransferringMessageHandler<?>) TestUtils.getPropertyValue(ftpOutbound3, "handler");
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.useTemporaryFileName", Boolean.class))
+		FileTransferringMessageHandler<?> handler = TestUtils.getPropertyValue(ftpOutbound3, "handler");
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "remoteFileTemplate.useTemporaryFileName"))
 				.isFalse();
 	}
 
 	@Test
 	public void testBeanExpressions() {
-		FileTransferringMessageHandler<?> handler =
-				TestUtils.getPropertyValue(withBeanExpressions, "handler", FileTransferringMessageHandler.class);
+		FileTransferringMessageHandler<?> handler = TestUtils.getPropertyValue(withBeanExpressions, "handler");
 		ExpressionEvaluatingMessageProcessor<?> dirExpProc = TestUtils.getPropertyValue(handler,
-				"remoteFileTemplate.directoryExpressionProcessor", ExpressionEvaluatingMessageProcessor.class);
+				"remoteFileTemplate.directoryExpressionProcessor");
 		assertThat(dirExpProc).isNotNull();
 		Message<String> message = MessageBuilder.withPayload("qux").build();
 		assertThat(dirExpProc.processMessage(message)).isEqualTo("foo");
 		ExpressionEvaluatingMessageProcessor<?> tempDirExpProc = TestUtils.getPropertyValue(handler,
-				"remoteFileTemplate.temporaryDirectoryExpressionProcessor", ExpressionEvaluatingMessageProcessor.class);
+				"remoteFileTemplate.temporaryDirectoryExpressionProcessor");
 		assertThat(tempDirExpProc).isNotNull();
 		assertThat(tempDirExpProc.processMessage(message)).isEqualTo("bar");
-		DefaultFileNameGenerator generator = TestUtils.getPropertyValue(handler,
-				"remoteFileTemplate.fileNameGenerator", DefaultFileNameGenerator.class);
+		DefaultFileNameGenerator generator = TestUtils.getPropertyValue(handler, "remoteFileTemplate.fileNameGenerator");
 		assertThat(generator).isNotNull();
 		assertThat(generator.generateFileName(message)).isEqualTo("baz");
 	}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpOutboundGatewayParserTests.java
@@ -51,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.1
  *
@@ -81,92 +82,99 @@ public class FtpOutboundGatewayParserTests {
 
 	@Test
 	public void testGateway1() {
-		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway1, "handler", FtpOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator")).isEqualTo("X");
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
+		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway1, "handler");
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator"))
+				.isEqualTo("X");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
 				.isEqualTo("local-test-dir");
-		assertThat(TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(gateway, "filter")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.LS);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "autoCreateLocalDirectory")).isFalse();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "filter")).isNotNull();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.LS);
 
 		@SuppressWarnings("unchecked")
-		Set<Option> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
+		Set<Option> options = TestUtils.getPropertyValue(gateway, "options");
 		assertThat(options.contains(Option.NAME_ONLY)).isTrue();
 		assertThat(options.contains(Option.NOSORT)).isTrue();
 
-		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
+		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout");
 		assertThat(sendTimeout).isEqualTo(Long.valueOf(777));
-		assertThat(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter")).isInstanceOf(ExpressionFileListFilter.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "fileExistsMode")).isEqualTo(FileExistsMode.APPEND);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "requiresReply")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mputFilter"))
+				.isInstanceOf(ExpressionFileListFilter.class);
+		assertThat(TestUtils.<FileExistsMode>getPropertyValue(gateway, "fileExistsMode"))
+				.isEqualTo(FileExistsMode.APPEND);
 	}
 
 	@Test
 	public void testGateway2() throws Exception {
-		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway2, "handler", FtpOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator")).isEqualTo("X");
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"))
+		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway2, "handler");
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator"))
+				.isEqualTo("X");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"))
 				.isInstanceOf(CachingSessionFactory.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.existsMode"))
+		assertThat(TestUtils.<FtpRemoteFileTemplate.ExistsMode>getPropertyValue(gateway, "remoteFileTemplate.existsMode"))
 				.isEqualTo(FtpRemoteFileTemplate.ExistsMode.NLST);
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
 				.isEqualTo("local-test-dir");
-		assertThat(TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.GET);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "autoCreateLocalDirectory")).isFalse();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.GET);
 		@SuppressWarnings("unchecked")
-		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
+		Set<String> options = TestUtils.getPropertyValue(gateway, "options");
 		assertThat(options.contains(Option.PRESERVE_TIMESTAMP)).isTrue();
 		gateway.handleMessage(new GenericMessage<>("foo"));
-		assertThat(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "requiresReply")).isFalse();
 		assertThat(adviceCalled).isEqualTo(1);
 
 		//INT-3129
-		assertThat(TestUtils.getPropertyValue(gateway, "localFilenameGeneratorExpression")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "localFilenameGeneratorExpression")).isNotNull();
 		final AtomicReference<Method> genMethod = new AtomicReference<>();
 		ReflectionUtils.doWithMethods(FtpOutboundGateway.class, method -> {
 			method.setAccessible(true);
 			genMethod.set(method);
 		}, method -> "generateLocalFileName".equals(method.getName()));
 		assertThat(genMethod.get().invoke(gateway, new GenericMessage<>(""), "foo")).isEqualTo("FOO.afoo");
-		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter")).isInstanceOf(SimplePatternFileListFilter.class);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mputFilter"))
+				.isInstanceOf(SimplePatternFileListFilter.class);
 	}
 
 	@Test
 	public void testGatewayMv() {
-		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway3, "handler", FtpOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.MV);
-		assertThat(TestUtils.getPropertyValue(gateway, "renameProcessor.expression.expression")).isEqualTo("'foo'");
+		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway3, "handler");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.MV);
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "renameProcessor.expression.expression"))
+				.isEqualTo("'foo'");
 	}
 
 	@Test
 	public void testGatewayMPut() {
-		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway4, "handler", FtpOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.MPUT);
-		assertThat(TestUtils.getPropertyValue(gateway, "renameProcessor.expression.expression")).isEqualTo("'foo'");
-		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter")).isInstanceOf(RegexPatternFileListFilter.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.fileNameGenerator")).isSameAs(generator);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.directoryExpressionProcessor.expression",
-						Expression.class)
+		FtpOutboundGateway gateway = TestUtils.getPropertyValue(gateway4, "handler");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.MPUT);
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "renameProcessor.expression.expression"))
+				.isEqualTo("'foo'");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mputFilter"))
+				.isInstanceOf(RegexPatternFileListFilter.class);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.fileNameGenerator"))
+				.isSameAs(generator);
+		assertThat(TestUtils.<Expression>getPropertyValue(
+				gateway, "remoteFileTemplate.directoryExpressionProcessor.expression")
 				.getExpressionString()).isEqualTo("/foo");
-		assertThat(TestUtils.getPropertyValue(gateway,
-						"remoteFileTemplate.temporaryDirectoryExpressionProcessor.expression",
-						Expression.class)
+		assertThat(TestUtils.<Expression>getPropertyValue(
+				gateway, "remoteFileTemplate.temporaryDirectoryExpressionProcessor.expression")
 				.getExpressionString()).isEqualTo("/bar");
 	}
 
 	@Test
 	public void testWithBeanExpression() {
-		FtpOutboundGateway gateway = TestUtils.getPropertyValue(withBeanExpression, "handler", FtpOutboundGateway.class);
-		ExpressionEvaluatingMessageProcessor<?> processor = TestUtils.getPropertyValue(gateway, "fileNameProcessor",
-				ExpressionEvaluatingMessageProcessor.class);
+		FtpOutboundGateway gateway = TestUtils.getPropertyValue(withBeanExpression, "handler");
+		ExpressionEvaluatingMessageProcessor<?> processor = TestUtils.getPropertyValue(gateway, "fileNameProcessor");
 		assertThat(processor).isNotNull();
 		assertThat(processor.processMessage(MessageBuilder.withPayload("bar").build())).isEqualTo("foo");
 	}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpStreamingInboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpStreamingInboundChannelAdapterParserTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -60,27 +61,27 @@ public class FtpStreamingInboundChannelAdapterParserTests {
 
 	@Test
 	public void testFtpInboundChannelAdapterComplete() throws Exception {
-		assertThat(TestUtils.getPropertyValue(this.ftpInbound, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.ftpInbound, "autoStartup")).isFalse();
 		assertThat(this.ftpInbound.getComponentName()).isEqualTo("ftpInbound");
 		assertThat(this.ftpInbound.getComponentType()).isEqualTo("ftp:inbound-streaming-channel-adapter");
-		assertThat(TestUtils.getPropertyValue(this.ftpInbound, "outputChannel")).isSameAs(this.ftpChannel);
-		FtpStreamingMessageSource source = TestUtils.getPropertyValue(ftpInbound, "source",
-				FtpStreamingMessageSource.class);
+		assertThat(TestUtils.<Object>getPropertyValue(this.ftpInbound, "outputChannel")).isSameAs(this.ftpChannel);
+		FtpStreamingMessageSource source = TestUtils.getPropertyValue(ftpInbound, "source");
 
-		assertThat(TestUtils.getPropertyValue(source, "comparator")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(source, "remoteFileSeparator", String.class)).isEqualTo("X");
+		assertThat(TestUtils.<Object>getPropertyValue(source, "comparator")).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(source, "remoteFileSeparator")).isEqualTo("X");
 
-		FileListFilter<?> filter = TestUtils.getPropertyValue(source, "filter", FileListFilter.class);
+		FileListFilter<?> filter = TestUtils.getPropertyValue(source, "filter");
 		assertThat(filter).isNotNull();
 		assertThat(filter).isInstanceOf(CompositeFileListFilter.class);
-		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters", Set.class);
+		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters");
 
 		Iterator<?> filtersIterator = fileFilters.iterator();
 		assertThat(filtersIterator.next()).isInstanceOf(FtpSimplePatternFileListFilter.class);
 		assertThat(filtersIterator.next()).isInstanceOf(FtpPersistentAcceptOnceFileListFilter.class);
 
-		assertThat(TestUtils.getPropertyValue(source, "remoteFileTemplate.sessionFactory")).isSameAs(this.csf);
-		assertThat(TestUtils.getPropertyValue(source, "maxFetchSize")).isEqualTo(31);
+		assertThat(TestUtils.<Object>getPropertyValue(source, "remoteFileTemplate.sessionFactory"))
+				.isSameAs(this.csf);
+		assertThat(TestUtils.<Integer>getPropertyValue(source, "maxFetchSize")).isEqualTo(31);
 	}
 
 	public static class TestSessionFactoryBean implements FactoryBean<DefaultFtpSessionFactory> {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsInboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsInboundChannelAdapterParserTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.ftp.config;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.endpoint.SourcePollingChannelAdapter;
 import org.springframework.integration.ftp.inbound.FtpInboundFileSynchronizer;
 import org.springframework.integration.ftp.inbound.FtpInboundFileSynchronizingMessageSource;
@@ -34,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -49,14 +51,13 @@ public class FtpsInboundChannelAdapterParserTests {
 	public void testFtpsInboundChannelAdapterComplete() {
 		assertThat(ftpInbound.getComponentName()).isEqualTo("ftpInbound");
 		assertThat(ftpInbound.getComponentType()).isEqualTo("ftp:inbound-channel-adapter");
-		assertThat(TestUtils.getPropertyValue(ftpInbound, "pollingTask")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(ftpInbound, "outputChannel")).isEqualTo(this.ftpChannel);
-		FtpInboundFileSynchronizingMessageSource inbound =
-				(FtpInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(ftpInbound, "source");
+		assertThat(TestUtils.<Object>getPropertyValue(ftpInbound, "pollingTask")).isNotNull();
+		assertThat(TestUtils.<DirectChannel>getPropertyValue(ftpInbound, "outputChannel"))
+				.isEqualTo(this.ftpChannel);
+		FtpInboundFileSynchronizingMessageSource inbound = TestUtils.getPropertyValue(ftpInbound, "source");
 
-		FtpInboundFileSynchronizer fisync =
-				(FtpInboundFileSynchronizer) TestUtils.getPropertyValue(inbound, "synchronizer");
-		assertThat(TestUtils.getPropertyValue(fisync, "filter")).isNotNull();
+		FtpInboundFileSynchronizer fisync = TestUtils.getPropertyValue(inbound, "synchronizer");
+		assertThat(TestUtils.<Object>getPropertyValue(fisync, "filter")).isNotNull();
 
 	}
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsOutboundChannelAdapterParserTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/config/FtpsOutboundChannelAdapterParserTests.java
@@ -21,6 +21,7 @@ import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.file.FileNameGenerator;
 import org.springframework.integration.file.remote.handler.FileTransferringMessageHandler;
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -56,18 +58,20 @@ public class FtpsOutboundChannelAdapterParserTests {
 	@Test
 	public void testFtpsOutboundChannelAdapterComplete() {
 		assertThat(ftpOutbound).isInstanceOf(EventDrivenConsumer.class);
-		assertThat(TestUtils.getPropertyValue(ftpOutbound, "inputChannel")).isEqualTo(this.ftpChannel);
+		assertThat(TestUtils.<DirectChannel>getPropertyValue(ftpOutbound, "inputChannel"))
+				.isEqualTo(this.ftpChannel);
 		assertThat(ftpOutbound.getComponentName()).isEqualTo("ftpOutbound");
 		FileTransferringMessageHandler<?> handler =
-				TestUtils.getPropertyValue(ftpOutbound, "handler", FileTransferringMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.fileNameGenerator"))
+				TestUtils.getPropertyValue(ftpOutbound, "handler");
+		assertThat(TestUtils.<FileNameGenerator>getPropertyValue(handler,
+				"remoteFileTemplate.fileNameGenerator"))
 				.isEqualTo(this.fileNameGenerator);
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.charset")).isEqualTo(StandardCharsets.UTF_8);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "remoteFileTemplate.charset"))
+				.isEqualTo(StandardCharsets.UTF_8);
 		DefaultFtpsSessionFactory sf =
-				TestUtils.getPropertyValue(handler, "remoteFileTemplate.sessionFactory",
-						DefaultFtpsSessionFactory.class);
-		assertThat(TestUtils.getPropertyValue(sf, "host")).isEqualTo("localhost");
-		assertThat(TestUtils.getPropertyValue(sf, "port")).isEqualTo(22);
+				TestUtils.getPropertyValue(handler, "remoteFileTemplate.sessionFactory");
+		assertThat(TestUtils.<String>getPropertyValue(sf, "host")).isEqualTo("localhost");
+		assertThat(TestUtils.<Integer>getPropertyValue(sf, "port")).isEqualTo(22);
 	}
 
 }

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/dsl/FtpTests.java
@@ -70,6 +70,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Joaquin Santana
  * @author Deepak Gunasekaran
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -102,11 +103,12 @@ public class FtpTests extends FtpTestSupport {
 				.channel(out)
 				.get();
 		IntegrationFlowRegistration registration = this.flowContext.registration(flow).register();
-		Map<?, ?> components = TestUtils.getPropertyValue(registration, "integrationFlow.integrationComponents", Map.class);
+		Map<?, ?> components = TestUtils.getPropertyValue(registration, "integrationFlow.integrationComponents");
 		Iterator<?> iterator = components.keySet().iterator();
 		iterator.next();
 		Object spcafb = iterator.next();
-		assertThat(TestUtils.getPropertyValue(spcafb, "source.fileSource.scanner")).isSameAs(scanner);
+		assertThat(TestUtils.<Object>getPropertyValue(spcafb, "source.fileSource.scanner"))
+				.isSameAs(scanner);
 		Message<?> message = out.receive(10_000);
 		assertThat(message).isNotNull();
 		assertThat(message.getHeaders())
@@ -141,7 +143,7 @@ public class FtpTests extends FtpTestSupport {
 		assertThat(FileCopyUtils.copyToString(new FileReader(file))).isEqualTo("New content");
 
 		MessageSource<?> source = context.getBean(FtpInboundFileSynchronizingMessageSource.class);
-		assertThat(TestUtils.getPropertyValue(source, "maxFetchSize")).isEqualTo(10);
+		assertThat(TestUtils.<Integer>getPropertyValue(source, "maxFetchSize")).isEqualTo(10);
 
 		registration.destroy();
 	}
@@ -172,7 +174,7 @@ public class FtpTests extends FtpTestSupport {
 		new IntegrationMessageHeaderAccessor(message).getCloseableResource().close();
 
 		MessageSource<?> source = context.getBean(FtpStreamingMessageSource.class);
-		assertThat(TestUtils.getPropertyValue(source, "maxFetchSize")).isEqualTo(11);
+		assertThat(TestUtils.<Integer>getPropertyValue(source, "maxFetchSize")).isEqualTo(11);
 		registration.destroy();
 	}
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
@@ -22,6 +22,7 @@ import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -65,6 +66,7 @@ import static org.mockito.Mockito.when;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -149,7 +151,7 @@ public class FtpInboundRemoteFileSystemSynchronizerTests implements TestApplicat
 		assertThat(new File("test/subdir/A.TEST.a").exists()).isTrue();
 		assertThat(new File("test/subdir/B.TEST.a").exists()).isTrue();
 
-		TestUtils.getPropertyValue(localAcceptOnceFilter, "seenSet", Collection.class).clear();
+		TestUtils.<HashSet<?>>getPropertyValue(localAcceptOnceFilter, "seenSet").clear();
 
 		File aFile = new File("test/subdir/A.TEST.a");
 		aFile.delete();
@@ -165,10 +167,10 @@ public class FtpInboundRemoteFileSystemSynchronizerTests implements TestApplicat
 		verify(synchronizer).close();
 		verify(store).close();
 
-		Map<?, ?> metadata = TestUtils.getPropertyValue(remoteFileMetadataStore, "metadata", Map.class);
+		Map<?, ?> metadata = TestUtils.getPropertyValue(remoteFileMetadataStore, "metadata");
 		assertThat(metadata).isEmpty();
 
-		Properties metadataProperties = TestUtils.getPropertyValue(store, "metadata", Properties.class);
+		Properties metadataProperties = TestUtils.getPropertyValue(store, "metadata");
 		metadataProperties.stringPropertyNames()
 				.forEach(name -> assertThat(name).startsWith("someKey/remote-test-dir/"));
 	}

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpStreamingMessageSourceTests.java
@@ -60,6 +60,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.3
  *
@@ -124,10 +125,10 @@ public class FtpStreamingMessageSourceTests extends FtpTestSupport {
 		assertThat(received).isNotNull();
 		assertThat(received.getHeaders().get(FileHeaders.REMOTE_FILE_INFO)).isInstanceOf(FtpFileInfo.class);
 		assertThat(received.getHeaders().get(FileHeaders.REMOTE_HOST_PORT, String.class)).contains("localhost:");
-		assertThat(TestUtils.getPropertyValue(source, "toBeReceived", BlockingQueue.class)).hasSize(1);
+		assertThat(TestUtils.<BlockingQueue<?>>getPropertyValue(source, "toBeReceived")).hasSize(1);
 		assertThat(this.metadataMap).hasSize(1);
 		this.adapter.stop();
-		assertThat(TestUtils.getPropertyValue(source, "toBeReceived", BlockingQueue.class)).isEmpty();
+		assertThat(TestUtils.<BlockingQueue<?>>getPropertyValue(source, "toBeReceived")).isEmpty();
 	}
 
 	@Test

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpOutboundTests.java
@@ -67,6 +67,7 @@ import static org.mockito.Mockito.when;
  * @author Artem Bilan
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 public class FtpOutboundTests implements TestApplicationContextAware {
 
@@ -156,7 +157,7 @@ public class FtpOutboundTests implements TestApplicationContextAware {
 
 		File srcFile = new File(UUID.randomUUID() + ".txt");
 
-		Log logger = spy(TestUtils.getPropertyValue(handler, "remoteFileTemplate.logger", Log.class));
+		Log logger = spy(TestUtils.<Log>getPropertyValue(handler, "remoteFileTemplate.logger"));
 		when(logger.isWarnEnabled()).thenReturn(true);
 		final AtomicReference<String> logged = new AtomicReference<>();
 		doAnswer(invocation -> {
@@ -164,8 +165,7 @@ public class FtpOutboundTests implements TestApplicationContextAware {
 			invocation.callRealMethod();
 			return null;
 		}).when(logger).warn(Mockito.anyString());
-		RemoteFileTemplate<?> template = TestUtils.getPropertyValue(handler, "remoteFileTemplate",
-				RemoteFileTemplate.class);
+		RemoteFileTemplate<?> template = TestUtils.getPropertyValue(handler, "remoteFileTemplate");
 		new DirectFieldAccessor(template).setPropertyValue("logger", logger);
 		assertThatExceptionOfType(MessageHandlingException.class)
 				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>(srcFile)))

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/FtpRemoteFileTemplateTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/FtpRemoteFileTemplateTests.java
@@ -54,6 +54,8 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
+ *
  * @since 4.1
  */
 @SpringJUnitConfig
@@ -137,7 +139,7 @@ public class FtpRemoteFileTemplateTests extends FtpTestSupport implements TestAp
 		file.delete();
 		newFile.delete();
 
-		SimplePool<?> pool = TestUtils.getPropertyValue(this.sessionFactory, "pool", SimplePool.class);
+		SimplePool<?> pool = TestUtils.getPropertyValue(this.sessionFactory, "pool");
 		assertThat(pool.getActiveCount()).isEqualTo(0);
 	}
 
@@ -154,7 +156,7 @@ public class FtpRemoteFileTemplateTests extends FtpTestSupport implements TestAp
 				.withStackTraceContaining("553 : No such file or directory");
 
 		Session<FTPFile> newSession = this.sessionFactory.getSession();
-		assertThat(TestUtils.getPropertyValue(newSession, "targetSession"))
+		assertThat(TestUtils.<Object>getPropertyValue(newSession, "targetSession"))
 				.isSameAs(TestUtils.getPropertyValue(session, "targetSession"));
 
 		newSession.close();

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/SessionFactoryTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/session/SessionFactoryTests.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.verify;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  */
 class SessionFactoryTests {
@@ -93,14 +94,14 @@ class SessionFactoryTests {
 	void testWithControlEncoding() {
 		DefaultFtpSessionFactory sessionFactory = new DefaultFtpSessionFactory();
 		sessionFactory.setControlEncoding("UTF-8");
-		assertThat(TestUtils.getPropertyValue(sessionFactory, "controlEncoding"))
+		assertThat(TestUtils.<String>getPropertyValue(sessionFactory, "controlEncoding"))
 				.as("Expected controlEncoding value of 'UTF-8'").isEqualTo("UTF-8");
 	}
 
 	@Test
 	void testWithoutControlEncoding() {
 		DefaultFtpSessionFactory sessionFactory = new DefaultFtpSessionFactory();
-		assertThat(TestUtils.getPropertyValue(sessionFactory, "controlEncoding"))
+		assertThat(TestUtils.<String>getPropertyValue(sessionFactory, "controlEncoding"))
 				.as("Expected controlEncoding value of 'ISO-8859-1'").isEqualTo("ISO-8859-1");
 	}
 
@@ -157,7 +158,7 @@ class SessionFactoryTests {
 		Session<FTPFile> secondSession = cachingFactory.getSession();
 		secondSession.close();
 		Session<FTPFile> nonStaleSession = cachingFactory.getSession();
-		assertThat(TestUtils.getPropertyValue(nonStaleSession, "targetSession"))
+		assertThat(TestUtils.<Object>getPropertyValue(nonStaleSession, "targetSession"))
 				.isEqualTo(TestUtils.getPropertyValue(firstSession, "targetSession"));
 	}
 
@@ -174,7 +175,7 @@ class SessionFactoryTests {
 		s1.close();
 		Session<FTPFile> s2 = cachingFactory.getSession();
 		s2.close();
-		assertThat(TestUtils.getPropertyValue(s2, "targetSession"))
+		assertThat(TestUtils.<Object>getPropertyValue(s2, "targetSession"))
 				.isEqualTo(TestUtils.getPropertyValue(s1, "targetSession"));
 		Mockito.verify(sessionFactory, Mockito.times(2)).getSession();
 	}

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/ScriptsFactoryTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/ScriptsFactoryTests.java
@@ -41,6 +41,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
+ *
  * @since 5.0
  */
 @SpringJUnitConfig
@@ -71,8 +73,7 @@ public class ScriptsFactoryTests {
 		assertThat(this.discardChannel.receive(10000).getPayload()).isEqualTo("bad");
 		assertThat(this.discardChannel.receive(0)).isNull();
 
-		MessageProcessor<?> delegate = TestUtils.getPropertyValue(this.scriptMessageProcessor, "delegate",
-				MessageProcessor.class);
+		MessageProcessor<?> delegate = TestUtils.getPropertyValue(this.scriptMessageProcessor, "delegate");
 
 		assertThat(delegate).isInstanceOf(GroovyScriptExecutingMessageProcessor.class);
 	}

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyFilterTests.java
@@ -27,7 +27,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.core.MessageSelector;
 import org.springframework.integration.filter.MessageFilter;
-import org.springframework.integration.filter.MethodInvokingSelector;
 import org.springframework.integration.groovy.GroovyScriptExecutingMessageProcessor;
 import org.springframework.integration.handler.MessageProcessor;
 import org.springframework.integration.support.MessageBuilder;
@@ -47,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -103,11 +103,10 @@ public class GroovyFilterTests {
 	@Test
 	public void testInt2433VerifyRiddingOfMessageProcessorsWrapping() {
 		assertThat(this.groovyFilterMessageHandler).isInstanceOf(MessageFilter.class);
-		MessageSelector selector = TestUtils.getPropertyValue(this.groovyFilterMessageHandler, "selector",
-				MethodInvokingSelector.class);
+		MessageSelector selector = TestUtils.getPropertyValue(this.groovyFilterMessageHandler, "selector");
 		@SuppressWarnings("rawtypes")
 		MessageProcessor messageProcessor =
-				TestUtils.getPropertyValue(selector, "messageProcessor", MessageProcessor.class);
+				TestUtils.<MessageProcessor>getPropertyValue(selector, "messageProcessor");
 		//before it was MethodInvokingMessageProcessor
 		assertThat(messageProcessor).isInstanceOf(GroovyScriptExecutingMessageProcessor.class);
 	}

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyHeaderEnricherTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -69,8 +70,7 @@ public class GroovyHeaderEnricherTests {
 	@Test
 	public void inlineScript() {
 		Map<String, HeaderValueMessageProcessor<?>> headers =
-				TestUtils.getPropertyValue(headerEnricherWithInlineGroovyScript,
-						"handler.transformer.headersToAdd", Map.class);
+				TestUtils.getPropertyValue(headerEnricherWithInlineGroovyScript, "handler.transformer.headersToAdd");
 		assertThat(headers.size()).isEqualTo(1);
 		HeaderValueMessageProcessor<?> headerValueMessageProcessor = headers.get("TEST_HEADER");
 		assertThat(headerValueMessageProcessor.getClass().getName())

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRouterTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyRouterTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -106,8 +107,8 @@ public class GroovyRouterTests {
 	public void testInt2433VerifyRiddingOfMessageProcessorsWrapping() {
 		assertThat(this.groovyRouterMessageHandler).isInstanceOf(MethodInvokingRouter.class);
 		@SuppressWarnings("rawtypes")
-		MessageProcessor messageProcessor = TestUtils.getPropertyValue(this.groovyRouterMessageHandler,
-				"messageProcessor", MessageProcessor.class);
+		MessageProcessor messageProcessor =
+				TestUtils.getPropertyValue(this.groovyRouterMessageHandler, "messageProcessor");
 		//before it was MethodInvokingMessageProcessor
 		assertThat(messageProcessor).isInstanceOf(GroovyScriptExecutingMessageProcessor.class);
 	}

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovySplitterTests.java
@@ -37,6 +37,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
+ *
  * @since 2.0
  */
 @SpringJUnitConfig
@@ -82,7 +84,7 @@ public class GroovySplitterTests {
 		assertThat(this.groovySplitterMessageHandler instanceof MethodInvokingSplitter).isTrue();
 		@SuppressWarnings("rawtypes")
 		MessageProcessor messageProcessor =
-				TestUtils.getPropertyValue(this.groovySplitterMessageHandler, "processor", MessageProcessor.class);
+				TestUtils.getPropertyValue(this.groovySplitterMessageHandler, "processor");
 		//before it was MethodInvokingMessageProcessor
 		assertThat(messageProcessor).isInstanceOf(GroovyScriptExecutingMessageProcessor.class);
 	}

--- a/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyTransformerTests.java
+++ b/spring-integration-groovy/src/test/java/org/springframework/integration/groovy/config/GroovyTransformerTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -86,11 +87,10 @@ public class GroovyTransformerTests {
 	@Test
 	public void testInt2433VerifyRiddingOfMessageProcessorsWrapping() {
 		assertThat(this.groovyTransformerMessageHandler instanceof MessageTransformingHandler).isTrue();
-		Transformer transformer =
-				TestUtils.getPropertyValue(this.groovyTransformerMessageHandler, "transformer", Transformer.class);
+		Transformer transformer = TestUtils.getPropertyValue(this.groovyTransformerMessageHandler, "transformer");
 		assertThat(transformer).isInstanceOf(AbstractMessageProcessingTransformer.class);
 		//before it was MethodInvokingMessageProcessor
-		assertThat(TestUtils.getPropertyValue(transformer, "messageProcessor"))
+		assertThat(TestUtils.<Object>getPropertyValue(transformer, "messageProcessor"))
 				.isInstanceOf(GroovyScriptExecutingMessageProcessor.class);
 	}
 

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/IdempotentReceiverIntegrationTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/IdempotentReceiverIntegrationTests.java
@@ -76,6 +76,7 @@ import static org.mockito.Mockito.spy;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 4.1
  */
@@ -126,13 +127,13 @@ public class IdempotentReceiverIntegrationTests {
 	@SuppressWarnings("unchecked")
 	public void testIdempotentReceiver() {
 		this.idempotentReceiverInterceptor.setThrowExceptionOnRejection(true);
-		TestUtils.getPropertyValue(this.store, "metadata", Map.class).clear();
+		TestUtils.<Map<?, ?>>getPropertyValue(this.store, "metadata").clear();
 		Message<String> message = new GenericMessage<>("foo");
 		this.input.send(message);
 		Message<?> receive = this.output.receive(10000);
 		assertThat(receive).isNotNull();
 		assertThat(this.adviceCalled.get()).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(this.store, "metadata", Map.class)).hasSize(1);
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(this.store, "metadata")).hasSize(1);
 		String foo = this.store.get("foo");
 		assertThat(foo).isEqualTo("FOO");
 
@@ -145,14 +146,14 @@ public class IdempotentReceiverIntegrationTests {
 		assertThat(receive).isNotNull();
 		assertThat(this.adviceCalled.get()).isEqualTo(2);
 		assertThat(receive.getHeaders()).containsEntry(IntegrationMessageHeaderAccessor.DUPLICATE_MESSAGE, true);
-		assertThat(TestUtils.getPropertyValue(store, "metadata", Map.class)).hasSize(1);
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(store, "metadata")).hasSize(1);
 
 		assertThat(this.txSupplied.get()).isTrue();
 	}
 
 	@Test
 	public void testIdempotentReceiverOnMethod() {
-		TestUtils.getPropertyValue(this.store, "metadata", Map.class).clear();
+		TestUtils.<Map<?, ?>>getPropertyValue(this.store, "metadata").clear();
 		Message<String> message = new GenericMessage<>("foo");
 		this.annotatedMethodChannel.send(message);
 		this.annotatedMethodChannel.send(message);

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/store/HazelcastMessageStoreTests.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/store/HazelcastMessageStoreTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Vinicius Carvalho
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class HazelcastMessageStoreTests {
 
@@ -114,9 +115,9 @@ public class HazelcastMessageStoreTests {
 
 	@Test
 	public void customMap() {
-		assertThat(TestUtils.getPropertyValue(store, "map")).isSameAs(map);
+		assertThat(TestUtils.<Object>getPropertyValue(store, "map")).isSameAs(map);
 		HazelcastMessageStore store2 = new HazelcastMessageStore(instance);
-		assertThat(TestUtils.getPropertyValue(store2, "map")).isNotSameAs(map);
+		assertThat(TestUtils.<Object>getPropertyValue(store2, "map")).isNotSameAs(map);
 	}
 
 	@Test

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/DefaultConfigurationTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/DefaultConfigurationTests.java
@@ -37,6 +37,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 1.0.3
  */
 @SpringJUnitConfig
@@ -64,14 +66,13 @@ public class DefaultConfigurationTests {
 	public void verifyTaskScheduler() {
 		Object taskScheduler = context.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME);
 		assertThat(taskScheduler.getClass()).isEqualTo(ThreadPoolTaskScheduler.class);
-		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler", ErrorHandler.class);
+		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler");
 		assertThat(errorHandler.getClass()).isEqualTo(MessagePublishingErrorHandler.class);
-		MessageChannel defaultErrorChannel = TestUtils.getPropertyValue(errorHandler,
-				"messagingTemplate.defaultDestination", MessageChannel.class);
+		MessageChannel defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNull();
 		errorHandler.handleError(new Throwable());
-		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination",
-				MessageChannel.class);
+		defaultErrorChannel = TestUtils.<MessageChannel>getPropertyValue(errorHandler,
+				"messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNotNull();
 		assertThat(defaultErrorChannel).isEqualTo(context.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME));
 	}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundChannelAdapterParserTests.java
@@ -64,6 +64,7 @@ import static org.mockito.BDDMockito.willReturn;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Biju Kunjummen
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -121,8 +122,8 @@ public class HttpInboundChannelAdapterParserTests extends AbstractHttpInboundTes
 	@Test
 	@SuppressWarnings("unchecked")
 	public void getRequestOk() throws Exception {
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "phase")).isEqualTo(1001);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultAdapter, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.defaultAdapter, "phase")).isEqualTo(1001);
 		MockHttpServletRequest request = new MockHttpServletRequest();
 		request.setMethod("GET");
 		request.setParameter("foo", "bar");
@@ -143,14 +144,15 @@ public class HttpInboundChannelAdapterParserTests extends AbstractHttpInboundTes
 		assertThat(map.keySet().iterator().next()).isEqualTo("foo");
 		assertThat(map.get("foo").size()).isEqualTo(1);
 		assertThat(map.getFirst("foo")).isEqualTo("bar");
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "errorChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "validator")).isSameAs(this.validator);
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultAdapter, "errorChannel")).isNotNull();
+		assertThat(TestUtils.<Validator>getPropertyValue(this.defaultAdapter, "validator"))
+				.isSameAs(this.validator);
 	}
 
 	@Test
 	public void getRequestWithHeaders() {
 		DefaultHttpHeaderMapper headerMapper =
-				TestUtils.getPropertyValue(withMappedHeaders, "headerMapper", DefaultHttpHeaderMapper.class);
+				TestUtils.<DefaultHttpHeaderMapper>getPropertyValue(withMappedHeaders, "headerMapper");
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("foo", "foo");
@@ -250,16 +252,16 @@ public class HttpInboundChannelAdapterParserTests extends AbstractHttpInboundTes
 	@Test
 	public void putOrDeleteMethodsSupported() {
 		HttpMethod[] supportedMethods =
-				TestUtils.getPropertyValue(putOrDeleteAdapter, "requestMapping.methods", HttpMethod[].class);
+				TestUtils.<HttpMethod[]>getPropertyValue(putOrDeleteAdapter, "requestMapping.methods");
 		assertThat(supportedMethods.length).isEqualTo(2);
 		assertThat(supportedMethods).containsExactly(HttpMethod.PUT, HttpMethod.DELETE);
 	}
 
 	@Test
 	public void testController() {
-		String errorCode = TestUtils.getPropertyValue(inboundController, "errorCode", String.class);
+		String errorCode = TestUtils.getPropertyValue(inboundController, "errorCode");
 		assertThat(errorCode).isEqualTo("oops");
-		Expression viewExpression = TestUtils.getPropertyValue(inboundController, "viewExpression", Expression.class);
+		Expression viewExpression = TestUtils.getPropertyValue(inboundController, "viewExpression");
 		assertThat(viewExpression.getExpressionString()).isEqualTo("foo");
 
 		MockHttpServletRequest request = new MockHttpServletRequest();
@@ -274,21 +276,20 @@ public class HttpInboundChannelAdapterParserTests extends AbstractHttpInboundTes
 
 	@Test
 	public void testInt2717ControllerWithViewExpression() {
-		Expression viewExpression = TestUtils
-				.getPropertyValue(inboundControllerViewExp, "viewExpression", Expression.class);
+		Expression viewExpression = TestUtils.getPropertyValue(inboundControllerViewExp, "viewExpression");
 		assertThat(viewExpression.getExpressionString()).isEqualTo("'foo'");
 	}
 
 	@Test
 	public void testAutoChannel() {
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "requestChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(autoChannelAdapter, "requestChannel"))
+				.isSameAs(autoChannel);
 	}
 
 	@Test
 	public void testInboundAdapterWithMessageConverterDefaults() {
-		@SuppressWarnings("unchecked")
-		List<HttpMessageConverter<?>> messageConverters = TestUtils
-				.getPropertyValue(adapterWithCustomConverterWithDefaults, "messageConverters", List.class);
+		List<HttpMessageConverter<?>> messageConverters = TestUtils.getPropertyValue(
+				adapterWithCustomConverterWithDefaults, "messageConverters");
 		assertThat(messageConverters.size() > 1)
 				.as("There should be more than 1 message converter. The customized one and the defaults.").isTrue();
 
@@ -298,9 +299,8 @@ public class HttpInboundChannelAdapterParserTests extends AbstractHttpInboundTes
 
 	@Test
 	public void testInboundAdapterWithNoMessageConverterDefaults() {
-		@SuppressWarnings("unchecked")
-		List<HttpMessageConverter<?>> messageConverters = TestUtils
-				.getPropertyValue(adapterWithCustomConverterNoDefaults, "messageConverters", List.class);
+		List<HttpMessageConverter<?>> messageConverters = TestUtils.getPropertyValue(
+				adapterWithCustomConverterNoDefaults, "messageConverters");
 		//First converter should be the customized one
 		assertThat(messageConverters.get(0)).isInstanceOf(SerializingHttpMessageConverter.class);
 		assertThat(messageConverters).as("There should be only the customized MessageConverter registered.")
@@ -309,9 +309,8 @@ public class HttpInboundChannelAdapterParserTests extends AbstractHttpInboundTes
 
 	@Test
 	public void testInboundAdapterWithNoMessageConverterNoDefaults() {
-		@SuppressWarnings("unchecked")
-		List<HttpMessageConverter<?>> messageConverters = TestUtils
-				.getPropertyValue(adapterNoCustomConverterNoDefaults, "messageConverters", List.class);
+		List<HttpMessageConverter<?>> messageConverters =
+				TestUtils.getPropertyValue(adapterNoCustomConverterNoDefaults, "messageConverters");
 		assertThat(messageConverters.size() > 1).as("There should be more than 1 message converter. The defaults.")
 				.isTrue();
 	}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpInboundGatewayParserTests.java
@@ -49,7 +49,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.integration.test.util.TestUtils.getPropertyValue;
 
 /**
  * @author Mark Fisher
@@ -59,6 +58,7 @@ import static org.springframework.integration.test.util.TestUtils.getPropertyVal
  * @author Gunnar Hillert
  * @author Biju Kunjummen
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -103,29 +103,32 @@ public class HttpInboundGatewayParserTests {
 	@Test
 	public void checkConfig() {
 		assertThat(this.gateway).isNotNull();
-		assertThat(getPropertyValue(this.gateway, "expectReply", Boolean.class)).isTrue();
-		assertThat(getPropertyValue(this.gateway, "convertExceptions", Boolean.class)).isTrue();
-		assertThat(getPropertyValue(this.gateway, "replyChannel")).isSameAs(this.responses);
-		assertThat(TestUtils.getPropertyValue(this.gateway, "errorChannel")).isNotNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.gateway, "expectReply")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.gateway, "convertExceptions")).isTrue();
+		assertThat(TestUtils.<PollableChannel>getPropertyValue(this.gateway, "replyChannel"))
+				.isSameAs(this.responses);
+		assertThat(TestUtils.<Object>getPropertyValue(this.gateway, "errorChannel")).isNotNull();
 		MessagingTemplate messagingTemplate =
-				TestUtils.getPropertyValue(this.gateway, "messagingTemplate", MessagingTemplate.class);
-		assertThat(TestUtils.getPropertyValue(messagingTemplate, "sendTimeout")).isEqualTo(1234L);
-		assertThat(TestUtils.getPropertyValue(messagingTemplate, "receiveTimeout")).isEqualTo(4567L);
+				TestUtils.<MessagingTemplate>getPropertyValue(this.gateway, "messagingTemplate");
+		assertThat(TestUtils.<Long>getPropertyValue(messagingTemplate, "sendTimeout"))
+				.isEqualTo(1234L);
+		assertThat(TestUtils.<Long>getPropertyValue(messagingTemplate, "receiveTimeout"))
+				.isEqualTo(4567L);
 
 		boolean registerDefaultConverters =
-				TestUtils.getPropertyValue(this.gateway, "mergeWithDefaultConverters", Boolean.class);
+				TestUtils.<Boolean>getPropertyValue(this.gateway, "mergeWithDefaultConverters");
 		assertThat(registerDefaultConverters).as("By default the register-default-converters flag should be false")
 				.isFalse();
 		@SuppressWarnings("unchecked")
 		List<HttpMessageConverter<?>> messageConverters =
-				TestUtils.getPropertyValue(this.gateway, "messageConverters", List.class);
+				TestUtils.getPropertyValue(this.gateway, "messageConverters");
 
 		assertThat(messageConverters.size() > 0)
 				.as("The default converters should have been registered, given there are no custom converters")
 				.isTrue();
 
-		assertThat(TestUtils.getPropertyValue(this.gateway, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.gateway, "phase")).isEqualTo(1001);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.gateway, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.gateway, "phase")).isEqualTo(1001);
 	}
 
 	@Test
@@ -176,7 +179,7 @@ public class HttpInboundGatewayParserTests {
 	@Test
 	public void requestWithHeaders() {
 		DefaultHttpHeaderMapper headerMapper =
-				TestUtils.getPropertyValue(this.withMappedHeaders, "headerMapper", DefaultHttpHeaderMapper.class);
+				TestUtils.<DefaultHttpHeaderMapper>getPropertyValue(this.withMappedHeaders, "headerMapper");
 
 		HttpHeaders headers = new HttpHeaders();
 		headers.set("foo", "foo");
@@ -200,8 +203,7 @@ public class HttpInboundGatewayParserTests {
 	@Test
 	public void requestWithHeadersWithConversionService() {
 		DefaultHttpHeaderMapper headerMapper =
-				TestUtils.getPropertyValue(this.withMappedHeadersAndConverter,
-						"headerMapper", DefaultHttpHeaderMapper.class);
+				TestUtils.<DefaultHttpHeaderMapper>getPropertyValue(this.withMappedHeadersAndConverter, "headerMapper");
 
 		headerMapper.setUserDefinedHeaderPrefix("X-");
 
@@ -231,9 +233,8 @@ public class HttpInboundGatewayParserTests {
 
 	@Test
 	public void testInboundGatewayWithMessageConverterDefaults() {
-		@SuppressWarnings("unchecked")
 		List<HttpMessageConverter<?>> messageConverters =
-				TestUtils.getPropertyValue(this.gatewayWithOneCustomConverter, "messageConverters", List.class);
+				TestUtils.getPropertyValue(this.gatewayWithOneCustomConverter, "messageConverters");
 		assertThat(messageConverters.size())
 				.as("There should be only 1 message converter, by default register-default-converters is off")
 				.isEqualTo(1);
@@ -244,9 +245,8 @@ public class HttpInboundGatewayParserTests {
 
 	@Test
 	public void testInboundGatewayWithNoMessageConverterDefaults() {
-		@SuppressWarnings("unchecked")
 		List<HttpMessageConverter<?>> messageConverters =
-				TestUtils.getPropertyValue(this.gatewayNoDefaultConverters, "messageConverters", List.class);
+				TestUtils.getPropertyValue(this.gatewayNoDefaultConverters, "messageConverters");
 		//First converter should be the customized one
 		assertThat(messageConverters.get(0)).isInstanceOf(SerializingHttpMessageConverter.class);
 
@@ -256,10 +256,8 @@ public class HttpInboundGatewayParserTests {
 
 	@Test
 	public void testInboundGatewayWithCustomAndDefaultMessageConverters() {
-		@SuppressWarnings("unchecked")
 		List<HttpMessageConverter<?>> messageConverters =
-				TestUtils.getPropertyValue(this.gatewayWithCustomAndDefaultConverters, "messageConverters",
-						List.class);
+				TestUtils.getPropertyValue(this.gatewayWithCustomAndDefaultConverters, "messageConverters");
 		//First converter should be the customized one
 		assertThat(messageConverters.get(0)).isInstanceOf(SerializingHttpMessageConverter.class);
 

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
@@ -59,6 +59,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Artem Bilan
  * @author Biju Kunjummen
  * @author Shiliang Li
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -109,7 +110,7 @@ public class HttpOutboundChannelAdapterParserTests {
 	public void minimalConfig() {
 		DirectFieldAccessor endpointAccessor = new DirectFieldAccessor(this.minimalConfig);
 		RestTemplate restTemplate =
-				TestUtils.getPropertyValue(this.minimalConfig, "handler.restTemplate", RestTemplate.class);
+				TestUtils.<RestTemplate>getPropertyValue(this.minimalConfig, "handler.restTemplate");
 		assertThat(restTemplate).isNotSameAs(customRestTemplate);
 		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor
 				.getPropertyValue("handler");
@@ -125,7 +126,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
 		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test1");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
@@ -148,7 +149,7 @@ public class HttpOutboundChannelAdapterParserTests {
 				new DirectFieldAccessor(handlerAccessor.getPropertyValue("restTemplate"));
 		ClientHttpRequestFactory requestFactory = (ClientHttpRequestFactory)
 				templateAccessor.getPropertyValue("requestFactory");
-		assertThat(TestUtils.getPropertyValue(handler, "expectedResponseTypeExpression", Expression.class).getValue())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "expectedResponseTypeExpression").getValue())
 				.isEqualTo(Boolean.class.getName());
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
 		Object converterListBean = this.applicationContext.getBean("converterList");
@@ -159,7 +160,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(templateAccessor.getPropertyValue("errorHandler")).isEqualTo(errorHandlerBean);
 		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test2/{foo}");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.GET.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(false);
@@ -175,15 +176,15 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(ObjectUtils.containsElement(mappedRequestHeaders, "requestHeader1")).isTrue();
 		assertThat(ObjectUtils.containsElement(mappedRequestHeaders, "requestHeader2")).isTrue();
 		assertThat(
-				TestUtils.getPropertyValue(handler,
-						"restTemplate.uriTemplateHandler.encodingMode", DefaultUriBuilderFactory.EncodingMode.class))
+				TestUtils.<DefaultUriBuilderFactory.EncodingMode>getPropertyValue(
+						handler, "restTemplate.uriTemplateHandler.encodingMode"))
 				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
 	}
 
 	@Test
 	public void restTemplateConfig() {
 		RestTemplate restTemplate =
-				TestUtils.getPropertyValue(this.restTemplateConfig, "handler.restTemplate", RestTemplate.class);
+				TestUtils.getPropertyValue(this.restTemplateConfig, "handler.restTemplate");
 		assertThat(restTemplate).isEqualTo(customRestTemplate);
 	}
 
@@ -198,8 +199,7 @@ public class HttpOutboundChannelAdapterParserTests {
 	@Test
 	public void withUrlAndTemplate() {
 		DirectFieldAccessor endpointAccessor = new DirectFieldAccessor(this.withUrlAndTemplate);
-		RestTemplate restTemplate =
-				TestUtils.getPropertyValue(this.withUrlAndTemplate, "handler.restTemplate", RestTemplate.class);
+		RestTemplate restTemplate = TestUtils.getPropertyValue(this.withUrlAndTemplate, "handler.restTemplate");
 		assertThat(restTemplate).isSameAs(customRestTemplate);
 		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor
 				.getPropertyValue("handler");
@@ -215,7 +215,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		assertThat(requestFactory instanceof SimpleClientHttpRequestFactory).isTrue();
 		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test1");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
@@ -232,8 +232,7 @@ public class HttpOutboundChannelAdapterParserTests {
 	@Test
 	public void withUrlExpression() {
 		DirectFieldAccessor endpointAccessor = new DirectFieldAccessor(this.withUrlExpression);
-		RestTemplate restTemplate =
-				TestUtils.getPropertyValue(this.withUrlExpression, "handler.restTemplate", RestTemplate.class);
+		RestTemplate restTemplate = TestUtils.getPropertyValue(this.withUrlExpression, "handler.restTemplate");
 		assertThat(restTemplate).isNotSameAs(customRestTemplate);
 		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor
 				.getPropertyValue("handler");
@@ -250,7 +249,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		SpelExpression expression = (SpelExpression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(expression).isNotNull();
 		assertThat(expression.getExpressionString()).isEqualTo("'http://localhost/test1'");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
@@ -258,7 +257,7 @@ public class HttpOutboundChannelAdapterParserTests {
 
 	@Test
 	public void withAdvice() {
-		MessageHandler handler = TestUtils.getPropertyValue(this.withAdvice, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(this.withAdvice, "handler");
 		handler.handleMessage(new GenericMessage<String>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}
@@ -267,8 +266,7 @@ public class HttpOutboundChannelAdapterParserTests {
 	public void withUrlExpressionAndTemplate() {
 		DirectFieldAccessor endpointAccessor = new DirectFieldAccessor(this.withUrlExpressionAndTemplate);
 		RestTemplate restTemplate =
-				TestUtils.getPropertyValue(this.withUrlExpressionAndTemplate, "handler.restTemplate",
-						RestTemplate.class);
+				TestUtils.getPropertyValue(this.withUrlExpressionAndTemplate, "handler.restTemplate");
 		assertThat(restTemplate).isSameAs(customRestTemplate);
 		HttpRequestExecutingMessageHandler handler = (HttpRequestExecutingMessageHandler) endpointAccessor
 				.getPropertyValue("handler");
@@ -285,7 +283,7 @@ public class HttpOutboundChannelAdapterParserTests {
 		SpelExpression expression = (SpelExpression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(expression).isNotNull();
 		assertThat(expression.getExpressionString()).isEqualTo("'http://localhost/test1'");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
@@ -56,6 +56,7 @@ import static org.mockito.Mockito.mock;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Biju Kunjummen
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -98,13 +99,13 @@ public class HttpOutboundGatewayParserTests {
 		assertThat(replyChannel).isNull();
 		Object requestFactory = TestUtils.getPropertyValue(handler, "restTemplate.requestFactory");
 		assertThat(requestFactory).isInstanceOf(SimpleClientHttpRequestFactory.class);
-		Expression uriExpression = TestUtils.getPropertyValue(handler, "uriExpression", Expression.class);
+		Expression uriExpression = TestUtils.getPropertyValue(handler, "uriExpression");
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test1");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
-		assertThat(TestUtils.getPropertyValue(handler, "charset")).isEqualTo(StandardCharsets.UTF_8);
-		assertThat(TestUtils.getPropertyValue(handler, "extractPayload")).isEqualTo(true);
-		assertThat(TestUtils.getPropertyValue(handler, "transferCookies")).isEqualTo(false);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "charset")).isEqualTo(StandardCharsets.UTF_8);
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "extractPayload")).isEqualTo(true);
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "transferCookies")).isEqualTo(false);
 	}
 
 	@Test
@@ -124,20 +125,22 @@ public class HttpOutboundGatewayParserTests {
 		Object requestFactory = TestUtils.getPropertyValue(handler, "restTemplate.requestFactory");
 		assertThat(requestFactory).isInstanceOf(SimpleClientHttpRequestFactory.class);
 		Object converterListBean = this.applicationContext.getBean("converterList");
-		assertThat(TestUtils.getPropertyValue(handler, "restTemplate.messageConverters")).isEqualTo(converterListBean);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "restTemplate.messageConverters"))
+				.isEqualTo(converterListBean);
 
-		assertThat(TestUtils.getPropertyValue(handler, "expectedResponseTypeExpression", Expression.class).getValue())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "expectedResponseTypeExpression").getValue())
 				.isEqualTo(String.class.getName());
 		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test2");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.PUT.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(false);
 		Object requestFactoryBean = this.applicationContext.getBean("testRequestFactory");
 		assertThat(requestFactory).isEqualTo(requestFactoryBean);
 		Object errorHandlerBean = this.applicationContext.getBean("testErrorHandler");
-		assertThat(TestUtils.getPropertyValue(handler, "restTemplate.errorHandler")).isEqualTo(errorHandlerBean);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "restTemplate.errorHandler"))
+				.isEqualTo(errorHandlerBean);
 		Object sendTimeout = new DirectFieldAccessor(
 				handlerAccessor.getPropertyValue("messagingTemplate")).getPropertyValue("sendTimeout");
 		assertThat(sendTimeout).isEqualTo(1234L);
@@ -173,7 +176,7 @@ public class HttpOutboundGatewayParserTests {
 		SpelExpression expression = (SpelExpression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(expression).isNotNull();
 		assertThat(expression.getExpressionString()).isEqualTo("'http://localhost/test1'");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
@@ -96,6 +96,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Shiliang Li
  * @author Gary Russell
  * @author Oleksii Komlyk
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -126,8 +127,7 @@ public class HttpDslTests {
 	public void testHttpProxyFlow() throws Exception {
 		RestTestClient restTestClient = RestTestClient.bindTo(this.mockMvc).build();
 		ClientHttpRequestFactory mockRequestFactory =
-				TestUtils.getPropertyValue(restTestClient, "restClient.clientRequestFactory",
-						ClientHttpRequestFactory.class);
+				TestUtils.getPropertyValue(restTestClient, "restClient.clientRequestFactory");
 		this.serviceInternalGatewayHandler.setRequestFactory(mockRequestFactory);
 
 		this.mockMvc.perform(

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/CrossOriginTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/inbound/CrossOriginTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.2
  */
@@ -176,14 +177,14 @@ public class CrossOriginTests {
 		if (isPreFlightRequest) {
 			Object handler = chain.getHandler();
 			assertThat(handler.getClass().getSimpleName().equals("PreFlightHttpRequestHandler")).isTrue();
-			return TestUtils.getPropertyValue(handler, "config", CorsConfiguration.class);
+			return TestUtils.getPropertyValue(handler, "config");
 		}
 		else {
 			HandlerInterceptor[] interceptors = chain.getInterceptors();
 			if (interceptors != null) {
 				for (HandlerInterceptor interceptor : interceptors) {
 					if (interceptor.getClass().getSimpleName().equals("CorsInterceptor")) {
-						return TestUtils.getPropertyValue(interceptor, "config", CorsConfiguration.class);
+						return TestUtils.getPropertyValue(interceptor, "config");
 					}
 				}
 			}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -82,6 +82,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Florian Schöffl
+ * @author Glenn Renfro
  */
 public class HttpRequestExecutingMessageHandlerTests implements TestApplicationContextAware {
 
@@ -451,7 +452,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		assertThat(aValue.get(1)).isEqualTo("2");
 
 		List<?> bValue = map.get("b");
-		assertThat(bValue.size()).isEqualTo(0);
+		assertThat(bValue).isEmpty();
 
 		List<?> cValue = map.get("c");
 		assertThat(cValue.size()).isEqualTo(1);
@@ -493,7 +494,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		assertThat(aValue.get(1).toString()).isEqualTo("Ambler");
 
 		List<?> bValue = map.get("b");
-		assertThat(bValue.size()).isEqualTo(0);
+		assertThat(bValue).isEmpty();
 
 		List<?> cValue = map.get("c");
 		assertThat(cValue.size()).isEqualTo(1);
@@ -674,7 +675,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = ctx.getBean("chain$child.adapter.handler",
 				HttpRequestExecutingMessageHandler.class);
 
-		assertThat(TestUtils.getPropertyValue(handler, "trustedSpel")).isEqualTo(Boolean.TRUE);
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "trustedSpel")).isEqualTo(Boolean.TRUE);
 		ctx.close();
 	}
 
@@ -787,7 +788,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
 
-		RestTemplate restTemplate = TestUtils.getPropertyValue(handler, "restTemplate", RestTemplate.class);
+		RestTemplate restTemplate = TestUtils.getPropertyValue(handler, "restTemplate");
 
 		HttpHeaders requestHeaders = setUpMocksToCaptureSentHeaders(restTemplate);
 
@@ -818,7 +819,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
 
-		RestTemplate restTemplate = TestUtils.getPropertyValue(handler, "restTemplate", RestTemplate.class);
+		RestTemplate restTemplate = TestUtils.getPropertyValue(handler, "restTemplate");
 
 		HttpHeaders requestHeaders = setUpMocksToCaptureSentHeaders(restTemplate);
 
@@ -922,7 +923,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 				throws RestClientException {
 
 			this.actualUrl.set(url.toString());
-			this.lastRequestEntity.set(TestUtils.getPropertyValue(requestCallback, "requestEntity", HttpEntity.class));
+			this.lastRequestEntity.set(TestUtils.getPropertyValue(requestCallback, "requestEntity"));
 			throw new RuntimeException("intentional");
 		}
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/ParserUnitTests.java
@@ -83,6 +83,7 @@ import static org.mockito.Mockito.mock;
  * @author Gary Russell
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -298,7 +299,7 @@ public class ParserUnitTests {
 		DatagramPacketMessageMapper mapper = (DatagramPacketMessageMapper) dfa.getPropertyValue("mapper");
 		DirectFieldAccessor mapperAccessor = new DirectFieldAccessor(mapper);
 		assertThat((Boolean) mapperAccessor.getPropertyValue("lookupHost")).isFalse();
-		assertThat(TestUtils.getPropertyValue(udpIn, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(udpIn, "autoStartup")).isFalse();
 		assertThat(dfa.getPropertyValue("phase")).isEqualTo(1234);
 		assertThat(dfa.getPropertyValue("socketCustomizer")).isSameAs(this.socketCustomizer);
 	}
@@ -330,27 +331,30 @@ public class ParserUnitTests {
 		assertThat(cfS1.isLookupHost()).isFalse();
 		assertThat(tcpIn.isAutoStartup()).isFalse();
 		assertThat(tcpIn.getPhase()).isEqualTo(124);
-		TcpMessageMapper cfS1Mapper = TestUtils.getPropertyValue(cfS1, "mapper", TcpMessageMapper.class);
+		TcpMessageMapper cfS1Mapper = TestUtils.getPropertyValue(cfS1, "mapper");
 		assertThat(cfS1Mapper).isSameAs(mapper);
-		assertThat(TestUtils.getPropertyValue(cfS1Mapper, "applySequence", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(cfS1Mapper, "applySequence")).isTrue();
 		Object socketSupport = TestUtils.getPropertyValue(cfS1, "tcpSocketFactorySupport");
 		assertThat(socketSupport instanceof DefaultTcpNetSSLSocketFactorySupport).isTrue();
-		assertThat(TestUtils.getPropertyValue(socketSupport, "sslContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(socketSupport, "sslContext")).isNotNull();
 
 		TcpSSLContextSupport tcpSSLContextSupport = new DefaultTcpSSLContextSupport("http:foo", "file:bar", "", "");
-		assertThat(TestUtils.getPropertyValue(tcpSSLContextSupport, "keyStore")).isInstanceOf(UrlResource.class);
-		assertThat(TestUtils.getPropertyValue(tcpSSLContextSupport, "trustStore")).isInstanceOf(UrlResource.class);
+		assertThat(TestUtils.<Object>getPropertyValue(tcpSSLContextSupport, "keyStore"))
+				.isInstanceOf(UrlResource.class);
+		assertThat(TestUtils.<Object>getPropertyValue(tcpSSLContextSupport, "trustStore"))
+				.isInstanceOf(UrlResource.class);
 	}
 
 	@Test
 	public void testInTcpNioSSLDefaultConfig() {
 		assertThat(cfS1Nio.isLookupHost()).isFalse();
-		assertThat(TestUtils.getPropertyValue(cfS1Nio, "mapper.applySequence", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(cfS1Nio, "mapper.applySequence")).isTrue();
 		Object connectionSupport = TestUtils.getPropertyValue(cfS1Nio, "tcpNioConnectionSupport");
 		assertThat(connectionSupport instanceof DefaultTcpNioSSLConnectionSupport).isTrue();
-		assertThat(TestUtils.getPropertyValue(connectionSupport, "sslContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(this.cfS1Nio, "sslHandshakeTimeout")).isEqualTo(43);
-		assertThat(TestUtils.getPropertyValue(this.cfS1Nio, "tcpNioConnectionSupport"))
+		assertThat(TestUtils.<Object>getPropertyValue(connectionSupport, "sslContext")).isNotNull();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.cfS1Nio, "sslHandshakeTimeout"))
+				.isEqualTo(43);
+		assertThat(TestUtils.<Object>getPropertyValue(this.cfS1Nio, "tcpNioConnectionSupport"))
 				.isSameAs(this.ctx.getBean(DefaultTcpNioSSLConnectionSupport.class));
 	}
 
@@ -439,15 +443,17 @@ public class ParserUnitTests {
 		assertThat(tcpOutEndpoint.getPhase()).isEqualTo(125);
 		assertThat((Boolean) TestUtils.getPropertyValue(
 				TestUtils.getPropertyValue(cfC1, "mapper"), "applySequence")).isFalse();
-		assertThat(TestUtils.getPropertyValue(cfC1, "readDelay")).isEqualTo(10000L);
-		assertThat(TestUtils.getPropertyValue(cfC1, "connectTimeout")).isEqualTo(Duration.ofSeconds(70));
+		assertThat(TestUtils.<Long>getPropertyValue(cfC1, "readDelay")).isEqualTo(10000L);
+		assertThat(TestUtils.<Duration>getPropertyValue(cfC1, "connectTimeout"))
+				.isEqualTo(Duration.ofSeconds(70));
 	}
 
 	@Test
 	public void testInGateway1() {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(tcpInboundGateway1);
 		assertThat(dfa.getPropertyValue("serverConnectionFactory")).isSameAs(cfS2);
-		assertThat(TestUtils.getPropertyValue(tcpInboundGateway1, "messagingTemplate.receiveTimeout")).isEqualTo(456L);
+		assertThat(TestUtils.<Long>getPropertyValue(tcpInboundGateway1, "messagingTemplate.receiveTimeout"))
+				.isEqualTo(456L);
 		assertThat(tcpInboundGateway1.getComponentName()).isEqualTo("inGateway1");
 		assertThat(tcpInboundGateway1.getComponentType()).isEqualTo("ip:tcp-inbound-gateway");
 		assertThat(tcpInboundGateway1.getErrorChannel()).isEqualTo(errorChannel);
@@ -456,14 +462,15 @@ public class ParserUnitTests {
 		assertThat(tcpInboundGateway1.getPhase()).isEqualTo(126);
 		assertThat((Boolean) TestUtils.getPropertyValue(
 				TestUtils.getPropertyValue(cfS2, "mapper"), "applySequence")).isFalse();
-		assertThat(TestUtils.getPropertyValue(cfS2, "readDelay")).isEqualTo(100L);
+		assertThat(TestUtils.<Long>getPropertyValue(cfS2, "readDelay")).isEqualTo(100L);
 	}
 
 	@Test
 	public void testInGateway2() {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(tcpInboundGateway2);
 		assertThat(dfa.getPropertyValue("serverConnectionFactory")).isSameAs(cfS3);
-		assertThat(TestUtils.getPropertyValue(tcpInboundGateway2, "messagingTemplate.receiveTimeout")).isEqualTo(456L);
+		assertThat(TestUtils.<Long>getPropertyValue(tcpInboundGateway2, "messagingTemplate.receiveTimeout"))
+				.isEqualTo(456L);
 		assertThat(tcpInboundGateway2.getComponentName()).isEqualTo("inGateway2");
 		assertThat(tcpInboundGateway2.getComponentType()).isEqualTo("ip:tcp-inbound-gateway");
 		assertThat(dfa.getPropertyValue("errorChannel")).isNull();
@@ -477,22 +484,22 @@ public class ParserUnitTests {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(tcpOutboundGateway);
 		assertThat(dfa.getPropertyValue("connectionFactory")).isSameAs(cfC2);
 		assertThat(dfa.getPropertyValue("requestTimeout")).isEqualTo(234L);
-		MessagingTemplate messagingTemplate = TestUtils.getPropertyValue(tcpOutboundGateway, "messagingTemplate",
-				MessagingTemplate.class);
-		assertThat(TestUtils.getPropertyValue(messagingTemplate, "sendTimeout", Long.class))
+		MessagingTemplate messagingTemplate = TestUtils.getPropertyValue(tcpOutboundGateway, "messagingTemplate");
+		assertThat(TestUtils.<Long>getPropertyValue(messagingTemplate, "sendTimeout"))
 				.isEqualTo(Long.valueOf(567));
-		assertThat(TestUtils.getPropertyValue(tcpOutboundGateway, "remoteTimeoutExpression.literalValue"))
-				.isEqualTo("789");
+		assertThat(TestUtils.<String>getPropertyValue(tcpOutboundGateway,
+				"remoteTimeoutExpression.literalValue")).isEqualTo("789");
 		assertThat(tcpOutboundGateway.getComponentName()).isEqualTo("outGateway");
 		assertThat(tcpOutboundGateway.getComponentType()).isEqualTo("ip:tcp-outbound-gateway");
 		assertThat(cfC2.isLookupHost()).isTrue();
 		assertThat(dfa.getPropertyValue("order")).isEqualTo(24);
 		assertThat(dfa.getPropertyValue("async")).isEqualTo(Boolean.TRUE);
 
-		assertThat(TestUtils.getPropertyValue(outAdviceGateway, "remoteTimeoutExpression.expression"))
-				.isEqualTo("4000");
-		assertThat(TestUtils.getPropertyValue(outAdviceGateway, "closeStreamAfterSend")).isEqualTo(Boolean.TRUE);
-		assertThat(TestUtils.getPropertyValue(outAdviceGateway, "async")).isEqualTo(Boolean.FALSE);
+		assertThat(TestUtils.<String>getPropertyValue(outAdviceGateway,
+				"remoteTimeoutExpression.expression")).isEqualTo("4000");
+		assertThat(TestUtils.<Boolean>getPropertyValue(outAdviceGateway, "closeStreamAfterSend"))
+				.isEqualTo(Boolean.TRUE);
+		assertThat(TestUtils.<Boolean>getPropertyValue(outAdviceGateway, "async")).isEqualTo(Boolean.FALSE);
 	}
 
 	@Test
@@ -648,12 +655,14 @@ public class ParserUnitTests {
 
 	@Test
 	public void testAutoTcp() {
-		assertThat(TestUtils.getPropertyValue(tcpAutoAdapter, "outputChannel")).isSameAs(tcpAutoChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(tcpAutoAdapter, "outputChannel"))
+				.isSameAs(tcpAutoChannel);
 	}
 
 	@Test
 	public void testAutoUdp() {
-		assertThat(TestUtils.getPropertyValue(udpAutoAdapter, "outputChannel")).isSameAs(udpAutoChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(udpAutoAdapter, "outputChannel"))
+				.isSameAs(udpAutoChannel);
 	}
 
 	@Test
@@ -661,7 +670,8 @@ public class ParserUnitTests {
 		DirectFieldAccessor dfa = new DirectFieldAccessor(secureServer);
 		assertThat(dfa.getPropertyValue("tcpSocketFactorySupport")).isSameAs(socketFactorySupport);
 		assertThat(dfa.getPropertyValue("tcpSocketSupport")).isSameAs(socketSupport);
-		assertThat(TestUtils.getPropertyValue(this.secureServerNio, "sslHandshakeTimeout")).isEqualTo(34);
+		assertThat(TestUtils.<Integer>getPropertyValue(this.secureServerNio, "sslHandshakeTimeout"))
+				.isEqualTo(34);
 		assertThat(dfa.getPropertyValue("tcpNetConnectionSupport")).isSameAs(this.netConnectionSupport);
 	}
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBeanTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/config/TcpConnectionFactoryFactoryBeanTests.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.1.1
  */
@@ -39,7 +40,7 @@ public class TcpConnectionFactoryFactoryBeanTests implements TestApplicationCont
 		fb.setApplicationContext(TEST_INTEGRATION_CONTEXT);
 		fb.afterPropertiesSet();
 		// INT-3578 IllegalArgumentException on 'readDelay'
-		assertThat(TestUtils.getPropertyValue(fb.getObject(), "readDelay")).isEqualTo(100L);
+		assertThat(TestUtils.<Long>getPropertyValue(fb.getObject(), "readDelay")).isEqualTo(100L);
 	}
 
 	@Test
@@ -50,7 +51,7 @@ public class TcpConnectionFactoryFactoryBeanTests implements TestApplicationCont
 		fb.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		fb.setApplicationContext(TEST_INTEGRATION_CONTEXT);
 		fb.afterPropertiesSet();
-		assertThat(TestUtils.getPropertyValue(fb.getObject(), "readDelay")).isEqualTo(1000L);
+		assertThat(TestUtils.<Long>getPropertyValue(fb.getObject(), "readDelay")).isEqualTo(1000L);
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/ConnectionFactoryTests.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.mock;
  * @author Gary Russell
  * @author Tim Ysewyn
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.0
  *
@@ -111,9 +112,9 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 				.connectionSupport(conSupp)
 				.socketFactorySupport(factSupp)
 				.getObject();
-		assertThat(TestUtils.getPropertyValue(server, "tcpSocketSupport")).isSameAs(sockSupp);
-		assertThat(TestUtils.getPropertyValue(server, "tcpNetConnectionSupport")).isSameAs(conSupp);
-		assertThat(TestUtils.getPropertyValue(server, "tcpSocketFactorySupport")).isSameAs(factSupp);
+		assertThat(TestUtils.<Object>getPropertyValue(server, "tcpSocketSupport")).isSameAs(sockSupp);
+		assertThat(TestUtils.<Object>getPropertyValue(server, "tcpNetConnectionSupport")).isSameAs(conSupp);
+		assertThat(TestUtils.<Object>getPropertyValue(server, "tcpSocketFactorySupport")).isSameAs(factSupp);
 	}
 
 	@Test
@@ -125,9 +126,9 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 				.directBuffers(true)
 				.connectionSupport(conSupp)
 				.getObject();
-		assertThat(TestUtils.getPropertyValue(server, "tcpSocketSupport")).isSameAs(sockSupp);
-		assertThat(TestUtils.getPropertyValue(server, "usingDirectBuffers", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(server, "tcpNioConnectionSupport")).isSameAs(conSupp);
+		assertThat(TestUtils.<Object>getPropertyValue(server, "tcpSocketSupport")).isSameAs(sockSupp);
+		assertThat(TestUtils.<Boolean>getPropertyValue(server, "usingDirectBuffers")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(server, "tcpNioConnectionSupport")).isSameAs(conSupp);
 	}
 
 	@Test
@@ -140,9 +141,9 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 				.connectionSupport(conSupp)
 				.socketFactorySupport(factSupp)
 				.getObject();
-		assertThat(TestUtils.getPropertyValue(client, "tcpSocketSupport")).isSameAs(sockSupp);
-		assertThat(TestUtils.getPropertyValue(client, "tcpNetConnectionSupport")).isSameAs(conSupp);
-		assertThat(TestUtils.getPropertyValue(client, "tcpSocketFactorySupport")).isSameAs(factSupp);
+		assertThat(TestUtils.<Object>getPropertyValue(client, "tcpSocketSupport")).isSameAs(sockSupp);
+		assertThat(TestUtils.<Object>getPropertyValue(client, "tcpNetConnectionSupport")).isSameAs(conSupp);
+		assertThat(TestUtils.<Object>getPropertyValue(client, "tcpSocketFactorySupport")).isSameAs(factSupp);
 	}
 
 	@Test
@@ -154,9 +155,9 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 				.directBuffers(true)
 				.connectionSupport(conSupp)
 				.getObject();
-		assertThat(TestUtils.getPropertyValue(client, "tcpSocketSupport")).isSameAs(sockSupp);
-		assertThat(TestUtils.getPropertyValue(client, "usingDirectBuffers", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(client, "tcpNioConnectionSupport")).isSameAs(conSupp);
+		assertThat(TestUtils.<Object>getPropertyValue(client, "tcpSocketSupport")).isSameAs(sockSupp);
+		assertThat(TestUtils.<Boolean>getPropertyValue(client, "usingDirectBuffers")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(client, "tcpNioConnectionSupport")).isSameAs(conSupp);
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/dsl/IpIntegrationTests.java
@@ -79,6 +79,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.0
  *
@@ -243,7 +244,7 @@ public class IpIntegrationTests implements TestApplicationContextAware {
 
 	@Test
 	void async() {
-		assertThat(TestUtils.getPropertyValue(this.tcpOutAsync, "async", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.tcpOutAsync, "async")).isTrue();
 	}
 
 	@Autowired

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ClientModeControlBusTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/ClientModeControlBusTests.java
@@ -36,6 +36,8 @@ import static org.awaitility.Awaitility.await;
 
 /**
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 2.1
  *
  */
@@ -71,7 +73,7 @@ public class ClientModeControlBusTests {
 		await("Connection never established").atMost(Duration.ofSeconds(10))
 				.until(() -> controlBus.boolResult("@tcpIn.isClientModeConnected()"));
 		assertThat(controlBus.boolResult("@tcpIn.isRunning()")).isTrue();
-		assertThat(TestUtils.getPropertyValue(tcpIn, "taskScheduler")).isSameAs(taskScheduler);
+		assertThat(TestUtils.<Object>getPropertyValue(tcpIn, "taskScheduler")).isSameAs(taskScheduler);
 		controlBus.voidResult("@tcpIn.retryConnection()");
 	}
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/CachingClientConnectionFactoryTests.java
@@ -91,6 +91,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gengwu Zhao
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -142,7 +143,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		TcpConnection conn1 = cachingFactory.getConnection();
 		// INT-3652
 		TcpConnectionInterceptorSupport cachedConn1 = (TcpConnectionInterceptorSupport) conn1;
-		Log logger = spy(TestUtils.getPropertyValue(cachedConn1, "logger", Log.class));
+		Log logger = spy(TestUtils.<Log>getPropertyValue(cachedConn1, "logger"));
 		when(logger.isDebugEnabled()).thenReturn(true);
 		new DirectFieldAccessor(cachedConn1).setPropertyValue("logger", logger);
 		cachedConn1.onMessage(new ErrorMessage(new RuntimeException()));
@@ -204,7 +205,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		when(mockConn1.isOpen()).thenReturn(false);
 		TcpConnection conn2a = cachingFactory.getConnection();
 		assertThat(conn2a.toString()).isEqualTo("Cached:" + mockConn2.toString());
-		assertThat(TestUtils.getPropertyValue(conn2a, "theConnection"))
+		assertThat(TestUtils.<Object>getPropertyValue(conn2a, "theConnection"))
 				.isSameAs(TestUtils.getPropertyValue(conn2, "theConnection"));
 		conn2a.close();
 	}
@@ -262,9 +263,9 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		when(mockConn2.isOpen()).thenReturn(false);
 		when(factory.isRunning()).thenReturn(true);
 		TcpConnection conn3 = cachingFactory.getConnection();
-		assertThat(TestUtils.getPropertyValue(conn3, "theConnection"))
+		assertThat(TestUtils.<Object>getPropertyValue(conn3, "theConnection"))
 				.isNotSameAs(TestUtils.getPropertyValue(conn1, "theConnection"));
-		assertThat(TestUtils.getPropertyValue(conn3, "theConnection"))
+		assertThat(TestUtils.<Object>getPropertyValue(conn3, "theConnection"))
 				.isNotSameAs(TestUtils.getPropertyValue(conn2, "theConnection"));
 	}
 
@@ -283,7 +284,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		TcpConnection conn2 = cachingFactory.getConnection();
 		assertThat(conn2).isNotSameAs(conn1);
 		Semaphore semaphore = TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(cachingFactory, "pool"), "permits", Semaphore.class);
+				TestUtils.getPropertyValue(cachingFactory, "pool"), "permits");
 		assertThat(semaphore.availablePermits()).isEqualTo(0);
 		cachingFactory.setPoolSize(4);
 		TcpConnection conn3 = cachingFactory.getConnection();
@@ -315,7 +316,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		TcpConnection conn3 = cachingFactory.getConnection();
 		TcpConnection conn4 = cachingFactory.getConnection();
 		Semaphore semaphore = TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(cachingFactory, "pool"), "permits", Semaphore.class);
+				TestUtils.getPropertyValue(cachingFactory, "pool"), "permits");
 		assertThat(semaphore.availablePermits()).isEqualTo(0);
 		conn1.close();
 		assertThat(semaphore.availablePermits()).isEqualTo(1);
@@ -459,8 +460,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		assertThat(m).isNotNull();
 		assertThat(new String((byte[]) m.getPayload())).isEqualTo("foo:" + "Hello, world!");
 
-		BlockingQueue<?> connections = TestUtils
-				.getPropertyValue(this.gatewayCF, "pool.available", BlockingQueue.class);
+		BlockingQueue<?> connections = TestUtils.getPropertyValue(this.gatewayCF, "pool.available");
 		// wait until the connection is returned to the pool
 		await().atMost(Duration.ofSeconds(10)).until(() -> connections.size() > 0);
 
@@ -590,7 +590,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		conn1.close();
 		conn2.close();
 		assertThat(latch2.await(10, TimeUnit.SECONDS)).isTrue();
-		SimplePool<?> pool = TestUtils.getPropertyValue(cachingFactory, "pool", SimplePool.class);
+		SimplePool<?> pool = TestUtils.getPropertyValue(cachingFactory, "pool");
 		assertThat(pool.getIdleCount()).isEqualTo(2);
 		cachingFactory.stop();
 		cachingFactory.destroy();
@@ -749,7 +749,7 @@ public class CachingClientConnectionFactoryTests implements TestApplicationConte
 		gate.setRemoteTimeout(20_000);
 		gate.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		gate.afterPropertiesSet();
-		LogAccessor logger = spy(TestUtils.getPropertyValue(gate, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(gate, "logger"));
 		new DirectFieldAccessor(gate).setPropertyValue("logger", logger);
 		when(logger.isDebugEnabled()).thenReturn(true);
 		doAnswer(new Answer<Void>() {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionEventTests.java
@@ -68,6 +68,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0
  *
@@ -285,7 +286,7 @@ public class ConnectionEventTests implements TestApplicationContextAware {
 		factory.setBeanName("sf");
 		factory.registerListener(message -> {
 		});
-		LogAccessor logger = spy(TestUtils.getPropertyValue(factory, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(factory, "logger"));
 		doNothing().when(logger).error(any(Throwable.class), anyString());
 		new DirectFieldAccessor(factory).setPropertyValue("logger", logger);
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionFactoryTests.java
@@ -74,6 +74,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0
  *
@@ -224,7 +225,7 @@ public class ConnectionFactoryTests implements TestApplicationContextAware {
 
 		factory.setBeanName("foo");
 		factory.registerListener(mock(TcpListener.class));
-		LogAccessor logAccessor = TestUtils.getPropertyValue(factory, "logger", LogAccessor.class);
+		LogAccessor logAccessor = TestUtils.getPropertyValue(factory, "logger");
 		Log logger = spy(logAccessor.getLog());
 		new DirectFieldAccessor(logAccessor).setPropertyValue("log", logger);
 		final CountDownLatch latch1 = new CountDownLatch(1);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionTimeoutTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/ConnectionTimeoutTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  */
@@ -53,7 +54,7 @@ public class ConnectionTimeoutTests {
 		setupClientCallback(client);
 		client.start();
 		TcpConnection connection = client.getConnection();
-		Socket socket = TestUtils.getPropertyValue(connection, "socket", Socket.class);
+		Socket socket = TestUtils.getPropertyValue(connection, "socket");
 		// should default to 0 (infinite) timeout
 		assertThat(socket.getSoTimeout()).isEqualTo(0);
 		connection.close();
@@ -75,7 +76,7 @@ public class ConnectionTimeoutTests {
 		setupClientCallback(client);
 		client.start();
 		TcpConnection connection = client.getConnection();
-		Socket socket = TestUtils.getPropertyValue(connection, "socket", Socket.class);
+		Socket socket = TestUtils.getPropertyValue(connection, "socket");
 		assertThat(socket.getSoTimeout()).isEqualTo(1000);
 		assertThat(clientCloseLatch.await(3, TimeUnit.SECONDS)).isTrue();
 		assertThat(connection.isOpen()).isFalse();
@@ -163,7 +164,7 @@ public class ConnectionTimeoutTests {
 		setupClientCallback(client);
 		client.start();
 		TcpConnection connection = client.getConnection();
-		Socket socket = TestUtils.getPropertyValue(connection, "socket", Socket.class);
+		Socket socket = TestUtils.getPropertyValue(connection, "socket");
 		assertThat(socket.getSoTimeout()).isEqualTo(2000);
 		Thread.sleep(1000);
 		connection.send(MessageBuilder.withPayload("foo").build());

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/FailoverClientConnectionFactoryTests.java
@@ -74,6 +74,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gengwu Zhao
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -138,7 +139,7 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 		failoverFactory.setCloseOnRefresh(closeOnRefresh);
 		failoverFactory.start();
 		TcpConnectionSupport connection = failoverFactory.getConnection();
-		assertThat(TestUtils.getPropertyValue(failoverFactory, "theConnection")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(failoverFactory, "theConnection")).isNotNull();
 		failoverFactory.setRefreshSharedInterval(interval);
 		InOrder inOrder = inOrder(factory1, factory2, conn1, conn2);
 		inOrder.verify(factory1).getConnection();
@@ -432,15 +433,15 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 		conn1.send(new GenericMessage<>("foo1"));
 		conn1.close();
 		TcpConnection conn2 = failoverFactory.getConnection();
-		assertThat((TestUtils.getPropertyValue(conn2, "delegate", TcpConnectionInterceptorSupport.class))
+		assertThat((TestUtils.<TcpConnectionInterceptorSupport>getPropertyValue(conn2, "delegate"))
 				.getTheConnection())
-				.isSameAs((TestUtils.getPropertyValue(conn1, "delegate", TcpConnectionInterceptorSupport.class))
+				.isSameAs((TestUtils.<TcpConnectionInterceptorSupport>getPropertyValue(conn1, "delegate"))
 						.getTheConnection());
 		conn2.send(new GenericMessage<>("foo2"));
 		conn1 = failoverFactory.getConnection();
-		assertThat((TestUtils.getPropertyValue(conn2, "delegate", TcpConnectionInterceptorSupport.class))
+		assertThat((TestUtils.<TcpConnectionInterceptorSupport>getPropertyValue(conn2, "delegate"))
 				.getTheConnection())
-				.isNotSameAs((TestUtils.getPropertyValue(conn1, "delegate", TcpConnectionInterceptorSupport.class))
+				.isNotSameAs((TestUtils.<TcpConnectionInterceptorSupport>getPropertyValue(conn1, "delegate"))
 						.getTheConnection());
 		conn1.send(new GenericMessage<>("foo3"));
 		conn1.close();
@@ -456,7 +457,7 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 		conn1.close();
 		conn2.close();
 		assertThat(latch2.await(10, TimeUnit.SECONDS)).isTrue();
-		SimplePool<?> pool = TestUtils.getPropertyValue(cachingFactory2, "pool", SimplePool.class);
+		SimplePool<?> pool = TestUtils.getPropertyValue(cachingFactory2, "pool");
 		assertThat(pool.getIdleCount()).isEqualTo(2);
 		server2.stop();
 	}
@@ -581,15 +582,15 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 		conn1.send(message);
 		conn1.close();
 		TcpConnection conn2 = failoverFactory.getConnection();
-		assertThat((TestUtils.getPropertyValue(conn2, "delegate", TcpConnectionInterceptorSupport.class))
+		assertThat((TestUtils.<TcpConnectionInterceptorSupport>getPropertyValue(conn2, "delegate"))
 				.getTheConnection())
-				.isSameAs((TestUtils.getPropertyValue(conn1, "delegate", TcpConnectionInterceptorSupport.class))
+				.isSameAs((TestUtils.<TcpConnectionInterceptorSupport>getPropertyValue(conn1, "delegate"))
 						.getTheConnection());
 		conn2.send(message);
 		conn1 = failoverFactory.getConnection();
-		assertThat((TestUtils.getPropertyValue(conn2, "delegate", TcpConnectionInterceptorSupport.class))
+		assertThat((TestUtils.<TcpConnectionInterceptorSupport>getPropertyValue(conn2, "delegate"))
 				.getTheConnection())
-				.isNotSameAs((TestUtils.getPropertyValue(conn1, "delegate", TcpConnectionInterceptorSupport.class))
+				.isNotSameAs((TestUtils.<TcpConnectionInterceptorSupport>getPropertyValue(conn1, "delegate"))
 						.getTheConnection());
 		conn1.send(message);
 		conn1.close();
@@ -700,10 +701,10 @@ public class FailoverClientConnectionFactoryTests implements TestApplicationCont
 
 	private Socket getSocket(AbstractClientConnectionFactory client) throws Exception {
 		if (client instanceof TcpNetClientConnectionFactory) {
-			return TestUtils.getPropertyValue(client.getConnection(), "socket", Socket.class);
+			return TestUtils.<Socket>getPropertyValue(client.getConnection(), "socket");
 		}
 		else {
-			return TestUtils.getPropertyValue(client.getConnection(), "socketChannel", SocketChannel.class).socket();
+			return TestUtils.<SocketChannel>getPropertyValue(client.getConnection(), "socketChannel").socket();
 		}
 	}
 

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/SocketSupportTests.java
@@ -65,6 +65,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  */
@@ -536,16 +537,18 @@ public class SocketSupportTests implements TestApplicationContextAware {
 		client.start();
 
 		TcpConnection connection = client.getConnection();
-		assertThat(TestUtils.getPropertyValue(connection, "handshakeTimeout")).isEqualTo(34);
+		assertThat(TestUtils.<Integer>getPropertyValue(connection, "handshakeTimeout"))
+				.isEqualTo(34);
 		connection.send(new GenericMessage<>("Hello, world!"));
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(new String((byte[]) messages.get(0).getPayload())).isEqualTo("Hello, world!");
 		assertThat(messages.get(0).getHeaders().get("cipher")).isNotNull();
 
-		Map<?, ?> connections = TestUtils.getPropertyValue(server, "connections", Map.class);
+		Map<?, ?> connections = TestUtils.getPropertyValue(server, "connections");
 		Object serverConnection = connections.get(serverConnectionId.get());
 		assertThat(serverConnection).isNotNull();
-		assertThat(TestUtils.getPropertyValue(serverConnection, "handshakeTimeout")).isEqualTo(43);
+		assertThat(TestUtils.<Integer>getPropertyValue(serverConnection, "handshakeTimeout"))
+				.isEqualTo(43);
 
 		client.stop();
 		server.stop();
@@ -663,7 +666,8 @@ public class SocketSupportTests implements TestApplicationContextAware {
 		client.start();
 
 		TcpConnection connection = client.getConnection();
-		assertThat(TestUtils.getPropertyValue(connection, "handshakeTimeout")).isEqualTo(30);
+		assertThat(TestUtils.<Integer>getPropertyValue(connection, "handshakeTimeout"))
+				.isEqualTo(30);
 		byte[] bytes = new byte[100000];
 		connection.send(new GenericMessage<>("Hello, world!" + new String(bytes)));
 		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
@@ -674,10 +678,11 @@ public class SocketSupportTests implements TestApplicationContextAware {
 		assertThat(payload.length).isEqualTo(13 + bytes.length);
 		assertThat(new String(payload).substring(0, 13)).isEqualTo("Hello, world!");
 
-		Map<?, ?> connections = TestUtils.getPropertyValue(server, "connections", Map.class);
+		Map<?, ?> connections = TestUtils.getPropertyValue(server, "connections");
 		Object serverConnection = connections.get(serverConnectionId.get());
 		assertThat(serverConnection).isNotNull();
-		assertThat(TestUtils.getPropertyValue(serverConnection, "handshakeTimeout")).isEqualTo(30);
+		assertThat(TestUtils.<Integer>getPropertyValue(serverConnection, "handshakeTimeout"))
+				.isEqualTo(30);
 
 		client.stop();
 		server.stop();
@@ -698,7 +703,7 @@ public class SocketSupportTests implements TestApplicationContextAware {
 
 		public void send(Message<?> message) throws Exception {
 			// force a renegotiation from the server side
-			SSLEngine sslEngine = TestUtils.getPropertyValue(this.connection, "sslEngine", SSLEngine.class);
+			SSLEngine sslEngine = TestUtils.getPropertyValue(this.connection, "sslEngine");
 			sslEngine.getSession().invalidate();
 			sslEngine.beginHandshake();
 			this.connection.send(message);

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNetConnectionTests.java
@@ -59,6 +59,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2.2
  *
@@ -100,7 +101,7 @@ public class TcpNetConnectionTests implements TestApplicationContextAware {
 		TcpNioConnection connection = new TcpNioConnection(socketChannel, true, false, e -> {
 		}, null);
 		ChannelInputStream inputStream =
-				TestUtils.getPropertyValue(connection, "channelInputStream", ChannelInputStream.class);
+				TestUtils.<ChannelInputStream>getPropertyValue(connection, "channelInputStream");
 		inputStream.write(ByteBuffer.wrap(new byte[] {(byte) 0x80}));
 		assertThat(inputStream.read()).isEqualTo(0x80);
 	}

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/outbound/TcpOutboundGatewayTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/outbound/TcpOutboundGatewayTests.java
@@ -97,6 +97,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -148,12 +149,14 @@ public class TcpOutboundGatewayTests {
 		gateway.setRequiresReply(true);
 		gateway.setOutputChannel(replyChannel);
 		// check the default remote timeout
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteTimeoutExpression.value")).isEqualTo(10000L);
+		assertThat(TestUtils.<Long>getPropertyValue(gateway, "remoteTimeoutExpression.value"))
+				.isEqualTo(10000L);
 		gateway.setSendTimeout(123);
 		gateway.setRemoteTimeout(60000);
 		gateway.setSendTimeout(61000);
 		// ensure this did NOT change the remote timeout
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteTimeoutExpression.value")).isEqualTo(60000L);
+		assertThat(TestUtils.<Long>getPropertyValue(gateway, "remoteTimeoutExpression.value"))
+				.isEqualTo(60000L);
 		gateway.setRequestTimeout(60000);
 		for (int i = 100; i < 200; i++) {
 			gateway.handleMessage(MessageBuilder.withPayload("Test" + i).build());
@@ -444,7 +447,7 @@ public class TcpOutboundGatewayTests {
 		assertThat(replies.size()).isEqualTo(1);
 		assertThat(replies.get(0)).isEqualTo(lastReceived.get().replace("Test", "Reply"));
 		done.set(true);
-		assertThat(TestUtils.getPropertyValue(gateway, "pendingReplies", Map.class).size()).isEqualTo(0);
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(gateway, "pendingReplies")).isEmpty();
 		gateway.stop();
 		ccf.stop();
 	}
@@ -740,7 +743,7 @@ public class TcpOutboundGatewayTests {
 		assertThat(thrown).isInstanceOf(MessageHandlingException.class);
 		assertThat(thrown.getCause()).isInstanceOf(MessagingException.class);
 		assertThat(thrown.getCause().getCause()).isInstanceOf(EOFException.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "pendingReplies", Map.class).size()).isEqualTo(0);
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(gateway, "pendingReplies")).isEmpty();
 		Message<?> reply = replyChannel.receive(0);
 		assertThat(reply).isNull();
 		done.set(true);
@@ -847,7 +850,7 @@ public class TcpOutboundGatewayTests {
 		assertThat(thrown).isInstanceOf(MessageHandlingException.class);
 		assertThat(thrown.getCause()).isInstanceOf(MessagingException.class);
 		assertThat(thrown.getCause().getCause()).isInstanceOf(SocketTimeoutException.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "pendingReplies", Map.class).size()).isEqualTo(0);
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(gateway, "pendingReplies")).isEmpty();
 		Message<?> reply = replyChannel.receive(0);
 		assertThat(reply).isNull();
 		done.set(true);
@@ -896,7 +899,7 @@ public class TcpOutboundGatewayTests {
 		this.executor.execute(() -> gateway.handleMessage(new GenericMessage<>("foo")));
 		int n = 0;
 		@SuppressWarnings("unchecked")
-		Map<String, ?> pending = TestUtils.getPropertyValue(gateway, "pendingReplies", Map.class);
+		Map<String, ?> pending = TestUtils.getPropertyValue(gateway, "pendingReplies");
 		await().atMost(Duration.ofSeconds(10)).until(() -> pending.size() > 0);
 		String connectionId = pending.keySet().iterator().next();
 		this.executor.execute(() -> gateway.onMessage(new ErrorMessage(new RuntimeException(),

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/PooledDeserializationTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/PooledDeserializationTests.java
@@ -29,6 +29,8 @@ import static org.assertj.core.api.Assertions.fail;
 
 /**
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 4.3
  *
  */
@@ -51,8 +53,9 @@ public class PooledDeserializationTests {
 		catch (SoftEndOfStreamException e) {
 			// expected
 		}
-		assertThat(TestUtils.getPropertyValue(deser, "pool.allocated", Set.class).size()).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(deser, "pool.inUse", Set.class).size()).isEqualTo(0);
+		assertThat(TestUtils.<Set<?>>getPropertyValue(deser, "pool.allocated").size())
+				.isEqualTo(1);
+		assertThat(TestUtils.<Set<?>>getPropertyValue(deser, "pool.inUse")).isEmpty();
 	}
 
 	@Test
@@ -63,9 +66,11 @@ public class PooledDeserializationTests {
 		ByteArrayInputStream bais = new ByteArrayInputStream("foo".getBytes());
 		byte[] bytes = deser.deserialize(bais);
 		assertThat(new String(bytes)).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(deser, "pool.allocated", Set.class).size()).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(deser, "pool.inUse", Set.class).size()).isEqualTo(0);
-		assertThat(TestUtils.getPropertyValue(deser, "pool.allocated", Set.class).iterator().next()).isNotSameAs(bytes);
+		assertThat(TestUtils.<Set<?>>getPropertyValue(deser, "pool.allocated").size())
+				.isEqualTo(1);
+		assertThat(TestUtils.<Set<?>>getPropertyValue(deser, "pool.inUse")).isEmpty();
+		assertThat(TestUtils.<Set<?>>getPropertyValue(deser, "pool.allocated").iterator().next())
+				.isNotSameAs(bytes);
 	}
 
 }

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/TcpCodecsTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/serializer/TcpCodecsTests.java
@@ -24,6 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 5.0
  *
  */
@@ -41,25 +43,25 @@ public class TcpCodecsTests {
 		assertThat(codec).isInstanceOf(ByteArrayStxEtxSerializer.class);
 		codec = TcpCodecs.singleTerminator((byte) 23);
 		assertThat(codec).isInstanceOf(ByteArraySingleTerminatorSerializer.class);
-		assertThat(TestUtils.getPropertyValue(codec, "terminator")).isEqualTo((byte) 23);
+		assertThat(TestUtils.<Byte>getPropertyValue(codec, "terminator")).isEqualTo((byte) 23);
 		codec = TcpCodecs.lengthHeader1();
 		assertThat(codec).isInstanceOf(ByteArrayLengthHeaderSerializer.class);
-		assertThat(TestUtils.getPropertyValue(codec, "headerSize")).isEqualTo(1);
+		assertThat(TestUtils.<Integer>getPropertyValue(codec, "headerSize")).isEqualTo(1);
 		codec = TcpCodecs.lengthHeader2();
 		assertThat(codec).isInstanceOf(ByteArrayLengthHeaderSerializer.class);
-		assertThat(TestUtils.getPropertyValue(codec, "headerSize")).isEqualTo(2);
+		assertThat(TestUtils.<Integer>getPropertyValue(codec, "headerSize")).isEqualTo(2);
 		codec = TcpCodecs.lengthHeader4();
 		assertThat(codec).isInstanceOf(ByteArrayLengthHeaderSerializer.class);
-		assertThat(TestUtils.getPropertyValue(codec, "headerSize")).isEqualTo(4);
+		assertThat(TestUtils.<Integer>getPropertyValue(codec, "headerSize")).isEqualTo(4);
 		codec = TcpCodecs.lengthHeader(1);
 		assertThat(codec).isInstanceOf(ByteArrayLengthHeaderSerializer.class);
-		assertThat(TestUtils.getPropertyValue(codec, "headerSize")).isEqualTo(1);
+		assertThat(TestUtils.<Integer>getPropertyValue(codec, "headerSize")).isEqualTo(1);
 		codec = TcpCodecs.lengthHeader(2);
 		assertThat(codec).isInstanceOf(ByteArrayLengthHeaderSerializer.class);
-		assertThat(TestUtils.getPropertyValue(codec, "headerSize")).isEqualTo(2);
+		assertThat(TestUtils.<Integer>getPropertyValue(codec, "headerSize")).isEqualTo(2);
 		codec = TcpCodecs.lengthHeader(4);
 		assertThat(codec).isInstanceOf(ByteArrayLengthHeaderSerializer.class);
-		assertThat(TestUtils.getPropertyValue(codec, "headerSize")).isEqualTo(4);
+		assertThat(TestUtils.<Integer>getPropertyValue(codec, "headerSize")).isEqualTo(4);
 	}
 
 	@Test
@@ -79,19 +81,19 @@ public class TcpCodecsTests {
 		codec = TcpCodecs.singleTerminator((byte) 23, 123);
 		assertThat(codec).isInstanceOf(ByteArraySingleTerminatorSerializer.class);
 		assertThat(codec.getMaxMessageSize()).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(codec, "terminator")).isEqualTo((byte) 23);
+		assertThat(TestUtils.<Byte>getPropertyValue(codec, "terminator")).isEqualTo((byte) 23);
 		codec = TcpCodecs.lengthHeader1(123);
 		assertThat(codec).isInstanceOf(ByteArrayLengthHeaderSerializer.class);
 		assertThat(codec.getMaxMessageSize()).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(codec, "headerSize")).isEqualTo(1);
+		assertThat(TestUtils.<Integer>getPropertyValue(codec, "headerSize")).isEqualTo(1);
 		codec = TcpCodecs.lengthHeader2(123);
 		assertThat(codec).isInstanceOf(ByteArrayLengthHeaderSerializer.class);
 		assertThat(codec.getMaxMessageSize()).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(codec, "headerSize")).isEqualTo(2);
+		assertThat(TestUtils.<Integer>getPropertyValue(codec, "headerSize")).isEqualTo(2);
 		codec = TcpCodecs.lengthHeader4(123);
 		assertThat(codec).isInstanceOf(ByteArrayLengthHeaderSerializer.class);
 		assertThat(codec.getMaxMessageSize()).isEqualTo(123);
-		assertThat(TestUtils.getPropertyValue(codec, "headerSize")).isEqualTo(4);
+		assertThat(TestUtils.<Integer>getPropertyValue(codec, "headerSize")).isEqualTo(4);
 	}
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/DelayerHandlerRescheduleIntegrationTests.java
@@ -51,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 public class DelayerHandlerRescheduleIntegrationTests {
 
@@ -80,8 +81,7 @@ public class DelayerHandlerRescheduleIntegrationTests {
 		MessageGroupStore messageStore = context.getBean("messageStore", MessageGroupStore.class);
 
 		ClassLoader messageStoreDeserializerClassLoader =
-				TestUtils.getPropertyValue(messageStore, "deserializer.defaultDeserializerClassLoader",
-						ClassLoader.class);
+				TestUtils.<ClassLoader>getPropertyValue(messageStore, "deserializer.defaultDeserializerClassLoader");
 		assertThat(messageStoreDeserializerClassLoader).isSameAs(context.getClassLoader());
 		assertThat(messageStore.getMessageGroupCount()).isEqualTo(0);
 		Message<String> message1 = MessageBuilder.withPayload("test1").build();

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcMessageHandlerParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcMessageHandlerParserTests.java
@@ -46,6 +46,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Glenn Renfro
+ *
  * @since 2.0
  *
  */
@@ -68,7 +70,7 @@ public class JdbcMessageHandlerParserTests {
 		assertThat(map.get("ID")).as("Wrong id").isEqualTo("FOO");
 		assertThat(map.get("name")).as("Wrong id").isEqualTo("foo");
 		JdbcMessageHandler handler = context.getBean(JdbcMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "order")).isEqualTo(23);
+		assertThat(TestUtils.<Integer>getPropertyValue(handler, "order")).isEqualTo(23);
 		assertThat(adviceCalled).isEqualTo(1);
 	}
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcOutboundGatewayParserTests.java
@@ -55,6 +55,7 @@ import static org.mockito.Mockito.verify;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gunnar Hillert
+ * @author Glenn Renfro
  *
  * @since 2.0
  *
@@ -89,8 +90,8 @@ public class JdbcOutboundGatewayParserTests {
 		assertThat(map.get("name")).as("Wrong name").isEqualTo("bar");
 
 		JdbcOutboundGateway gateway = context.getBean("jdbcGateway.handler", JdbcOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "order")).isEqualTo(23);
-		assertThat(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Integer>getPropertyValue(gateway, "order")).isEqualTo(23);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "requiresReply")).isTrue();
 		assertThat(adviceCalled).isEqualTo(1);
 	}
 
@@ -118,10 +119,9 @@ public class JdbcOutboundGatewayParserTests {
 
 		Object insertGateway = this.context.getBean("insertGatewayWithSetter.handler");
 		JdbcTemplate handlerJdbcTemplate =
-				TestUtils.getPropertyValue(insertGateway,
-						"handler.jdbcOperations.classicJdbcTemplate", JdbcTemplate.class);
+				TestUtils.getPropertyValue(insertGateway, "handler.jdbcOperations.classicJdbcTemplate");
 
-		Log logger = spy(TestUtils.getPropertyValue(handlerJdbcTemplate, "logger", Log.class));
+		Log logger = spy(TestUtils.<Log>getPropertyValue(handlerJdbcTemplate, "logger"));
 
 		given(logger.isDebugEnabled()).willReturn(true);
 
@@ -162,10 +162,9 @@ public class JdbcOutboundGatewayParserTests {
 
 		Object insertGateway = this.context.getBean("jdbcOutboundGateway.handler");
 		JdbcTemplate pollerJdbcTemplate =
-				TestUtils.getPropertyValue(insertGateway,
-						"poller.jdbcOperations.classicJdbcTemplate", JdbcTemplate.class);
+				TestUtils.getPropertyValue(insertGateway, "poller.jdbcOperations.classicJdbcTemplate");
 
-		Log logger = spy(TestUtils.getPropertyValue(pollerJdbcTemplate, "logger", Log.class));
+		Log logger = spy(TestUtils.<Log>getPropertyValue(pollerJdbcTemplate, "logger"));
 
 		given(logger.isDebugEnabled()).willReturn(true);
 
@@ -269,7 +268,7 @@ public class JdbcOutboundGatewayParserTests {
 
 		MessageChannel channel = this.context.getBean("jdbcOutboundGatewayInsideChain", MessageChannel.class);
 
-		assertThat(TestUtils.getPropertyValue(jdbcMessageHandler, "requiresReply", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(jdbcMessageHandler, "requiresReply")).isFalse();
 
 		channel.send(MessageBuilder.withPayload(Collections.singletonMap("foo", "bar")).build());
 

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcPollingChannelAdapterParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/JdbcPollingChannelAdapterParserTests.java
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author David Syer
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  *
@@ -173,7 +174,7 @@ public class JdbcPollingChannelAdapterParserTests {
 		setUp("autoChannelJdbcPollingChannelAdapterParserTests-context.xml", getClass());
 		MessageChannel autoChannel = appCtx.getBean("autoChannel", MessageChannel.class);
 		SourcePollingChannelAdapter autoChannelAdapter = appCtx.getBean("autoChannel.adapter", SourcePollingChannelAdapter.class);
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
 	}
 
 	@AfterEach

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcMessageHandlerParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcMessageHandlerParserTests.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.1
  *
@@ -166,7 +167,7 @@ public class StoredProcMessageHandlerParserTests {
 	public void adviceCalled() {
 		setUp("advisedStoredProcOutboundChannelAdapterTest.xml", getClass());
 
-		MessageHandler handler = TestUtils.getPropertyValue(this.consumer, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(this.consumer, "handler");
 		handler.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcOutboundGatewayParserTests.java
@@ -48,6 +48,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
+ *
  * @since 2.1
  *
  */
@@ -277,7 +279,7 @@ public class StoredProcOutboundGatewayParserTests {
 	public void advised() throws Exception {
 		setUp("advisedStoredProcOutboundGatewayParserTest.xml", getClass());
 
-		MessageHandler handler = TestUtils.getPropertyValue(this.outboundGateway, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(this.outboundGateway, "handler");
 		handler.handleMessage(new GenericMessage<String>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParserTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/config/StoredProcPollingChannelAdapterParserTests.java
@@ -47,6 +47,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
+ *
  * @since 2.1
  */
 public class StoredProcPollingChannelAdapterParserTests {
@@ -73,9 +75,7 @@ public class StoredProcPollingChannelAdapterParserTests {
 		setUp("storedProcPollingChannelAdapterParserTest2.xml", getClass());
 
 		Expression storedProcedureNameExpression =
-				TestUtils.getPropertyValue(this.pollingAdapter,
-						"source.executor.storedProcedureNameExpression",
-						Expression.class);
+				TestUtils.getPropertyValue(this.pollingAdapter, "source.executor.storedProcedureNameExpression");
 
 		assertThat(storedProcedureNameExpression.getExpressionString()).as("Wrong stored procedure name")
 				.isEqualTo("'GET_PRIME_NUMBERS'");
@@ -86,9 +86,7 @@ public class StoredProcPollingChannelAdapterParserTests {
 		setUp("storedProcPollingChannelAdapterParserTest.xml", getClass());
 
 		Integer cacheSize =
-				TestUtils.getPropertyValue(this.pollingAdapter,
-						"source.executor.jdbcCallOperationsCacheSize",
-						Integer.class);
+				TestUtils.getPropertyValue(this.pollingAdapter, "source.executor.jdbcCallOperationsCacheSize");
 
 		assertThat(cacheSize).as("Wrong Default JdbcCallOperations Cache Size").isEqualTo(Integer.valueOf(10));
 	}
@@ -97,9 +95,7 @@ public class StoredProcPollingChannelAdapterParserTests {
 	public void testJdbcCallOperationsCacheSizeIsSet() {
 		setUp("storedProcPollingChannelAdapterParserTest2.xml", getClass());
 
-		Integer cacheSize = TestUtils.getPropertyValue(this.pollingAdapter,
-				"source.executor.jdbcCallOperationsCacheSize",
-				Integer.class);
+		Integer cacheSize = TestUtils.getPropertyValue(this.pollingAdapter, "source.executor.jdbcCallOperationsCacheSize");
 
 		assertThat(cacheSize).as("Wrong JdbcCallOperations Cache Size").isEqualTo(Integer.valueOf(77));
 	}
@@ -263,10 +259,10 @@ public class StoredProcPollingChannelAdapterParserTests {
 		MessageChannel autoChannel = context.getBean("autoChannel", MessageChannel.class);
 		SourcePollingChannelAdapter autoChannelAdapter =
 				context.getBean("autoChannel.adapter", SourcePollingChannelAdapter.class);
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "source.executor.returnValueRequired", Boolean.class))
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<Boolean>getPropertyValue(autoChannelAdapter, "source.executor.returnValueRequired"))
 				.isFalse();
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "source.executor.isFunction", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(autoChannelAdapter, "source.executor.isFunction"))
 				.isFalse();
 		autoChannelAdapter.stop();
 	}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryDelegateTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryDelegateTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.when;
  * @author Olivier Hubaut
  * @author Fran Aranda
  * @author Eddie Cho
+ * @author Glenn Renfro
  *
  * @since 5.2.11
  */
@@ -69,7 +70,7 @@ class JdbcLockRegistryDelegateTests {
 			lock.unlock();
 		}
 
-		assertThat(TestUtils.getPropertyValue(lock, "delegate", ReentrantLock.class).isLocked()).isTrue();
+		assertThat(TestUtils.<ReentrantLock>getPropertyValue(lock, "delegate").isLocked()).isTrue();
 	}
 
 	@Test
@@ -87,7 +88,7 @@ class JdbcLockRegistryDelegateTests {
 			lock.unlock();
 		}
 
-		assertThat(TestUtils.getPropertyValue(lock, "delegate", ReentrantLock.class).isLocked()).isFalse();
+		assertThat(TestUtils.<ReentrantLock>getPropertyValue(lock, "delegate").isLocked()).isFalse();
 	}
 
 	@Test
@@ -101,7 +102,7 @@ class JdbcLockRegistryDelegateTests {
 
 		lock.unlock();
 
-		assertThat(TestUtils.getPropertyValue(lock, "delegate", ReentrantLock.class).isLocked()).isFalse();
+		assertThat(TestUtils.<ReentrantLock>getPropertyValue(lock, "delegate").isLocked()).isFalse();
 	}
 
 	@Test
@@ -115,7 +116,7 @@ class JdbcLockRegistryDelegateTests {
 
 		lock.unlock();
 
-		assertThat(TestUtils.getPropertyValue(lock, "delegate", ReentrantLock.class).isLocked()).isFalse();
+		assertThat(TestUtils.<ReentrantLock>getPropertyValue(lock, "delegate").isLocked()).isFalse();
 	}
 
 	@Test
@@ -129,7 +130,7 @@ class JdbcLockRegistryDelegateTests {
 
 		lock.unlock();
 
-		assertThat(TestUtils.getPropertyValue(lock, "delegate", ReentrantLock.class).isLocked()).isFalse();
+		assertThat(TestUtils.<ReentrantLock>getPropertyValue(lock, "delegate").isLocked()).isFalse();
 	}
 
 }

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Alexandre Strubel
  * @author Unseok Kim
  * @author Eddie Cho
+ * @author Glenn Renfro
  *
  * @since 4.3
  */
@@ -94,7 +95,7 @@ class JdbcLockRegistryTests {
 			Lock lock = this.registry.obtain("foo");
 			lock.lock();
 			try {
-				assertThat(TestUtils.getPropertyValue(this.registry, "locks", Map.class).size()).isEqualTo(1);
+				assertThat(TestUtils.<Map<String, Lock>>getPropertyValue(this.registry, "locks").size()).isEqualTo(1);
 			}
 			finally {
 				lock.unlock();
@@ -103,7 +104,7 @@ class JdbcLockRegistryTests {
 
 		Thread.sleep(10);
 		this.registry.expireUnusedOlderThan(0);
-		assertThat(TestUtils.getPropertyValue(this.registry, "locks", Map.class).size()).isEqualTo(0);
+		assertThat(TestUtils.<Map<String, Lock>>getPropertyValue(this.registry, "locks")).isEmpty();
 	}
 
 	@Test
@@ -112,7 +113,7 @@ class JdbcLockRegistryTests {
 			Lock lock = this.registry.obtain("foo");
 			lock.lockInterruptibly();
 			try {
-				assertThat(TestUtils.getPropertyValue(this.registry, "locks", Map.class).size()).isEqualTo(1);
+				assertThat(TestUtils.<Map<String, Lock>>getPropertyValue(this.registry, "locks").size()).isEqualTo(1);
 			}
 			finally {
 				lock.unlock();
@@ -129,7 +130,7 @@ class JdbcLockRegistryTests {
 			DistributedLock lock = lockRegistry.obtain("foo");
 			lock.lock(Duration.ofMillis(200));
 			try {
-				assertThat(TestUtils.getPropertyValue(lockRegistry, "locks", Map.class)).hasSize(1);
+				assertThat(TestUtils.<Map<String, Lock>>getPropertyValue(lockRegistry, "locks")).hasSize(1);
 				Thread.sleep(sleepTimeLongerThanDefaultTTL);
 			}
 			finally {
@@ -138,7 +139,7 @@ class JdbcLockRegistryTests {
 		}
 
 		lockRegistry.expireUnusedOlderThan(0);
-		assertThat(TestUtils.getPropertyValue(lockRegistry, "locks", Map.class)).isEmpty();
+		assertThat(TestUtils.<Map<String, Lock>>getPropertyValue(lockRegistry, "locks")).isEmpty();
 	}
 
 	@Test
@@ -150,7 +151,7 @@ class JdbcLockRegistryTests {
 			DistributedLock lock = lockRegistry.obtain("foo");
 			lock.tryLock(Duration.ofMillis(100), Duration.ofMillis(200));
 			try {
-				assertThat(TestUtils.getPropertyValue(lockRegistry, "locks", Map.class)).hasSize(1);
+				assertThat(TestUtils.<Map<String, Lock>>getPropertyValue(lockRegistry, "locks")).hasSize(1);
 				Thread.sleep(sleepTimeLongerThanDefaultTTL);
 			}
 			finally {
@@ -159,7 +160,7 @@ class JdbcLockRegistryTests {
 		}
 
 		lockRegistry.expireUnusedOlderThan(0);
-		assertThat(TestUtils.getPropertyValue(lockRegistry, "locks", Map.class)).isEmpty();
+		assertThat(TestUtils.<Map<String, Lock>>getPropertyValue(lockRegistry, "locks")).isEmpty();
 	}
 
 	@Test
@@ -628,14 +629,13 @@ class JdbcLockRegistryTests {
 
 		final String lockKey = "foo";
 		Lock lock = registry.obtain(lockKey);
-		String lockPath = TestUtils.getPropertyValue(lock, "path", String.class);
+		String lockPath = TestUtils.getPropertyValue(lock, "path");
 
 		assertThat(lockPath).isEqualTo(lockKey);
 	}
 
-	@SuppressWarnings("unchecked")
 	private static Map<String, Lock> getRegistryLocks(JdbcLockRegistry registry) {
-		return TestUtils.getPropertyValue(registry, "locks", Map.class);
+		return TestUtils.getPropertyValue(registry, "locks");
 	}
 
 	private static String toUUID(String key) {

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
@@ -59,6 +59,8 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
+ *
  * @since 2.0
  */
 public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
@@ -259,8 +261,7 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 		channel.afterPropertiesSet();
 
 		AbstractMessageListenerContainer container = TestUtils
-				.getPropertyValue(channel, "container",
-						AbstractMessageListenerContainer.class);
+				.getPropertyValue(channel, "container");
 		MessageListener listener = (MessageListener) container.getMessageListener();
 
 		assertThatExceptionOfType(MessageDeliveryException.class)
@@ -281,8 +282,7 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 		channel.afterPropertiesSet();
 
 		AbstractMessageListenerContainer container = TestUtils
-				.getPropertyValue(channel, "container",
-						AbstractMessageListenerContainer.class);
+				.getPropertyValue(channel, "container");
 		MessageListener listener = (MessageListener) container.getMessageListener();
 		List<String> logList = insertMockLoggerInListener(channel);
 		listener.onMessage(new StubTextMessage("Hello, world!"));
@@ -290,8 +290,7 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 	}
 
 	private static List<String> insertMockLoggerInListener(SubscribableJmsChannel channel) {
-		AbstractMessageListenerContainer container = TestUtils.getPropertyValue(
-				channel, "container", AbstractMessageListenerContainer.class);
+		AbstractMessageListenerContainer container = TestUtils.getPropertyValue(channel, "container");
 		Log logger = mock(Log.class);
 		final ArrayList<String> logList = new ArrayList<>();
 		doAnswer(invocation -> {

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/DefaultConfigurationTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/DefaultConfigurationTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -64,14 +65,13 @@ public class DefaultConfigurationTests {
 	public void verifyTaskScheduler() {
 		Object taskScheduler = context.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME);
 		assertThat(taskScheduler.getClass()).isEqualTo(ThreadPoolTaskScheduler.class);
-		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler", ErrorHandler.class);
+		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler");
 		assertThat(errorHandler.getClass()).isEqualTo(MessagePublishingErrorHandler.class);
-		MessageChannel defaultErrorChannel = TestUtils.getPropertyValue(errorHandler,
-				"messagingTemplate.defaultDestination", MessageChannel.class);
+		MessageChannel defaultErrorChannel =
+				TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNull();
 		errorHandler.handleError(new Throwable());
-		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination",
-				MessageChannel.class);
+		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNotNull();
 		assertThat(defaultErrorChannel).isEqualTo(context.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME));
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -127,12 +128,12 @@ public class JmsChannelParserTests extends ActiveMQMultiContextTests {
 				(AbstractMessageListenerContainer) accessor.getPropertyValue("container");
 		assertThat(jmsTemplate.getDefaultDestination()).isEqualTo(queue);
 		assertThat(container.getDestination()).isEqualTo(queue);
-		assertThat(TestUtils.getPropertyValue(jmsTemplate, "explicitQosEnabled")).isEqualTo(true);
-		assertThat(TestUtils.getPropertyValue(jmsTemplate, "deliveryMode")).isEqualTo(DeliveryMode.PERSISTENT);
-		assertThat(TestUtils.getPropertyValue(jmsTemplate, "timeToLive")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(jmsTemplate, "priority")).isEqualTo(12);
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue())
+		assertThat(TestUtils.<Boolean>getPropertyValue(jmsTemplate, "explicitQosEnabled")).isEqualTo(true);
+		assertThat(TestUtils.<Integer>getPropertyValue(jmsTemplate, "deliveryMode")).isEqualTo(DeliveryMode.PERSISTENT);
+		assertThat(TestUtils.<Long>getPropertyValue(jmsTemplate, "timeToLive")).isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(jmsTemplate, "priority")).isEqualTo(12);
+		assertThat(TestUtils.<Integer>getPropertyValue(
+				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers").intValue())
 				.isEqualTo(Integer.MAX_VALUE);
 	}
 
@@ -146,10 +147,10 @@ public class JmsChannelParserTests extends ActiveMQMultiContextTests {
 				"container");
 		assertThat(jmsTemplate.getDefaultDestinationName()).isEqualTo("test.queue");
 		assertThat(container.getDestinationName()).isEqualTo("test.queue");
-		assertThat(TestUtils.getPropertyValue(
-				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers", Integer.class).intValue())
+		assertThat(TestUtils.<Integer>getPropertyValue(
+				TestUtils.getPropertyValue(channel, "dispatcher"), "maxSubscribers").intValue())
 				.isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(container, "taskExecutor.threadNamePrefix"))
+		assertThat(TestUtils.<String>getPropertyValue(container, "taskExecutor.threadNamePrefix"))
 				.isEqualTo("queueNameChannel.container-");
 	}
 
@@ -175,7 +176,7 @@ public class JmsChannelParserTests extends ActiveMQMultiContextTests {
 				"container");
 		assertThat(jmsTemplate.getDefaultDestination()).isEqualTo(topic);
 		assertThat(container.getDestination()).isEqualTo(topic);
-		assertThat(TestUtils.getPropertyValue(channel, "container.messageListener.messageBuilderFactory"))
+		assertThat(TestUtils.<Object>getPropertyValue(channel, "container.messageListener.messageBuilderFactory"))
 				.isSameAs(this.messageBuilderFactory);
 	}
 
@@ -272,8 +273,7 @@ public class JmsChannelParserTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void withPlaceholders() {
-		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(withPlaceholders, "container",
-				DefaultMessageListenerContainer.class);
+		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(withPlaceholders, "container");
 		assertThat(container.getDestination().toString()).isEqualTo("ActiveMQQueue[test.queue]");
 		assertThat(container.getConcurrentConsumers()).isEqualTo(5);
 		assertThat(container.getMaxConcurrentConsumers()).isEqualTo(25);
@@ -281,41 +281,32 @@ public class JmsChannelParserTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void withDefaultContainer() {
-		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(
-				withDefaultContainer, "container",
-				DefaultMessageListenerContainer.class);
+		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(withDefaultContainer, "container");
 		assertThat(container.getDestinationName()).isEqualTo("default.container.queue");
 	}
 
 	@Test
 	public void withExplicitDefaultContainer() {
-		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(
-				withExplicitDefaultContainer, "container",
-				DefaultMessageListenerContainer.class);
+		DefaultMessageListenerContainer container =
+				TestUtils.getPropertyValue(withExplicitDefaultContainer, "container");
 		assertThat(container.getDestinationName()).isEqualTo("explicit.default.container.queue");
 	}
 
 	@Test
 	public void withSimpleContainer() {
-		SimpleMessageListenerContainer container = TestUtils.getPropertyValue(
-				withSimpleContainer, "container",
-				SimpleMessageListenerContainer.class);
+		SimpleMessageListenerContainer container = TestUtils.getPropertyValue(withSimpleContainer, "container");
 		assertThat(container.getDestinationName()).isEqualTo("simple.container.queue");
 	}
 
 	@Test
 	public void withContainerClass() {
-		CustomTestMessageListenerContainer container = TestUtils.getPropertyValue(
-				withContainerClass, "container",
-				CustomTestMessageListenerContainer.class);
+		CustomTestMessageListenerContainer container = TestUtils.getPropertyValue(withContainerClass, "container");
 		assertThat(container.getDestinationName()).isEqualTo("custom.container.queue");
 	}
 
 	@Test
 	public void withContainerClassSpEL() {
-		CustomTestMessageListenerContainer container = TestUtils.getPropertyValue(
-				withContainerClassSpEL, "container",
-				CustomTestMessageListenerContainer.class);
+		CustomTestMessageListenerContainer container = TestUtils.getPropertyValue(withContainerClassSpEL, "container");
 		assertThat(container.getDestinationName()).isEqualTo("custom.container.queue");
 	}
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsInboundChannelAdapterParserTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class JmsInboundChannelAdapterParserTests {
 
@@ -66,8 +67,8 @@ public class JmsInboundChannelAdapterParserTests {
 				"jmsInboundWithJmsTemplate.xml", this.getClass())) {
 
 			JmsTemplate jmsTemplate =
-					TestUtils.getPropertyValue(context.getBean("inboundAdapterWithoutJmsTemplate"),
-							"source.jmsTemplate", JmsTemplate.class);
+					TestUtils.getPropertyValue(
+							context.getBean("inboundAdapterWithoutJmsTemplate"), "source.jmsTemplate");
 			assertThat(jmsTemplate.isSessionTransacted()).isTrue();
 		}
 	}
@@ -81,7 +82,7 @@ public class JmsInboundChannelAdapterParserTests {
 			Message<?> message = output.receive(timeoutOnReceive);
 			assertThat(message).as("message should not be null").isNotNull();
 			assertThat(message.getPayload()).isEqualTo("polling-test");
-			assertThat(TestUtils.getPropertyValue(context.getBean("adapter"), "source.jmsTemplate", JmsTemplate.class)
+			assertThat(TestUtils.<JmsTemplate>getPropertyValue(context.getBean("adapter"), "source.jmsTemplate")
 					.isSessionTransacted()).isFalse();
 		}
 	}
@@ -98,7 +99,7 @@ public class JmsInboundChannelAdapterParserTests {
 			JmsDestinationPollingSource jmsDestinationPollingSource = context
 					.getBean(JmsDestinationPollingSource.class);
 			JmsTemplate jmsTemplate =
-					TestUtils.getPropertyValue(jmsDestinationPollingSource, "jmsTemplate", JmsTemplate.class);
+					TestUtils.<JmsTemplate>getPropertyValue(jmsDestinationPollingSource, "jmsTemplate");
 			assertThat(jmsTemplate.getReceiveTimeout()).isEqualTo(1000);
 		}
 	}
@@ -179,7 +180,7 @@ public class JmsInboundChannelAdapterParserTests {
 				"jmsInboundWithReceiveTimeout.xml", this.getClass())) {
 
 			JmsTemplate jmsTemplate =
-					TestUtils.getPropertyValue(context.getBean("adapter"), "source.jmsTemplate", JmsTemplate.class);
+					TestUtils.<JmsTemplate>getPropertyValue(context.getBean("adapter"), "source.jmsTemplate");
 			assertThat(jmsTemplate.getReceiveTimeout()).isEqualTo(99);
 		}
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsInboundGatewayParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsInboundGatewayParserTests.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class JmsInboundGatewayParserTests extends ActiveMQMultiContextTests {
 
@@ -250,7 +251,7 @@ public class JmsInboundGatewayParserTests extends ActiveMQMultiContextTests {
 		SmartLifecycleRoleController roleController = context.getBean(SmartLifecycleRoleController.class);
 		@SuppressWarnings("unchecked")
 		MultiValueMap<String, SmartLifecycle> lifecycles =
-				TestUtils.getPropertyValue(roleController, "lifecycles", MultiValueMap.class);
+				TestUtils.getPropertyValue(roleController, "lifecycles");
 		assertThat(lifecycles.containsKey("foo")).isTrue();
 		assertThat(lifecycles.getFirst("foo")).isSameAs(gateway);
 		gateway.start();

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenChannelAdapterParserTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Michael Bannister
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 public class JmsMessageDrivenChannelAdapterParserTests {
 
@@ -66,8 +67,7 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsInboundWithPubSubDomain.xml", this.getClass());
 		JmsMessageDrivenEndpoint endpoint = context.getBean("messageDrivenAdapter", JmsMessageDrivenEndpoint.class);
-		AbstractMessageListenerContainer container =
-				TestUtils.getPropertyValue(endpoint, "listenerContainer", AbstractMessageListenerContainer.class);
+		AbstractMessageListenerContainer container = TestUtils.getPropertyValue(endpoint, "listenerContainer");
 		assertThat(container.isPubSubDomain()).isEqualTo(Boolean.TRUE);
 		assertThat(container.isSubscriptionDurable()).isFalse();
 		assertThat(container.getDurableSubscriptionName()).isNull();
@@ -80,8 +80,7 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsInboundWithDurableSubscription.xml", this.getClass());
 		JmsMessageDrivenEndpoint endpoint = context.getBean("messageDrivenAdapter", JmsMessageDrivenEndpoint.class);
-		DefaultMessageListenerContainer container =
-				TestUtils.getPropertyValue(endpoint, "listenerContainer", DefaultMessageListenerContainer.class);
+		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(endpoint, "listenerContainer");
 		assertThat(container.isPubSubDomain()).isEqualTo(Boolean.TRUE);
 		assertThat(container.isSubscriptionDurable()).isEqualTo(Boolean.TRUE);
 		assertThat(container.getDurableSubscriptionName()).isEqualTo("testDurableSubscriptionName");
@@ -97,9 +96,8 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 				"jmsInboundWithTaskExecutor.xml", this.getClass());
 		JmsMessageDrivenEndpoint endpoint =
 				context.getBean("messageDrivenAdapter.adapter", JmsMessageDrivenEndpoint.class);
-		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(endpoint, "listenerContainer",
-				DefaultMessageListenerContainer.class);
-		assertThat(TestUtils.getPropertyValue(container, "taskExecutor")).isSameAs(context.getBean("exec"));
+		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(endpoint, "listenerContainer");
+		assertThat(TestUtils.<Object>getPropertyValue(container, "taskExecutor")).isSameAs(context.getBean("exec"));
 		endpoint.stop();
 		context.close();
 	}
@@ -111,7 +109,7 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		JmsMessageDrivenEndpoint adapter =
 				context.getBean("adapterWithReceiveTimeout.adapter", JmsMessageDrivenEndpoint.class);
 		adapter.start();
-		assertThat(TestUtils.getPropertyValue(adapter, "listenerContainer.receiveTimeout")).isEqualTo(1111L);
+		assertThat(TestUtils.<Long>getPropertyValue(adapter, "listenerContainer.receiveTimeout")).isEqualTo(1111L);
 		adapter.stop();
 		context.close();
 	}
@@ -144,7 +142,8 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		JmsMessageDrivenEndpoint adapter =
 				context.getBean("adapterWithIdleTaskExecutionLimit.adapter", JmsMessageDrivenEndpoint.class);
 		adapter.start();
-		assertThat(TestUtils.getPropertyValue(adapter, "listenerContainer.idleTaskExecutionLimit")).isEqualTo(7);
+		assertThat(TestUtils.<Integer>getPropertyValue(adapter, "listenerContainer.idleTaskExecutionLimit"))
+				.isEqualTo(7);
 		adapter.stop();
 		context.close();
 	}
@@ -171,21 +170,23 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		JmsMessageDrivenEndpoint adapter =
 				context.getBean("adapterWithIdleConsumerLimit.adapter", JmsMessageDrivenEndpoint.class);
 		MessageChannel channel = context.getBean("adapterWithIdleConsumerLimit", MessageChannel.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel")).isSameAs(channel);
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel"))
+				.isSameAs(channel);
 		adapter.start();
-		FooContainer container = TestUtils.getPropertyValue(adapter, "listenerContainer", FooContainer.class);
+		FooContainer container = TestUtils.getPropertyValue(adapter, "listenerContainer");
 		assertThat(context.getBean("adapterWithIdleConsumerLimit.container")).isSameAs(container);
 		assertThat(new DirectFieldAccessor(container).getPropertyValue("idleConsumerLimit")).isEqualTo(33);
 		assertThat(new DirectFieldAccessor(container).getPropertyValue("cacheLevel")).isEqualTo(3);
-		assertThat(TestUtils.getPropertyValue(container, "messageListener"))
+		assertThat(TestUtils.<Object>getPropertyValue(container, "messageListener"))
 				.isSameAs(context.getBean("adapterWithIdleConsumerLimit.listener"));
 		adapter.stop();
 
 		adapter = context.getBean("adapterWithIdleConsumerLimit2.adapter", JmsMessageDrivenEndpoint.class);
 		channel = context.getBean("adapterWithIdleConsumerLimit2", MessageChannel.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel")).isSameAs(channel);
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel"))
+				.isSameAs(channel);
 		adapter.start();
-		container = TestUtils.getPropertyValue(adapter, "listenerContainer", FooContainer.class);
+		container = TestUtils.getPropertyValue(adapter, "listenerContainer");
 		assertThat(context.getBean("adapterWithIdleConsumerLimit2.container")).isSameAs(container);
 		assertThat(new DirectFieldAccessor(container).getPropertyValue("idleConsumerLimit")).isEqualTo(33);
 		assertThat(new DirectFieldAccessor(container).getPropertyValue("cacheLevel")).isEqualTo(3);
@@ -194,9 +195,10 @@ public class JmsMessageDrivenChannelAdapterParserTests {
 		adapter = context.getBean("org.springframework.integration.jms.inbound.JmsMessageDrivenEndpoint#0",
 				JmsMessageDrivenEndpoint.class);
 		channel = context.getBean("in", MessageChannel.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel")).isSameAs(channel);
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "listener.gatewayDelegate.requestChannel"))
+				.isSameAs(channel);
 		adapter.start();
-		container = TestUtils.getPropertyValue(adapter, "listenerContainer", FooContainer.class);
+		container = TestUtils.getPropertyValue(adapter, "listenerContainer");
 		assertThat(context.getBean("org.springframework.integration.jms.inbound.JmsMessageDrivenEndpoint#0.container"))
 				.isSameAs(container);
 		assertThat(new DirectFieldAccessor(container).getPropertyValue("idleConsumerLimit")).isEqualTo(33);

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenEndpointTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsMessageDrivenEndpointTests.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.1
  *
@@ -68,12 +69,12 @@ public class JmsMessageDrivenEndpointTests extends ActiveMQMultiContextTests {
 		template.convertAndSend("stop.start", "foo");
 		assertThat(out.receive(10_000).getPayload()).isEqualTo("foo");
 		endpoint.stop();
-		assertThat(TestUtils.getPropertyValue(endpoint, "listenerContainer.sharedConnection")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(endpoint, "listenerContainer.sharedConnection")).isNull();
 		endpoint.start();
 		template.convertAndSend("stop.start", "bar");
 		assertThat(out.receive(10_000).getPayload()).isEqualTo("bar");
 
-		assertThat(TestUtils.getPropertyValue(endpoint, "listener.gatewayDelegate.errorMessageStrategy"))
+		assertThat(TestUtils.<Object>getPropertyValue(endpoint, "listener.gatewayDelegate.errorMessageStrategy"))
 				.isSameAs(mockErrorMessageStrategy);
 	}
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsOutboundChannelAdapterParserTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class JmsOutboundChannelAdapterParserTests {
 
@@ -52,7 +53,7 @@ public class JmsOutboundChannelAdapterParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(
 				new DirectFieldAccessor(endpoint).getPropertyValue("handler"));
 		assertThat(accessor.getPropertyValue("jmsTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.jmsTemplate.sessionTransacted", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "handler.jmsTemplate.sessionTransacted"))
 				.isTrue();
 		context.close();
 	}
@@ -62,7 +63,7 @@ public class JmsOutboundChannelAdapterParserTests {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext(
 				"jmsOutboundWithConnectionFactoryAndDestination.xml", this.getClass());
 		EventDrivenConsumer endpoint = (EventDrivenConsumer) context.getBean("advised");
-		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler");
 		handler.handleMessage(new GenericMessage<String>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 		context.close();
@@ -76,7 +77,7 @@ public class JmsOutboundChannelAdapterParserTests {
 		DirectFieldAccessor accessor = new DirectFieldAccessor(
 				new DirectFieldAccessor(endpoint).getPropertyValue("handler"));
 		assertThat(accessor.getPropertyValue("jmsTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler.jmsTemplate.sessionTransacted", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "handler.jmsTemplate.sessionTransacted"))
 				.isFalse();
 		context.close();
 	}
@@ -142,9 +143,9 @@ public class JmsOutboundChannelAdapterParserTests {
 		assertThat(jmsTemplate.isExplicitQosEnabled()).isTrue();
 		assertThat(jmsTemplate.getPriority()).isEqualTo(7);
 		assertThat(jmsTemplate.getTimeToLive()).isEqualTo(12345);
-		assertThat(TestUtils.getPropertyValue(handler, "deliveryModeExpression.expression", String.class))
+		assertThat(TestUtils.<String>getPropertyValue(handler, "deliveryModeExpression.expression"))
 				.isEqualTo("1");
-		assertThat(TestUtils.getPropertyValue(handler, "timeToLiveExpression.expression", String.class))
+		assertThat(TestUtils.<String>getPropertyValue(handler, "timeToLiveExpression.expression"))
 				.isEqualTo("100");
 		context.close();
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
@@ -91,6 +91,7 @@ import static org.mockito.Mockito.mock;
  * @author Gary Russell
  * @author Nasko Vasilev
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -187,7 +188,7 @@ public class JmsTests extends ActiveMQMultiContextTests {
 	@Test
 	public void testJmsOutboundInboundFlow() {
 		JmsTemplate jmsTemplate =
-				TestUtils.getPropertyValue(this.jmsDestinationPollingSource, "jmsTemplate", JmsTemplate.class);
+				TestUtils.<JmsTemplate>getPropertyValue(this.jmsDestinationPollingSource, "jmsTemplate");
 
 		assertThat(jmsTemplate.getReceiveTimeout()).isEqualTo(1000);
 
@@ -202,8 +203,8 @@ public class JmsTests extends ActiveMQMultiContextTests {
 				.extracting(Message::getPayload)
 				.isEqualTo("HELLO THROUGH THE JMS");
 
-		assertThat(TestUtils.getPropertyValue(this.containerWithObservation, "listenerContainer.observationRegistry"))
-				.isSameAs(this.observationRegistry);
+		assertThat(TestUtils.<Object>getPropertyValue(this.containerWithObservation,
+				"listenerContainer.observationRegistry")).isSameAs(this.observationRegistry);
 
 		this.jmsOutboundInboundChannel.send(MessageBuilder.withPayload("hello THROUGH the JMS")
 				.setHeader(SimpMessageHeaderAccessor.DESTINATION_HEADER, "jmsMessageDriven")
@@ -244,7 +245,7 @@ public class JmsTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void testJmsPipelineFlow() {
-		assertThat(TestUtils.getPropertyValue(this.jmsOutboundGatewayHandler, "idleReplyContainerTimeout", Long.class))
+		assertThat(TestUtils.<Long>getPropertyValue(this.jmsOutboundGatewayHandler, "idleReplyContainerTimeout"))
 				.isEqualTo(10000L);
 		PollableChannel replyChannel = new QueueChannel();
 		Message<String> message = MessageBuilder.withPayload("hello through the jms pipeline")

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/ChannelPublishingJmsMessageListenerTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/ChannelPublishingJmsMessageListenerTests.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.spy;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class ChannelPublishingJmsMessageListenerTests implements TestApplicationContextAware {
 
@@ -73,7 +74,7 @@ public class ChannelPublishingJmsMessageListenerTests implements TestApplication
 	public void testBadConversion() throws Exception {
 		final QueueChannel requestChannel = new QueueChannel();
 		ChannelPublishingJmsMessageListener listener = new ChannelPublishingJmsMessageListener();
-		LogAccessor logger = spy(TestUtils.getPropertyValue(listener, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(listener, "logger"));
 		doNothing().when(logger).error(any(Throwable.class), anyString());
 		new DirectFieldAccessor(listener).setPropertyValue("logger", logger);
 		listener.setRequestChannel(requestChannel);

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/JmsOutboundGatewayTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/JmsOutboundGatewayTests.java
@@ -61,6 +61,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2.4
  */
@@ -77,7 +78,7 @@ public class JmsOutboundGatewayTests extends ActiveMQMultiContextTests implement
 		gateway.setReplyContainerProperties(new ReplyContainerProperties());
 		gateway.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		gateway.afterPropertiesSet();
-		assertThat(TestUtils.getPropertyValue(gateway, "replyContainer.beanName"))
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "replyContainer.beanName"))
 				.isEqualTo("JMS_OutboundGateway@" + ObjectUtils.getIdentityHexString(gateway) +
 						".replyListener");
 	}
@@ -145,7 +146,7 @@ public class JmsOutboundGatewayTests extends ActiveMQMultiContextTests implement
 				Thread.sleep(100);
 			}
 			assertThat(count.get() > 4).isTrue();
-			assertThat(errors.size()).isEqualTo(0);
+			assertThat(errors).isEmpty();
 		}
 		finally {
 			gateway.stop();

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/OutboundGatewayFunctionTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/OutboundGatewayFunctionTests.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gengwu Zhao
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -362,8 +363,7 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 		});
 
 		assertThat(gateway.handleRequestMessage(new GenericMessage<>("test"))).isNotNull();
-		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(gateway, "replyContainer",
-				DefaultMessageListenerContainer.class);
+		DefaultMessageListenerContainer container = TestUtils.getPropertyValue(gateway, "replyContainer");
 		int n = 0;
 		while (n++ < 100 && container.isRunning()) {
 			Thread.sleep(100);

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCachedConsumersTests.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Oleg Zhurakousky
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 @LongRunningTest
 public class RequestReplyScenariosWithCachedConsumersTests extends ActiveMQMultiContextTests {
@@ -210,7 +211,7 @@ public class RequestReplyScenariosWithCachedConsumersTests extends ActiveMQMulti
 
 			latch.await();
 
-			TestUtils.getPropertyValue(context.getBean("fastGateway"), "handler", JmsOutboundGateway.class)
+			TestUtils.<JmsOutboundGateway>getPropertyValue(context.getBean("fastGateway"), "handler")
 					.setReceiveTimeout(10000);
 			Thread.sleep(1000);
 			assertThat(gateway.exchange(new GenericMessage<>("test")).getPayload()).isEqualTo("test");

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/request_reply/RequestReplyScenariosWithCorrelationKeyProvidedTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @LongRunningTest
 public class RequestReplyScenariosWithCorrelationKeyProvidedTests extends ActiveMQMultiContextTests {
@@ -95,7 +96,7 @@ public class RequestReplyScenariosWithCorrelationKeyProvidedTests extends Active
 		}
 
 		JmsOutboundGateway outGateway =
-				TestUtils.getPropertyValue(context.getBean("outGateway"), "handler", JmsOutboundGateway.class);
+				TestUtils.<JmsOutboundGateway>getPropertyValue(context.getBean("outGateway"), "handler");
 		outGateway.setReceiveTimeout(5000);
 		assertThat(gateway.exchange(MessageBuilder.withPayload("test").build()).getPayload()).isEqualTo("test");
 		context.close();

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/AttributePollingChannelAdapterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/AttributePollingChannelAdapterParserTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -67,7 +68,8 @@ public class AttributePollingChannelAdapterParserTests {
 
 	@Test
 	public void testAutoChannel() {
-		assertThat(TestUtils.getPropertyValue(this.autoChannelAdapter, "outputChannel")).isSameAs(this.autoChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(this.autoChannelAdapter, "outputChannel"))
+				.isSameAs(this.autoChannel);
 	}
 
 }

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanExporterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanExporterParserTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -51,13 +52,14 @@ public class MBeanExporterParserTests {
 	public void testMBeanExporterExists() {
 		IntegrationMBeanExporter exporter = this.context.getBean(IntegrationMBeanExporter.class);
 		MBeanServer server = this.context.getBean("mbs", MBeanServer.class);
-		Properties properties = TestUtils.getPropertyValue(exporter, "objectNameStaticProperties", Properties.class);
+		Properties properties = TestUtils.getPropertyValue(exporter, "objectNameStaticProperties");
 		assertThat(properties).isNotNull();
 		assertThat(properties.size()).isEqualTo(2);
 		assertThat(properties.containsKey("foo")).isTrue();
 		assertThat(properties.containsKey("bar")).isTrue();
 		assertThat(exporter.getServer()).isEqualTo(server);
-		assertThat(TestUtils.getPropertyValue(exporter, "namingStrategy")).isSameAs(context.getBean("keyNamer"));
+		assertThat(TestUtils.<Object>getPropertyValue(exporter, "namingStrategy"))
+				.isSameAs(context.getBean("keyNamer"));
 		exporter.destroy();
 	}
 

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/MBeanTreePollingChannelAdapterParserTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Stuart Williams
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  */
 @SpringJUnitConfig
@@ -141,10 +142,10 @@ public class MBeanTreePollingChannelAdapterParserTests {
 	public void pollQueryNameAdapter() throws Exception {
 		adapterQueryName.start();
 
-		ObjectName queryName = TestUtils.getPropertyValue(adapterQueryName, "source.queryName", ObjectName.class);
+		ObjectName queryName = TestUtils.getPropertyValue(adapterQueryName, "source.queryName");
 		assertThat(queryName.getCanonicalName()).isEqualTo("java.lang:type=Runtime");
 
-		QueryExp queryExp = TestUtils.getPropertyValue(adapterQueryName, "source.queryExpression", QueryExp.class);
+		QueryExp queryExp = TestUtils.getPropertyValue(adapterQueryName, "source.queryExpression");
 		assertThat(queryExp.apply(new ObjectName("java.lang:type=Runtime"))).isTrue();
 
 		Message<?> result = channel3.receive(testTimeout);
@@ -224,7 +225,8 @@ public class MBeanTreePollingChannelAdapterParserTests {
 		// test for a couple of MBeans
 		assertThat(beans).containsKeys("java.lang:type=OperatingSystem", "java.lang:type=Runtime");
 
-		assertThat(TestUtils.getPropertyValue(adapterConverter, "source.converter")).isSameAs(converter);
+		assertThat(TestUtils.<Object>getPropertyValue(adapterConverter, "source.converter"))
+				.isSameAs(converter);
 	}
 
 }

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/NotificationListeningChannelAdapterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/NotificationListeningChannelAdapterParserTests.java
@@ -35,6 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Mark Fisher
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 2.0
  */
 @SpringJUnitConfig
@@ -94,7 +96,8 @@ public class NotificationListeningChannelAdapterParserTests {
 
 	@Test
 	public void testAutoChannel() {
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(autoChannelAdapter, "outputChannel"))
+				.isSameAs(autoChannel);
 	}
 
 }

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingChannelAdapterParserTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingChannelAdapterParserTests.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.verify;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -86,7 +87,7 @@ public class OperationInvokingChannelAdapterParserTests {
 
 	@Test
 	public void adapterWithDefaults() {
-		assertThat(testBean.messages.size()).isEqualTo(0);
+		assertThat(testBean.messages).isEmpty();
 		input.send(new GenericMessage<>("test1"));
 		input.send(new GenericMessage<>("test2"));
 		input.send(new GenericMessage<>("test3"));
@@ -96,9 +97,7 @@ public class OperationInvokingChannelAdapterParserTests {
 
 	@Test
 	public void testOutboundAdapterWithNonNullReturn() {
-		LogAccessor logger = spy(TestUtils.getPropertyValue(this.operationWithNonNullReturnHandler, "logger",
-
-				LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(this.operationWithNonNullReturnHandler, "logger"));
 
 		willReturn(true)
 				.given(logger)
@@ -117,7 +116,7 @@ public class OperationInvokingChannelAdapterParserTests {
 	@Test
 	// Headers should be ignored
 	public void adapterWitJmxHeaders() {
-		assertThat(testBean.messages.size()).isEqualTo(0);
+		assertThat(testBean.messages).isEmpty();
 		this.input2.send(createMessage("1"));
 		this.input2.send(createMessage("2"));
 		this.input2.send(createMessage("3"));
@@ -133,8 +132,7 @@ public class OperationInvokingChannelAdapterParserTests {
 	@Test
 	public void testOperationWithinChainWithNonNullReturn() {
 		LogAccessor logger =
-				spy(TestUtils.getPropertyValue(this.operationWithinChainWithNonNullReturnHandler, "logger",
-						LogAccessor.class));
+				spy(TestUtils.<LogAccessor>getPropertyValue(this.operationWithinChainWithNonNullReturnHandler, "logger"));
 
 		willReturn(true)
 				.given(logger)

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/config/OperationInvokingOutboundGatewayTests.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  */
 @SpringJUnitConfig
@@ -140,11 +141,11 @@ public class OperationInvokingOutboundGatewayTests {
 
 	@Test //INT-1029, INT-2822
 	public void testOutboundGatewayInsideChain() throws Exception {
-		List<?> handlers = TestUtils.getPropertyValue(this.operationInvokingWithinChain, "handlers", List.class);
+		List<?> handlers = TestUtils.getPropertyValue(this.operationInvokingWithinChain, "handlers");
 		assertThat(handlers.size()).isEqualTo(1);
 		Object handler = handlers.get(0);
 		assertThat(handler instanceof OperationInvokingMessageHandler).isTrue();
-		assertThat(TestUtils.getPropertyValue(handler, "requiresReply", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "requiresReply")).isTrue();
 
 		jmxOutboundGatewayInsideChain.send(MessageBuilder.withPayload("1").build());
 		assertThat(((List<?>) withReplyChannelOutput.receive().getPayload()).size()).isEqualTo(1);

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/configuration/EnableMBeanExportTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/jmx/configuration/EnableMBeanExportTests.java
@@ -50,6 +50,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
+ *
  * @since 4.0
  */
 @SpringJUnitConfig(initializers = EnableMBeanExportTests.EnvironmentApplicationContextInitializer.class)
@@ -68,26 +70,25 @@ public class EnableMBeanExportTests {
 	@Autowired
 	private IntegrationManagementConfigurer configurer;
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testEnableMBeanExport() throws MalformedObjectNameException, ClassNotFoundException {
 		assertThat(beanFactory.containsBean("jsonPath")).isFalse(); // GH-3541
 		assertThat(beanFactory.containsBean("xPath")).isFalse(); // GH-3541
 
 		assertThat(this.exporter.getServer()).isSameAs(this.mBeanServer);
-		String[] componentNamePatterns = TestUtils.getPropertyValue(this.exporter, "componentNamePatterns", String[].class);
+		String[] componentNamePatterns = TestUtils.getPropertyValue(this.exporter, "componentNamePatterns");
 		assertThat(componentNamePatterns).containsExactly("input", "inputX", "in*");
-		assertThat(TestUtils.getPropertyValue(this.configurer, "defaultLoggingEnabled", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.configurer, "defaultLoggingEnabled")).isFalse();
 
 		Set<ObjectName> names = this.mBeanServer.queryNames(ObjectName.getInstance("FOO:type=MessageChannel,*"), null);
 		// Only one registered (out of >2 available)
 		assertThat(names.size()).isEqualTo(1);
 		assertThat(names.iterator().next().getKeyProperty("name")).isEqualTo("input");
 		names = this.mBeanServer.queryNames(ObjectName.getInstance("FOO:type=MessageHandler,*"), null);
-		assertThat(names.size()).isEqualTo(0);
+		assertThat(names).isEmpty();
 
 		Class<?> clazz = Class.forName("org.springframework.integration.jmx.config.MBeanExporterHelper");
-		List<Object> beanPostProcessors = TestUtils.getPropertyValue(beanFactory, "beanPostProcessors", List.class);
+		List<Object> beanPostProcessors = TestUtils.getPropertyValue(beanFactory, "beanPostProcessors");
 		Object mBeanExporterHelper = null;
 		for (Object beanPostProcessor : beanPostProcessors) {
 			if (clazz.isAssignableFrom(beanPostProcessor.getClass())) {
@@ -96,10 +97,10 @@ public class EnableMBeanExportTests {
 			}
 		}
 		assertThat(mBeanExporterHelper).isNotNull();
-		assertThat(TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames", Set.class).contains("input"))
-				.isTrue();
-		assertThat(TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames", Set.class).contains("output"))
-				.isTrue();
+		assertThat(TestUtils.<Set<?>>getPropertyValue(mBeanExporterHelper, "siBeanNames")
+				.contains("input"));
+		assertThat(TestUtils.<Set<?>>getPropertyValue(mBeanExporterHelper, "siBeanNames")
+				.contains("output"));
 	}
 
 	@Configuration

--- a/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/MBeanExporterIntegrationTests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration/monitor/MBeanExporterIntegrationTests.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.fail;
  * @author Dave Syer
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  */
 public class MBeanExporterIntegrationTests {
@@ -252,8 +253,10 @@ public class MBeanExporterIntegrationTests {
 	public void testSingleMBeanServer() {
 		AnnotationConfigApplicationContext ctx1 = new AnnotationConfigApplicationContext(Config1.class);
 		AnnotationConfigApplicationContext ctx2 = new AnnotationConfigApplicationContext(Config2.class);
-		assertThat(TestUtils.getPropertyValue(ctx2.getBean(IntegrationMBeanExporter.class), "server"))
-				.isSameAs(TestUtils.getPropertyValue(ctx1.getBean(IntegrationMBeanExporter.class), "server"));
+		assertThat(TestUtils.<Object>getPropertyValue(
+				ctx2.getBean(IntegrationMBeanExporter.class), "server"))
+				.isSameAs(TestUtils.getPropertyValue(
+						ctx1.getBean(IntegrationMBeanExporter.class), "server"));
 		ctx1.close();
 		ctx2.close();
 	}

--- a/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
+++ b/spring-integration-jmx/src/test/java/org/springframework/integration_/mbeanexporterhelper/Int2307Tests.java
@@ -34,10 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class Int2307Tests {
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt2307_DefaultMBeanExporter() throws Exception {
 		ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("single-config.xml", getClass());
@@ -62,7 +62,7 @@ public class Int2307Tests {
 
 		Class<?> clazz = Class.forName("org.springframework.integration.jmx.config.MBeanExporterHelper");
 		List<Object> beanPostProcessors =
-				TestUtils.getPropertyValue(context, "beanFactory.beanPostProcessors", List.class);
+				TestUtils.getPropertyValue(context, "beanFactory.beanPostProcessors");
 		Object mBeanExporterHelper = null;
 		for (Object beanPostProcessor : beanPostProcessors) {
 			if (clazz.isAssignableFrom(beanPostProcessor.getClass())) {
@@ -71,24 +71,23 @@ public class Int2307Tests {
 			}
 		}
 		assertThat(mBeanExporterHelper).isNotNull();
-		assertThat(TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames", Set.class).contains("z")).isTrue();
-		assertThat(TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames", Set.class).contains("zz")).isTrue();
+		assertThat(TestUtils.<Set<?>>getPropertyValue(mBeanExporterHelper, "siBeanNames").contains("z"));
+		assertThat(TestUtils.<Set<?>>getPropertyValue(mBeanExporterHelper, "siBeanNames").contains("zz"));
 		context.close();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testInt2307_CustomMBeanExporter() throws Exception {
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("single-config-custom-exporter.xml", getClass());
 		MBeanExporter exporter = context.getBean("myExporter", MBeanExporter.class);
-		Set<String> excludedBeanNames = TestUtils.getPropertyValue(exporter, "excludedBeans", Set.class);
-		assertThat(excludedBeanNames.contains("x")).isTrue();
-		assertThat(excludedBeanNames.contains("y")).isTrue();
-		assertThat(excludedBeanNames.contains("foo")).isTrue(); // non SI bean
+		Set<String> excludedBeanNames = TestUtils.getPropertyValue(exporter, "excludedBeans");
+		assertThat(excludedBeanNames.contains("x"));
+		assertThat(excludedBeanNames.contains("y"));
+		assertThat(excludedBeanNames.contains("foo")); // non SI bean
 		Class<?> clazz = Class.forName("org.springframework.integration.jmx.config.MBeanExporterHelper");
 		List<Object> beanPostProcessors =
-				TestUtils.getPropertyValue(context, "beanFactory.beanPostProcessors", List.class);
+				TestUtils.getPropertyValue(context, "beanFactory.beanPostProcessors");
 		Object mBeanExporterHelper = null;
 		for (Object beanPostProcessor : beanPostProcessors) {
 			if (clazz.isAssignableFrom(beanPostProcessor.getClass())) {
@@ -97,7 +96,7 @@ public class Int2307Tests {
 			}
 		}
 		assertThat(mBeanExporterHelper).isNotNull();
-		assertThat(TestUtils.getPropertyValue(mBeanExporterHelper, "siBeanNames", Set.class).contains("z")).isTrue();
+		assertThat(TestUtils.<Set<?>>getPropertyValue(mBeanExporterHelper, "siBeanNames").contains("z"));
 		context.close();
 	}
 

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaInboundChannelAdapterParserTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaInboundChannelAdapterParserTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Amol Nayak
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -58,85 +59,82 @@ public class JpaInboundChannelAdapterParserTests {
 	private SourcePollingChannelAdapter jpaInboundChannelAdapter3;
 
 	@Test
-	public void testJpaInboundChannelAdapterParser() throws Exception {
+	public void testJpaInboundChannelAdapterParser() {
 		AbstractMessageChannel outputChannel =
-				TestUtils.getPropertyValue(this.jpaInboundChannelAdapter1, "outputChannel", AbstractMessageChannel.class);
+				TestUtils.getPropertyValue(this.jpaInboundChannelAdapter1, "outputChannel");
 
 		assertThat(outputChannel.getComponentName()).isEqualTo("out");
 
-		JpaExecutor jpaExecutor =
-				TestUtils.getPropertyValue(this.jpaInboundChannelAdapter1, "source.jpaExecutor", JpaExecutor.class);
+		JpaExecutor jpaExecutor = TestUtils.getPropertyValue(this.jpaInboundChannelAdapter1, "source.jpaExecutor");
 
 		assertThat(jpaExecutor).isNotNull();
 
-		Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass", Class.class);
+		Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass");
 
 		assertThat(entityClass.getName()).isEqualTo("org.springframework.integration.jpa.test.entity.StudentDomain");
 
-		JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations", JpaOperations.class);
+		JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations");
 
 		assertThat(jpaOperations).isNotNull();
 
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "expectSingleResult", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaExecutor, "expectSingleResult")).isTrue();
 		ParameterSource parameterSource = this.context.getBean(ParameterSource.class);
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "parameterSource")).isSameAs(parameterSource);
+		assertThat(TestUtils.<Object>getPropertyValue(jpaExecutor, "parameterSource")).isSameAs(parameterSource);
 	}
 
 	@Test
 	public void testJpaInboundChannelAdapterParserWithMaxResults() {
 		AbstractMessageChannel outputChannel =
-				TestUtils.getPropertyValue(this.jpaInboundChannelAdapter2, "outputChannel", AbstractMessageChannel.class);
+				TestUtils.getPropertyValue(this.jpaInboundChannelAdapter2, "outputChannel");
 
 		assertThat(outputChannel.getComponentName()).isEqualTo("out");
 
-		JpaExecutor jpaExecutor =
-				TestUtils.getPropertyValue(this.jpaInboundChannelAdapter2, "source.jpaExecutor", JpaExecutor.class);
+		JpaExecutor jpaExecutor = TestUtils.getPropertyValue(this.jpaInboundChannelAdapter2, "source.jpaExecutor");
 
 		assertThat(jpaExecutor).isNotNull();
 
-		Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass", Class.class);
+		Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass");
 
 		assertThat(entityClass.getName()).isEqualTo("org.springframework.integration.jpa.test.entity.StudentDomain");
 
-		JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations", JpaOperations.class);
+		JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations");
 
 		assertThat(jpaOperations).isNotNull();
 
-		LiteralExpression expression = TestUtils.getPropertyValue(jpaExecutor, "maxResultsExpression", LiteralExpression.class);
+		LiteralExpression expression = TestUtils.getPropertyValue(jpaExecutor, "maxResultsExpression");
 
 		assertThat(expression).isNotNull();
 
-		assertThat(TestUtils.getPropertyValue(expression, "literalValue")).isEqualTo("13");
+		assertThat(TestUtils.<String>getPropertyValue(expression, "literalValue")).isEqualTo("13");
 
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "deleteAfterPoll", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "flush", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaExecutor, "deleteAfterPoll")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaExecutor, "flush")).isTrue();
 	}
 
 	@Test
 	public void testJpaInboundChannelAdapterParserWithMaxResultsExpression() {
 		AbstractMessageChannel outputChannel =
-				TestUtils.getPropertyValue(this.jpaInboundChannelAdapter3, "outputChannel", AbstractMessageChannel.class);
+				TestUtils.<AbstractMessageChannel>getPropertyValue(this.jpaInboundChannelAdapter3, "outputChannel");
 
 		assertThat(outputChannel.getComponentName()).isEqualTo("out");
 
-		JpaExecutor jpaExecutor =
-				TestUtils.getPropertyValue(this.jpaInboundChannelAdapter3, "source.jpaExecutor", JpaExecutor.class);
+		JpaExecutor jpaExecutor = TestUtils.getPropertyValue(this.jpaInboundChannelAdapter3, "source.jpaExecutor");
 
 		assertThat(jpaExecutor).isNotNull();
 
-		Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass", Class.class);
+		Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass");
 
 		assertThat(entityClass.getName()).isEqualTo("org.springframework.integration.jpa.test.entity.StudentDomain");
 
-		final JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations", JpaOperations.class);
+		final JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations");
 
 		assertThat(jpaOperations).isNotNull();
 
-		SpelExpression expression = TestUtils.getPropertyValue(jpaExecutor, "maxResultsExpression", SpelExpression.class);
+		SpelExpression expression = TestUtils.getPropertyValue(jpaExecutor, "maxResultsExpression");
 
 		assertThat(expression).isNotNull();
 
-		assertThat(TestUtils.getPropertyValue(expression, "expression")).isEqualTo("@maxNumberOfResults");
+		assertThat(TestUtils.<String>getPropertyValue(expression, "expression")).isEqualTo("@maxNumberOfResults");
 	}
 
 	@Test

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaMessageHandlerParserTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaMessageHandlerParserTests.java
@@ -43,6 +43,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
+ *
  * @since 2.2
  *
  */
@@ -58,34 +60,34 @@ public class JpaMessageHandlerParserTests {
 	public void testJpaMessageHandlerParser() throws Exception {
 		setUp("JpaMessageHandlerParserTests.xml", getClass());
 
-		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(this.consumer, "inputChannel", AbstractMessageChannel.class);
+		final AbstractMessageChannel inputChannel = TestUtils.<AbstractMessageChannel>getPropertyValue(this.consumer, "inputChannel");
 
 		assertThat(inputChannel.getComponentName()).isEqualTo("target");
 
-		final JpaExecutor jpaExecutor = TestUtils.getPropertyValue(this.consumer, "handler.jpaExecutor", JpaExecutor.class);
+		final JpaExecutor jpaExecutor = TestUtils.<JpaExecutor>getPropertyValue(this.consumer, "handler.jpaExecutor");
 
 		assertThat(jpaExecutor).isNotNull();
 
-		final String query = TestUtils.getPropertyValue(jpaExecutor, "jpaQuery", String.class);
+		final String query = TestUtils.<String>getPropertyValue(jpaExecutor, "jpaQuery");
 
 		assertThat(query).isEqualTo("from Student");
 
-		final JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations", JpaOperations.class);
+		final JpaOperations jpaOperations = TestUtils.<JpaOperations>getPropertyValue(jpaExecutor, "jpaOperations");
 
 		assertThat(jpaOperations).isNotNull();
 
-		final PersistMode persistMode = TestUtils.getPropertyValue(jpaExecutor, "persistMode", PersistMode.class);
+		final PersistMode persistMode = TestUtils.<PersistMode>getPropertyValue(jpaExecutor, "persistMode");
 
 		assertThat(persistMode).isEqualTo(PersistMode.PERSIST);
 
 		@SuppressWarnings("unchecked")
-		List<JpaParameter> jpaParameters = TestUtils.getPropertyValue(jpaExecutor, "jpaParameters", List.class);
+		List<JpaParameter> jpaParameters = TestUtils.getPropertyValue(jpaExecutor, "jpaParameters");
 
 		assertThat(jpaParameters).isNotNull();
 		assertThat(jpaParameters.size() == 3).isTrue();
 
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "flushSize", Integer.class)).isEqualTo(Integer.valueOf(10));
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "clearOnFlush", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Integer>getPropertyValue(jpaExecutor, "flushSize")).isEqualTo(Integer.valueOf(10));
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaExecutor, "clearOnFlush")).isTrue();
 	}
 
 	@Test
@@ -94,11 +96,11 @@ public class JpaMessageHandlerParserTests {
 
 		EventDrivenConsumer consumer = this.context.getBean("advised", EventDrivenConsumer.class);
 
-		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel", AbstractMessageChannel.class);
+		final AbstractMessageChannel inputChannel = TestUtils.<AbstractMessageChannel>getPropertyValue(consumer, "inputChannel");
 
 		assertThat(inputChannel.getComponentName()).isEqualTo("target");
 
-		final MessageHandler handler = TestUtils.getPropertyValue(consumer, "handler", MessageHandler.class);
+		final MessageHandler handler = TestUtils.<MessageHandler>getPropertyValue(consumer, "handler");
 
 		adviceCalled = 0;
 
@@ -116,11 +118,11 @@ public class JpaMessageHandlerParserTests {
 
 		EventDrivenConsumer consumer = this.context.getBean("advisedAndTransactional", EventDrivenConsumer.class);
 
-		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel", AbstractMessageChannel.class);
+		final AbstractMessageChannel inputChannel = TestUtils.<AbstractMessageChannel>getPropertyValue(consumer, "inputChannel");
 
 		assertThat(inputChannel.getComponentName()).isEqualTo("target");
 
-		final MessageHandler handler = TestUtils.getPropertyValue(consumer, "handler", MessageHandler.class);
+		final MessageHandler handler = TestUtils.<MessageHandler>getPropertyValue(consumer, "handler");
 
 		adviceCalled = 0;
 
@@ -133,28 +135,28 @@ public class JpaMessageHandlerParserTests {
 	public void testJpaMessageHandlerParserWithEntityManagerFactory() throws Exception {
 		setUp("JpaMessageHandlerParserTestsWithEmFactory.xml", getClass());
 
-		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(this.consumer, "inputChannel", AbstractMessageChannel.class);
+		final AbstractMessageChannel inputChannel = TestUtils.<AbstractMessageChannel>getPropertyValue(this.consumer, "inputChannel");
 
 		assertThat(inputChannel.getComponentName()).isEqualTo("target");
 
-		final JpaExecutor jpaExecutor = TestUtils.getPropertyValue(this.consumer, "handler.jpaExecutor", JpaExecutor.class);
+		final JpaExecutor jpaExecutor = TestUtils.<JpaExecutor>getPropertyValue(this.consumer, "handler.jpaExecutor");
 
 		assertThat(jpaExecutor).isNotNull();
 
-		final String query = TestUtils.getPropertyValue(jpaExecutor, "jpaQuery", String.class);
+		final String query = TestUtils.<String>getPropertyValue(jpaExecutor, "jpaQuery");
 
 		assertThat(query).isEqualTo("select student from Student student");
 
-		final JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations", JpaOperations.class);
+		final JpaOperations jpaOperations = TestUtils.<JpaOperations>getPropertyValue(jpaExecutor, "jpaOperations");
 
 		assertThat(jpaOperations).isNotNull();
 
-		final PersistMode persistMode = TestUtils.getPropertyValue(jpaExecutor, "persistMode", PersistMode.class);
+		final PersistMode persistMode = TestUtils.<PersistMode>getPropertyValue(jpaExecutor, "persistMode");
 
 		assertThat(persistMode).isEqualTo(PersistMode.PERSIST);
 
 		@SuppressWarnings("unchecked")
-		List<JpaParameter> jpaParameters = TestUtils.getPropertyValue(jpaExecutor, "jpaParameters", List.class);
+		List<JpaParameter> jpaParameters = TestUtils.getPropertyValue(jpaExecutor, "jpaParameters");
 
 		assertThat(jpaParameters).isNotNull();
 		assertThat(jpaParameters.size() == 3).isTrue();
@@ -166,8 +168,8 @@ public class JpaMessageHandlerParserTests {
 	public void testProcedureParametersAreSet() throws Exception {
 		setUp("JpaMessageHandlerParserTestsWithEmFactory.xml", getClass());
 
-		final JpaExecutor jpaExecutor = TestUtils.getPropertyValue(this.consumer, "handler.jpaExecutor", JpaExecutor.class);
-		final List<JpaParameter> jpaParameters = TestUtils.getPropertyValue(jpaExecutor, "jpaParameters", List.class);
+		final JpaExecutor jpaExecutor = TestUtils.<JpaExecutor>getPropertyValue(this.consumer, "handler.jpaExecutor");
+		final List<JpaParameter> jpaParameters = TestUtils.getPropertyValue(jpaExecutor, "jpaParameters");
 
 		assertThat(jpaParameters.size() == 3).isTrue();
 
@@ -195,8 +197,7 @@ public class JpaMessageHandlerParserTests {
 		setUp("JpaMessageHandlerTransactionalParserTests.xml", getClass());
 
 		AbstractReplyProducingMessageHandler.RequestHandler handler =
-				TestUtils.getPropertyValue(this.consumer, "handler.advisedRequestHandler",
-						AbstractReplyProducingMessageHandler.RequestHandler.class);
+				TestUtils.getPropertyValue(this.consumer, "handler.advisedRequestHandler");
 		assertThat(handler).isNotNull();
 		assertThat(AopUtils.isAopProxy(handler)).isTrue();
 	}

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParserTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/config/xml/JpaOutboundGatewayParserTests.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.verify;
  * @author Amol Nayak
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  *
@@ -69,69 +70,67 @@ public class JpaOutboundGatewayParserTests extends AbstractRequestHandlerAdvice 
 	public void testRetrievingJpaOutboundGatewayParser() {
 		setUp("retrievingJpaOutboundGateway");
 		final AbstractMessageChannel inputChannel =
-				TestUtils.getPropertyValue(this.consumer, "inputChannel", AbstractMessageChannel.class);
+				TestUtils.<AbstractMessageChannel>getPropertyValue(this.consumer, "inputChannel");
 		assertThat(inputChannel.getComponentName()).isEqualTo("in");
-		final JpaOutboundGateway jpaOutboundGateway =
-				TestUtils.getPropertyValue(this.consumer, "handler", JpaOutboundGateway.class);
+		final JpaOutboundGateway jpaOutboundGateway = TestUtils.getPropertyValue(this.consumer, "handler");
 		final OutboundGatewayType gatewayType =
-				TestUtils.getPropertyValue(jpaOutboundGateway, "gatewayType", OutboundGatewayType.class);
+				TestUtils.<OutboundGatewayType>getPropertyValue(jpaOutboundGateway, "gatewayType");
 		assertThat(gatewayType).isEqualTo(OutboundGatewayType.RETRIEVING);
-		long sendTimeout = TestUtils.getPropertyValue(jpaOutboundGateway, "messagingTemplate.sendTimeout", Long.class);
+		long sendTimeout = TestUtils.getPropertyValue(jpaOutboundGateway, "messagingTemplate.sendTimeout");
 		assertThat(sendTimeout).isEqualTo(100);
-		assertThat(TestUtils.getPropertyValue(jpaOutboundGateway, "requiresReply", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaOutboundGateway, "requiresReply")).isFalse();
 		final JpaExecutor jpaExecutor =
-				TestUtils.getPropertyValue(this.consumer, "handler.jpaExecutor", JpaExecutor.class);
+				TestUtils.<JpaExecutor>getPropertyValue(this.consumer, "handler.jpaExecutor");
 		assertThat(jpaExecutor).isNotNull();
-		final Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass", Class.class);
+		final Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass");
 		assertThat(entityClass.getName()).isEqualTo("org.springframework.integration.jpa.test.entity.StudentDomain");
 		final JpaOperations jpaOperations =
-				TestUtils.getPropertyValue(jpaExecutor, "jpaOperations", JpaOperations.class);
+				TestUtils.<JpaOperations>getPropertyValue(jpaExecutor, "jpaOperations");
 		assertThat(jpaOperations).isNotNull();
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "expectSingleResult", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaExecutor, "expectSingleResult")).isTrue();
 		final LiteralExpression maxResultsExpression =
-				TestUtils.getPropertyValue(jpaExecutor, "maxResultsExpression", LiteralExpression.class);
+				TestUtils.<LiteralExpression>getPropertyValue(jpaExecutor, "maxResultsExpression");
 		assertThat(maxResultsExpression).isNotNull();
-		assertThat(TestUtils.getPropertyValue(maxResultsExpression, "literalValue")).isEqualTo("55");
+		assertThat(TestUtils.<String>getPropertyValue(maxResultsExpression, "literalValue")).isEqualTo("55");
 
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "deleteAfterPoll", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "flush", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaExecutor, "deleteAfterPoll")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaExecutor, "flush")).isTrue();
 	}
 
 	@Test
 	public void testRetrievingJpaOutboundGatewayParserWithFirstResult() {
 		setUp("retrievingJpaOutboundGatewayWithFirstResult");
 		final JpaOutboundGateway jpaOutboundGateway =
-				TestUtils.getPropertyValue(this.consumer, "handler", JpaOutboundGateway.class);
+				TestUtils.<JpaOutboundGateway>getPropertyValue(this.consumer, "handler");
 		Expression firstResultExpression =
-				TestUtils.getPropertyValue(jpaOutboundGateway, "jpaExecutor.firstResultExpression", Expression.class);
+				TestUtils.<Expression>getPropertyValue(jpaOutboundGateway, "jpaExecutor.firstResultExpression");
 		assertThat(firstResultExpression).isNotNull();
 		assertThat(firstResultExpression.getClass()).isEqualTo(LiteralExpression.class);
-		assertThat(TestUtils.getPropertyValue(firstResultExpression, "literalValue", String.class)).isEqualTo("1");
+		assertThat(TestUtils.<String>getPropertyValue(firstResultExpression, "literalValue")).isEqualTo("1");
 	}
 
 	@Test
 	public void testRetrievingJpaOutboundGatewayParserWithFirstResultExpression() {
 		setUp("retrievingJpaOutboundGatewayWithFirstResultExpression");
 		final JpaOutboundGateway jpaOutboundGateway =
-				TestUtils.getPropertyValue(this.consumer, "handler", JpaOutboundGateway.class);
+				TestUtils.<JpaOutboundGateway>getPropertyValue(this.consumer, "handler");
 		Expression firstResultExpression =
-				TestUtils.getPropertyValue(jpaOutboundGateway, "jpaExecutor.firstResultExpression", Expression.class);
+				TestUtils.<Expression>getPropertyValue(jpaOutboundGateway, "jpaExecutor.firstResultExpression");
 		assertThat(firstResultExpression).isNotNull();
 		assertThat(firstResultExpression.getClass()).isEqualTo(SpelExpression.class);
-		assertThat(TestUtils.getPropertyValue(firstResultExpression, "expression", String.class))
+		assertThat(TestUtils.<String>getPropertyValue(firstResultExpression, "expression"))
 				.isEqualTo("header['firstResult']");
 	}
 
 	@Test
 	public void testRetrievingJpaOutboundGatewayParserWithMaxResultExpression() {
 		setUp("retrievingJpaOutboundGatewayWithMaxResultExpression");
-		final JpaOutboundGateway jpaOutboundGateway =
-				TestUtils.getPropertyValue(this.consumer, "handler", JpaOutboundGateway.class);
+		final JpaOutboundGateway jpaOutboundGateway = TestUtils.getPropertyValue(this.consumer, "handler");
 		Expression maxNumberOfResultExpression =
-				TestUtils.getPropertyValue(jpaOutboundGateway, "jpaExecutor.maxResultsExpression", Expression.class);
+				TestUtils.getPropertyValue(jpaOutboundGateway, "jpaExecutor.maxResultsExpression");
 		assertThat(maxNumberOfResultExpression).isNotNull();
 		assertThat(maxNumberOfResultExpression.getClass()).isEqualTo(SpelExpression.class);
-		assertThat(TestUtils.getPropertyValue(maxNumberOfResultExpression, "expression", String.class))
+		assertThat(TestUtils.<String>getPropertyValue(maxNumberOfResultExpression, "expression"))
 				.isEqualTo("header['maxResults']");
 	}
 
@@ -139,53 +138,48 @@ public class JpaOutboundGatewayParserTests extends AbstractRequestHandlerAdvice 
 	public void testUpdatingJpaOutboundGatewayParser() {
 		setUp("updatingJpaOutboundGateway");
 
-		AbstractMessageChannel inputChannel =
-				TestUtils.getPropertyValue(this.consumer, "inputChannel", AbstractMessageChannel.class);
+		AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(this.consumer, "inputChannel");
 
 		assertThat(inputChannel.getComponentName()).isEqualTo("in");
 
-		final JpaOutboundGateway jpaOutboundGateway =
-				TestUtils.getPropertyValue(this.consumer, "handler", JpaOutboundGateway.class);
+		final JpaOutboundGateway jpaOutboundGateway = TestUtils.getPropertyValue(this.consumer, "handler");
 
-		final OutboundGatewayType gatewayType =
-				TestUtils.getPropertyValue(jpaOutboundGateway, "gatewayType", OutboundGatewayType.class);
+		final OutboundGatewayType gatewayType = TestUtils.getPropertyValue(jpaOutboundGateway, "gatewayType");
 
 		assertThat(gatewayType).isEqualTo(OutboundGatewayType.UPDATING);
 
-		long sendTimeout = TestUtils.getPropertyValue(jpaOutboundGateway, "messagingTemplate.sendTimeout", Long.class);
+		long sendTimeout = TestUtils.getPropertyValue(jpaOutboundGateway, "messagingTemplate.sendTimeout");
 
 		assertThat(sendTimeout).isEqualTo(100);
 
-		assertThat(TestUtils.getPropertyValue(jpaOutboundGateway, "requiresReply", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaOutboundGateway, "requiresReply")).isFalse();
 
-		final JpaExecutor jpaExecutor =
-				TestUtils.getPropertyValue(this.consumer, "handler.jpaExecutor", JpaExecutor.class);
+		final JpaExecutor jpaExecutor = TestUtils.getPropertyValue(this.consumer, "handler.jpaExecutor");
 
 		assertThat(jpaExecutor).isNotNull();
 
-		final Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass", Class.class);
+		final Class<?> entityClass = TestUtils.getPropertyValue(jpaExecutor, "entityClass");
 
 		assertThat(entityClass.getName()).isEqualTo("org.springframework.integration.jpa.test.entity.StudentDomain");
 
-		JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations", JpaOperations.class);
+		JpaOperations jpaOperations = TestUtils.getPropertyValue(jpaExecutor, "jpaOperations");
 
 		assertThat(jpaOperations).isNotNull();
 
-		Boolean usePayloadAsParameterSource =
-				TestUtils.getPropertyValue(jpaExecutor, "usePayloadAsParameterSource", Boolean.class);
+		Boolean usePayloadAsParameterSource = TestUtils.getPropertyValue(jpaExecutor, "usePayloadAsParameterSource");
 
 		assertThat(usePayloadAsParameterSource).isTrue();
 
-		final Integer order = TestUtils.getPropertyValue(jpaOutboundGateway, "order", Integer.class);
+		final Integer order = TestUtils.getPropertyValue(jpaOutboundGateway, "order");
 
 		assertThat(order).isEqualTo(Integer.valueOf(2));
 
-		final PersistMode persistMode = TestUtils.getPropertyValue(jpaExecutor, "persistMode", PersistMode.class);
+		final PersistMode persistMode = TestUtils.getPropertyValue(jpaExecutor, "persistMode");
 
 		assertThat(persistMode).isEqualTo(PersistMode.PERSIST);
 
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "flushSize", Integer.class)).isEqualTo(Integer.valueOf(100));
-		assertThat(TestUtils.getPropertyValue(jpaExecutor, "clearOnFlush", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Integer>getPropertyValue(jpaExecutor, "flushSize")).isEqualTo(Integer.valueOf(100));
+		assertThat(TestUtils.<Boolean>getPropertyValue(jpaExecutor, "clearOnFlush")).isTrue();
 	}
 
 	@Test
@@ -193,7 +187,7 @@ public class JpaOutboundGatewayParserTests extends AbstractRequestHandlerAdvice 
 		setUp("advised");
 		EventDrivenConsumer jpaOutboundGatewayEndpoint = context.getBean("advised", EventDrivenConsumer.class);
 		MessageHandler jpaOutboundGateway =
-				TestUtils.getPropertyValue(jpaOutboundGatewayEndpoint, "handler", MessageHandler.class);
+				TestUtils.<MessageHandler>getPropertyValue(jpaOutboundGatewayEndpoint, "handler");
 		FooAdvice advice = context.getBean("jpaFooAdvice", FooAdvice.class);
 		assertThat(AopUtils.isAopProxy(jpaOutboundGateway)).isTrue();
 

--- a/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/core/JpaExecutorTests.java
+++ b/spring-integration-jpa/src/test/java/org/springframework/integration/jpa/core/JpaExecutorTests.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.mock;
  * @author Amol Nayak
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.2
  */
@@ -89,29 +90,29 @@ public class JpaExecutorTests implements TestApplicationContextAware {
 	public void testSetMultipleQueryTypes() {
 		final JpaExecutor executor = new JpaExecutor(mock(EntityManager.class));
 		executor.setJpaQuery("select s from Student s");
-		assertThat(TestUtils.getPropertyValue(executor, "jpaQuery", String.class)).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(executor, "jpaQuery")).isNotNull();
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> executor.setNamedQuery("NamedQuery"))
 				.withMessage("Only one of the properties 'jpaQuery', 'nativeQuery', 'namedQuery' can be defined");
 
-		assertThat(TestUtils.getPropertyValue(executor, "namedQuery")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(executor, "namedQuery")).isNull();
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> executor.setNativeQuery("select * from Student"))
 				.withMessage("Only one of the properties 'jpaQuery', 'nativeQuery', 'namedQuery' can be defined");
 
-		assertThat(TestUtils.getPropertyValue(executor, "nativeQuery")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(executor, "nativeQuery")).isNull();
 
 		final JpaExecutor executor2 = new JpaExecutor(mock(EntityManager.class));
 		executor2.setNamedQuery("NamedQuery");
-		assertThat(TestUtils.getPropertyValue(executor2, "namedQuery", String.class)).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(executor2, "namedQuery")).isNotNull();
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> executor2.setJpaQuery("select s from Student s"))
 				.withMessage("Only one of the properties 'jpaQuery', 'nativeQuery', 'namedQuery' can be defined");
 
-		assertThat(TestUtils.getPropertyValue(executor2, "jpaQuery")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(executor2, "jpaQuery")).isNull();
 	}
 
 	@Test

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/ChannelParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/ChannelParserTests.java
@@ -40,6 +40,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.4
  *
@@ -68,17 +69,17 @@ public class ChannelParserTests {
 
 	@Test
 	void testParser() {
-		assertThat(TestUtils.getPropertyValue(this.ptp, "topic")).isEqualTo("ptpTopic");
-		assertThat(TestUtils.getPropertyValue(this.pubSub, "topic")).isEqualTo("pubSubTopic");
-		assertThat(TestUtils.getPropertyValue(this.ptp, "container")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(this.pubSub, "container")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(this.ptp, "template")).isSameAs(this.template);
-		assertThat(TestUtils.getPropertyValue(this.pubSub, "template")).isSameAs(this.template);
-		assertThat(TestUtils.getPropertyValue(this.pollable, "template")).isSameAs(this.template);
-		assertThat(TestUtils.getPropertyValue(this.pollable, "source")).isSameAs(this.source);
-		assertThat(TestUtils.getPropertyValue(this.ptp, "groupId")).isEqualTo("ptpGroup");
-		assertThat(TestUtils.getPropertyValue(this.pubSub, "groupId")).isEqualTo("pubSubGroup");
-		assertThat(TestUtils.getPropertyValue(this.pollable, "groupId")).isEqualTo("pollableGroup");
+		assertThat(TestUtils.<String>getPropertyValue(this.ptp, "topic")).isEqualTo("ptpTopic");
+		assertThat(TestUtils.<String>getPropertyValue(this.pubSub, "topic")).isEqualTo("pubSubTopic");
+		assertThat(TestUtils.<Object>getPropertyValue(this.ptp, "container")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(this.pubSub, "container")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(this.ptp, "template")).isSameAs(this.template);
+		assertThat(TestUtils.<Object>getPropertyValue(this.pubSub, "template")).isSameAs(this.template);
+		assertThat(TestUtils.<Object>getPropertyValue(this.pollable, "template")).isSameAs(this.template);
+		assertThat(TestUtils.<Object>getPropertyValue(this.pollable, "source")).isSameAs(this.source);
+		assertThat(TestUtils.<String>getPropertyValue(this.ptp, "groupId")).isEqualTo("ptpGroup");
+		assertThat(TestUtils.<String>getPropertyValue(this.pubSub, "groupId")).isEqualTo("pubSubGroup");
+		assertThat(TestUtils.<String>getPropertyValue(this.pollable, "groupId")).isEqualTo("pollableGroup");
 	}
 
 	@Configuration

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundChannelAdapterParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundChannelAdapterParserTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 5.4
  *
@@ -53,23 +54,24 @@ public class KafkaInboundChannelAdapterParserTests {
 
 	@Test
 	public void testProps() {
-		assertThat(TestUtils.getPropertyValue(this.source1, "consumerProperties.topics")).isEqualTo(new String[] {"topic1"});
-		assertThat(TestUtils.getPropertyValue(this.source1, "consumerFactory"))
+		assertThat(TestUtils.<String[]>getPropertyValue(this.source1, "consumerProperties.topics"))
+				.isEqualTo(new String[] {"topic1"});
+		assertThat(TestUtils.<Object>getPropertyValue(this.source1, "consumerFactory"))
 				.isSameAs(this.context.getBean("consumerFactory"));
-		assertThat(TestUtils.getPropertyValue(this.source1, "ackCallbackFactory"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.source1, "ackCallbackFactory"))
 				.isSameAs(this.context.getBean("ackFactory"));
-		assertThat(TestUtils.getPropertyValue(this.source1, "consumerProperties.clientId")).isEqualTo("client");
-		assertThat(TestUtils.getPropertyValue(this.source1, "consumerProperties.groupId")).isEqualTo("group");
-		assertThat(TestUtils.getPropertyValue(this.source1, "messageConverter"))
+		assertThat(TestUtils.<String>getPropertyValue(this.source1, "consumerProperties.clientId")).isEqualTo("client");
+		assertThat(TestUtils.<String>getPropertyValue(this.source1, "consumerProperties.groupId")).isEqualTo("group");
+		assertThat(TestUtils.<Object>getPropertyValue(this.source1, "messageConverter"))
 				.isSameAs(this.context.getBean("converter"));
-		assertThat(TestUtils.getPropertyValue(this.source1, "payloadType")).isEqualTo(String.class);
-		assertThat(TestUtils.getPropertyValue(this.source1, "rawMessageHeader", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.source1, "consumerProperties.consumerRebalanceListener"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.source1, "payloadType")).isEqualTo(String.class);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.source1, "rawMessageHeader")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(this.source1, "consumerProperties.consumerRebalanceListener"))
 				.isSameAs(this.context.getBean("rebal"));
 
-		assertThat(TestUtils.getPropertyValue(this.source2, "consumerProperties.topics")).isEqualTo(new String[] {"topic1", "topic2"});
-		DefaultKafkaConsumerFactory<?, ?> cf = TestUtils.getPropertyValue(this.source2, "consumerFactory",
-				DefaultKafkaConsumerFactory.class);
+		assertThat(TestUtils.<String[]>getPropertyValue(this.source2, "consumerProperties.topics"))
+				.isEqualTo(new String[] {"topic1", "topic2"});
+		DefaultKafkaConsumerFactory<?, ?> cf = TestUtils.getPropertyValue(this.source2, "consumerFactory");
 		assertThat(cf).isSameAs(this.context.getBean("multiFetchConsumerFactory"));
 		assertThat(cf.getConfigurationProperties().get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo("10");
 	}

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundGatewayTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaInboundGatewayTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.4
  *
@@ -54,25 +55,24 @@ public class KafkaInboundGatewayTests {
 		assertThat(this.gateway1.isAutoStartup()).isFalse();
 		assertThat(this.gateway1.isRunning()).isFalse();
 		assertThat(this.gateway1.getPhase()).isEqualTo(100);
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "requestChannelName")).isEqualTo("nullChannel");
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "replyChannelName")).isEqualTo("errorChannel");
+		assertThat(TestUtils.<String>getPropertyValue(this.gateway1, "requestChannelName")).isEqualTo("nullChannel");
+		assertThat(TestUtils.<String>getPropertyValue(this.gateway1, "replyChannelName")).isEqualTo("errorChannel");
 		KafkaMessageListenerContainer<?, ?> container =
-				TestUtils.getPropertyValue(this.gateway1, "messageListenerContainer",
-						KafkaMessageListenerContainer.class);
+				TestUtils.getPropertyValue(this.gateway1, "messageListenerContainer");
 		assertThat(container).isNotNull();
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "listener.fallbackType"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.gateway1, "listener.fallbackType"))
 				.isEqualTo(String.class);
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "errorMessageStrategy"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.gateway1, "errorMessageStrategy"))
 				.isSameAs(this.context.getBean("ems"));
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "retryTemplate"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.gateway1, "retryTemplate"))
 				.isSameAs(this.context.getBean("retryTemplate"));
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "recoveryCallback"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.gateway1, "recoveryCallback"))
 				.isSameAs(this.context.getBean("recoveryCallback"));
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "onPartitionsAssignedSeekCallback"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.gateway1, "onPartitionsAssignedSeekCallback"))
 				.isSameAs(this.context.getBean("onPartitionsAssignedSeekCallback"));
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "messagingTemplate.sendTimeout")).isEqualTo(5000L);
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "messagingTemplate.receiveTimeout")).isEqualTo(43L);
-		assertThat(TestUtils.getPropertyValue(this.gateway1, "bindSourceRecord", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Long>getPropertyValue(this.gateway1, "messagingTemplate.sendTimeout")).isEqualTo(5000L);
+		assertThat(TestUtils.<Long>getPropertyValue(this.gateway1, "messagingTemplate.receiveTimeout")).isEqualTo(43L);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.gateway1, "bindSourceRecord")).isTrue();
 		assertThat(this.roleController.getRoles()).contains("testRole");
 		assertThat(this.roleController.getEndpointsRunningStatus("testRole")).containsEntry("gateway1", false);
 	}

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaMessageDrivenChannelAdapterParserTests.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 5.4
  */
@@ -84,26 +85,27 @@ class KafkaMessageDrivenChannelAdapterParserTests implements TestApplicationCont
 		assertThat(this.kafkaListener.isAutoStartup()).isFalse();
 		assertThat(this.kafkaListener.isRunning()).isFalse();
 		assertThat(this.kafkaListener.getPhase()).isEqualTo(100);
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "outputChannel")).isSameAs(this.nullChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(this.kafkaListener, "outputChannel")).isSameAs(this.nullChannel);
 		KafkaMessageListenerContainer<?, ?> container =
-				TestUtils.getPropertyValue(this.kafkaListener, "messageListenerContainer",
-						KafkaMessageListenerContainer.class);
+				TestUtils.getPropertyValue(this.kafkaListener, "messageListenerContainer");
 		assertThat(container).isNotNull();
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "mode", ListenerMode.class))
+		assertThat(TestUtils.<ListenerMode>getPropertyValue(this.kafkaListener, "mode"))
 				.isEqualTo(ListenerMode.record);
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "recordListener.fallbackType"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.kafkaListener, "recordListener.fallbackType"))
 				.isEqualTo(String.class);
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "batchListener.fallbackType"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.kafkaListener, "batchListener.fallbackType"))
 				.isEqualTo(String.class);
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "errorMessageStrategy")).isSameAs(this.ems);
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "retryTemplate")).isSameAs(this.retryTemplate);
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "recoveryCallback")).isSameAs(this.recoveryCallback);
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "onPartitionsAssignedSeekCallback"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.kafkaListener, "errorMessageStrategy")).isSameAs(this.ems);
+		assertThat(TestUtils.<Object>getPropertyValue(this.kafkaListener, "retryTemplate"))
+				.isSameAs(this.retryTemplate);
+		assertThat(TestUtils.<Object>getPropertyValue(this.kafkaListener, "recoveryCallback"))
+				.isSameAs(this.recoveryCallback);
+		assertThat(TestUtils.<Object>getPropertyValue(this.kafkaListener, "onPartitionsAssignedSeekCallback"))
 				.isSameAs(this.context.getBean("onPartitionsAssignedSeekCallback"));
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "bindSourceRecord", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "filterInRetry", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "ackDiscarded", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.kafkaListener, "recordFilterStrategy"))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.kafkaListener, "bindSourceRecord")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.kafkaListener, "filterInRetry")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.kafkaListener, "ackDiscarded")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(this.kafkaListener, "recordFilterStrategy"))
 				.isSameAs(this.context.getBean("recordFilterStrategy"));
 	}
 
@@ -112,13 +114,14 @@ class KafkaMessageDrivenChannelAdapterParserTests implements TestApplicationCont
 		assertThat(this.kafkaBatchListener.isAutoStartup()).isFalse();
 		assertThat(this.kafkaBatchListener.isRunning()).isFalse();
 		assertThat(this.kafkaBatchListener.getPhase()).isEqualTo(100);
-		assertThat(TestUtils.getPropertyValue(this.kafkaBatchListener, "outputChannel")).isSameAs(this.nullChannel);
-		assertThat(TestUtils.getPropertyValue(this.kafkaBatchListener, "errorChannel")).isSameAs(this.errorChannel);
-		KafkaMessageListenerContainer<?, ?> container =
-				TestUtils.getPropertyValue(this.kafkaBatchListener, "messageListenerContainer",
-						KafkaMessageListenerContainer.class);
+		assertThat(TestUtils.<NullChannel>getPropertyValue(this.kafkaBatchListener, "outputChannel"))
+				.isSameAs(this.nullChannel);
+		assertThat(TestUtils.<PublishSubscribeChannel>getPropertyValue(this.kafkaBatchListener, "errorChannel"))
+				.isSameAs(this.errorChannel);
+		KafkaMessageListenerContainer<?, ?> container = TestUtils.getPropertyValue(this.kafkaBatchListener,
+						"messageListenerContainer");
 		assertThat(container).isNotNull();
-		assertThat(TestUtils.getPropertyValue(this.kafkaBatchListener, "mode", ListenerMode.class))
+		assertThat(TestUtils.<ListenerMode>getPropertyValue(this.kafkaBatchListener, "mode"))
 				.isEqualTo(ListenerMode.batch);
 	}
 
@@ -137,7 +140,7 @@ class KafkaMessageDrivenChannelAdapterParserTests implements TestApplicationCont
 		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		adapter.afterPropertiesSet();
 
-		containerProps = TestUtils.getPropertyValue(container, "containerProperties", ContainerProperties.class);
+		containerProps = TestUtils.<ContainerProperties>getPropertyValue(container, "containerProperties");
 
 		Object messageListener = containerProps.getMessageListener();
 		assertThat(messageListener).isInstanceOf(FilteringMessageListenerAdapter.class);

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundAdapterParserTests.java
@@ -56,6 +56,7 @@ import static org.mockito.Mockito.mock;
  * @author Gary Russell
  * @author Biju Kunjummen
  * @author Tom van den Berge
+ * @author Glenn Renfro
  *
  * @since 5.4
  */
@@ -72,32 +73,39 @@ class KafkaOutboundAdapterParserTests implements TestApplicationContextAware {
 				= this.appContext.getBean("kafkaOutboundChannelAdapter.handler", KafkaProducerMessageHandler.class);
 		assertThat(messageHandler).isNotNull();
 		assertThat(messageHandler.getOrder()).isEqualTo(3);
-		assertThat(TestUtils.getPropertyValue(messageHandler, "topicExpression.literalValue")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "messageKeyExpression.expression")).isEqualTo("'bar'");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "partitionIdExpression.expression")).isEqualTo("'2'");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sync", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sendTimeoutExpression.expression")).isEqualTo("1000");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "timestampExpression.expression"))
+		assertThat(TestUtils.<String>getPropertyValue(messageHandler, "topicExpression.literalValue"))
+				.isEqualTo("foo");
+		assertThat(TestUtils.<String>getPropertyValue(messageHandler, "messageKeyExpression.expression"))
+				.isEqualTo("'bar'");
+		assertThat(TestUtils.<String>getPropertyValue(messageHandler, "partitionIdExpression.expression"))
+				.isEqualTo("'2'");
+		assertThat(TestUtils.<Boolean>getPropertyValue(messageHandler, "sync")).isTrue();
+		assertThat(TestUtils.<String>getPropertyValue(messageHandler, "sendTimeoutExpression.expression"))
+				.isEqualTo("1000");
+		assertThat(TestUtils.<String>getPropertyValue(messageHandler, "timestampExpression.expression"))
 				.isEqualTo("T(System).currentTimeMillis()");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "flushExpression.expression"))
+		assertThat(TestUtils.<String>getPropertyValue(messageHandler, "flushExpression.expression"))
 				.isEqualTo("headers['foo']");
 
-		assertThat(TestUtils.getPropertyValue(messageHandler, "errorMessageStrategy"))
+		assertThat(TestUtils.<Object>getPropertyValue(messageHandler, "errorMessageStrategy"))
 				.isSameAs(this.appContext.getBean("ems"));
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sendFailureChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(messageHandler, "sendFailureChannel"))
 				.isSameAs(this.appContext.getBean("failures"));
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sendSuccessChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(messageHandler, "sendSuccessChannel"))
 				.isSameAs(this.appContext.getBean("successes"));
-		assertThat(TestUtils.getPropertyValue(messageHandler, "headerMapper"))
+		assertThat(TestUtils.<Object>getPropertyValue(messageHandler, "headerMapper"))
 				.isSameAs(this.appContext.getBean("customHeaderMapper"));
 
 		messageHandler
-				= this.appContext.getBean("kafkaOutboundChannelAdapter2.handler", KafkaProducerMessageHandler.class);
+				= this.appContext.getBean(
+						"kafkaOutboundChannelAdapter2.handler", KafkaProducerMessageHandler.class);
 		assertThat(messageHandler).isNotNull();
-		assertThat(TestUtils.getPropertyValue(messageHandler, "partitionIdExpression.literalValue")).isEqualTo("0");
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sync", Boolean.class)).isFalse();
+		assertThat(TestUtils.<String>getPropertyValue(messageHandler, "partitionIdExpression.literalValue"))
+				.isEqualTo("0");
+		assertThat(TestUtils.<Boolean>getPropertyValue(messageHandler, "sync")).isFalse();
 
-		assertThat(TestUtils.getPropertyValue(messageHandler, "sendTimeoutExpression.literalValue")).isEqualTo("500");
+		assertThat(TestUtils.<String>getPropertyValue(messageHandler, "sendTimeoutExpression.literalValue"))
+				.isEqualTo("500");
 	}
 
 	@Test

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/config/xml/KafkaOutboundGatewayParserTests.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Gary Russell
  * @author Tom van den Berge
+ * @author Glenn Renfro
  *
  * @since 5.4
  *
@@ -58,28 +59,32 @@ public class KafkaOutboundGatewayParserTests {
 
 	@Test
 	public void testProps() {
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "errorMessageStrategy")).isInstanceOf(EMS.class);
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "kafkaTemplate"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.messageHandler, "errorMessageStrategy"))
+				.isInstanceOf(EMS.class);
+		assertThat(TestUtils.<Object>getPropertyValue(this.messageHandler, "kafkaTemplate"))
 				.isSameAs(this.context.getBean("template"));
 		assertThat(this.messageHandler.getOrder()).isEqualTo(23);
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "topicExpression.expression")).isEqualTo("'topic'");
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "messageKeyExpression.expression"))
+		assertThat(TestUtils.<String>getPropertyValue(this.messageHandler, "topicExpression.expression"))
+				.isEqualTo("'topic'");
+		assertThat(TestUtils.<String>getPropertyValue(this.messageHandler, "messageKeyExpression.expression"))
 				.isEqualTo("'key'");
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "partitionIdExpression.expression")).isEqualTo("2");
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "sync", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "sendTimeoutExpression.expression")).isEqualTo("44");
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "timestampExpression.expression"))
+		assertThat(TestUtils.<String>getPropertyValue(this.messageHandler, "partitionIdExpression.expression"))
+				.isEqualTo("2");
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.messageHandler, "sync")).isTrue();
+		assertThat(TestUtils.<String>getPropertyValue(this.messageHandler, "sendTimeoutExpression.expression"))
+				.isEqualTo("44");
+		assertThat(TestUtils.<String>getPropertyValue(this.messageHandler, "timestampExpression.expression"))
 				.isEqualTo("T(System).currentTimeMillis()");
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "flushExpression.expression"))
+		assertThat(TestUtils.<String>getPropertyValue(this.messageHandler, "flushExpression.expression"))
 				.isEqualTo("headers['foo']");
 
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "errorMessageStrategy"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.messageHandler, "errorMessageStrategy"))
 				.isSameAs(this.context.getBean("ems"));
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "sendFailureChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.messageHandler, "sendFailureChannel"))
 				.isSameAs(this.context.getBean("failures"));
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "sendSuccessChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.messageHandler, "sendSuccessChannel"))
 				.isSameAs(this.context.getBean("successes"));
-		assertThat(TestUtils.getPropertyValue(this.messageHandler, "headerMapper"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.messageHandler, "headerMapper"))
 				.isSameAs(this.context.getBean("customHeaderMapper"));
 	}
 

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
@@ -96,6 +96,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Anshul Mehra
  * @author Jooyoung Pyoung
+ * @author Glenn Renfro
  *
  * @since 5.4
  */
@@ -176,7 +177,8 @@ public class KafkaDslTests {
 	void testKafkaAdapters() throws Exception {
 		this.sendToKafkaFlowInput.send(new GenericMessage<>("foo", Collections.singletonMap("foo", "bar")));
 
-		assertThat(TestUtils.getPropertyValue(this.kafkaProducer1, "headerMapper")).isSameAs(this.mapper);
+		assertThat(TestUtils.<JsonKafkaHeaderMapper>getPropertyValue(this.kafkaProducer1, "headerMapper"))
+				.isSameAs(this.mapper);
 
 		for (int i = 0; i < 200; i++) {
 			Message<?> future = this.futuresChannel.receive(10000);

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageSourceTests.java
@@ -92,6 +92,7 @@ import static org.mockito.Mockito.times;
  * @author Gary Russell
  * @author Anshul Mehra
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.4
  *
@@ -571,14 +572,14 @@ class MessageSourceTests {
 		Message<?> received2 = source.receive(); // inflight
 		assertThat(received1.getHeaders().get(KafkaHeaders.OFFSET)).isEqualTo(0L);
 		AcknowledgmentCallback ack1 = StaticMessageHeaderAccessor.getAcknowledgmentCallback(received1);
-		Log log1 = spy(KafkaTestUtils.getPropertyValue(ack1, "logger.log", Log.class));
+		Log log1 = (Log) spy(KafkaTestUtils.getPropertyValue(ack1, "logger.log"));
 		new DirectFieldAccessor(ack1).setPropertyValue("logger.log", log1);
 		given(log1.isWarnEnabled()).willReturn(true);
 		willDoNothing().given(log1).warn(any());
 		ack1.acknowledge(AcknowledgmentCallback.Status.REQUEUE);
 		assertThat(received2.getHeaders().get(KafkaHeaders.OFFSET)).isEqualTo(1L);
 		AcknowledgmentCallback ack2 = StaticMessageHeaderAccessor.getAcknowledgmentCallback(received2);
-		Log log2 = spy(KafkaTestUtils.getPropertyValue(ack2, "logger.log", Log.class));
+		Log log2 = (Log) spy(KafkaTestUtils.getPropertyValue(ack2, "logger.log"));
 		new DirectFieldAccessor(ack2).setPropertyValue("logger.log", log2);
 		given(log2.isWarnEnabled()).willReturn(true);
 		willDoNothing().given(log2).warn(any());
@@ -625,11 +626,11 @@ class MessageSourceTests {
 	void testMaxPollRecords() {
 		KafkaMessageSource source = new KafkaMessageSource(new DefaultKafkaConsumerFactory<>(Collections.emptyMap()),
 				new ConsumerProperties("topic"));
-		assertThat((TestUtils.getPropertyValue(source, "consumerFactory.configs", Map.class)
+		assertThat((TestUtils.<Map>getPropertyValue(source, "consumerFactory.configs")
 				.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG))).isEqualTo(1);
 		source = new KafkaMessageSource(new DefaultKafkaConsumerFactory<>(
 				Collections.singletonMap(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2)), new ConsumerProperties("topic"));
-		assertThat((TestUtils.getPropertyValue(source, "consumerFactory.configs", Map.class)
+		assertThat((TestUtils.<Map>getPropertyValue(source, "consumerFactory.configs")
 				.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG))).isEqualTo(1);
 
 		assertThatIllegalArgumentException()

--- a/spring-integration-kafka/src/test/kotlin/org/springframework/integration/kafka/dsl/kotlin/KafkaDslKotlinTests.kt
+++ b/spring-integration-kafka/src/test/kotlin/org/springframework/integration/kafka/dsl/kotlin/KafkaDslKotlinTests.kt
@@ -68,6 +68,7 @@ import java.util.stream.Stream
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 5.4
  */
@@ -134,7 +135,7 @@ class KafkaDslKotlinTests {
 	fun testKafkaAdapters() {
 		this.sendToKafkaFlowInput.send(GenericMessage("foo", hashMapOf<String, Any>("foo" to "bar")))
 
-		assertThat(TestUtils.getPropertyValue(this.kafkaProducer1, "headerMapper")).isSameInstanceAs(this.mapper)
+		assertThat(TestUtils.getPropertyValue<Any>(this.kafkaProducer1, "headerMapper")).isSameInstanceAs(this.mapper)
 
 		for (i in 0..99) {
 			val receive = this.listeningFromKafkaResults1.receive(20000)

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/DefaultConfigurationTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/DefaultConfigurationTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -65,14 +66,13 @@ public class DefaultConfigurationTests {
 	public void verifyTaskScheduler() {
 		Object taskScheduler = context.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME);
 		assertThat(taskScheduler.getClass()).isEqualTo(ThreadPoolTaskScheduler.class);
-		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler", ErrorHandler.class);
+		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler");
 		assertThat(errorHandler.getClass()).isEqualTo(MessagePublishingErrorHandler.class);
-		MessageChannel defaultErrorChannel = TestUtils.getPropertyValue(errorHandler,
-				"messagingTemplate.defaultDestination", MessageChannel.class);
+		MessageChannel defaultErrorChannel =
+				TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNull();
 		errorHandler.handleError(new Throwable());
-		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination",
-				MessageChannel.class);
+		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNotNull();
 		assertThat(defaultErrorChannel).isEqualTo(context.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME));
 	}

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleChannelAdapterParserTests.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -167,12 +168,13 @@ public class ImapIdleChannelAdapterParserTests {
 		assertThat(properties.getProperty("foo")).isEqualTo("bar");
 		assertThat(receiverAccessor.getPropertyValue("shouldDeleteMessages")).isEqualTo(Boolean.FALSE);
 		SearchTermStrategy stStrategy = context.getBean("searchTermStrategy", SearchTermStrategy.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "mailReceiver.searchTermStrategy")).isEqualTo(stStrategy);
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "mailReceiver.searchTermStrategy"))
+				.isEqualTo(stStrategy);
 	}
 
 	@Test
 	public void testAutoChannel() {
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
 	}
 
 	@Test

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleIntegrationTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/ImapIdleIntegrationTests.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class ImapIdleIntegrationTests {
 
@@ -53,8 +54,8 @@ public class ImapIdleIntegrationTests {
 				new ClassPathXmlApplicationContext("imap-idle-mock-integration-config.xml", this.getClass());
 		PostTransactionProcessor processor = context.getBean("syncProcessor", PostTransactionProcessor.class);
 		ImapIdleChannelAdapter adapter = context.getBean("customAdapter", ImapIdleChannelAdapter.class);
-		assertThat(TestUtils.getPropertyValue(adapter, "applicationEventPublisher")).isNotNull();
-		ImapMailReceiver receiver = TestUtils.getPropertyValue(adapter, "mailReceiver", ImapMailReceiver.class);
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "applicationEventPublisher")).isNotNull();
+		ImapMailReceiver receiver = TestUtils.getPropertyValue(adapter, "mailReceiver");
 
 		// setup mock scenario
 		receiver = spy(receiver);

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/InboundChannelAdapterParserTests.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 1.0.5
  */
@@ -138,7 +139,7 @@ public class InboundChannelAdapterParserTests {
 		assertThat(receiver.getClass()).isEqualTo(ImapMailReceiver.class);
 		Boolean value = (Boolean) new DirectFieldAccessor(receiver).getPropertyValue("shouldDeleteMessages");
 		assertThat(value).isTrue();
-		assertThat(TestUtils.getPropertyValue(receiver, "evaluationContext.beanResolver")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(receiver, "evaluationContext.beanResolver")).isNotNull();
 	}
 
 	@Test
@@ -308,7 +309,7 @@ public class InboundChannelAdapterParserTests {
 
 	@Test
 	public void testAutoChannel() {
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
 	}
 
 }

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/MailOutboundChannelAdapterParserTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/config/MailOutboundChannelAdapterParserTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class MailOutboundChannelAdapterParserTests {
 
@@ -89,7 +90,7 @@ public class MailOutboundChannelAdapterParserTests {
 		ConfigurableApplicationContext context = new ClassPathXmlApplicationContext(
 				"mailOutboundChannelAdapterParserTests.xml", this.getClass());
 		PollingConsumer pc = context.getBean("adapterWithPollableChannel", PollingConsumer.class);
-		QueueChannel pollableChannel = TestUtils.getPropertyValue(pc, "inputChannel", QueueChannel.class);
+		QueueChannel pollableChannel = TestUtils.getPropertyValue(pc, "inputChannel");
 		assertThat(pollableChannel.getComponentName()).isEqualTo("pollableChannel");
 		context.close();
 	}

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/dsl/MailTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/dsl/MailTests.java
@@ -65,6 +65,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Alexander Pinske
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -114,10 +115,10 @@ public class MailTests {
 
 	@Test
 	public void testSmtp() throws Exception {
-		assertThat(TestUtils.getPropertyValue(this.sendMailHandler, "mailSender.host")).isEqualTo("localhost");
+		assertThat(TestUtils.<String>getPropertyValue(this.sendMailHandler, "mailSender.host")).isEqualTo("localhost");
 
-		Properties javaMailProperties = TestUtils.getPropertyValue(this.sendMailHandler,
-				"mailSender.javaMailProperties", Properties.class);
+		Properties javaMailProperties =
+				TestUtils.getPropertyValue(this.sendMailHandler, "mailSender.javaMailProperties");
 		assertThat(javaMailProperties.getProperty("mail.debug")).isEqualTo("false");
 
 		this.sendMailChannel.send(MessageBuilder.withPayload("foo").build());
@@ -190,7 +191,7 @@ public class MailTests {
 		assertThat(message.getPayload()).isEqualTo("foo\r\n");
 		assertThat(message.getHeaders()).containsKey(IntegrationMessageHeaderAccessor.CLOSEABLE_RESOURCE);
 		this.imapIdleAdapter.stop();
-		assertThat(TestUtils.getPropertyValue(this.imapIdleAdapter, "shouldReconnectAutomatically", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.imapIdleAdapter, "shouldReconnectAutomatically"))
 				.isFalse();
 	}
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/inbound/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/inbound/ImapMailReceiverTests.java
@@ -111,6 +111,7 @@ import static org.mockito.Mockito.when;
  * @author Alexander Pinske
  * @author Dominik Simmen
  * @author Filip Hrisafov
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @ContextConfiguration(
@@ -373,7 +374,7 @@ public class ImapMailReceiverTests implements TestApplicationContextAware {
 	public void receiveAndDebugIsDisabledNotLogFiltered() throws Exception {
 		AbstractMailReceiver receiver = new ImapMailReceiver();
 
-		LogAccessor logger = spy(TestUtils.getPropertyValue(receiver, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(receiver, "logger"));
 		new DirectFieldAccessor(receiver).setPropertyValue("logger", logger);
 		when(logger.isDebugEnabled()).thenReturn(false);
 
@@ -394,7 +395,7 @@ public class ImapMailReceiverTests implements TestApplicationContextAware {
 	public void receiveExpungedAndNotExpungedLogFiltered() throws Exception {
 		AbstractMailReceiver receiver = new ImapMailReceiver();
 
-		LogAccessor logger = spy(TestUtils.getPropertyValue(receiver, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(receiver, "logger"));
 		new DirectFieldAccessor(receiver).setPropertyValue("logger", logger);
 		when(logger.isDebugEnabled()).thenReturn(true);
 
@@ -956,7 +957,7 @@ public class ImapMailReceiverTests implements TestApplicationContextAware {
 		storeField.set(receiver, store);
 
 		ImapIdleChannelAdapter adapter = new ImapIdleChannelAdapter(receiver);
-		LogAccessor logger = spy(TestUtils.getPropertyValue(adapter, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(adapter, "logger"));
 		new DirectFieldAccessor(adapter).setPropertyValue("logger", logger);
 		willDoNothing().given(logger).warn(any(Throwable.class), anyString());
 		willAnswer(i -> {

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbInboundChannelAdapterParserTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Yaron Yamin
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -85,32 +86,34 @@ public class MongoDbInboundChannelAdapterParserTests {
 
 	@Test
 	public void minimalConfig() {
-		MongoDbMessageSource source = TestUtils.getPropertyValue(this.minimalConfigAdapter, "source",
-				MongoDbMessageSource.class);
+		MongoDbMessageSource source = TestUtils.getPropertyValue(this.minimalConfigAdapter, "source");
 
-		assertThat(TestUtils.getPropertyValue(this.minimalConfigAdapter, "shouldTrack")).isEqualTo(false);
-		assertThat(TestUtils.getPropertyValue(source, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(source, "mongoDbFactory")).isEqualTo(this.mongoDbFactory);
-		assertThat(TestUtils.getPropertyValue(source, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.minimalConfigAdapter, "shouldTrack")).isEqualTo(false);
+		assertThat(TestUtils.<Object>getPropertyValue(source, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<MongoDatabaseFactory>getPropertyValue(source, "mongoDbFactory"))
+				.isEqualTo(this.mongoDbFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(source, "evaluationContext")).isNotNull();
 		assertThat(TestUtils.getPropertyValue(source, "collectionNameExpression") instanceof LiteralExpression)
 				.isTrue();
-		assertThat(TestUtils.getPropertyValue(source, "collectionNameExpression.literalValue")).isEqualTo("data");
+		assertThat(TestUtils.<String>getPropertyValue(source, "collectionNameExpression.literalValue"))
+				.isEqualTo("data");
 	}
 
 	@Test
 	public void fullConfigWithCollectionExpression() {
 		MongoDbMessageSource source = assertMongoDbMessageSource(this.fullConfigWithCollectionExpressionAdapter);
 		assertThat(TestUtils.getPropertyValue(source, "collectionNameExpression") instanceof SpelExpression).isTrue();
-		assertThat(TestUtils.getPropertyValue(source, "collectionNameExpression.expression")).isEqualTo("'foo'");
+		assertThat(TestUtils.<String>getPropertyValue(source, "collectionNameExpression.expression"))
+				.isEqualTo("'foo'");
 	}
 
 	@Test
 	public void fullConfigWithQueryExpression() {
 		MongoDbMessageSource source = assertMongoDbMessageSource(this.fullConfigWithQueryExpressionAdapter);
 		assertThat(TestUtils.getPropertyValue(source, "queryExpression") instanceof SpelExpression).isTrue();
-		assertThat(TestUtils.getPropertyValue(source, "queryExpression.expression"))
+		assertThat(TestUtils.<String>getPropertyValue(source, "queryExpression.expression"))
 				.isEqualTo("new BasicQuery('{''address.state'' : ''PA''}').limit(2)");
-		assertThat(TestUtils.getPropertyValue(source, "updateExpression.literalValue"))
+		assertThat(TestUtils.<String>getPropertyValue(source, "updateExpression.literalValue"))
 				.isEqualTo("{ $set: {'address.state' : 'NJ'} }");
 	}
 
@@ -118,7 +121,7 @@ public class MongoDbInboundChannelAdapterParserTests {
 	public void fullConfigWithSpelQuery() {
 		MongoDbMessageSource source = assertMongoDbMessageSource(this.fullConfigWithSpelQueryAdapter);
 		assertThat(TestUtils.getPropertyValue(source, "queryExpression") instanceof LiteralExpression).isTrue();
-		assertThat(TestUtils.getPropertyValue(source, "queryExpression.literalValue"))
+		assertThat(TestUtils.<String>getPropertyValue(source, "queryExpression.literalValue"))
 				.isEqualTo("{''address.state'' : ''PA''}");
 	}
 
@@ -126,7 +129,7 @@ public class MongoDbInboundChannelAdapterParserTests {
 	public void fullConfigWithQuery() {
 		MongoDbMessageSource source = assertMongoDbMessageSource(this.fullConfigWithQueryAdapter);
 		assertThat(TestUtils.getPropertyValue(source, "queryExpression") instanceof LiteralExpression).isTrue();
-		assertThat(TestUtils.getPropertyValue(source, "queryExpression.literalValue"))
+		assertThat(TestUtils.<String>getPropertyValue(source, "queryExpression.literalValue"))
 				.isEqualTo("{'address.state' : 'PA'}");
 	}
 
@@ -135,21 +138,23 @@ public class MongoDbInboundChannelAdapterParserTests {
 		MongoDbMessageSource source = assertMongoDbMessageSource(this.fullConfigWithCollectionNameAdapter);
 		assertThat(TestUtils.getPropertyValue(source, "collectionNameExpression") instanceof LiteralExpression)
 				.isTrue();
-		assertThat(TestUtils.getPropertyValue(source, "collectionNameExpression.literalValue")).isEqualTo("foo");
+		assertThat(TestUtils.<String>getPropertyValue(source, "collectionNameExpression.literalValue"))
+				.isEqualTo("foo");
 	}
 
 	@Test
 	public void fullConfigWithMongoTemplate() {
-		MongoDbMessageSource source = TestUtils.getPropertyValue(this.fullConfigWithMongoTemplateAdapter, "source",
-				MongoDbMessageSource.class);
+		MongoDbMessageSource source = TestUtils.getPropertyValue(this.fullConfigWithMongoTemplateAdapter, "source");
 
-		assertThat(TestUtils.getPropertyValue(this.fullConfigWithMongoTemplateAdapter, "shouldTrack")).isEqualTo(false);
-		assertThat(TestUtils.getPropertyValue(source, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(source, "mongoTemplate")).isSameAs(this.mongoDbTemplate);
-		assertThat(TestUtils.getPropertyValue(source, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(source, "collectionNameExpression") instanceof LiteralExpression)
-				.isTrue();
-		assertThat(TestUtils.getPropertyValue(source, "collectionNameExpression.literalValue")).isEqualTo("foo");
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.fullConfigWithMongoTemplateAdapter, "shouldTrack"))
+				.isEqualTo(false);
+		assertThat(TestUtils.<Object>getPropertyValue(source, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(source, "mongoTemplate")).isSameAs(this.mongoDbTemplate);
+		assertThat(TestUtils.<Object>getPropertyValue(source, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<LiteralExpression>getPropertyValue(source, "collectionNameExpression"))
+				.isInstanceOf(LiteralExpression.class);
+		assertThat(TestUtils.<String>getPropertyValue(source, "collectionNameExpression.literalValue"))
+				.isEqualTo("foo");
 	}
 
 	@Test
@@ -169,13 +174,13 @@ public class MongoDbInboundChannelAdapterParserTests {
 	}
 
 	private MongoDbMessageSource assertMongoDbMessageSource(Object testedBean) {
-		MongoDbMessageSource source = TestUtils.getPropertyValue(testedBean, "source", MongoDbMessageSource.class);
+		MongoDbMessageSource source = TestUtils.getPropertyValue(testedBean, "source");
 
-		assertThat(TestUtils.getPropertyValue(testedBean, "shouldTrack")).isEqualTo(false);
-		assertThat(TestUtils.getPropertyValue(source, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(source, "mongoDbFactory")).isEqualTo(this.mongoDbFactory);
-		assertThat(TestUtils.getPropertyValue(source, "mongoConverter")).isEqualTo(this.mongoConverter);
-		assertThat(TestUtils.getPropertyValue(source, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(testedBean, "shouldTrack")).isEqualTo(false);
+		assertThat(TestUtils.<Object>getPropertyValue(source, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<MongoDatabaseFactory>getPropertyValue(source, "mongoDbFactory")).isEqualTo(this.mongoDbFactory);
+		assertThat(TestUtils.<MongoConverter>getPropertyValue(source, "mongoConverter")).isEqualTo(this.mongoConverter);
+		assertThat(TestUtils.<Object>getPropertyValue(source, "evaluationContext")).isNotNull();
 		return source;
 	}
 

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundChannelAdapterParserTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundChannelAdapterParserTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 public class MongoDbOutboundChannelAdapterParserTests {
@@ -51,59 +52,66 @@ public class MongoDbOutboundChannelAdapterParserTests {
 	@Test
 	public void minimalConfig() {
 		MongoDbStoringMessageHandler handler =
-				TestUtils.getPropertyValue(context.getBean("minimalConfig.adapter"), "handler",
-						MongoDbStoringMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "componentName")).isEqualTo("minimalConfig.adapter");
-		assertThat(TestUtils.getPropertyValue(handler, "shouldTrack")).isEqualTo(false);
-		assertThat(TestUtils.getPropertyValue(handler, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "mongoDbFactory")).isEqualTo(context.getBean("mongoDbFactory"));
-		assertThat(TestUtils.getPropertyValue(handler, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "collectionNameExpression")).isInstanceOf(LiteralExpression.class);
-		assertThat(TestUtils.getPropertyValue(handler, "collectionNameExpression.literalValue")).isEqualTo("data");
+				TestUtils.getPropertyValue(context.getBean("minimalConfig.adapter"), "handler");
+		assertThat(TestUtils.<String>getPropertyValue(handler, "componentName")).isEqualTo("minimalConfig.adapter");
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "shouldTrack")).isEqualTo(false);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "mongoDbFactory"))
+				.isEqualTo(context.getBean("mongoDbFactory"));
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "collectionNameExpression"))
+				.isInstanceOf(LiteralExpression.class);
+		assertThat(TestUtils.<String>getPropertyValue(handler, "collectionNameExpression.literalValue"))
+				.isEqualTo("data");
 	}
 
 	@Test
 	public void fullConfigWithCollectionExpression() {
 		MongoDbStoringMessageHandler handler =
-				TestUtils.getPropertyValue(context.getBean("fullConfigWithCollectionExpression.adapter"), "handler",
-						MongoDbStoringMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "componentName"))
+				TestUtils.getPropertyValue(context.getBean("fullConfigWithCollectionExpression.adapter"), "handler");
+		assertThat(TestUtils.<String>getPropertyValue(handler, "componentName"))
 				.isEqualTo("fullConfigWithCollectionExpression.adapter");
-		assertThat(TestUtils.getPropertyValue(handler, "shouldTrack")).isEqualTo(false);
-		assertThat(TestUtils.getPropertyValue(handler, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "mongoDbFactory")).isEqualTo(context.getBean("mongoDbFactory"));
-		assertThat(TestUtils.getPropertyValue(handler, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "collectionNameExpression")).isInstanceOf(SpelExpression.class);
-		assertThat(TestUtils.getPropertyValue(handler, "collectionNameExpression.expression"))
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "shouldTrack")).isEqualTo(false);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "mongoDbFactory"))
+				.isEqualTo(context.getBean("mongoDbFactory"));
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "collectionNameExpression"))
+				.isInstanceOf(SpelExpression.class);
+		assertThat(TestUtils.<String>getPropertyValue(handler, "collectionNameExpression.expression"))
 				.isEqualTo("headers.collectionName");
 	}
 
 	@Test
 	public void fullConfigWithCollection() {
 		MongoDbStoringMessageHandler handler =
-				TestUtils.getPropertyValue(context.getBean("fullConfigWithCollection.adapter"), "handler",
-						MongoDbStoringMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "componentName")).isEqualTo("fullConfigWithCollection.adapter");
-		assertThat(TestUtils.getPropertyValue(handler, "shouldTrack")).isEqualTo(false);
-		assertThat(TestUtils.getPropertyValue(handler, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "mongoDbFactory")).isEqualTo(context.getBean("mongoDbFactory"));
-		assertThat(TestUtils.getPropertyValue(handler, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "collectionNameExpression")).isInstanceOf(LiteralExpression.class);
-		assertThat(TestUtils.getPropertyValue(handler, "collectionNameExpression.literalValue")).isEqualTo("foo");
+				TestUtils.getPropertyValue(context.getBean("fullConfigWithCollection.adapter"), "handler");
+		assertThat(TestUtils.<String>getPropertyValue(handler, "componentName"))
+				.isEqualTo("fullConfigWithCollection.adapter");
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "shouldTrack")).isEqualTo(false);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "mongoDbFactory"))
+				.isEqualTo(context.getBean("mongoDbFactory"));
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "collectionNameExpression"))
+				.isInstanceOf(LiteralExpression.class);
+		assertThat(TestUtils.<String>getPropertyValue(handler, "collectionNameExpression.literalValue"))
+				.isEqualTo("foo");
 	}
 
 	@Test
 	public void fullConfigWithMongoTemplate() {
 		MongoDbStoringMessageHandler handler =
-				TestUtils.getPropertyValue(context.getBean("fullConfigWithMongoTemplate.adapter"), "handler",
-						MongoDbStoringMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "componentName"))
+				TestUtils.getPropertyValue(context.getBean("fullConfigWithMongoTemplate.adapter"), "handler");
+		assertThat(TestUtils.<String>getPropertyValue(handler, "componentName"))
 				.isEqualTo("fullConfigWithMongoTemplate.adapter");
-		assertThat(TestUtils.getPropertyValue(handler, "shouldTrack")).isEqualTo(false);
-		assertThat(TestUtils.getPropertyValue(handler, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "collectionNameExpression")).isInstanceOf(LiteralExpression.class);
-		assertThat(TestUtils.getPropertyValue(handler, "collectionNameExpression.literalValue")).isEqualTo("foo");
+		assertThat(TestUtils.<Boolean>getPropertyValue(handler, "shouldTrack")).isEqualTo(false);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "collectionNameExpression"))
+				.isInstanceOf(LiteralExpression.class);
+		assertThat(TestUtils.<String>getPropertyValue(handler, "collectionNameExpression.literalValue"))
+				.isEqualTo("foo");
 	}
 
 	@Test
@@ -126,7 +134,7 @@ public class MongoDbOutboundChannelAdapterParserTests {
 	public void testInt3024PollerAndRequestHandlerAdviceChain() {
 		AbstractEndpoint endpoint = context.getBean("pollableAdapter", AbstractEndpoint.class);
 		assertThat(endpoint).isInstanceOf(PollingConsumer.class);
-		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler");
 		assertThat(AopUtils.isAopProxy(handler)).isTrue();
 		assertThat(((Advised) handler).getAdvisors()[0].getAdvice()).isInstanceOf(RequestHandlerRetryAdvice.class);
 	}

--- a/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests.java
+++ b/spring-integration-mongodb/src/test/java/org/springframework/integration/mongodb/config/MongoDbOutboundGatewayParserTests.java
@@ -44,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Xavier Padro
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -63,78 +64,82 @@ public class MongoDbOutboundGatewayParserTests {
 	@Test
 	public void minimalConfig() {
 		AbstractEndpoint endpoint = this.context.getBean("minimalConfig", AbstractEndpoint.class);
-		MongoDbOutboundGateway gateway =
-				TestUtils.getPropertyValue(endpoint, "handler", MongoDbOutboundGateway.class);
+		MongoDbOutboundGateway gateway = TestUtils.getPropertyValue(endpoint, "handler");
 
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoDbFactory")).isSameAs(this.mongoDbFactory);
-		assertThat(TestUtils.getPropertyValue(gateway, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoDbFactory")).isSameAs(this.mongoDbFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "collectionNameExpression"))
 				.isInstanceOf(LiteralExpression.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression.literalValue")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout")).isEqualTo(30000L);
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "collectionNameExpression.literalValue"))
+				.isEqualTo("foo");
+		assertThat(TestUtils.<Long>getPropertyValue(gateway, "messagingTemplate.sendTimeout")).isEqualTo(30000L);
 
 		assertThat(endpoint).isInstanceOf(PollingConsumer.class);
-		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class);
-		List<?> advices = TestUtils.getPropertyValue(handler, "adviceChain", List.class);
+		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler");
+		List<?> advices = TestUtils.getPropertyValue(handler, "adviceChain");
 		assertThat(advices.get(0)).isInstanceOf(RequestHandlerRetryAdvice.class);
 	}
 
 	@Test
 	public void fullConfigWithCollectionExpression() {
-		MongoDbOutboundGateway gateway = TestUtils.getPropertyValue(
-				context.getBean("fullConfigWithCollectionExpression"), "handler", MongoDbOutboundGateway.class);
+		MongoDbOutboundGateway gateway =
+				TestUtils.getPropertyValue(context.getBean("fullConfigWithCollectionExpression"), "handler");
 
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoDbFactory")).isSameAs(this.mongoDbFactory);
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoConverter")).isSameAs(this.mongoConverter);
-		assertThat(TestUtils.getPropertyValue(gateway, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression")).isInstanceOf(SpelExpression.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression.expression"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoDbFactory")).isSameAs(this.mongoDbFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoConverter")).isSameAs(this.mongoConverter);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "collectionNameExpression")).isInstanceOf(SpelExpression.class);
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "collectionNameExpression.expression"))
 				.isEqualTo("headers.collectionName");
 	}
 
 	@Test
 	public void fullConfigWithCollection() {
-		MongoDbOutboundGateway gateway = TestUtils.getPropertyValue(
-				context.getBean("fullConfigWithCollection"), "handler", MongoDbOutboundGateway.class);
+		MongoDbOutboundGateway gateway =
+				TestUtils.getPropertyValue(context.getBean("fullConfigWithCollection"), "handler");
 
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoTemplate")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoDbFactory")).isSameAs(this.mongoDbFactory);
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoConverter")).isSameAs(this.mongoConverter);
-		assertThat(TestUtils.getPropertyValue(gateway, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoTemplate")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoDbFactory")).isSameAs(this.mongoDbFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoConverter")).isSameAs(this.mongoConverter);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "collectionNameExpression"))
 				.isInstanceOf(LiteralExpression.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression.literalValue")).isEqualTo("foo");
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "collectionNameExpression.literalValue"))
+				.isEqualTo("foo");
 	}
 
 	@Test
 	public void fullConfigWithMongoTemplate() {
-		MongoDbOutboundGateway gateway = TestUtils.getPropertyValue(
-				context.getBean("fullConfigWithTemplate"), "handler", MongoDbOutboundGateway.class);
+		MongoDbOutboundGateway gateway =
+				TestUtils.getPropertyValue(context.getBean("fullConfigWithTemplate"), "handler");
 
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoTemplate")).isSameAs(context.getBean("mongoDbTemplate"));
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoDbFactory")).isNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoConverter")).isNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoTemplate"))
+				.isSameAs(context.getBean("mongoDbTemplate"));
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoDbFactory")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoConverter")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "collectionNameExpression"))
 				.isInstanceOf(LiteralExpression.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression.literalValue")).isEqualTo("foo");
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "collectionNameExpression.literalValue")).isEqualTo("foo");
 	}
 
 	@Test
 	public void fullConfigWithMongoDbCollectionCallback() {
-		MongoDbOutboundGateway gateway = TestUtils.getPropertyValue(
-				context.getBean("fullConfigWithMongoDbCollectionCallback"), "handler", MongoDbOutboundGateway.class);
+		MongoDbOutboundGateway gateway =
+				TestUtils.getPropertyValue(context.getBean("fullConfigWithMongoDbCollectionCallback"), "handler");
 
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoTemplate")).isSameAs(context.getBean("mongoDbTemplate"));
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoDbFactory")).isNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "mongoConverter")).isNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "evaluationContext")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoTemplate"))
+				.isSameAs(context.getBean("mongoDbTemplate"));
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoDbFactory")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mongoConverter")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "evaluationContext")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "collectionNameExpression"))
 				.isInstanceOf(LiteralExpression.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionNameExpression.literalValue")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(gateway, "collectionCallback"))
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "collectionNameExpression.literalValue"))
+				.isEqualTo("foo");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "collectionCallback"))
 				.isInstanceOf(MessageCollectionCallback.class);
 	}
 

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/DownstreamExceptionTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/DownstreamExceptionTests.java
@@ -46,6 +46,7 @@ import static org.mockito.Mockito.verify;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.0
  *
@@ -70,7 +71,7 @@ public class DownstreamExceptionTests implements MosquittoContainerTest {
 	@SuppressWarnings("unchecked")
 	public void testNoErrorChannel() throws Exception {
 		service.n = 0;
-		LogAccessor logger = spy(TestUtils.getPropertyValue(noErrorChannel, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(noErrorChannel, "logger"));
 		final CountDownLatch latch = new CountDownLatch(1);
 		doAnswer(invocation -> {
 			if (((Supplier<String>) invocation.getArgument(1)).get().contains("Unhandled")) {
@@ -99,7 +100,7 @@ public class DownstreamExceptionTests implements MosquittoContainerTest {
 
 	@Test
 	public void testWithErrorChannel() throws Exception {
-		assertThat(TestUtils.getPropertyValue(this.withErrorChannel, "errorChannel")).isSameAs(this.errors);
+		assertThat(TestUtils.<Object>getPropertyValue(this.withErrorChannel, "errorChannel")).isSameAs(this.errors);
 		service.n = 0;
 		MqttPahoMessageHandler adapter = new MqttPahoMessageHandler(MosquittoContainerTest.mqttUrl(), "si-test-out");
 		adapter.setDefaultTopic("mqtt-fooEx2");

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/MqttAdapterTests.java
@@ -402,17 +402,17 @@ public class MqttAdapterTests implements TestApplicationContextAware {
 		MqttPahoMessageHandler handler = ctx.getBean("handler", MqttPahoMessageHandler.class);
 		GenericMessage<String> message = new GenericMessage<>("foo");
 		handler.setApplicationContext(ctx);
-		assertThat(TestUtils.getPropertyValue(handler, "topicProcessor", MessageProcessor.class)
+		assertThat(TestUtils.<MessageProcessor<?>>getPropertyValue(handler, "topicProcessor")
 				.processMessage(message)).isEqualTo("fooTopic");
-		assertThat(TestUtils.getPropertyValue(handler, "converter.qosProcessor", MessageProcessor.class)
+		assertThat(TestUtils.<MessageProcessor<?>>getPropertyValue(handler, "converter.qosProcessor")
 				.processMessage(message)).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(handler, "converter.retainedProcessor", MessageProcessor.class)
+		assertThat(TestUtils.<MessageProcessor<?>>getPropertyValue(handler, "converter.retainedProcessor")
 				.processMessage(message)).isEqualTo(Boolean.TRUE);
 
 		handler = ctx.getBean("handlerWithNullExpressions", MqttPahoMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "converter", DefaultPahoMessageConverter.class)
+		assertThat(TestUtils.<DefaultPahoMessageConverter>getPropertyValue(handler, "converter")
 				.fromMessage(message, null).getQos()).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(handler, "converter", DefaultPahoMessageConverter.class)
+		assertThat(TestUtils.<DefaultPahoMessageConverter>getPropertyValue(handler, "converter")
 				.fromMessage(message, null).isRetained()).isEqualTo(Boolean.TRUE);
 		ctx.close();
 	}
@@ -506,7 +506,7 @@ public class MqttAdapterTests implements TestApplicationContextAware {
 			method.set(m);
 		}, m -> m.getName().equals("subscribe"));
 		assertThat(method.get()).isNotNull();
-		LogAccessor logger = spy(TestUtils.getPropertyValue(adapter, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(adapter, "logger"));
 		new DirectFieldAccessor(adapter).setPropertyValue("logger", logger);
 		given(logger.isWarnEnabled()).willReturn(true);
 		method.get().invoke(adapter);

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttMessageDrivenChannelAdapterParserTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.0
  *
@@ -72,61 +73,65 @@ public class MqttMessageDrivenChannelAdapterParserTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testNoTopics() {
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapter, "url")).isEqualTo("tcp://localhost:1883");
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapter, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapter, "clientId")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapter, "topics", Map.class)).hasSize(0);
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapter, "outputChannel")).isSameAs(out);
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapter, "clientFactory")).isSameAs(clientFactory);
-		assertThat(TestUtils.getPropertyValue(this.noTopicsAdapter, "manualAcks", Boolean.class)).isTrue();
+		assertThat(TestUtils.<String>getPropertyValue(noTopicsAdapter, "url")).isEqualTo("tcp://localhost:1883");
+		assertThat(TestUtils.<Boolean>getPropertyValue(noTopicsAdapter, "autoStartup")).isFalse();
+		assertThat(TestUtils.<String>getPropertyValue(noTopicsAdapter, "clientId")).isEqualTo("foo");
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(noTopicsAdapter, "topics")).hasSize(0);
+		assertThat(TestUtils.<Object>getPropertyValue(noTopicsAdapter, "outputChannel")).isSameAs(out);
+		assertThat(TestUtils.<Object>getPropertyValue(noTopicsAdapter, "clientFactory")).isSameAs(clientFactory);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.noTopicsAdapter, "manualAcks")).isTrue();
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testNoTopicsDefaultCF() {
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "url")).isEqualTo("tcp://localhost:1883");
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "clientId")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "topics", Map.class)).hasSize(0);
-		assertThat(TestUtils.getPropertyValue(noTopicsAdapterDefaultCF, "outputChannel")).isSameAs(out);
-		assertThat(TestUtils.getPropertyValue(this.noTopicsAdapterDefaultCF, "manualAcks", Boolean.class)).isFalse();
+		assertThat(TestUtils.<String>getPropertyValue(noTopicsAdapterDefaultCF, "url"))
+				.isEqualTo("tcp://localhost:1883");
+		assertThat(TestUtils.<Boolean>getPropertyValue(noTopicsAdapterDefaultCF, "autoStartup")).isFalse();
+		assertThat(TestUtils.<String>getPropertyValue(noTopicsAdapterDefaultCF, "clientId")).isEqualTo("foo");
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(noTopicsAdapterDefaultCF, "topics")).hasSize(0);
+		assertThat(TestUtils.<Object>getPropertyValue(noTopicsAdapterDefaultCF, "outputChannel")).isSameAs(out);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.noTopicsAdapterDefaultCF, "manualAcks")).isFalse();
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testOneTopic() {
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "url")).isEqualTo("tcp://localhost:1883");
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "phase")).isEqualTo(25);
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "clientId")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "topics", Map.class)).containsEntry("bar", 1);
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "converter")).isSameAs(converter);
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "outputChannel")).isSameAs(out);
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "clientFactory")).isSameAs(clientFactory);
-		assertThat(TestUtils.getPropertyValue(oneTopicAdapter, "errorChannel")).isSameAs(errors);
+		assertThat(TestUtils.<String>getPropertyValue(oneTopicAdapter, "url")).isEqualTo("tcp://localhost:1883");
+		assertThat(TestUtils.<Boolean>getPropertyValue(oneTopicAdapter, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(oneTopicAdapter, "phase")).isEqualTo(25);
+		assertThat(TestUtils.<String>getPropertyValue(oneTopicAdapter, "clientId")).isEqualTo("foo");
+		assertThat(TestUtils.<Map<String, Integer>>getPropertyValue(oneTopicAdapter, "topics")).containsEntry("bar", 1);
+		assertThat(TestUtils.<MqttMessageConverter>getPropertyValue(oneTopicAdapter, "converter")).isSameAs(converter);
+		assertThat(TestUtils.<Long>getPropertyValue(oneTopicAdapter, "messagingTemplate.sendTimeout")).
+				isEqualTo(123L);
+		assertThat(TestUtils.<Object>getPropertyValue(oneTopicAdapter, "outputChannel")).isSameAs(out);
+		assertThat(TestUtils.<DefaultMqttPahoClientFactory>getPropertyValue(oneTopicAdapter, "clientFactory"))
+				.isSameAs(clientFactory);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(oneTopicAdapter, "errorChannel")).isSameAs(errors);
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testTwoTopics() {
-		assertThat(TestUtils.getPropertyValue(twoTopicsAdapter, "url")).isEqualTo("tcp://localhost:1883");
-		assertThat(TestUtils.getPropertyValue(twoTopicsAdapter, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(twoTopicsAdapter, "phase")).isEqualTo(25);
-		assertThat(TestUtils.getPropertyValue(twoTopicsAdapter, "clientId")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(twoTopicsAdapter, "topics", Map.class))
+		assertThat(TestUtils.<String>getPropertyValue(twoTopicsAdapter, "url")).isEqualTo("tcp://localhost:1883");
+		assertThat(TestUtils.<Boolean>getPropertyValue(twoTopicsAdapter, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(twoTopicsAdapter, "phase")).isEqualTo(25);
+		assertThat(TestUtils.<String>getPropertyValue(twoTopicsAdapter, "clientId")).isEqualTo("foo");
+		assertThat(TestUtils.<Map<String, Integer>>getPropertyValue(twoTopicsAdapter, "topics"))
 				.containsEntry("bar", 0)
 				.containsEntry("baz", 2);
-		assertThat(TestUtils.getPropertyValue(twoTopicsAdapter, "converter")).isSameAs(converter);
-		assertThat(TestUtils.getPropertyValue(twoTopicsAdapter, "messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(twoTopicsAdapter, "outputChannel")).isSameAs(out);
-		assertThat(TestUtils.getPropertyValue(twoTopicsAdapter, "clientFactory")).isSameAs(clientFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(twoTopicsAdapter, "converter")).isSameAs(converter);
+		assertThat(TestUtils.<Long>getPropertyValue(twoTopicsAdapter, "messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(twoTopicsAdapter, "outputChannel")).isSameAs(out);
+		assertThat(TestUtils.<DefaultMqttPahoClientFactory>getPropertyValue(twoTopicsAdapter, "clientFactory"))
+				.isSameAs(clientFactory);
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testTwoTopicsSingleQos() {
-		assertThat(TestUtils.getPropertyValue(twoTopicsSingleQosAdapter, "topics", Map.class))
+		assertThat(TestUtils.<Map<String, Integer>>getPropertyValue(twoTopicsSingleQosAdapter, "topics"))
 				.containsEntry("bar", 0)
 				.containsEntry("baz", 0);
 	}

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttOutboundChannelAdapterParserTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/config/xml/MqttOutboundChannelAdapterParserTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.0
  */
@@ -68,20 +69,20 @@ public class MqttOutboundChannelAdapterParserTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void testWithConverter() throws Exception {
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "url")).isEqualTo("tcp://localhost:1883");
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "clientId")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "defaultTopic")).isEqualTo("bar");
+		assertThat(TestUtils.<String>getPropertyValue(withConverterHandler, "url")).isEqualTo("tcp://localhost:1883");
+		assertThat(TestUtils.<String>getPropertyValue(withConverterHandler, "clientId")).isEqualTo("foo");
+		assertThat(TestUtils.<String>getPropertyValue(withConverterHandler, "defaultTopic")).isEqualTo("bar");
 		GenericMessage<String> message = new GenericMessage<>("foo");
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "topicProcessor", MessageProcessor.class)
+		assertThat(TestUtils.<MessageProcessor<?>>getPropertyValue(withConverterHandler, "topicProcessor")
 				.processMessage(message)).isEqualTo("bar");
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "qosProcessor", MessageProcessor.class)
+		assertThat(TestUtils.<MessageProcessor<?>>getPropertyValue(withConverterHandler, "qosProcessor")
 				.processMessage(message)).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "retainedProcessor", MessageProcessor.class)
+		assertThat(TestUtils.<MessageProcessor<?>>getPropertyValue(withConverterHandler, "retainedProcessor")
 				.processMessage(message)).isEqualTo(Boolean.TRUE);
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "converter")).isSameAs(converter);
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "clientFactory")).isSameAs(clientFactory);
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "async", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(withConverterHandler, "asyncEvents", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Object>getPropertyValue(withConverterHandler, "converter")).isSameAs(converter);
+		assertThat(TestUtils.<Object>getPropertyValue(withConverterHandler, "clientFactory")).isSameAs(clientFactory);
+		assertThat(TestUtils.<Boolean>getPropertyValue(withConverterHandler, "async")).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(withConverterHandler, "asyncEvents")).isFalse();
 
 		Object handler = TestUtils.getPropertyValue(this.withConverterEndpoint, "handler");
 
@@ -95,19 +96,19 @@ public class MqttOutboundChannelAdapterParserTests {
 	@Test
 	public void testWithDefaultConverter() {
 		GenericMessage<String> message = new GenericMessage<>("foo");
-		assertThat(TestUtils.getPropertyValue(withDefaultConverterHandler, "url")).isEqualTo("tcp://localhost:1883");
-		assertThat(TestUtils.getPropertyValue(withDefaultConverterHandler, "clientId")).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(withDefaultConverterHandler, "defaultTopic")).isEqualTo("bar");
-		assertThat(TestUtils.getPropertyValue(withDefaultConverterHandler, "defaultQos")).isEqualTo(1);
-		assertThat(TestUtils.getPropertyValue(withDefaultConverterHandler, "defaultRetained", Boolean.class))
+		assertThat(TestUtils.<String>getPropertyValue(withDefaultConverterHandler, "url")).isEqualTo("tcp://localhost:1883");
+		assertThat(TestUtils.<String>getPropertyValue(withDefaultConverterHandler, "clientId")).isEqualTo("foo");
+		assertThat(TestUtils.<String>getPropertyValue(withDefaultConverterHandler, "defaultTopic")).isEqualTo("bar");
+		assertThat(TestUtils.<Integer>getPropertyValue(withDefaultConverterHandler, "defaultQos")).isEqualTo(1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(withDefaultConverterHandler, "defaultRetained"))
 				.isEqualTo(Boolean.TRUE);
-		DefaultPahoMessageConverter defaultConverter = TestUtils.getPropertyValue(withDefaultConverterHandler,
-				"converter", DefaultPahoMessageConverter.class);
+		DefaultPahoMessageConverter defaultConverter = TestUtils.getPropertyValue(withDefaultConverterHandler, "converter");
 		assertThat(defaultConverter.fromMessage(message, null).getQos()).isEqualTo(1);
 		assertThat(defaultConverter.fromMessage(message, null).isRetained()).isTrue();
-		assertThat(TestUtils.getPropertyValue(withDefaultConverterHandler, "clientFactory")).isSameAs(clientFactory);
-		assertThat(TestUtils.getPropertyValue(withDefaultConverterHandler, "async", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(withDefaultConverterHandler, "asyncEvents", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(withDefaultConverterHandler, "clientFactory"))
+				.isSameAs(clientFactory);
+		assertThat(TestUtils.<Boolean>getPropertyValue(withDefaultConverterHandler, "async")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(withDefaultConverterHandler, "asyncEvents")).isTrue();
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/RedisContainerTest.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/RedisContainerTest.java
@@ -51,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 6.0
  */
@@ -100,7 +101,7 @@ public interface RedisContainerTest {
 		int n = 0;
 		while (n++ < 300 &&
 				(connection =
-						TestUtils.getPropertyValue(container, "subscriber.connection", RedisConnection.class))
+						TestUtils.<RedisConnection>getPropertyValue(container, "subscriber.connection"))
 						== null) {
 
 			Thread.sleep(100);
@@ -116,8 +117,7 @@ public interface RedisContainerTest {
 
 	static void awaitContainerSubscribedWithPatterns(RedisMessageListenerContainer container) throws Exception {
 		awaitContainerSubscribed(container);
-		RedisConnection connection = TestUtils.getPropertyValue(container, "subscriber.connection",
-				RedisConnection.class);
+		RedisConnection connection = TestUtils.getPropertyValue(container, "subscriber.connection");
 
 		int n = 0;
 		while (n++ < 300 && connection.getSubscription().getPatterns().size() == 0) {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/channel/SubscribableRedisChannelTests.java
@@ -44,6 +44,8 @@ import static org.mockito.Mockito.mock;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
+ *
  * @since 2.0
  */
 class SubscribableRedisChannelTests implements RedisContainerTest {
@@ -63,8 +65,7 @@ class SubscribableRedisChannelTests implements RedisContainerTest {
 		channel.afterPropertiesSet();
 		channel.start();
 
-		RedisContainerTest.awaitContainerSubscribed(TestUtils.getPropertyValue(channel, "container",
-				RedisMessageListenerContainer.class));
+		RedisContainerTest.awaitContainerSubscribed(TestUtils.getPropertyValue(channel, "container"));
 
 		final CountDownLatch latch = new CountDownLatch(3);
 		MessageHandler handler = message -> latch.countDown();
@@ -84,8 +85,7 @@ class SubscribableRedisChannelTests implements RedisContainerTest {
 		channel.setBeanFactory(mock(BeanFactory.class));
 		channel.afterPropertiesSet();
 
-		RedisMessageListenerContainer container = TestUtils.getPropertyValue(
-				channel, "container", RedisMessageListenerContainer.class);
+		RedisMessageListenerContainer container = TestUtils.getPropertyValue(channel, "container");
 		@SuppressWarnings("unchecked")
 		Map<?, Set<MessageListenerAdapter>> channelMapping = (Map<?, Set<MessageListenerAdapter>>) TestUtils
 				.getPropertyValue(container, "channelMapping");

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisChannelParserTests.java
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -74,27 +75,25 @@ class RedisChannelParserTests implements RedisContainerTest {
 	@Test
 	void testPubSubChannelConfig() {
 		RedisConnectionFactory connectionFactory =
-				TestUtils.getPropertyValue(this.redisChannel, "connectionFactory", RedisConnectionFactory.class);
-		RedisSerializer<?> redisSerializer = TestUtils.getPropertyValue(redisChannel, "serializer",
-				RedisSerializer.class);
+				TestUtils.<RedisConnectionFactory>getPropertyValue(this.redisChannel, "connectionFactory");
+		RedisSerializer<?> redisSerializer = TestUtils.getPropertyValue(redisChannel, "serializer");
 		assertThat(this.context.getBean("redisConnectionFactory")).isEqualTo(connectionFactory);
 		assertThat(this.context.getBean("redisSerializer")).isEqualTo(redisSerializer);
-		assertThat(TestUtils.getPropertyValue(redisChannel, "topicName")).isEqualTo("si.test.topic.parser");
-		assertThat(TestUtils.getPropertyValue(
-						TestUtils.getPropertyValue(this.redisChannel, "dispatcher"), "maxSubscribers", Integer.class)
+		assertThat(TestUtils.<String>getPropertyValue(redisChannel, "topicName")).isEqualTo("si.test.topic.parser");
+		assertThat(TestUtils.<Integer>getPropertyValue(
+						TestUtils.getPropertyValue(this.redisChannel, "dispatcher"), "maxSubscribers")
 				.intValue()).isEqualTo(Integer.MAX_VALUE);
 
-		assertThat(TestUtils.getPropertyValue(this.redisChannelWithSubLimit, "dispatcher.maxSubscribers",
-						Integer.class)
+		assertThat(TestUtils.<Integer>getPropertyValue(this.redisChannelWithSubLimit, "dispatcher.maxSubscribers")
 				.intValue()).isEqualTo(1);
 		Object mbf = this.context.getBean(IntegrationUtils.INTEGRATION_MESSAGE_BUILDER_FACTORY_BEAN_NAME);
-		assertThat(TestUtils.getPropertyValue(this.redisChannelWithSubLimit, "messageBuilderFactory")).isSameAs(mbf);
+		assertThat(TestUtils.<Object>getPropertyValue(this.redisChannelWithSubLimit, "messageBuilderFactory"))
+				.isSameAs(mbf);
 	}
 
 	@Test
 	void testPubSubChannelUsage() throws Exception {
-		RedisContainerTest.awaitContainerSubscribed(TestUtils.getPropertyValue(this.redisChannel, "container",
-				RedisMessageListenerContainer.class));
+		RedisContainerTest.awaitContainerSubscribed(TestUtils.<RedisMessageListenerContainer>getPropertyValue(this.redisChannel, "container"));
 
 		final Message<?> m = new GenericMessage<>("Hello Redis");
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisInboundChannelAdapterParserTests.java
@@ -25,7 +25,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.redis.RedisContainerTest;
 import org.springframework.integration.redis.inbound.RedisInboundChannelAdapter;
@@ -46,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Venil Noronha
  * @author Artem Bilan
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -85,15 +85,14 @@ class RedisInboundChannelAdapterParserTests implements RedisContainerTest {
 
 		Object bean = context.getBean("withoutSerializer.adapter");
 		assertThat(bean).isNotNull();
-		assertThat(TestUtils.getPropertyValue(bean, "serializer")).isNull();
+		assertThat(TestUtils.<RedisInboundChannelAdapter>getPropertyValue(bean, "serializer")).isNull();
 	}
 
 	@Test
 	void testInboundChannelAdapterMessaging() throws Exception {
 		RedisInboundChannelAdapter adapter = context.getBean("adapter", RedisInboundChannelAdapter.class);
 		adapter.start();
-		RedisContainerTest.awaitContainerSubscribedWithPatterns(TestUtils.getPropertyValue(adapter, "container",
-				RedisMessageListenerContainer.class));
+		RedisContainerTest.awaitContainerSubscribedWithPatterns(TestUtils.getPropertyValue(adapter, "container"));
 
 		redisConnectionFactory.getConnection().publish("foo".getBytes(), "Hello Redis from foo".getBytes());
 		redisConnectionFactory.getConnection().publish("bar".getBytes(), "Hello Redis from bar".getBytes());
@@ -110,7 +109,8 @@ class RedisInboundChannelAdapterParserTests implements RedisContainerTest {
 
 	@Test
 	void testAutoChannel() {
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(autoChannelAdapter, "outputChannel"))
+				.isSameAs(autoChannel);
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisOutboundChannelAdapterParserTests.java
@@ -25,7 +25,6 @@ import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.expression.Expression;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
@@ -50,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -101,8 +101,7 @@ class RedisOutboundChannelAdapterParserTests implements RedisContainerTest {
 	@Test
 	void testOutboundChannelAdapterMessaging() throws Exception {
 		MessageChannel sendChannel = context.getBean("sendChannel", MessageChannel.class);
-		RedisContainerTest.awaitContainerSubscribed(TestUtils.getPropertyValue(fooInbound, "container",
-				RedisMessageListenerContainer.class));
+		RedisContainerTest.awaitContainerSubscribed(TestUtils.getPropertyValue(fooInbound, "container"));
 		sendChannel.send(new GenericMessage<>("Hello Redis"));
 		QueueChannel receiveChannel = context.getBean("receiveChannel", QueueChannel.class);
 		Message<?> message = receiveChannel.receive(10000);
@@ -121,8 +120,7 @@ class RedisOutboundChannelAdapterParserTests implements RedisContainerTest {
 		//INT-2275
 	void testOutboundChannelAdapterWithinChain() throws Exception {
 		MessageChannel sendChannel = context.getBean("redisOutboundChain", MessageChannel.class);
-		RedisContainerTest.awaitContainerSubscribed(TestUtils.getPropertyValue(fooInbound, "container",
-				RedisMessageListenerContainer.class));
+		RedisContainerTest.awaitContainerSubscribed(TestUtils.getPropertyValue(fooInbound, "container"));
 		sendChannel.send(new GenericMessage<>("Hello Redis from chain"));
 		QueueChannel receiveChannel = context.getBean("receiveChannel", QueueChannel.class);
 		Message<?> message = receiveChannel.receive(10000);

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueGatewayIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueGatewayIntegrationTests.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author David Liu
  * @author Artem Bilan
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  *
  * @since 4.1
  */
@@ -91,7 +92,7 @@ class RedisQueueGatewayIntegrationTests implements RedisContainerTest {
 
 	@Test
 	void testInboundGatewayStop() {
-		Integer receiveTimeout = TestUtils.getPropertyValue(this.outboundGateway, "receiveTimeout", Integer.class);
+		Integer receiveTimeout = TestUtils.getPropertyValue(this.outboundGateway, "receiveTimeout");
 		this.outboundGateway.setReceiveTimeout(1);
 		this.inboundGateway.stop();
 		try {
@@ -107,7 +108,7 @@ class RedisQueueGatewayIntegrationTests implements RedisContainerTest {
 
 	@Test
 	void testNullSerializer() {
-		Integer receiveTimeout = TestUtils.getPropertyValue(this.outboundGateway, "receiveTimeout", Integer.class);
+		Integer receiveTimeout = TestUtils.getPropertyValue(this.outboundGateway, "receiveTimeout");
 		this.outboundGateway.setReceiveTimeout(1);
 		this.inboundGateway.setSerializer(null);
 		try {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundChannelAdapterParserTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Rainer Frey
  * @author Matthias Jeschke
+ * @author Glenn Renfro
  *
  * @since 3.0
  */
@@ -89,44 +90,50 @@ public class RedisQueueInboundChannelAdapterParserTests {
 	@SuppressWarnings("unchecked")
 	public void testInt3017DefaultConfig() {
 		BoundListOperations<String, byte[]> boundListOperations =
-				TestUtils.getPropertyValue(this.defaultAdapter, "boundListOperations", BoundListOperations.class);
+				TestUtils.getPropertyValue(this.defaultAdapter, "boundListOperations");
 		assertThat(boundListOperations.getKey()).isEqualTo("si.test.Int3017.Inbound1");
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "expectMessage", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "receiveTimeout")).isEqualTo(1000L);
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "recoveryInterval")).isEqualTo(5000L);
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "errorChannel")).isNull();
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "taskExecutor"))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultAdapter, "expectMessage")).isFalse();
+		assertThat(TestUtils.<Long>getPropertyValue(this.defaultAdapter, "receiveTimeout"))
+				.isEqualTo(1000L);
+		assertThat(TestUtils.<Long>getPropertyValue(this.defaultAdapter, "recoveryInterval"))
+				.isEqualTo(5000L);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(this.defaultAdapter, "errorChannel")).isNull();
+		assertThat(TestUtils.<ErrorHandlingTaskExecutor>getPropertyValue(this.defaultAdapter, "taskExecutor"))
 				.isInstanceOf(ErrorHandlingTaskExecutor.class);
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "serializer"))
+		assertThat(TestUtils.<JdkSerializationRedisSerializer>getPropertyValue(this.defaultAdapter, "serializer"))
 				.isInstanceOf(JdkSerializationRedisSerializer.class);
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "autoStartup", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "phase")).isEqualTo(Integer.MAX_VALUE / 2);
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "outputChannel"))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultAdapter, "autoStartup")).isTrue();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.defaultAdapter, "phase")).isEqualTo(Integer.MAX_VALUE / 2);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(this.defaultAdapter, "outputChannel"))
 				.isSameAs(this.defaultAdapterChannel);
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "rightPop", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultAdapter, "rightPop")).isTrue();
 	}
 
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testInt3017CustomConfig() {
 		BoundListOperations<String, byte[]> boundListOperations =
-				TestUtils.getPropertyValue(this.customAdapter, "boundListOperations", BoundListOperations.class);
+				TestUtils.getPropertyValue(this.customAdapter, "boundListOperations");
 		assertThat(boundListOperations.getKey()).isEqualTo("si.test.Int3017.Inbound2");
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "expectMessage", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "receiveTimeout")).isEqualTo(2000L);
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "recoveryInterval")).isEqualTo(3000L);
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "errorChannel")).isSameAs(this.errorChannel);
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "taskExecutor")).isSameAs(this.taskExecutor);
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "serializer")).isSameAs(this.serializer);
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "phase")).isEqualTo(100);
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "outputChannel")).isSameAs(this.sendChannel);
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "rightPop", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customAdapter, "expectMessage")).isTrue();
+		assertThat(TestUtils.<Long>getPropertyValue(this.customAdapter, "receiveTimeout")).isEqualTo(2000L);
+		assertThat(TestUtils.<Long>getPropertyValue(this.customAdapter, "recoveryInterval")).isEqualTo(3000L);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(this.customAdapter, "errorChannel"))
+				.isSameAs(this.errorChannel);
+		assertThat(TestUtils.<TaskExecutor>getPropertyValue(this.customAdapter, "taskExecutor"))
+				.isSameAs(this.taskExecutor);
+		assertThat(TestUtils.<RedisSerializer<?>>getPropertyValue(this.customAdapter, "serializer"))
+				.isSameAs(this.serializer);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customAdapter, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.customAdapter, "phase")).isEqualTo(100);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(this.customAdapter, "outputChannel"))
+				.isSameAs(this.sendChannel);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customAdapter, "rightPop")).isFalse();
 	}
 
 	@Test
 	public void testInt4341ZeroReceiveTimeoutConfig() {
-		assertThat(TestUtils.getPropertyValue(this.zeroReceiveTimeoutAdapter, "receiveTimeout")).isEqualTo(0L);
+		assertThat(TestUtils.<Long>getPropertyValue(this.zeroReceiveTimeoutAdapter, "receiveTimeout")).isEqualTo(0L);
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundGatewayParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueInboundGatewayParserTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author David Liu
  * @author Artem Bilan
  * @author Matthias Jeschke
+ * @author Glenn Renfro
  *
  * since 4.1
  */
@@ -61,20 +62,23 @@ public class RedisQueueInboundGatewayParserTests {
 
 	@Test
 	public void testDefaultConfig() {
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "extractPayload", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "serializer")).isSameAs(this.serializer);
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "serializerExplicitlySet", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultGateway, "extractPayload")).isFalse();
+		assertThat(TestUtils.<RedisSerializer<?>>getPropertyValue(this.defaultGateway, "serializer"))
+				.isSameAs(this.serializer);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultGateway, "serializerExplicitlySet")).isTrue();
 		assertThat(this.defaultGateway.getReplyChannel()).isSameAs(this.receiveChannel);
 		assertThat(this.defaultGateway.getRequestChannel()).isSameAs(this.requestChannel);
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "messagingTemplate.receiveTimeout")).isEqualTo(2000L);
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "taskExecutor")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "phase")).isEqualTo(3);
+		assertThat(TestUtils.<Long>getPropertyValue(this.defaultGateway, "messagingTemplate.receiveTimeout"))
+				.isEqualTo(2000L);
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultGateway, "taskExecutor")).isNotNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultGateway, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.defaultGateway, "phase")).isEqualTo(3);
 	}
 
 	@Test
 	public void testZeroReceiveTimeoutConfig() {
-		assertThat(TestUtils.getPropertyValue(this.zeroReceiveTimeoutGateway, "receiveTimeout")).isEqualTo(0L);
+		assertThat(TestUtils.<Long>getPropertyValue(this.zeroReceiveTimeoutGateway, "receiveTimeout"))
+				.isEqualTo(0L);
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueOutboundChannelAdapterParserTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Rainer Frey
+ * @author Glenn Renfro
  *
  * @since 3.0
  */
@@ -70,12 +71,12 @@ public class RedisQueueOutboundChannelAdapterParserTests {
 
 	@Test
 	public void testInt3017DefaultConfig() throws Exception {
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "template.connectionFactory"))
-				.isSameAs(this.connectionFactory);
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "queueNameExpression", Expression.class)
+		assertThat(TestUtils.<RedisConnectionFactory>getPropertyValue(this.defaultAdapter,
+				"template.connectionFactory")).isSameAs(this.connectionFactory);
+		assertThat(TestUtils.<Expression>getPropertyValue(this.defaultAdapter, "queueNameExpression")
 				.getExpressionString()).isEqualTo("foo");
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "extractPayload", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "serializerExplicitlySet", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultAdapter, "extractPayload")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultAdapter, "serializerExplicitlySet")).isFalse();
 
 		Object handler = TestUtils.getPropertyValue(this.defaultEndpoint, "handler");
 
@@ -84,19 +85,20 @@ public class RedisQueueOutboundChannelAdapterParserTests {
 		assertThat(this.defaultAdapter).isSameAs(((Advised) handler).getTargetSource().getTarget());
 
 		assertThat(((Advised) handler).getAdvisors()[0].getAdvice()).isInstanceOf(RequestHandlerRetryAdvice.class);
-		assertThat(TestUtils.getPropertyValue(this.defaultAdapter, "leftPush", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultAdapter, "leftPush")).isTrue();
 	}
 
 	@Test
 	public void testInt3017CustomConfig() {
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "template.connectionFactory"))
-				.isSameAs(this.customRedisConnectionFactory);
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "queueNameExpression.expression"))
+		assertThat(TestUtils.<RedisConnectionFactory>getPropertyValue(this.customAdapter,
+				"template.connectionFactory")).isSameAs(this.customRedisConnectionFactory);
+		assertThat(TestUtils.<String>getPropertyValue(this.customAdapter, "queueNameExpression.expression"))
 				.isEqualTo("headers['redis_queue']");
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "extractPayload", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "serializerExplicitlySet", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "serializer")).isSameAs(this.serializer);
-		assertThat(TestUtils.getPropertyValue(this.customAdapter, "leftPush", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customAdapter, "extractPayload")).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customAdapter, "serializerExplicitlySet")).isTrue();
+		assertThat(TestUtils.<RedisSerializer<?>>getPropertyValue(this.customAdapter, "serializer"))
+				.isSameAs(this.serializer);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customAdapter, "leftPush")).isFalse();
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueOutboundGatewayParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisQueueOutboundGatewayParserTests.java
@@ -33,7 +33,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author David Liu
  * @author Gary Russell
- * since 4.1
+ * @author Glenn Renfro
+ *
+ * @since 4.1
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -60,16 +62,20 @@ public class RedisQueueOutboundGatewayParserTests {
 
 	@Test
 	public void testDefaultConfig() throws Exception {
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "extractPayload", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "serializer")).isSameAs(this.serializer);
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "serializerExplicitlySet", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "outputChannel")).isSameAs(this.receiveChannel);
-		assertThat(TestUtils.getPropertyValue(this.consumer, "inputChannel")).isSameAs(this.requestChannel);
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "requiresReply", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.defaultGateway, "receiveTimeout")).isEqualTo(2000);
-		assertThat(TestUtils.getPropertyValue(this.consumer, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.consumer, "phase")).isEqualTo(3);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultGateway, "extractPayload")).isFalse();
+		assertThat(TestUtils.<RedisSerializer<?>>getPropertyValue(this.defaultGateway, "serializer"))
+				.isSameAs(this.serializer);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultGateway, "serializerExplicitlySet")).isTrue();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.defaultGateway, "order")).isEqualTo(2);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(this.defaultGateway, "outputChannel"))
+				.isSameAs(this.receiveChannel);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(this.consumer, "inputChannel"))
+				.isSameAs(this.requestChannel);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultGateway, "requiresReply")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.defaultGateway, "receiveTimeout"))
+				.isEqualTo(2000);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.consumer, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.consumer, "phase")).isEqualTo(3);
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisStoreInboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisStoreInboundChannelAdapterParserTests.java
@@ -37,6 +37,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
+ *
  * @since 2.2
  */
 @SpringJUnitConfig
@@ -52,24 +54,25 @@ class RedisStoreInboundChannelAdapterParserTests {
 	@Test
 	void validateWithStringTemplate() {
 		RedisStoreMessageSource withStringTemplate =
-				TestUtils.getPropertyValue(context.getBean("withStringTemplate"), "source", RedisStoreMessageSource.class);
+				TestUtils.<RedisStoreMessageSource>getPropertyValue(context.getBean("withStringTemplate"), "source");
 		assertThat(((SpelExpression) TestUtils.getPropertyValue(withStringTemplate, "keyExpression"))
 				.getExpressionString()).isEqualTo("'presidents'");
-		assertThat(TestUtils.getPropertyValue(withStringTemplate, "collectionType"))
+		assertThat(TestUtils.<Object>getPropertyValue(withStringTemplate, "collectionType"))
 				.hasToString("LIST");
-		assertThat(TestUtils.getPropertyValue(withStringTemplate, "redisTemplate"))
+		assertThat(TestUtils.<Object>getPropertyValue(withStringTemplate, "redisTemplate"))
 				.isInstanceOf(StringRedisTemplate.class);
 	}
 
 	@Test
 	void validateWithExternalTemplate() {
 		RedisStoreMessageSource withExternalTemplate =
-				TestUtils.getPropertyValue(context.getBean("withExternalTemplate"), "source", RedisStoreMessageSource.class);
+				TestUtils.getPropertyValue(context.getBean("withExternalTemplate"), "source");
 		assertThat(((SpelExpression) TestUtils.getPropertyValue(withExternalTemplate, "keyExpression"))
 				.getExpressionString()).isEqualTo("'presidents'");
-		assertThat((TestUtils.getPropertyValue(withExternalTemplate, "collectionType")))
-				.hasToString("LIST");
-		assertThat(TestUtils.getPropertyValue(withExternalTemplate, "redisTemplate")).isSameAs(redisTemplate);
+		assertThat((TestUtils.<Object>getPropertyValue(withExternalTemplate,
+				"collectionType"))).hasToString("LIST");
+		assertThat(TestUtils.<Object>getPropertyValue(withExternalTemplate, "redisTemplate"))
+				.isSameAs(redisTemplate);
 	}
 
 	@Test

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisStoreOutboundChannelAdapterParserTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/config/RedisStoreOutboundChannelAdapterParserTests.java
@@ -41,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -71,15 +72,14 @@ public class RedisStoreOutboundChannelAdapterParserTests {
 
 		assertThat(((Advised) handler).getAdvisors()[0].getAdvice()).isInstanceOf(RequestHandlerRetryAdvice.class);
 
-		assertThat(TestUtils.getPropertyValue(withStringTemplate, "zsetIncrementScoreExpression",
-				Expression.class).getExpressionString()).isEqualTo("true");
+		assertThat(TestUtils.<Expression>getPropertyValue(withStringTemplate, "zsetIncrementScoreExpression")
+				.getExpressionString()).isEqualTo("true");
 	}
 
 	@Test
 	public void validateWithStringObjectTemplate() {
 		RedisStoreWritingMessageHandler withStringObjectTemplate =
-				TestUtils.getPropertyValue(context.getBean("withStringObjectTemplate.adapter"), "handler",
-						RedisStoreWritingMessageHandler.class);
+				TestUtils.<RedisStoreWritingMessageHandler>getPropertyValue(context.getBean("withStringObjectTemplate.adapter"), "handler");
 		assertThat(((LiteralExpression) TestUtils.getPropertyValue(withStringObjectTemplate,
 				"keyExpression")).getExpressionString()).isEqualTo("pepboys");
 		assertThat((TestUtils.getPropertyValue(withStringObjectTemplate, "collectionType")).toString())
@@ -99,13 +99,13 @@ public class RedisStoreOutboundChannelAdapterParserTests {
 	@Test
 	public void validateWithExternalTemplate() {
 		RedisStoreWritingMessageHandler withExternalTemplate =
-				TestUtils.getPropertyValue(context.getBean("withExternalTemplate.adapter"), "handler",
-						RedisStoreWritingMessageHandler.class);
+				TestUtils.getPropertyValue(context.getBean("withExternalTemplate.adapter"), "handler");
 		assertThat(((LiteralExpression) TestUtils.getPropertyValue(withExternalTemplate,
 				"keyExpression")).getExpressionString()).isEqualTo("pepboys");
 		assertThat((TestUtils.getPropertyValue(withExternalTemplate, "collectionType")).toString())
 				.isEqualTo("PROPERTIES");
-		assertThat(TestUtils.getPropertyValue(withExternalTemplate, "redisTemplate")).isSameAs(redisTemplate);
+		assertThat(TestUtils.<Object>getPropertyValue(withExternalTemplate, "redisTemplate"))
+				.isSameAs(redisTemplate);
 	}
 
 }

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisInboundChannelAdapterTests.java
@@ -38,6 +38,7 @@ import static org.mockito.Mockito.mock;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -74,7 +75,7 @@ class RedisInboundChannelAdapterTests implements RedisContainerTest {
 		StringRedisTemplate redisTemplate = new StringRedisTemplate(connectionFactory);
 		redisTemplate.afterPropertiesSet();
 
-		RedisContainerTest.awaitFullySubscribed(TestUtils.getPropertyValue(adapter, "container", RedisMessageListenerContainer.class),
+		RedisContainerTest.awaitFullySubscribed(TestUtils.<RedisMessageListenerContainer>getPropertyValue(adapter, "container"),
 				redisTemplate, redisChannelName, channel, "foo");
 
 		for (int i = 0; i < numToTest; i++) {
@@ -108,7 +109,7 @@ class RedisInboundChannelAdapterTests implements RedisContainerTest {
 		template.setEnableDefaultSerializer(false);
 		template.afterPropertiesSet();
 
-		RedisContainerTest.awaitFullySubscribed(TestUtils.getPropertyValue(adapter, "container", RedisMessageListenerContainer.class),
+		RedisContainerTest.awaitFullySubscribed(TestUtils.<RedisMessageListenerContainer>getPropertyValue(adapter, "container"),
 				template, redisChannelName, channel, "foo".getBytes());
 
 		for (int i = 0; i < numToTest; i++) {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/inbound/RedisQueueMessageDrivenEndpointTests.java
@@ -72,6 +72,7 @@ import static org.mockito.Mockito.verify;
  * @author Gary Russell
  * @author Rainer Frey
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  *
  * @since 3.0
  */
@@ -259,7 +260,7 @@ class RedisQueueMessageDrivenEndpointTests implements RedisContainerTest {
 		RedisQueueMessageDrivenEndpoint endpoint = new RedisQueueMessageDrivenEndpoint(TEST_QUEUE,
 				this.connectionFactory);
 		BoundListOperations<String, byte[]> boundListOperations =
-				TestUtils.getPropertyValue(endpoint, "boundListOperations", BoundListOperations.class);
+				TestUtils.getPropertyValue(endpoint, "boundListOperations");
 		boundListOperations = Mockito.spy(boundListOperations);
 		DirectFieldAccessor dfa = new DirectFieldAccessor(endpoint);
 		dfa.setPropertyValue("boundListOperations", boundListOperations);

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreOutboundChannelAdapterIntegrationTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/outbound/RedisStoreOutboundChannelAdapterIntegrationTests.java
@@ -65,6 +65,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  *
  * @since 2.2
  */
@@ -289,7 +290,8 @@ class RedisStoreOutboundChannelAdapterIntegrationTests implements RedisContainer
 
 		RedisStoreWritingMessageHandler handler =
 				this.beanFactory.getBean("mapToZset.handler", RedisStoreWritingMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "keyExpression.expression")).isEqualTo("'presidents'");
+		assertThat(TestUtils.<String>getPropertyValue(handler, "keyExpression.expression"))
+				.isEqualTo("'presidents'");
 
 		this.mapToZsetChannel.send(message);
 
@@ -331,9 +333,9 @@ class RedisStoreOutboundChannelAdapterIntegrationTests implements RedisContainer
 
 		RedisStoreWritingMessageHandler handler = this.beanFactory.getBean("mapToMapA.handler",
 				RedisStoreWritingMessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "keyExpression", LiteralExpression.class).getExpressionString())
+		assertThat(TestUtils.<LiteralExpression>getPropertyValue(handler, "keyExpression").getExpressionString())
 				.isEqualTo("pepboys");
-		assertThat(TestUtils.getPropertyValue(handler, "mapKeyExpression", SpelExpression.class).getExpressionString())
+		assertThat(TestUtils.<SpelExpression>getPropertyValue(handler, "mapKeyExpression").getExpressionString())
 				.isEqualTo("'foo'");
 	}
 

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
@@ -71,6 +71,7 @@ import static org.mockito.Mockito.mock;
  * @author Anton Gabov
  * @author Eddie Cho
  * @author Youbin Wu
+ * @author Glenn Renfro
  *
  * @since 4.0
  *
@@ -1020,7 +1021,7 @@ class RedisLockRegistryTests implements RedisContainerTest {
 
 	private Long getExpire(RedisLockRegistry registry, String lockKey) {
 		StringRedisTemplate template = createTemplate();
-		String registryKey = TestUtils.getPropertyValue(registry, "registryKey", String.class);
+		String registryKey = TestUtils.getPropertyValue(registry, "registryKey");
 		return template.getExpire(registryKey + ":" + lockKey);
 	}
 
@@ -1033,9 +1034,8 @@ class RedisLockRegistryTests implements RedisContainerTest {
 		assertThat(n < 100).as(key + " key did not expire").isTrue();
 	}
 
-	@SuppressWarnings("unchecked")
 	private static Map<String, Lock> getRedisLockRegistryLocks(RedisLockRegistry registry) {
-		return TestUtils.getPropertyValue(registry, "locks", Map.class);
+		return TestUtils.getPropertyValue(registry, "locks");
 	}
 
 }

--- a/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketInboundGatewayParserTests.java
+++ b/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketInboundGatewayParserTests.java
@@ -30,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.2
  */
@@ -45,16 +46,16 @@ class RSocketInboundGatewayParserTests {
 
 	@Test
 	void testInboundGatewayParser() {
-		assertThat(TestUtils.getPropertyValue(this.inboundGateway, "rsocketConnector"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.inboundGateway, "rsocketConnector"))
 				.isSameAs(this.clientRSocketConnector);
-		assertThat(TestUtils.getPropertyValue(this.inboundGateway, "rsocketStrategies"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.inboundGateway, "rsocketStrategies"))
 				.isSameAs(this.clientRSocketConnector.getRSocketStrategies());
 		assertThat(this.inboundGateway.getPath()).containsExactly("testPath");
-		assertThat(TestUtils.getPropertyValue(this.inboundGateway, "requestElementType.resolved"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.inboundGateway, "requestElementType.resolved"))
 				.isEqualTo(byte[].class);
 		assertThat(this.inboundGateway.getInteractionModels())
 				.containsExactly(RSocketInteractionModel.fireAndForget, RSocketInteractionModel.requestChannel);
-		assertThat(TestUtils.getPropertyValue(this.inboundGateway, "decodeFluxAsUnit", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.inboundGateway, "decodeFluxAsUnit")).isTrue();
 	}
 
 }

--- a/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketOutboundGatewayParserTests.java
+++ b/spring-integration-rsocket/src/test/java/org/springframework/integration/rsocket/config/RSocketOutboundGatewayParserTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.2
  */
@@ -48,18 +49,18 @@ class RSocketOutboundGatewayParserTests {
 
 	@Test
 	void testOutboundGatewayParser() {
-		assertThat(TestUtils.getPropertyValue(this.outboundGateway, "clientRSocketConnector"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.outboundGateway, "clientRSocketConnector"))
 				.isSameAs(this.clientRSocketConnector);
-		assertThat(TestUtils.getPropertyValue(this.outboundGateway, "interactionModelExpression.literalValue"))
+		assertThat(TestUtils.<String>getPropertyValue(this.outboundGateway, "interactionModelExpression.literalValue"))
 				.isEqualTo("fireAndForget");
-		assertThat(TestUtils.getPropertyValue(this.outboundGateway, "routeExpression.expression"))
+		assertThat(TestUtils.<String>getPropertyValue(this.outboundGateway, "routeExpression.expression"))
 				.isEqualTo("'testRoute'");
-		assertThat(TestUtils.getPropertyValue(this.outboundGateway, "publisherElementTypeExpression.literalValue"))
+		assertThat(TestUtils.<String>getPropertyValue(this.outboundGateway, "publisherElementTypeExpression.literalValue"))
 				.isEqualTo("byte[]");
-		assertThat(TestUtils.getPropertyValue(this.outboundGateway, "expectedResponseTypeExpression.literalValue"))
+		assertThat(TestUtils.<String>getPropertyValue(this.outboundGateway, "expectedResponseTypeExpression.literalValue"))
 				.isEqualTo("java.util.Date");
 		Expression metadataExpression =
-				TestUtils.getPropertyValue(this.outboundGateway, "metadataExpression", Expression.class);
+				TestUtils.<Expression>getPropertyValue(this.outboundGateway, "metadataExpression");
 		assertThat(metadataExpression.getValue())
 				.isEqualTo(Collections.singletonMap("metadata", new MimeType("*")));
 	}

--- a/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/jsr223/DeriveLanguageFromExtensionTests.java
+++ b/spring-integration-scripting/src/test/java/org/springframework/integration/scripting/jsr223/DeriveLanguageFromExtensionTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author David Turanski
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  */
 @SpringJUnitConfig
@@ -60,9 +61,9 @@ public class DeriveLanguageFromExtensionTests {
 								(argumentsAccessor.getInvocationIndex() - 1),
 						ScriptExecutingMessageProcessor.class);
 
-		ScriptExecutor executor = TestUtils.getPropertyValue(processor, "scriptExecutor", ScriptExecutor.class);
+		ScriptExecutor executor = TestUtils.getPropertyValue(processor, "scriptExecutor");
 		if (executor instanceof PolyglotScriptExecutor) {
-			assertThat(TestUtils.getPropertyValue(executor, "language")).isEqualTo(language);
+			assertThat(TestUtils.<Object>getPropertyValue(executor, "language")).isEqualTo(language);
 		}
 		else {
 			AbstractScriptExecutor abstractScriptExecutor = (AbstractScriptExecutor) executor;

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/InboundChannelAdapterParserTests.java
@@ -47,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class InboundChannelAdapterParserTests {
 
@@ -73,26 +74,24 @@ public class InboundChannelAdapterParserTests {
 
 		Object adapter = context.getBean("sftpAdapterAutoCreate");
 		assertThat(adapter instanceof SourcePollingChannelAdapter).isTrue();
-		SftpInboundFileSynchronizingMessageSource source =
-				(SftpInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(adapter, "source");
+		SftpInboundFileSynchronizingMessageSource source = TestUtils.getPropertyValue(adapter, "source");
 		assertThat(source).isNotNull();
 
 		PriorityBlockingQueue<?> blockingQueue =
-				TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived", PriorityBlockingQueue.class);
+				TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived");
 		Comparator<?> comparator = blockingQueue.comparator();
 
 		assertThat(comparator).isNotNull();
-		SftpInboundFileSynchronizer synchronizer =
-				TestUtils.getPropertyValue(source, "synchronizer", SftpInboundFileSynchronizer.class);
-		assertThat(TestUtils.getPropertyValue(synchronizer, "remoteDirectoryExpression", Expression.class)
+		SftpInboundFileSynchronizer synchronizer = TestUtils.getPropertyValue(source, "synchronizer");
+		assertThat(TestUtils.<Expression>getPropertyValue(synchronizer, "remoteDirectoryExpression")
 				.getExpressionString()).isEqualTo("'/foo'");
-		assertThat(TestUtils.getPropertyValue(synchronizer, "localFilenameGeneratorExpression")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(synchronizer, "preserveTimestamp", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(synchronizer, "localFilenameGeneratorExpression")).isNotNull();
+		assertThat(TestUtils.<Boolean>getPropertyValue(synchronizer, "preserveTimestamp")).isTrue();
 		String remoteFileSeparator = (String) TestUtils.getPropertyValue(synchronizer, "remoteFileSeparator");
-		assertThat(TestUtils.getPropertyValue(synchronizer, "temporaryFileSuffix", String.class)).isEqualTo(".bar");
-		assertThat(TestUtils.getPropertyValue(synchronizer, "remoteFileMetadataStore"))
+		assertThat(TestUtils.<String>getPropertyValue(synchronizer, "temporaryFileSuffix")).isEqualTo(".bar");
+		assertThat(TestUtils.<Object>getPropertyValue(synchronizer, "remoteFileMetadataStore"))
 				.isSameAs(context.getBean(MetadataStore.class));
-		assertThat(TestUtils.getPropertyValue(synchronizer, "metadataStorePrefix", String.class))
+		assertThat(TestUtils.<String>getPropertyValue(synchronizer, "metadataStorePrefix"))
 				.isEqualTo("testPrefix");
 		assertThat(remoteFileSeparator).isNotNull();
 		assertThat(remoteFileSeparator).isEqualTo(".");
@@ -100,9 +99,8 @@ public class InboundChannelAdapterParserTests {
 		((Lifecycle) adapter).start();
 		assertThat(requestChannel.receive(10000)).isNotNull();
 		FileListFilter<?> acceptAllFilter = context.getBean("acceptAllFilter", FileListFilter.class);
-		@SuppressWarnings("unchecked")
 		Collection<FileListFilter<?>> filters =
-				TestUtils.getPropertyValue(source, "fileSource.scanner.filter.fileFilters", Collection.class);
+				TestUtils.getPropertyValue(source, "fileSource.scanner.filter.fileFilters");
 		assertThat(filters).contains(acceptAllFilter);
 		assertThat(source.getMaxFetchSize()).isEqualTo(42);
 		context.close();
@@ -117,11 +115,13 @@ public class InboundChannelAdapterParserTests {
 		SourcePollingChannelAdapter autoChannelAdapter = context.getBean("autoChannel.adapter",
 				SourcePollingChannelAdapter.class);
 		assertThat(TestUtils
-				.getPropertyValue(autoChannelAdapter, "source.synchronizer.remoteDirectoryExpression",
-						Expression.class)
-				.getExpressionString()).isEqualTo("/foo");
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "source.maxFetchSize")).isEqualTo(Integer.MIN_VALUE);
+				.<Expression>getPropertyValue(autoChannelAdapter,
+						"source.synchronizer.remoteDirectoryExpression").getExpressionString())
+				.isEqualTo("/foo");
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(autoChannelAdapter, "outputChannel"))
+				.isSameAs(autoChannel);
+		assertThat(TestUtils.<Integer>getPropertyValue(autoChannelAdapter, "source.maxFetchSize"))
+				.isEqualTo(Integer.MIN_VALUE);
 		context.close();
 	}
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/OutboundChannelAdapterParserTests.java
@@ -52,6 +52,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author David Turanski
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -66,84 +67,76 @@ public class OutboundChannelAdapterParserTests {
 	public void testOutboundChannelAdapterWithId() {
 		EventDrivenConsumer consumer = this.context.getBean("sftpOutboundAdapter", EventDrivenConsumer.class);
 		PublishSubscribeChannel channel = this.context.getBean("inputChannel", PublishSubscribeChannel.class);
-		assertThat(TestUtils.getPropertyValue(consumer, "inputChannel")).isEqualTo(channel);
+		assertThat(TestUtils.<PublishSubscribeChannel>getPropertyValue(consumer, "inputChannel")).isEqualTo(channel);
 		assertThat(consumer.getComponentName()).isEqualTo("sftpOutboundAdapter");
-		FileTransferringMessageHandler<?> handler = TestUtils.getPropertyValue(consumer, "handler",
-				FileTransferringMessageHandler.class);
-		String remoteFileSeparator =
-				TestUtils.getPropertyValue(handler, "remoteFileTemplate.remoteFileSeparator", String.class);
+		FileTransferringMessageHandler<?> handler = TestUtils.getPropertyValue(consumer, "handler");
+		String remoteFileSeparator = TestUtils.getPropertyValue(handler, "remoteFileTemplate.remoteFileSeparator");
 		assertThat(remoteFileSeparator).isNotNull();
 		assertThat(remoteFileSeparator).isEqualTo(".");
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.temporaryFileSuffix", String.class))
+		assertThat(TestUtils.<String>getPropertyValue(handler, "remoteFileTemplate.temporaryFileSuffix"))
 				.isEqualTo(".bar");
 		Expression remoteDirectoryExpression =
-				TestUtils.getPropertyValue(handler, "remoteFileTemplate.directoryExpressionProcessor.expression",
-						Expression.class);
+				TestUtils.getPropertyValue(handler, "remoteFileTemplate.directoryExpressionProcessor.expression");
 		assertThat(remoteDirectoryExpression)
 				.isNotNull()
 				.isInstanceOf(LiteralExpression.class);
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.temporaryDirectoryExpressionProcessor"))
-				.isNotNull();
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.fileNameGenerator"))
+		assertThat(TestUtils.<Object>getPropertyValue(handler,
+				"remoteFileTemplate.temporaryDirectoryExpressionProcessor")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "remoteFileTemplate.fileNameGenerator"))
 				.isEqualTo(this.context.getBean("fileNameGenerator"));
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.charset")).isEqualTo(StandardCharsets.UTF_8);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "remoteFileTemplate.charset"))
+				.isEqualTo(StandardCharsets.UTF_8);
 		CachingSessionFactory<?> sessionFactory =
-				TestUtils.getPropertyValue(handler, "remoteFileTemplate.sessionFactory", CachingSessionFactory.class);
-		DefaultSftpSessionFactory clientFactory =
-				TestUtils.getPropertyValue(sessionFactory, "sessionFactory", DefaultSftpSessionFactory.class);
-		assertThat(TestUtils.getPropertyValue(clientFactory, "host")).isEqualTo("localhost");
-		assertThat(TestUtils.getPropertyValue(clientFactory, "port")).isEqualTo(2222);
-		assertThat(TestUtils.getPropertyValue(handler, "order")).isEqualTo(23);
+				TestUtils.getPropertyValue(handler, "remoteFileTemplate.sessionFactory");
+		DefaultSftpSessionFactory clientFactory = TestUtils.getPropertyValue(sessionFactory, "sessionFactory");
+		assertThat(TestUtils.<String>getPropertyValue(clientFactory, "host")).isEqualTo("localhost");
+		assertThat(TestUtils.<Integer>getPropertyValue(clientFactory, "port")).isEqualTo(2222);
+		assertThat(TestUtils.<Integer>getPropertyValue(handler, "order")).isEqualTo(23);
 		//verify subscription order
-		@SuppressWarnings("unchecked")
-		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
-				.getPropertyValue(
-						TestUtils.getPropertyValue(channel, "dispatcher"),
-						"handlers");
+		Set<MessageHandler> handlers = TestUtils.getPropertyValue(TestUtils.getPropertyValue(channel, "dispatcher"),
+				"handlers");
 		Iterator<MessageHandler> iterator = handlers.iterator();
 		assertThat(iterator.next())
 				.isSameAs(TestUtils.getPropertyValue(
 						this.context.getBean("sftpOutboundAdapterWithExpression"), "handler"));
 		assertThat(iterator.next()).isSameAs(handler);
-		assertThat(TestUtils.getPropertyValue(handler, "chmod")).isEqualTo(384);
+		assertThat(TestUtils.<Integer>getPropertyValue(handler, "chmod")).isEqualTo(384);
 	}
 
 	@Test
 	public void testOutboundChannelAdapterWithWithRemoteDirectoryAndFileExpression() {
 		EventDrivenConsumer consumer =
 				this.context.getBean("sftpOutboundAdapterWithExpression", EventDrivenConsumer.class);
-		assertThat(TestUtils.getPropertyValue(consumer, "inputChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(consumer, "inputChannel"))
 				.isEqualTo(this.context.getBean("inputChannel"));
 		assertThat(consumer.getComponentName()).isEqualTo("sftpOutboundAdapterWithExpression");
-		FileTransferringMessageHandler<?> handler = TestUtils
-				.getPropertyValue(consumer, "handler", FileTransferringMessageHandler.class);
+		FileTransferringMessageHandler<?> handler = TestUtils.getPropertyValue(consumer, "handler");
 		SpelExpression remoteDirectoryExpression =
-				TestUtils.getPropertyValue(handler, "remoteFileTemplate.directoryExpressionProcessor.expression",
-						SpelExpression.class);
+				TestUtils.getPropertyValue(handler, "remoteFileTemplate.directoryExpressionProcessor.expression");
 		assertThat(remoteDirectoryExpression).isNotNull();
 		assertThat(remoteDirectoryExpression.getExpressionString()).isEqualTo("'foo' + '/' + 'bar'");
 		FileNameGenerator generator =
-				TestUtils.getPropertyValue(handler, "remoteFileTemplate.fileNameGenerator", FileNameGenerator.class);
-		Expression fileNameGeneratorExpression = TestUtils.getPropertyValue(generator, "expression", Expression.class);
+				TestUtils.getPropertyValue(handler, "remoteFileTemplate.fileNameGenerator");
+		Expression fileNameGeneratorExpression = TestUtils.getPropertyValue(generator, "expression");
 		assertThat(fileNameGeneratorExpression).isNotNull();
 		assertThat(fileNameGeneratorExpression.getExpressionString()).isEqualTo("payload.getName() + '-foo'");
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.charset")).isEqualTo(StandardCharsets.UTF_8);
-		assertThat(TestUtils.getPropertyValue(handler, "remoteFileTemplate.temporaryDirectoryExpressionProcessor"))
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "remoteFileTemplate.charset"))
+				.isEqualTo(StandardCharsets.UTF_8);
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "remoteFileTemplate.temporaryDirectoryExpressionProcessor"))
 				.isNull();
 	}
 
 	@Test
 	public void testOutboundChannelAdapterWithNoTemporaryFileName() {
 		Object consumer = this.context.getBean("sftpOutboundAdapterWithNoTemporaryFileName");
-		FileTransferringMessageHandler<?> handler = TestUtils
-				.getPropertyValue(consumer, "handler", FileTransferringMessageHandler.class);
+		FileTransferringMessageHandler<?> handler = TestUtils.getPropertyValue(consumer, "handler");
 		assertThat((Boolean) TestUtils.getPropertyValue(handler, "remoteFileTemplate.useTemporaryFileName")).isFalse();
 	}
 
 	@Test
 	public void advised() {
 		Object consumer = this.context.getBean("advised");
-		MessageHandler handler = TestUtils.getPropertyValue(consumer, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(consumer, "handler");
 		handler.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpOutboundGatewayParserTests.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.1
  *
@@ -85,91 +86,100 @@ public class SftpOutboundGatewayParserTests {
 
 	@Test
 	public void testGateway1() {
-		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway1, "handler", SftpOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator")).isEqualTo("X");
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
+		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway1, "handler");
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator"))
+				.isEqualTo("X");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
 				.isEqualTo("local-test-dir");
 		assertThat((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory")).isFalse();
-		assertThat(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(gateway, "filter")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.LS);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "requiresReply")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "filter")).isNotNull();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.LS);
 		@SuppressWarnings("unchecked")
-		Set<Option> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
+		Set<Option> options = TestUtils.getPropertyValue(gateway, "options");
 		assertThat(options.contains(Option.NAME_ONLY)).isTrue();
 		assertThat(options.contains(Option.NOSORT)).isTrue();
 
-		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
+		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout");
 		assertThat(sendTimeout).isEqualTo(Long.valueOf(777));
-		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter")).isInstanceOf(RegexPatternFileListFilter.class);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mputFilter"))
+				.isInstanceOf(RegexPatternFileListFilter.class);
 	}
 
 	@Test
 	public void testGateway2() throws Exception {
-		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway2, "handler", SftpOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator")).isEqualTo("X");
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"))
+		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway2, "handler");
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator"))
+				.isEqualTo("X");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"))
 				.isInstanceOf(CachingSessionFactory.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
 				.isEqualTo("local-test-dir");
 		assertThat((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory")).isFalse();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.GET);
-		assertThat(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.GET);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "requiresReply")).isFalse();
 		@SuppressWarnings("unchecked")
-		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
+		Set<String> options = TestUtils.getPropertyValue(gateway, "options");
 		assertThat(options.contains(Option.PRESERVE_TIMESTAMP)).isTrue();
 
-		assertThat(TestUtils.getPropertyValue(gateway, "localFilenameGeneratorExpression")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "localFilenameGeneratorExpression")).isNotNull();
 		final AtomicReference<Method> genMethod = new AtomicReference<>();
 		ReflectionUtils.doWithMethods(SftpOutboundGateway.class, method -> {
 			method.setAccessible(true);
 			genMethod.set(method);
 		}, method -> "generateLocalFileName".equals(method.getName()));
 		assertThat(genMethod.get().invoke(gateway, new GenericMessage<>(""), "foo")).isEqualTo("FOO.afoo");
-		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter")).isInstanceOf(SimplePatternFileListFilter.class);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mputFilter"))
+				.isInstanceOf(SimplePatternFileListFilter.class);
 	}
 
 	@Test
 	public void testGatewayMv() {
-		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway3, "handler", SftpOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.MV);
-		assertThat(TestUtils.getPropertyValue(gateway, "renameProcessor.expression.expression")).isEqualTo("'foo'");
+		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway3, "handler");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.MV);
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "renameProcessor.expression.expression"))
+				.isEqualTo("'foo'");
 	}
 
 	@Test
 	public void testGatewayMPut() {
-		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway4, "handler", SftpOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.MPUT);
-		assertThat(TestUtils.getPropertyValue(gateway, "renameProcessor.expression.expression")).isEqualTo("'foo'");
-		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter")).isInstanceOf(RegexPatternFileListFilter.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.fileNameGenerator")).isSameAs(generator);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.directoryExpressionProcessor.expression",
-				Expression.class).getExpressionString())
+		SftpOutboundGateway gateway = TestUtils.getPropertyValue(gateway4, "handler");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.MPUT);
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "renameProcessor.expression.expression"))
+				.isEqualTo("'foo'");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mputFilter"))
+				.isInstanceOf(RegexPatternFileListFilter.class);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.fileNameGenerator"))
+				.isSameAs(generator);
+		assertThat(TestUtils.<Expression>getPropertyValue(
+				gateway, "remoteFileTemplate.directoryExpressionProcessor.expression").getExpressionString())
 				.isEqualTo("/foo");
-		assertThat(TestUtils.getPropertyValue(gateway,
-						"remoteFileTemplate.temporaryDirectoryExpressionProcessor.expression", Expression.class)
+		assertThat(TestUtils.<Expression>getPropertyValue(
+						gateway, "remoteFileTemplate.temporaryDirectoryExpressionProcessor.expression")
 				.getExpressionString()).isEqualTo("/bar");
 	}
 
 	@Test
 	public void advised() {
-		SftpOutboundGateway gateway = TestUtils.getPropertyValue(advised, "handler", SftpOutboundGateway.class);
+		SftpOutboundGateway gateway = TestUtils.getPropertyValue(advised, "handler");
 		gateway.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}
 
 	@Test
 	void noExpression() {
-		assertThat(TestUtils.getPropertyValue(this.noExpressionLS, "handler.fileNameProcessor")).isNull();
-		assertThat(TestUtils.getPropertyValue(this.noExpressionPUT, "handler.fileNameProcessor")).isNull();
-		assertThat(TestUtils.getPropertyValue(this.noExpressionGET, "handler.fileNameProcessor.expression.expression"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.noExpressionLS, "handler.fileNameProcessor")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(this.noExpressionPUT, "handler.fileNameProcessor")).isNull();
+		assertThat(TestUtils.<String>getPropertyValue(
+				this.noExpressionGET, "handler.fileNameProcessor.expression.expression"))
 				.isEqualTo("payload");
 	}
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpStreamingInboundChannelAdapterParserTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/config/SftpStreamingInboundChannelAdapterParserTests.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -64,31 +65,29 @@ public class SftpStreamingInboundChannelAdapterParserTests {
 
 	@Test
 	public void testFtpInboundChannelAdapterComplete() throws Exception {
-		assertThat(TestUtils.getPropertyValue(this.sftpInbound, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.sftpInbound, "autoStartup")).isFalse();
 		assertThat(this.sftpInbound.getComponentName()).isEqualTo("sftpInbound");
 		assertThat(this.sftpInbound.getComponentType()).isEqualTo("sftp:inbound-streaming-channel-adapter");
-		assertThat(TestUtils.getPropertyValue(this.sftpInbound, "outputChannel")).isSameAs(this.sftpChannel);
-		SftpStreamingMessageSource source = TestUtils.getPropertyValue(sftpInbound, "source",
-				SftpStreamingMessageSource.class);
+		assertThat(TestUtils.<Object>getPropertyValue(this.sftpInbound, "outputChannel")).isSameAs(this.sftpChannel);
+		SftpStreamingMessageSource source = TestUtils.getPropertyValue(sftpInbound, "source");
 
-		assertThat(TestUtils.getPropertyValue(source, "comparator")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(source, "remoteFileSeparator", String.class)).isEqualTo("X");
+		assertThat(TestUtils.<Object>getPropertyValue(source, "comparator")).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(source, "remoteFileSeparator")).isEqualTo("X");
 
-		FileListFilter<?> filter = TestUtils.getPropertyValue(source, "filter", FileListFilter.class);
+		FileListFilter<?> filter = TestUtils.getPropertyValue(source, "filter");
 		assertThat(filter).isNotNull();
 		assertThat(filter).isInstanceOf(CompositeFileListFilter.class);
-		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters", Set.class);
+		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters");
 
 		Iterator<?> filtersIterator = fileFilters.iterator();
 		assertThat(filtersIterator.next()).isInstanceOf(SftpSimplePatternFileListFilter.class);
 		assertThat(filtersIterator.next()).isInstanceOf(SftpPersistentAcceptOnceFileListFilter.class);
 
-		assertThat(TestUtils.getPropertyValue(source, "remoteFileTemplate.sessionFactory")).isSameAs(this.csf);
-		assertThat(TestUtils.getPropertyValue(source, "maxFetchSize")).isEqualTo(31);
+		assertThat(TestUtils.<Object>getPropertyValue(source, "remoteFileTemplate.sessionFactory")).isSameAs(this.csf);
+		assertThat(TestUtils.<Integer>getPropertyValue(source, "maxFetchSize")).isEqualTo(31);
 
-		source = TestUtils.getPropertyValue(this.contextLoadsWithNoComparator, "source",
-				SftpStreamingMessageSource.class);
-		assertThat(TestUtils.getPropertyValue(source, "filter")).isInstanceOf(ExpressionFileListFilter.class);
+		source = TestUtils.getPropertyValue(this.contextLoadsWithNoComparator, "source");
+		assertThat(TestUtils.<Object>getPropertyValue(source, "filter")).isInstanceOf(ExpressionFileListFilter.class);
 	}
 
 	public static class TestSessionFactoryBean implements FactoryBean<DefaultSftpSessionFactory> {

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/inbound/SftpInboundRemoteFileSystemSynchronizerTests.java
@@ -23,9 +23,9 @@ import java.nio.file.attribute.FileTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.sshd.sftp.client.SftpClient;
 import org.junit.jupiter.api.AfterEach;
@@ -62,6 +62,7 @@ import static org.mockito.Mockito.when;
  * @author Artem Bilan
  * @author Joaquin Santana
  * @author Darryl Smith
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -130,7 +131,7 @@ public class SftpInboundRemoteFileSystemSynchronizerTests implements TestApplica
 
 		@SuppressWarnings("unchecked")
 		Map<String, String> remoteFileMetadataStore =
-				TestUtils.getPropertyValue(synchronizer, "remoteFileMetadataStore.metadata", Map.class);
+				TestUtils.getPropertyValue(synchronizer, "remoteFileMetadataStore.metadata");
 
 		String next = remoteFileMetadataStore.values().iterator().next();
 		assertThat(URI.create(next).getHost()).isEqualTo("mock.sftp.host");
@@ -150,7 +151,7 @@ public class SftpInboundRemoteFileSystemSynchronizerTests implements TestApplica
 		assertThat(new File("test/a.test").exists()).isTrue();
 		assertThat(new File("test/b.test").exists()).isTrue();
 
-		TestUtils.getPropertyValue(localAcceptOnceFilter, "seenSet", Collection.class).clear();
+		TestUtils.<Set<?>>getPropertyValue(localAcceptOnceFilter, "seenSet").clear();
 
 		new File("test/a.test").delete();
 		new File("test/b.test").delete();

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpOutboundTests.java
@@ -77,6 +77,7 @@ import static org.mockito.Mockito.when;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Darryl Smith
+ * @author Glenn Renfro
  */
 public class SftpOutboundTests implements TestApplicationContextAware {
 
@@ -253,11 +254,11 @@ public class SftpOutboundTests implements TestApplicationContextAware {
 			Session<SftpClient.DirEntry> s1 = f.getSession();
 			Session<SftpClient.DirEntry> s2 = f.getSession();
 			if (sharedSession) {
-				assertThat(TestUtils.getPropertyValue(s2, "sftpClient"))
+				assertThat(TestUtils.<Object>getPropertyValue(s2, "sftpClient"))
 						.isSameAs(TestUtils.getPropertyValue(s1, "sftpClient"));
 			}
 			else {
-				assertThat(TestUtils.getPropertyValue(s2, "sftpClient"))
+				assertThat(TestUtils.<Object>getPropertyValue(s2, "sftpClient"))
 						.isNotSameAs(TestUtils.getPropertyValue(s1, "sftpClient"));
 			}
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
@@ -86,6 +86,7 @@ import static org.mockito.Mockito.verify;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Darryl Smith
+ * @author Glenn Renfro
  *
  * @since 3.0
  */
@@ -476,8 +477,8 @@ public class SftpServerOutboundTests extends SftpTestSupport {
 		this.config.latch = new CountDownLatch(1);
 		Session<?> session = sessionFactory.getSession();
 		session.close();
-		session = TestUtils.getPropertyValue(session, "targetSession", Session.class);
-		SftpClient sftpClient = spy(TestUtils.getPropertyValue(session, "sftpClient", SftpClient.class));
+		session = TestUtils.getPropertyValue(session, "targetSession");
+		SftpClient sftpClient = spy(TestUtils.<SftpClient>getPropertyValue(session, "sftpClient"));
 		doNothing().when(sftpClient).setStat(anyString(), any(SftpClient.Attributes.class));
 		new DirectFieldAccessor(session).setPropertyValue("sftpClient", sftpClient);
 

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
@@ -54,6 +54,8 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Darryl Smith
+ * @author Glenn Renfro
+ *
  * @since 4.1
  */
 @SpringJUnitConfig
@@ -179,7 +181,7 @@ public class SftpRemoteFileTemplateTests extends SftpTestSupport implements Test
 				.withStackTraceContaining("(SSH_FX_NO_SUCH_FILE): No such file or directory");
 
 		Session<SftpClient.DirEntry> newSession = this.sessionFactory.getSession();
-		assertThat(TestUtils.getPropertyValue(newSession, "targetSession"))
+		assertThat(TestUtils.<Object>getPropertyValue(newSession, "targetSession"))
 				.isSameAs(TestUtils.getPropertyValue(session, "targetSession"));
 
 		newSession.close();

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbInboundChannelAdapterParserTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbInboundChannelAdapterParserTests.java
@@ -16,8 +16,8 @@
 
 package org.springframework.integration.smb.config;
 
-import java.util.Collection;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.PriorityBlockingQueue;
@@ -50,6 +50,7 @@ import static org.mockito.Mockito.when;
  * @author Artem Bilan
  * @author Prafull Kumar Soni
  * @author Gregory Bragg
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -59,31 +60,27 @@ public class SmbInboundChannelAdapterParserTests {
 	ApplicationContext applicationContext;
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testSmbInboundChannelAdapterComplete() {
 
 		final SourcePollingChannelAdapter adapter =
 				this.applicationContext.getBean("smbInbound", SourcePollingChannelAdapter.class);
-		final PriorityBlockingQueue<?> queue =
-				TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived", PriorityBlockingQueue.class);
+		final PriorityBlockingQueue<?> queue = TestUtils.getPropertyValue(adapter, "source.fileSource.toBeReceived");
 		assertThat(queue.comparator()).isNotNull();
 		assertThat("smbInbound").isEqualTo(adapter.getComponentName());
 		assertThat("smb:inbound-channel-adapter").isEqualTo(adapter.getComponentType());
 		assertThat(applicationContext.getBean("smbChannel"))
 				.isEqualTo(TestUtils.getPropertyValue(adapter, "outputChannel"));
-		SmbInboundFileSynchronizingMessageSource inbound =
-				(SmbInboundFileSynchronizingMessageSource) TestUtils.getPropertyValue(adapter, "source");
+		SmbInboundFileSynchronizingMessageSource inbound = TestUtils.getPropertyValue(adapter, "source");
 
-		SmbInboundFileSynchronizer fisync =
-				(SmbInboundFileSynchronizer) TestUtils.getPropertyValue(inbound, "synchronizer");
-		assertThat(".working.tmp").isEqualTo(TestUtils.getPropertyValue(fisync, "temporaryFileSuffix", String.class));
-		String remoteFileSeparator = (String) TestUtils.getPropertyValue(fisync, "remoteFileSeparator");
+		SmbInboundFileSynchronizer fisync = TestUtils.getPropertyValue(inbound, "synchronizer");
+		assertThat(".working.tmp").isEqualTo(TestUtils.getPropertyValue(fisync, "temporaryFileSuffix"));
+		String remoteFileSeparator = TestUtils.getPropertyValue(fisync, "remoteFileSeparator");
 		assertThat(remoteFileSeparator).isNotNull();
 		assertThat(remoteFileSeparator).isEqualTo("");
-		FileListFilter<?> filter = TestUtils.getPropertyValue(fisync, "filter", FileListFilter.class);
+		FileListFilter<?> filter = TestUtils.getPropertyValue(fisync, "filter");
 		assertThat(filter).isNotNull();
 		assertThat(filter).isInstanceOf(CompositeFileListFilter.class);
-		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters", Set.class);
+		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters");
 
 		Iterator<?> filtersIterator = fileFilters.iterator();
 		assertThat(filtersIterator.next()).isInstanceOf(SmbSimplePatternFileListFilter.class);
@@ -93,8 +90,8 @@ public class SmbInboundChannelAdapterParserTests {
 
 		FileListFilter<?> acceptAllFilter = this.applicationContext.getBean("acceptAllFilter", FileListFilter.class);
 
-		assertThat(TestUtils.getPropertyValue(inbound, "fileSource.scanner.filter.fileFilters", Collection.class))
-				.contains(acceptAllFilter);
+		assertThat(TestUtils.<LinkedHashSet<FileListFilter<?>>>getPropertyValue(inbound,
+				"fileSource.scanner.filter.fileFilters")).contains(acceptAllFilter);
 	}
 
 	@Test
@@ -104,9 +101,8 @@ public class SmbInboundChannelAdapterParserTests {
 		Object sessionFactory =
 				TestUtils.getPropertyValue(adapter, "source.synchronizer.remoteFileTemplate.sessionFactory");
 		assertThat(sessionFactory).isInstanceOf(SmbSessionFactory.class);
-		SmbInboundFileSynchronizer fisync =
-				TestUtils.getPropertyValue(adapter, "source.synchronizer", SmbInboundFileSynchronizer.class);
-		String remoteFileSeparator = (String) TestUtils.getPropertyValue(fisync, "remoteFileSeparator");
+		SmbInboundFileSynchronizer fisync = TestUtils.getPropertyValue(adapter, "source.synchronizer");
+		String remoteFileSeparator = TestUtils.getPropertyValue(fisync, "remoteFileSeparator");
 		assertThat(remoteFileSeparator).isNotNull();
 		assertThat(remoteFileSeparator).isEqualTo("/");
 	}

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbOutboundChannelAdapterParserTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbOutboundChannelAdapterParserTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  * @author Prafull Kumar Soni
  * @author Gregory Bragg
+ * @author Glenn Renfro
  */
 public class SmbOutboundChannelAdapterParserTests extends AbstractBaseTests {
 
@@ -54,7 +55,7 @@ public class SmbOutboundChannelAdapterParserTests extends AbstractBaseTests {
 
 			Object messageHandler = TestUtils.getPropertyValue(consumer, "handler");
 			String remoteFileSeparator =
-					TestUtils.getPropertyValue(messageHandler, "remoteFileTemplate.remoteFileSeparator", String.class);
+					TestUtils.<String>getPropertyValue(messageHandler, "remoteFileTemplate.remoteFileSeparator");
 			assertThat(remoteFileSeparator).isNotNull();
 			assertThat(".working.tmp")
 					.isEqualTo(TestUtils.getPropertyValue(messageHandler, "remoteFileTemplate.temporaryFileSuffix"));
@@ -62,7 +63,7 @@ public class SmbOutboundChannelAdapterParserTests extends AbstractBaseTests {
 			assertThat(ac.getBean("fileNameGenerator"))
 					.isEqualTo(TestUtils.getPropertyValue(messageHandler, "remoteFileTemplate.fileNameGenerator"));
 			assertThat(StandardCharsets.UTF_8)
-					.isEqualTo(TestUtils.getPropertyValue(messageHandler, "remoteFileTemplate.charset", Charset.class));
+					.isEqualTo(TestUtils.<Charset>getPropertyValue(messageHandler, "remoteFileTemplate.charset"));
 
 			Object sessionFactoryProp = TestUtils.getPropertyValue(messageHandler, "remoteFileTemplate.sessionFactory");
 			assertThat(SmbSessionFactory.class).isEqualTo(sessionFactoryProp.getClass());
@@ -74,10 +75,10 @@ public class SmbOutboundChannelAdapterParserTests extends AbstractBaseTests {
 
 			// verify subscription order
 			@SuppressWarnings("unchecked")
-			Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils.getPropertyValue(
-					TestUtils.getPropertyValue(channel, "dispatcher"), "handlers");
+			Set<MessageHandler> handlers =
+					TestUtils.getPropertyValue(TestUtils.getPropertyValue(channel, "dispatcher"), "handlers");
 			Iterator<MessageHandler> iterator = handlers.iterator();
-			assertThat(TestUtils.getPropertyValue(ac.getBean("smbOutboundChannelAdapter2"), "handler"))
+			assertThat(TestUtils.<Object>getPropertyValue(ac.getBean("smbOutboundChannelAdapter2"), "handler"))
 					.isSameAs(iterator.next());
 			assertThat(messageHandler).isSameAs(iterator.next());
 		}

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbOutboundGatewayParserTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbOutboundGatewayParserTests.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Gregory Bragg
+ * @author Glenn Renfro
  *
  * @since 6.0
  */
@@ -88,97 +89,101 @@ public class SmbOutboundGatewayParserTests {
 
 	@Test
 	public void testGateway1() {
-		SmbOutboundGateway gateway = TestUtils.getPropertyValue(gateway1,
-				"handler", SmbOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator")).isEqualTo("X");
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
+		SmbOutboundGateway gateway = TestUtils.getPropertyValue(gateway1, "handler");
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator"))
+				.isEqualTo("X");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
 				.isEqualTo("local-test-dir");
 		assertThat((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory")).isFalse();
-		assertThat(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(gateway, "filter")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.LS);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "requiresReply")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "filter")).isNotNull();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.LS);
 		@SuppressWarnings("unchecked")
-		Set<Option> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
+		Set<Option> options = TestUtils.getPropertyValue(gateway, "options");
 		assertThat(options.contains(Option.NAME_ONLY)).isTrue();
 		assertThat(options.contains(Option.NOSORT)).isTrue();
 
-		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
+		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout");
 		assertThat(sendTimeout).isEqualTo(Long.valueOf(777));
-		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter")).isInstanceOf(RegexPatternFileListFilter.class);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mputFilter"))
+				.isInstanceOf(RegexPatternFileListFilter.class);
 	}
 
 	@Test
 	public void testGateway2() throws Exception {
-		SmbOutboundGateway gateway = TestUtils.getPropertyValue(gateway2,
-				"handler", SmbOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator")).isEqualTo("X");
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		SmbOutboundGateway gateway = TestUtils.getPropertyValue(gateway2, "handler");
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "remoteFileTemplate.remoteFileSeparator")).isEqualTo("X");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"))
+				.isNotNull();
 		assertThat(TestUtils
 				.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory") instanceof CachingSessionFactory)
 				.isTrue();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "localDirectoryExpression.literalValue"))
 				.isEqualTo("local-test-dir");
 		assertThat((Boolean) TestUtils.getPropertyValue(gateway, "autoCreateLocalDirectory")).isFalse();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.GET);
-		assertThat(TestUtils.getPropertyValue(gateway, "requiresReply", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.GET);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "requiresReply")).isFalse();
 		@SuppressWarnings("unchecked")
-		Set<String> options = TestUtils.getPropertyValue(gateway, "options", Set.class);
+		Set<String> options = TestUtils.getPropertyValue(gateway, "options");
 		assertThat(options.contains(Option.PRESERVE_TIMESTAMP)).isTrue();
 
 		//INT-3129
-		assertThat(TestUtils.getPropertyValue(gateway, "localFilenameGeneratorExpression")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "localFilenameGeneratorExpression")).isNotNull();
 		final AtomicReference<Method> genMethod = new AtomicReference<>();
 		ReflectionUtils.doWithMethods(SmbOutboundGateway.class, method -> {
 			method.setAccessible(true);
 			genMethod.set(method);
 		}, method -> "generateLocalFileName".equals(method.getName()));
 		assertThat(genMethod.get().invoke(gateway, new GenericMessage<String>(""), "foo")).isEqualTo("FOO.afoo");
-		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter")).isInstanceOf(SimplePatternFileListFilter.class);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "mputFilter"))
+				.isInstanceOf(SimplePatternFileListFilter.class);
 	}
 
 	@Test
 	public void testGatewayMv() {
-		SmbOutboundGateway gateway = TestUtils.getPropertyValue(gateway3, "handler", SmbOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.MV);
-		assertThat(TestUtils.getPropertyValue(gateway, "renameProcessor.expression.expression")).isEqualTo("'foo'");
+		SmbOutboundGateway gateway = TestUtils.getPropertyValue(gateway3, "handler");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory"))
+				.isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.MV);
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "renameProcessor.expression.expression"))
+				.isEqualTo("'foo'");
 	}
 
 	@Test
 	public void testGatewayMPut() {
-		SmbOutboundGateway gateway = TestUtils.getPropertyValue(gateway4, "handler", SmbOutboundGateway.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "outputChannel")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(gateway, "command")).isEqualTo(Command.MPUT);
-		assertThat(TestUtils.getPropertyValue(gateway, "renameProcessor.expression.expression")).isEqualTo("'foo'");
-		assertThat(TestUtils.getPropertyValue(gateway, "mputFilter")).isInstanceOf(RegexPatternFileListFilter.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "remoteFileTemplate.fileNameGenerator")).isSameAs(generator);
+		SmbOutboundGateway gateway = TestUtils.getPropertyValue(gateway4, "handler");
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "remoteFileTemplate.sessionFactory")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "outputChannel")).isNotNull();
+		assertThat(TestUtils.<Command>getPropertyValue(gateway, "command")).isEqualTo(Command.MPUT);
+		assertThat(TestUtils.<String>getPropertyValue(gateway, "renameProcessor.expression.expression")).isEqualTo("'foo'");
+		assertThat(TestUtils.<RegexPatternFileListFilter>getPropertyValue(gateway, "mputFilter")).isInstanceOf(RegexPatternFileListFilter.class);
+		assertThat(TestUtils.<FileNameGenerator>getPropertyValue(gateway, "remoteFileTemplate.fileNameGenerator")).isSameAs(generator);
 		assertThat(TestUtils
-				.getPropertyValue(gateway, "remoteFileTemplate.directoryExpressionProcessor.expression",
-						Expression.class)
+				.<Expression>getPropertyValue(gateway,
+						"remoteFileTemplate.directoryExpressionProcessor.expression")
 				.getExpressionString()).isEqualTo("/foo");
 		assertThat(TestUtils
-				.getPropertyValue(gateway, "remoteFileTemplate.temporaryDirectoryExpressionProcessor.expression",
-						Expression.class)
+				.<Expression>getPropertyValue(gateway,
+						"remoteFileTemplate.temporaryDirectoryExpressionProcessor.expression")
 				.getExpressionString()).isEqualTo("/bar");
 	}
 
 	@Test
 	public void advised() {
-		SmbOutboundGateway gateway = TestUtils.getPropertyValue(advised, "handler", SmbOutboundGateway.class);
+		SmbOutboundGateway gateway = TestUtils.getPropertyValue(advised, "handler");
 		gateway.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}
 
 	@Test
 	void noExpression() {
-		assertThat(TestUtils.getPropertyValue(this.noExpressionLS, "handler.fileNameProcessor")).isNull();
-		assertThat(TestUtils.getPropertyValue(this.noExpressionPUT, "handler.fileNameProcessor")).isNull();
-		assertThat(TestUtils.getPropertyValue(this.noExpressionGET,
+		assertThat(TestUtils.<Object>getPropertyValue(this.noExpressionLS, "handler.fileNameProcessor")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(this.noExpressionPUT, "handler.fileNameProcessor")).isNull();
+		assertThat(TestUtils.<String>getPropertyValue(this.noExpressionGET,
 				"handler.fileNameProcessor.expression.expression")).isEqualTo("payload");
 	}
 

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbStreamingInboundChannelAdapterParserTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/config/SmbStreamingInboundChannelAdapterParserTests.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Gregory Bragg
+ * @author Glenn Renfro
  *
  * @since 6.0
  */
@@ -70,31 +71,29 @@ public class SmbStreamingInboundChannelAdapterParserTests {
 
 	@Test
 	public void testSmbInboundChannelAdapterComplete() {
-		assertThat(TestUtils.getPropertyValue(this.smbInbound, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.smbInbound, "autoStartup")).isFalse();
 		assertThat(this.smbInbound.getComponentName()).isEqualTo("smbInbound");
 		assertThat(this.smbInbound.getComponentType()).isEqualTo("smb:inbound-streaming-channel-adapter");
-		assertThat(TestUtils.getPropertyValue(this.smbInbound, "outputChannel")).isSameAs(this.smbChannel);
-		SmbStreamingMessageSource source = TestUtils.getPropertyValue(smbInbound, "source",
-				SmbStreamingMessageSource.class);
+		assertThat(TestUtils.<Object>getPropertyValue(this.smbInbound, "outputChannel")).isSameAs(this.smbChannel);
+		SmbStreamingMessageSource source = TestUtils.getPropertyValue(smbInbound, "source");
 
-		assertThat(TestUtils.getPropertyValue(source, "comparator")).isNotNull();
-		assertThat(TestUtils.getPropertyValue(source, "remoteFileSeparator", String.class)).isEqualTo("X");
+		assertThat(TestUtils.<Object>getPropertyValue(source, "comparator")).isNotNull();
+		assertThat(TestUtils.<String>getPropertyValue(source, "remoteFileSeparator")).isEqualTo("X");
 
-		FileListFilter<?> filter = TestUtils.getPropertyValue(source, "filter", FileListFilter.class);
+		FileListFilter<?> filter = TestUtils.getPropertyValue(source, "filter");
 		assertThat(filter).isNotNull();
 		assertThat(filter).isInstanceOf(CompositeFileListFilter.class);
-		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters", Set.class);
+		Set<?> fileFilters = TestUtils.getPropertyValue(filter, "fileFilters");
 
 		Iterator<?> filtersIterator = fileFilters.iterator();
 		assertThat(filtersIterator.next()).isInstanceOf(SmbSimplePatternFileListFilter.class);
 		assertThat(filtersIterator.next()).isInstanceOf(SmbPersistentAcceptOnceFileListFilter.class);
 
-		assertThat(TestUtils.getPropertyValue(source, "remoteFileTemplate.sessionFactory")).isSameAs(this.csf);
-		assertThat(TestUtils.getPropertyValue(source, "maxFetchSize")).isEqualTo(31);
+		assertThat(TestUtils.<Object>getPropertyValue(source, "remoteFileTemplate.sessionFactory")).isSameAs(this.csf);
+		assertThat(TestUtils.<Integer>getPropertyValue(source, "maxFetchSize")).isEqualTo(31);
 
-		source = TestUtils.getPropertyValue(this.contextLoadsWithNoComparator, "source",
-				SmbStreamingMessageSource.class);
-		assertThat(TestUtils.getPropertyValue(source, "filter")).isInstanceOf(ExpressionFileListFilter.class);
+		source = TestUtils.getPropertyValue(this.contextLoadsWithNoComparator, "source");
+		assertThat(TestUtils.<Object>getPropertyValue(source, "filter")).isInstanceOf(ExpressionFileListFilter.class);
 	}
 
 	public static class TestSessionFactoryBean implements FactoryBean<SmbSessionFactory> {

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/dsl/SmbTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/dsl/SmbTests.java
@@ -73,6 +73,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Vozhdayenko
  * @author Artem Bilan
  * @author Daniel Frey
+ * @author Glenn Renfro
  *
  * @since 6.0
  */
@@ -103,12 +104,11 @@ public class SmbTests extends SmbTestSupport {
 				.channel(out)
 				.get();
 		IntegrationFlowRegistration registration = this.flowContext.registration(flow).register();
-		Map<?, ?> components =
-				TestUtils.getPropertyValue(registration, "integrationFlow.integrationComponents", Map.class);
+		Map<?, ?> components = TestUtils.getPropertyValue(registration, "integrationFlow.integrationComponents");
 		Iterator<?> iterator = components.keySet().iterator();
 		iterator.next();
 		Object spcafb = iterator.next();
-		assertThat(TestUtils.getPropertyValue(spcafb, "source.fileSource.scanner")).isSameAs(scanner);
+		assertThat(TestUtils.<Object>getPropertyValue(spcafb, "source.fileSource.scanner")).isSameAs(scanner);
 		Message<?> message = out.receive(10_000);
 		assertThat(message).isNotNull();
 		assertThat(message.getHeaders())
@@ -128,7 +128,7 @@ public class SmbTests extends SmbTestSupport {
 		assertThat(out.receive(10)).isNull();
 
 		MessageSource<?> source = context.getBean(SmbInboundFileSynchronizingMessageSource.class);
-		assertThat(TestUtils.getPropertyValue(source, "maxFetchSize")).isEqualTo(10);
+		assertThat(TestUtils.<Integer>getPropertyValue(source, "maxFetchSize")).isEqualTo(10);
 
 		registration.destroy();
 	}
@@ -160,7 +160,7 @@ public class SmbTests extends SmbTestSupport {
 		new IntegrationMessageHeaderAccessor(message).getCloseableResource().close();
 
 		MessageSource<?> source = context.getBean(SmbStreamingMessageSource.class);
-		assertThat(TestUtils.getPropertyValue(source, "maxFetchSize")).isEqualTo(11);
+		assertThat(TestUtils.<Integer>getPropertyValue(source, "maxFetchSize")).isEqualTo(11);
 		registration.destroy();
 	}
 

--- a/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
+++ b/spring-integration-smb/src/test/java/org/springframework/integration/smb/session/SmbSessionTests.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gregory Bragg
  * @author Artem Bilan
  * @author Daniel Frey
+ * @author Glenn Renfro
  *
  */
 public class SmbSessionTests extends SmbTestSupport {
@@ -105,7 +106,7 @@ public class SmbSessionTests extends SmbTestSupport {
 				.withStackTraceContaining("The system cannot find the file specified");
 
 		Session<SmbFile> newSession = cachingSessionFactory.getSession();
-		assertThat(TestUtils.getPropertyValue(newSession, "targetSession"))
+		assertThat(TestUtils.<Object>getPropertyValue(newSession, "targetSession"))
 				.isSameAs(TestUtils.getPropertyValue(session, "targetSession"));
 
 		newSession.close();

--- a/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/config/StompAdaptersParserTests.java
+++ b/spring-integration-stomp/src/test/java/org/springframework/integration/stomp/config/StompAdaptersParserTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.2
  */
@@ -98,65 +99,66 @@ public class StompAdaptersParserTests {
 
 	@Test
 	public void testParsers() {
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "outputChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultInboundAdapter, "outputChannel"))
 				.isSameAs(this.defaultInboundAdapterChannel);
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "stompSessionManager"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultInboundAdapter, "stompSessionManager"))
 				.isSameAs(this.stompSessionManager);
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "errorChannel")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultInboundAdapter, "errorChannel")).isNull();
 		Object headerMapper = TestUtils.getPropertyValue(this.defaultInboundAdapter, "headerMapper");
 		assertThat(headerMapper).isNotNull();
 		assertThat(headerMapper).isNotSameAs(this.headerMapper);
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "payloadType", Class.class))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultInboundAdapter, "payloadType"))
 				.isEqualTo(String.class);
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "autoStartup", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultInboundAdapter, "autoStartup")).isTrue();
 
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "outputChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customInboundAdapter, "outputChannel"))
 				.isSameAs(this.inboundChannel);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "stompSessionManager"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customInboundAdapter, "stompSessionManager"))
 				.isSameAs(this.stompSessionManager);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "errorChannel")).isSameAs(this.errorChannel);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "destinations"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customInboundAdapter, "errorChannel"))
+				.isSameAs(this.errorChannel);
+		assertThat(TestUtils.<Object>getPropertyValue(this.customInboundAdapter, "destinations"))
 				.isEqualTo(Collections.singleton("foo"));
 		headerMapper = TestUtils.getPropertyValue(this.customInboundAdapter, "headerMapper");
 		assertThat(headerMapper).isNotNull();
 		assertThat(headerMapper).isNotSameAs(this.headerMapper);
-		assertThat(TestUtils.getPropertyValue(headerMapper, "inboundHeaderNames", String[].class))
+		assertThat(TestUtils.<String[]>getPropertyValue(headerMapper, "inboundHeaderNames"))
 				.isEqualTo(new String[] {"bar", "foo"});
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "payloadType", Class.class))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customInboundAdapter, "payloadType"))
 				.isEqualTo(Integer.class);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "phase")).isEqualTo(200);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "messagingTemplate.sendTimeout"))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customInboundAdapter, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.customInboundAdapter, "phase")).isEqualTo(200);
+		assertThat(TestUtils.<Long>getPropertyValue(this.customInboundAdapter, "messagingTemplate.sendTimeout"))
 				.isEqualTo(2000L);
 
-		assertThat(TestUtils.getPropertyValue(this.defaultOutboundAdapterHandler, "stompSessionManager"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultOutboundAdapterHandler, "stompSessionManager"))
 				.isSameAs(this.stompSessionManager);
 		headerMapper = TestUtils.getPropertyValue(this.defaultOutboundAdapterHandler, "headerMapper");
 		assertThat(headerMapper).isNotNull();
 		assertThat(headerMapper).isNotSameAs(this.headerMapper);
-		assertThat(TestUtils.getPropertyValue(this.defaultOutboundAdapterHandler, "destinationExpression")).isNull();
-		assertThat(TestUtils.getPropertyValue(this.defaultOutboundAdapter, "handler"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultOutboundAdapterHandler, "destinationExpression"))
+				.isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultOutboundAdapter, "handler"))
 				.isSameAs(this.defaultOutboundAdapterHandler);
-		assertThat(TestUtils.getPropertyValue(this.defaultOutboundAdapter, "inputChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultOutboundAdapter, "inputChannel"))
 				.isSameAs(this.defaultOutboundAdapterChannel);
-		assertThat(TestUtils.getPropertyValue(this.defaultOutboundAdapter, "autoStartup", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultOutboundAdapter, "autoStartup")).isTrue();
 
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapterHandler, "stompSessionManager"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customOutboundAdapterHandler, "stompSessionManager"))
 				.isSameAs(this.stompSessionManager);
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapterHandler, "headerMapper"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customOutboundAdapterHandler, "headerMapper"))
 				.isSameAs(this.headerMapper);
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapterHandler, "destinationExpression.literalValue"))
-				.isEqualTo("baz");
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapter, "handler"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customOutboundAdapterHandler,
+				"destinationExpression.literalValue")).isEqualTo("baz");
+		assertThat(TestUtils.<Object>getPropertyValue(this.customOutboundAdapter, "handler"))
 				.isSameAs(this.customOutboundAdapterHandler);
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapter, "inputChannel"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.customOutboundAdapter, "inputChannel"))
 				.isSameAs(this.outboundChannel);
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapter, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapter, "phase")).isEqualTo(100);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customOutboundAdapter, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.customOutboundAdapter, "phase")).isEqualTo(100);
 
-		@SuppressWarnings("unchecked")
-		MultiValueMap<String, SmartLifecycle> lifecycles = (MultiValueMap<String, SmartLifecycle>)
-				TestUtils.getPropertyValue(this.roleController, "lifecycles", MultiValueMap.class);
+		MultiValueMap<String, SmartLifecycle> lifecycles =
+				TestUtils.getPropertyValue(this.roleController, "lifecycles");
 		assertThat(lifecycles.containsKey("bar")).isTrue();
 		List<SmartLifecycle> bars = lifecycles.get("bar");
 		bars.contains(this.customInboundAdapter);

--- a/spring-integration-stream/src/test/java/org/springframework/integration/stream/config/ConsoleInboundChannelAdapterParserTests.java
+++ b/spring-integration-stream/src/test/java/org/springframework/integration/stream/config/ConsoleInboundChannelAdapterParserTests.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -91,7 +92,7 @@ public class ConsoleInboundChannelAdapterParserTests {
 		assertThat(message.getPayload()).isEqualTo("foo");
 		adapter = context.getBean("pipedAdapterNoCharset.adapter", SourcePollingChannelAdapter.class);
 		source = adapter.getMessageSource();
-		assertThat(TestUtils.getPropertyValue(source, "blockToDetectEOF", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(source, "blockToDetectEOF")).isTrue();
 	}
 
 	@Test
@@ -113,7 +114,7 @@ public class ConsoleInboundChannelAdapterParserTests {
 		assertThat(message.getPayload()).isEqualTo("foo");
 		adapter = context.getBean("pipedAdapterWithCharset.adapter", SourcePollingChannelAdapter.class);
 		source = adapter.getMessageSource();
-		assertThat(TestUtils.getPropertyValue(source, "blockToDetectEOF", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(source, "blockToDetectEOF")).isTrue();
 		bufferedReader = (Reader) sourceAccessor.getPropertyValue("reader");
 		assertThat(bufferedReader.getClass()).isEqualTo(BufferedReader.class);
 		bufferedReaderAccessor = new DirectFieldAccessor(bufferedReader);

--- a/spring-integration-stream/src/test/java/org/springframework/integration/stream/config/ConsoleOutboundChannelAdapterParserTests.java
+++ b/spring-integration-stream/src/test/java/org/springframework/integration/stream/config/ConsoleOutboundChannelAdapterParserTests.java
@@ -52,6 +52,7 @@ import static org.mockito.Mockito.verify;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 
 @SpringJUnitConfig
@@ -84,8 +85,8 @@ public class ConsoleOutboundChannelAdapterParserTests {
 	@Test
 	public void stdoutAdapterWithDefaultCharset() throws IOException {
 		BufferedWriter bufferedWriter =
-				TestUtils.getPropertyValue(this.stdoutAdapterWithDefaultCharsetHandler, "writer", BufferedWriter.class);
-		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out", Writer.class);
+				TestUtils.<BufferedWriter>getPropertyValue(this.stdoutAdapterWithDefaultCharsetHandler, "writer");
+		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out");
 		assertThat(writer.getClass()).isEqualTo(OutputStreamWriter.class);
 		Charset writerCharset = Charset.forName(((OutputStreamWriter) writer).getEncoding());
 		assertThat(writerCharset).isEqualTo(Charset.defaultCharset());
@@ -101,14 +102,15 @@ public class ConsoleOutboundChannelAdapterParserTests {
 		this.stdoutAdapterWithDefaultCharsetHandler.handleMessage(new GenericMessage<>("foo"));
 
 		verify(bufferedWriter, times(1)).write(eq("foo"));
-		assertThat(TestUtils.getPropertyValue(this.stdoutAdapterWithDefaultCharsetHandler, "order")).isEqualTo(23);
+		assertThat(TestUtils.<Integer>getPropertyValue(this.stdoutAdapterWithDefaultCharsetHandler, "order"))
+				.isEqualTo(23);
 	}
 
 	@Test
 	public void stdoutAdapterWithProvidedCharset() throws IOException {
 		BufferedWriter bufferedWriter =
-				TestUtils.getPropertyValue(this.stdoutAdapterWithProvidedCharsetHandler, "writer", BufferedWriter.class);
-		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out", Writer.class);
+				TestUtils.getPropertyValue(this.stdoutAdapterWithProvidedCharsetHandler, "writer");
+		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out");
 		assertThat(writer.getClass()).isEqualTo(OutputStreamWriter.class);
 		Charset writerCharset = Charset.forName(((OutputStreamWriter) writer).getEncoding());
 		assertThat(writerCharset).isEqualTo(StandardCharsets.UTF_8);
@@ -137,8 +139,8 @@ public class ConsoleOutboundChannelAdapterParserTests {
 	@Test
 	public void stderrAdapter() throws IOException {
 		BufferedWriter bufferedWriter =
-				TestUtils.getPropertyValue(this.stderrAdapterHandler, "writer", BufferedWriter.class);
-		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out", Writer.class);
+				TestUtils.<BufferedWriter>getPropertyValue(this.stderrAdapterHandler, "writer");
+		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out");
 		assertThat(writer.getClass()).isEqualTo(OutputStreamWriter.class);
 		Charset writerCharset = Charset.forName(((OutputStreamWriter) writer).getEncoding());
 		assertThat(writerCharset).isEqualTo(Charset.defaultCharset());
@@ -155,14 +157,14 @@ public class ConsoleOutboundChannelAdapterParserTests {
 
 		verify(bufferedWriter, times(1)).write(eq("bar"));
 
-		assertThat(TestUtils.getPropertyValue(this.stderrAdapterHandler, "order")).isEqualTo(34);
+		assertThat(TestUtils.<Integer>getPropertyValue(this.stderrAdapterHandler, "order")).isEqualTo(34);
 	}
 
 	@Test
 	public void stdoutAdatperWithAppendNewLine() throws IOException {
 		BufferedWriter bufferedWriter =
-				TestUtils.getPropertyValue(this.newlineAdapterHandler, "writer", BufferedWriter.class);
-		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out", Writer.class);
+				TestUtils.<BufferedWriter>getPropertyValue(this.newlineAdapterHandler, "writer");
+		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out");
 		assertThat(writer.getClass()).isEqualTo(OutputStreamWriter.class);
 		Charset writerCharset = Charset.forName(((OutputStreamWriter) writer).getEncoding());
 		assertThat(writerCharset).isEqualTo(Charset.defaultCharset());
@@ -184,17 +186,17 @@ public class ConsoleOutboundChannelAdapterParserTests {
 
 	@Test //INT-2275
 	public void stdoutInsideNestedChain() throws IOException {
-		List<?> handlers = TestUtils.getPropertyValue(this.stdoutChainHandler, "handlers", List.class);
+		List<?> handlers = TestUtils.getPropertyValue(this.stdoutChainHandler, "handlers");
 		assertThat(handlers.size()).isEqualTo(2);
 		Object chainHandler = handlers.get(1);
 		assertThat(chainHandler instanceof MessageHandlerChain).isTrue();
-		List<?> nestedChainHandlers = TestUtils.getPropertyValue(chainHandler, "handlers", List.class);
+		List<?> nestedChainHandlers = TestUtils.getPropertyValue(chainHandler, "handlers");
 		assertThat(nestedChainHandlers.size()).isEqualTo(1);
 		Object stdoutHandler = nestedChainHandlers.get(0);
 		assertThat(stdoutHandler instanceof CharacterStreamWritingMessageHandler).isTrue();
 
-		BufferedWriter bufferedWriter = TestUtils.getPropertyValue(stdoutHandler, "writer", BufferedWriter.class);
-		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out", Writer.class);
+		BufferedWriter bufferedWriter = TestUtils.getPropertyValue(stdoutHandler, "writer");
+		Writer writer = TestUtils.getPropertyValue(bufferedWriter, "out");
 		assertThat(writer.getClass()).isEqualTo(OutputStreamWriter.class);
 		Charset writerCharset = Charset.forName(((OutputStreamWriter) writer).getEncoding());
 		assertThat(writerCharset).isEqualTo(Charset.defaultCharset());

--- a/spring-integration-stream/src/test/java/org/springframework/integration/stream/config/DefaultConfigurationTests.java
+++ b/spring-integration-stream/src/test/java/org/springframework/integration/stream/config/DefaultConfigurationTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -65,14 +66,13 @@ public class DefaultConfigurationTests {
 	public void verifyTaskScheduler() {
 		Object taskScheduler = context.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME);
 		assertThat(taskScheduler.getClass()).isEqualTo(ThreadPoolTaskScheduler.class);
-		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler", ErrorHandler.class);
+		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler");
 		assertThat(errorHandler.getClass()).isEqualTo(MessagePublishingErrorHandler.class);
-		MessageChannel defaultErrorChannel = TestUtils.getPropertyValue(errorHandler,
-				"messagingTemplate.defaultDestination", MessageChannel.class);
+		MessageChannel defaultErrorChannel =
+				TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNull();
 		errorHandler.handleError(new Throwable());
-		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination",
-				MessageChannel.class);
+		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNotNull();
 		assertThat(defaultErrorChannel).isEqualTo(context.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME));
 	}

--- a/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterParserTests-context.xml
+++ b/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/config/SyslogReceivingChannelAdapterParserTests-context.xml
@@ -9,11 +9,12 @@
 		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-	<int-syslog:inbound-channel-adapter id="foo" port="0" />
+	<int-syslog:inbound-channel-adapter id="outputChannel" port="0" />
 
-	<int-syslog:inbound-channel-adapter id="foobar" channel="foo" port="1514" auto-startup="false" />
+	<int-syslog:inbound-channel-adapter id="udpSyslogReceivingChannelAdapter" channel="outputChannel"
+										port="1514" auto-startup="false" />
 
-	<int:channel id="foo">
+	<int:channel id="outputChannel">
 		<int:queue/>
 	</int:channel>
 
@@ -28,7 +29,7 @@
 	</int:channel>
 
 	<int-syslog:inbound-channel-adapter id="fullBoatUdp"
-		channel="foo"
+		channel="outputChannel"
 		auto-startup="false"
 		phase="123"
 		converter="converter"
@@ -40,15 +41,15 @@
 	<bean id="converter"
 		class="org.springframework.integration.syslog.config.SyslogReceivingChannelAdapterParserTests$PassThruConverter" />
 
-	<int-syslog:inbound-channel-adapter id="bar" protocol="tcp" port="0" />
+	<int-syslog:inbound-channel-adapter id="outputChannelAlternate" protocol="tcp" port="0" />
 
-	<int:channel id="bar">
+	<int:channel id="outputChannelAlternate">
 		<int:queue/>
 	</int:channel>
 
 	<int-syslog:inbound-channel-adapter id="fullBoatTcp"
 		protocol="tcp"
-		channel="bar"
+		channel="outputChannelAlternate"
 		connection-factory="cf"
 		auto-startup="false"
 		phase="123"

--- a/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterTests.java
+++ b/spring-integration-syslog/src/test/java/org/springframework/integration/syslog/inbound/SyslogReceivingChannelAdapterTests.java
@@ -63,6 +63,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author David Liu
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 3.0
  *
@@ -80,8 +81,7 @@ public class SyslogReceivingChannelAdapterTests {
 		factory.setApplicationEventPublisher(mock());
 		factory.afterPropertiesSet();
 		factory.start();
-		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter",
-				UnicastReceivingChannelAdapter.class);
+		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter");
 		TestingUtilities.waitListening(server, null);
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
 		adapter.setBeanFactory(mock());
@@ -115,11 +115,10 @@ public class SyslogReceivingChannelAdapterTests {
 		factory.setBeanFactory(getBeanFactory());
 		factory.afterPropertiesSet();
 		factory.start();
-		AbstractServerConnectionFactory server = TestUtils.getPropertyValue(factory, "syslogAdapter.connectionFactory",
-				AbstractServerConnectionFactory.class);
+		AbstractServerConnectionFactory server = TestUtils.getPropertyValue(factory, "syslogAdapter.connectionFactory");
 		TestingUtilities.waitListening(server, null);
 		TcpSyslogReceivingChannelAdapter adapter = (TcpSyslogReceivingChannelAdapter) factory.getObject();
-		LogAccessor logger = spy(TestUtils.getPropertyValue(adapter, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(adapter, "logger"));
 		doReturn(true).when(logger).isDebugEnabled();
 		final CountDownLatch sawLog = new CountDownLatch(1);
 		doAnswer(invocation -> {
@@ -154,8 +153,7 @@ public class SyslogReceivingChannelAdapterTests {
 		factory.setApplicationEventPublisher(mock());
 		factory.afterPropertiesSet();
 		factory.start();
-		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter",
-				UnicastReceivingChannelAdapter.class);
+		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter");
 		server.setBeanFactory(mock());
 		TestingUtilities.waitListening(server, null);
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
@@ -206,7 +204,7 @@ public class SyslogReceivingChannelAdapterTests {
 		TestingUtilities.waitListening(connectionFactory, null);
 		TcpSyslogReceivingChannelAdapter adapter = (TcpSyslogReceivingChannelAdapter) factory.getObject();
 		adapter.setBeanFactory(getBeanFactory());
-		LogAccessor logger = spy(TestUtils.getPropertyValue(adapter, "logger", LogAccessor.class));
+		LogAccessor logger = spy(TestUtils.<LogAccessor>getPropertyValue(adapter, "logger"));
 		doReturn(true).when(logger).isDebugEnabled();
 		final CountDownLatch sawLog = new CountDownLatch(1);
 		doAnswer(invocation -> {
@@ -247,8 +245,7 @@ public class SyslogReceivingChannelAdapterTests {
 		factory.setApplicationEventPublisher(mock());
 		factory.afterPropertiesSet();
 		factory.start();
-		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter",
-				UnicastReceivingChannelAdapter.class);
+		UnicastReceivingChannelAdapter server = TestUtils.getPropertyValue(factory, "syslogAdapter.udpAdapter");
 		TestingUtilities.waitListening(server, null);
 		UdpSyslogReceivingChannelAdapter adapter = (UdpSyslogReceivingChannelAdapter) factory.getObject();
 		byte[] buf = ("<14>1 2014-06-20T09:14:07+00:00 loggregator d0602076-b14a-4c55-852a-981e7afeed38 DEA - " +

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/TestApplicationContextAware.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/support/TestApplicationContextAware.java
@@ -63,7 +63,7 @@ public interface TestApplicationContextAware {
 			}
 		}
 		Object nullChannel = TEST_INTEGRATION_CONTEXT.getBean("nullChannel");
-		TestUtils.getPropertyValue(nullChannel, "queue", LinkedBlockingQueue.class).clear();
+		TestUtils.<LinkedBlockingQueue<?>>getPropertyValue(nullChannel, "queue").clear();
 	}
 
 	@AfterAll

--- a/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/TestUtils.java
+++ b/spring-integration-test-support/src/main/java/org/springframework/integration/test/util/TestUtils.java
@@ -62,13 +62,14 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 public abstract class TestUtils {
 
 	private static final Log LOGGER = LogFactory.getLog(TestUtils.class);
 
 	/**
-	 * Obtain a value for the property from the provide object
+	 * Obtain a value for the property from the provided object
 	 * and try to cast it to the provided type.
 	 * Supports nested properties via period delimiter.
 	 * @param root the object to obtain the property value
@@ -79,6 +80,7 @@ public abstract class TestUtils {
 	 * @return the value of the property or null
 	 * @see DirectFieldAccessor
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	@SuppressWarnings("unchecked")
 	public static <T>  @Nullable T getPropertyValue(Object root, String propertyPath, Class<T> type) {
 		Object value = getPropertyValue(root, propertyPath);
@@ -89,7 +91,7 @@ public abstract class TestUtils {
 	}
 
 	/**
-	 * Obtain a value for the property from the provide object.
+	 * Obtain a value for the property from the provided object.
 	 * Supports nested properties via period delimiter.
 	 * @param root the object to obtain the property value
 	 * @param propertyPath the property name to obtain a value.
@@ -97,14 +99,17 @@ public abstract class TestUtils {
 	 * @return the value of the property or null
 	 * @see DirectFieldAccessor
 	 */
-	public static @Nullable Object getPropertyValue(Object root, String propertyPath) {
+	@SuppressWarnings("unchecked")
+	public static <T> @Nullable T getPropertyValue(Object root, String propertyPath) {
 		Object value = null;
 		DirectFieldAccessor accessor = new DirectFieldAccessor(root);
 		String[] tokens = propertyPath.split("\\.");
 		for (int i = 0; i < tokens.length; i++) {
 			value = accessor.getPropertyValue(tokens[i]);
 			if (value != null) {
-				accessor = new DirectFieldAccessor(value);
+				if (i < tokens.length - 1) {
+					accessor = new DirectFieldAccessor(value);
+				}
 			}
 			else if (i == tokens.length - 1) {
 				return null;
@@ -114,7 +119,7 @@ public abstract class TestUtils {
 						"intermediate property '" + tokens[i] + "' is null");
 			}
 		}
-		return value;
+		return (T) value;
 	}
 
 	/**

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContext.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/context/MockIntegrationContext.java
@@ -61,6 +61,7 @@ import org.springframework.util.ObjectUtils;
  * @author Artem Bilan
  * @author Yicheng Feng
  * @author Alexander Hain
+ * @author Glenn Renfro
  *
  * @since 5.0
  *
@@ -236,8 +237,7 @@ public class MockIntegrationContext implements BeanPostProcessor, SmartInitializ
 			}
 			else {
 				if (mockMessageHandler instanceof MockMessageHandler) {
-					if (Boolean.TRUE.equals(TestUtils.getPropertyValue(
-							mockMessageHandler, "hasReplies", Boolean.class))) {
+					if (Boolean.TRUE.equals(TestUtils.<Boolean>getPropertyValue(mockMessageHandler, "hasReplies"))) {
 						throw new IllegalStateException("The [" + mockMessageHandler + "] " +
 								"with replies can't replace simple MessageHandler [" + targetMessageHandler + "]");
 					}

--- a/spring-integration-test/src/main/java/org/springframework/integration/test/mock/MockMessageHandler.java
+++ b/spring-integration-test/src/main/java/org/springframework/integration/test/mock/MockMessageHandler.java
@@ -56,6 +56,7 @@ import org.springframework.util.Assert;
  *
  * @author Artem Bilan
  * @author Christian Tzolov
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -71,11 +72,9 @@ public class MockMessageHandler extends AbstractMessageProducingHandler {
 
 	protected boolean hasReplies;
 
-	@SuppressWarnings("unchecked")
 	protected MockMessageHandler(@Nullable ArgumentCaptor<Message<?>> messageArgumentCaptor) {
 		if (messageArgumentCaptor != null) {
-			this.capturingMatcher = TestUtils.getPropertyValue(messageArgumentCaptor,
-					"capturingMatcher", CapturingMatcher.class);
+			this.capturingMatcher = TestUtils.getPropertyValue(messageArgumentCaptor, "capturingMatcher");
 		}
 		else {
 			this.capturingMatcher = null;

--- a/spring-integration-test/src/test/java/org/springframework/integration/test/mock/MockMessageHandlerTests.java
+++ b/spring-integration-test/src/test/java/org/springframework/integration/test/mock/MockMessageHandlerTests.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.reactivestreams.Subscriber;
 import reactor.core.publisher.Mono;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,6 +67,7 @@ import static org.springframework.integration.test.mock.MockIntegration.mockMess
 /**
  * @author Artem Bilan
  * @author Yicheng Feng
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -195,7 +195,7 @@ public class MockMessageHandlerTests {
 		this.mockIntegrationContext.substituteMessageHandlerFor(endpointId, mockMessageHandler);
 
 		Object endpoint = this.context.getBean(endpointId);
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class)).isSameAs(mockMessageHandler);
+		assertThat(TestUtils.<MessageHandler>getPropertyValue(endpoint, "handler")).isSameAs(mockMessageHandler);
 
 		GenericMessage<String> message = new GenericMessage<>("foo");
 
@@ -219,9 +219,9 @@ public class MockMessageHandlerTests {
 
 		this.mockIntegrationContext.resetBeans();
 
-		assertThat(TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class))
+		assertThat(TestUtils.<MessageHandler>getPropertyValue(endpoint, "handler"))
 				.isNotSameAs(mockMessageHandler2);
-		assertThat(TestUtils.getPropertyValue(endpoint, "subscriber", Subscriber.class))
+		assertThat(TestUtils.<Object>getPropertyValue(endpoint, "subscriber"))
 				.isNotSameAs(mockMessageHandler2);
 	}
 
@@ -264,10 +264,10 @@ public class MockMessageHandlerTests {
 
 		verify(mockMessageHandler).handleMessage(any(Message.class));
 
-		assertThat(TestUtils.getPropertyValue(this.mockIntegrationContext, "beans", Map.class)).hasSize(1);
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(this.mockIntegrationContext, "beans")).hasSize(1);
 
 		assertThat(
-				TestUtils.getPropertyValue(
+				TestUtils.<Object>getPropertyValue(
 						this.context.getBean("mockMessageHandlerTests.Config.myService.serviceActivator"), "handler"))
 				.isSameAs(mockMessageHandler);
 	}

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundChannelAdapterParserTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -62,8 +63,7 @@ public class WebFluxOutboundChannelAdapterParserTests {
 	@Test
 	public void reactiveMinimalConfig() {
 		DirectFieldAccessor endpointAccessor = new DirectFieldAccessor(this.reactiveMinimalConfig);
-		WebClient webClient =
-				TestUtils.getPropertyValue(this.reactiveMinimalConfig, "handler.webClient", WebClient.class);
+		WebClient webClient = TestUtils.getPropertyValue(this.reactiveMinimalConfig, "handler.webClient");
 		assertThat(webClient).isNotSameAs(this.webClient);
 		Object handler = endpointAccessor.getPropertyValue("handler");
 		DirectFieldAccessor handlerAccessor = new DirectFieldAccessor(handler);
@@ -73,21 +73,21 @@ public class WebFluxOutboundChannelAdapterParserTests {
 		assertThat(handlerAccessor.getPropertyValue("outputChannel")).isNull();
 		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test1");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
 		assertThat(
-				TestUtils.getPropertyValue(handler, "webClient.uriBuilderFactory.encodingMode",
-						DefaultUriBuilderFactory.EncodingMode.class))
+				TestUtils.<DefaultUriBuilderFactory.EncodingMode>getPropertyValue(handler,
+						"webClient.uriBuilderFactory.encodingMode"))
 				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
 	}
 
 	@Test
 	public void reactiveWebClientConfig() {
-		assertThat(TestUtils.getPropertyValue(this.reactiveWebClientConfig, "handler.webClient"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.reactiveWebClientConfig, "handler.webClient"))
 				.isSameAs(this.webClient);
-		assertThat(TestUtils.getPropertyValue(this.reactiveWebClientConfig,
+		assertThat(TestUtils.<Object>getPropertyValue(this.reactiveWebClientConfig,
 				"handler.publisherElementTypeExpression.value"))
 				.isSameAs(Date.class);
 	}

--- a/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
+++ b/spring-integration-webflux/src/test/java/org/springframework/integration/webflux/config/WebFluxOutboundGatewayParserTests.java
@@ -45,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Artem Bilan
  * @author Jatin Saxena
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -81,7 +82,7 @@ public class WebFluxOutboundGatewayParserTests {
 		assertThat(handlerAccessor.getPropertyValue("webClient")).isSameAs(this.webClient);
 		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test1");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.POST.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(true);
@@ -104,11 +105,11 @@ public class WebFluxOutboundGatewayParserTests {
 		assertThat(replyChannel).isNotNull();
 		assertThat(replyChannel).isEqualTo(this.applicationContext.getBean("replies"));
 
-		assertThat(TestUtils.getPropertyValue(handler, "expectedResponseTypeExpression", Expression.class).getValue())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "expectedResponseTypeExpression").getValue())
 				.isEqualTo(String.class.getName());
 		Expression uriExpression = (Expression) handlerAccessor.getPropertyValue("uriExpression");
 		assertThat(uriExpression.getValue()).isEqualTo("http://localhost/test2");
-		assertThat(TestUtils.getPropertyValue(handler, "httpMethodExpression", Expression.class).getExpressionString())
+		assertThat(TestUtils.<Expression>getPropertyValue(handler, "httpMethodExpression").getExpressionString())
 				.isEqualTo(HttpMethod.PUT.name());
 		assertThat(handlerAccessor.getPropertyValue("charset")).isEqualTo(StandardCharsets.UTF_8);
 		assertThat(handlerAccessor.getPropertyValue("extractPayload")).isEqualTo(false);

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/ClientWebSocketContainerTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/ClientWebSocketContainerTests.java
@@ -51,6 +51,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 /**
  * @author Artem Bilan
  * @author Julian Koch
+ * @author Glenn Renfro
  *
  * @since 4.1
  */
@@ -217,8 +218,7 @@ public class ClientWebSocketContainerTests {
 			this.sendTimeLimit = sessionDecorator.getSendTimeLimit();
 			this.sendBufferSizeLimit = sessionDecorator.getBufferSizeLimit();
 			this.sendBufferOverflowStrategy =
-					TestUtils.getPropertyValue(sessionDecorator, "overflowStrategy",
-							ConcurrentWebSocketSessionDecorator.OverflowStrategy.class);
+					TestUtils.getPropertyValue(sessionDecorator, "overflowStrategy");
 
 			this.sessionStartedLatch.countDown();
 		}

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/config/WebSocketParserTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/config/WebSocketParserTests.java
@@ -62,6 +62,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  * @author Julian Koch
  * @author Jooyoung Pyoung
+ * @author Glenn Renfro
  *
  * @since 4.1
  */
@@ -140,44 +141,44 @@ public class WebSocketParserTests {
 	@Test
 	@SuppressWarnings("unckecked")
 	public void testDefaultInboundChannelAdapterAndServerContainer() {
-		Map<?, ?> urlMap = TestUtils.getPropertyValue(this.handlerMapping, "urlMap", Map.class);
+		Map<?, ?> urlMap = TestUtils.getPropertyValue(this.handlerMapping, "urlMap");
 		assertThat(urlMap.size()).isEqualTo(1);
 		assertThat(urlMap.containsKey("/ws/**")).isTrue();
 		Object mappedHandler = urlMap.get("/ws/**");
 		//WebSocketHttpRequestHandler -> ExceptionWebSocketHandlerDecorator - > LoggingWebSocketHandlerDecorator
 		// -> IntegrationWebSocketContainer$IntegrationWebSocketHandler
-		assertThat(TestUtils.getPropertyValue(mappedHandler, "webSocketHandler.delegate.delegate"))
+		assertThat(TestUtils.<Object>getPropertyValue(mappedHandler, "webSocketHandler.delegate.delegate"))
 				.isSameAs(TestUtils.getPropertyValue(this.serverWebSocketContainer, "webSocketHandler"));
-		assertThat(TestUtils.getPropertyValue(this.serverWebSocketContainer, "handshakeHandler"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.serverWebSocketContainer, "handshakeHandler"))
 				.isSameAs(this.handshakeHandler);
 		HandshakeInterceptor[] interceptors =
-				TestUtils.getPropertyValue(this.serverWebSocketContainer, "interceptors", HandshakeInterceptor[].class);
+				TestUtils.getPropertyValue(this.serverWebSocketContainer, "interceptors");
 		assertThat(interceptors).isNotNull();
 		assertThat(interceptors.length).isEqualTo(1);
 		assertThat(interceptors[0]).isSameAs(this.handshakeInterceptor);
-		assertThat(TestUtils.getPropertyValue(this.serverWebSocketContainer, "sendTimeLimit")).isEqualTo(100);
-		assertThat(TestUtils.getPropertyValue(this.serverWebSocketContainer, "sendBufferSizeLimit")).isEqualTo(100000);
-		assertThat(TestUtils.getPropertyValue(this.serverWebSocketContainer, "sendBufferOverflowStrategy"))
+		assertThat(TestUtils.<Integer>getPropertyValue(this.serverWebSocketContainer, "sendTimeLimit")).isEqualTo(100);
+		assertThat(TestUtils.<Integer>getPropertyValue(this.serverWebSocketContainer, "sendBufferSizeLimit"))
+				.isEqualTo(100000);
+		assertThat(TestUtils.<Object>getPropertyValue(this.serverWebSocketContainer, "sendBufferOverflowStrategy"))
 				.isEqualTo(ConcurrentWebSocketSessionDecorator.OverflowStrategy.DROP);
-		assertThat(TestUtils.getPropertyValue(this.serverWebSocketContainer, "origins", String[].class))
+		assertThat(TestUtils.<String[]>getPropertyValue(this.serverWebSocketContainer, "origins"))
 				.isEqualTo(new String[] {"https://foo.com"});
 
 		WebSocketHandlerDecoratorFactory[] decoratorFactories =
-				TestUtils.getPropertyValue(this.serverWebSocketContainer, "decoratorFactories",
-						WebSocketHandlerDecoratorFactory[].class);
+				TestUtils.getPropertyValue(this.serverWebSocketContainer, "decoratorFactories");
 		assertThat(decoratorFactories).isNotNull();
 		assertThat(decoratorFactories.length).isEqualTo(1);
 		assertThat(decoratorFactories[0]).isSameAs(this.decoratorFactory);
 
-		TransportHandlingSockJsService sockJsService =
-				TestUtils.getPropertyValue(mappedHandler, "sockJsService", TransportHandlingSockJsService.class);
+		TransportHandlingSockJsService sockJsService = TestUtils.getPropertyValue(mappedHandler, "sockJsService");
 		assertThat(sockJsService.getTaskScheduler()).isSameAs(this.taskScheduler);
 		assertThat(sockJsService.getMessageCodec()).isSameAs(this.sockJsMessageCodec);
 		Map<TransportType, TransportHandler> transportHandlers = sockJsService.getTransportHandlers();
 
 		//If "handshake-handler" is provided, "transport-handlers" isn't allowed
 		assertThat(transportHandlers.size()).isEqualTo(6);
-		assertThat(TestUtils.getPropertyValue(transportHandlers.get(TransportType.WEBSOCKET), "handshakeHandler"))
+		assertThat(TestUtils.<Object>getPropertyValue(
+				transportHandlers.get(TransportType.WEBSOCKET), "handshakeHandler"))
 				.isSameAs(this.handshakeHandler);
 		assertThat(sockJsService.getDisconnectDelay()).isEqualTo(4000L);
 		assertThat(sockJsService.getHeartbeatTime()).isEqualTo(30000L);
@@ -188,44 +189,44 @@ public class WebSocketParserTests {
 		assertThat(sockJsService.isWebSocketEnabled()).isFalse();
 		assertThat(sockJsService.shouldSuppressCors()).isTrue();
 
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "webSocketContainer"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultInboundAdapter, "webSocketContainer"))
 				.isSameAs(this.serverWebSocketContainer);
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "messageConverters")).isNull();
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "defaultConverters"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultInboundAdapter, "messageConverters")).isNull();
+		assertThat(TestUtils.<List<?>>getPropertyValue(this.defaultInboundAdapter, "defaultConverters"))
 				.isEqualTo(TestUtils.getPropertyValue(this.defaultInboundAdapter, "messageConverter.converters"));
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "payloadType", Class.class))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultInboundAdapter, "payloadType"))
 				.isEqualTo(String.class);
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "useBroker", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.defaultInboundAdapter, "brokerHandler"))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultInboundAdapter, "useBroker")).isTrue();
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultInboundAdapter, "brokerHandler"))
 				.isSameAs(this.brokerHandler);
 
-		SubProtocolHandlerRegistry subProtocolHandlerRegistry = TestUtils.getPropertyValue(this.defaultInboundAdapter,
-				"subProtocolHandlerRegistry", SubProtocolHandlerRegistry.class);
-		assertThat(TestUtils.getPropertyValue(subProtocolHandlerRegistry, "defaultProtocolHandler"))
+		SubProtocolHandlerRegistry subProtocolHandlerRegistry =
+				TestUtils.getPropertyValue(this.defaultInboundAdapter, "subProtocolHandlerRegistry");
+		assertThat(TestUtils.<Object>getPropertyValue(subProtocolHandlerRegistry, "defaultProtocolHandler"))
 				.isInstanceOf(PassThruSubProtocolHandler.class);
-		assertThat(TestUtils.getPropertyValue(subProtocolHandlerRegistry, "protocolHandlers", Map.class).isEmpty())
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(subProtocolHandlerRegistry, "protocolHandlers").isEmpty())
 				.isTrue();
 	}
 
 	@Test
 	public void testCustomInboundChannelAdapterAndClientContainer() throws URISyntaxException {
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "outputChannel"))
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(this.customInboundAdapter, "outputChannel"))
 				.isSameAs(this.clientInboundChannel);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "errorChannel")).isSameAs(this.errorChannel);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "webSocketContainer"))
-				.isSameAs(this.clientWebSocketContainer);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "messagingTemplate.sendTimeout"))
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(this.customInboundAdapter, "errorChannel"))
+				.isSameAs(this.errorChannel);
+		assertThat(TestUtils.<IntegrationWebSocketContainer>getPropertyValue(this.customInboundAdapter,
+				"webSocketContainer")).isSameAs(this.clientWebSocketContainer);
+		assertThat(TestUtils.<Long>getPropertyValue(this.customInboundAdapter, "messagingTemplate.sendTimeout"))
 				.isEqualTo(2000L);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "phase")).isEqualTo(200);
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "payloadType", Class.class))
+		assertThat(TestUtils.<Integer>getPropertyValue(this.customInboundAdapter, "phase")).isEqualTo(200);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customInboundAdapter, "autoStartup")).isFalse();
+		assertThat(TestUtils.<Object>getPropertyValue(this.customInboundAdapter, "payloadType"))
 				.isEqualTo(Integer.class);
-		SubProtocolHandlerRegistry subProtocolHandlerRegistry = TestUtils.getPropertyValue(this.customInboundAdapter,
-				"subProtocolHandlerRegistry", SubProtocolHandlerRegistry.class);
-		assertThat(TestUtils.getPropertyValue(subProtocolHandlerRegistry,
+		SubProtocolHandlerRegistry subProtocolHandlerRegistry =
+				TestUtils.getPropertyValue(this.customInboundAdapter, "subProtocolHandlerRegistry");
+		assertThat(TestUtils.<Object>getPropertyValue(subProtocolHandlerRegistry,
 				"defaultProtocolHandler")).isSameAs(this.stompSubProtocolHandler);
-		Map<?, ?> protocolHandlers =
-				TestUtils.getPropertyValue(subProtocolHandlerRegistry, "protocolHandlers", Map.class);
+		Map<?, ?> protocolHandlers = TestUtils.getPropertyValue(subProtocolHandlerRegistry, "protocolHandlers");
 		assertThat(protocolHandlers.size()).isEqualTo(3);
 		//PassThruSubProtocolHandler is ignored because it doesn't provide any 'protocol' by default.
 		//See warn log message.
@@ -233,10 +234,10 @@ public class WebSocketParserTests {
 			assertThat(handler).isSameAs(this.stompSubProtocolHandler);
 		}
 
-		assertThat(TestUtils.getPropertyValue(this.customInboundAdapter, "mergeWithDefaultConverters", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customInboundAdapter, "mergeWithDefaultConverters"))
 				.isTrue();
-		CompositeMessageConverter compositeMessageConverter = TestUtils.getPropertyValue(this.customInboundAdapter,
-				"messageConverter", CompositeMessageConverter.class);
+		CompositeMessageConverter compositeMessageConverter =
+				TestUtils.getPropertyValue(this.customInboundAdapter, "messageConverter");
 		List<MessageConverter> converters = compositeMessageConverter.getConverters();
 		assertThat(converters.size()).isEqualTo(5);
 		assertThat(converters.get(0)).isSameAs(this.simpleMessageConverter);
@@ -244,67 +245,67 @@ public class WebSocketParserTests {
 		assertThat(converters.get(2)).isInstanceOf(StringMessageConverter.class);
 
 		//Test ClientWebSocketContainer parser
-		assertThat(TestUtils.getPropertyValue(this.clientWebSocketContainer, "messageListener"))
-				.isSameAs(this.customInboundAdapter);
-		assertThat(TestUtils.getPropertyValue(this.clientWebSocketContainer, "sendTimeLimit")).isEqualTo(100);
-		assertThat(TestUtils.getPropertyValue(this.clientWebSocketContainer, "sendBufferSizeLimit")).isEqualTo(1000);
-		assertThat(TestUtils.getPropertyValue(this.clientWebSocketContainer, "sendBufferOverflowStrategy"))
+		assertThat(TestUtils.<WebSocketInboundChannelAdapter>getPropertyValue(this.clientWebSocketContainer,
+				"messageListener")).isSameAs(this.customInboundAdapter);
+		assertThat(TestUtils.<Integer>getPropertyValue(this.clientWebSocketContainer, "sendTimeLimit")).isEqualTo(100);
+		assertThat(TestUtils.<Integer>getPropertyValue(this.clientWebSocketContainer, "sendBufferSizeLimit"))
+				.isEqualTo(1000);
+		assertThat(TestUtils.<ConcurrentWebSocketSessionDecorator.OverflowStrategy>getPropertyValue(
+				this.clientWebSocketContainer, "sendBufferOverflowStrategy"))
 				.isEqualTo(ConcurrentWebSocketSessionDecorator.OverflowStrategy.DROP);
-		assertThat(TestUtils.getPropertyValue(this.clientWebSocketContainer, "connectionManager.uri", URI.class))
+		assertThat(TestUtils.<URI>getPropertyValue(this.clientWebSocketContainer, "connectionManager.uri"))
 				.isEqualTo(new URI("ws://foo.bar/ws?service=user"));
-		assertThat(TestUtils.getPropertyValue(this.clientWebSocketContainer, "connectionManager.client"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.clientWebSocketContainer, "connectionManager.client"))
 				.isSameAs(this.webSocketClient);
-		assertThat(TestUtils.getPropertyValue(this.clientWebSocketContainer, "connectionManager.phase")).isEqualTo(100);
-		WebSocketHttpHeaders headers = TestUtils.getPropertyValue(this.clientWebSocketContainer, "headers",
-				WebSocketHttpHeaders.class);
+		assertThat(TestUtils.<Integer>getPropertyValue(this.clientWebSocketContainer, "connectionManager.phase"))
+				.isEqualTo(100);
+		WebSocketHttpHeaders headers = TestUtils.getPropertyValue(this.clientWebSocketContainer, "headers");
 		assertThat(headers.getOrigin()).isEqualTo("FOO");
 		assertThat(headers.get("FOO")).isEqualTo(Arrays.asList("BAR", "baz"));
 
-		assertThat(TestUtils.getPropertyValue(this.simpleClientWebSocketContainer, "sendTimeLimit"))
+		assertThat(TestUtils.<Integer>getPropertyValue(this.simpleClientWebSocketContainer, "sendTimeLimit"))
 				.isEqualTo(10 * 1000);
-		assertThat(TestUtils.getPropertyValue(this.simpleClientWebSocketContainer, "sendBufferSizeLimit"))
+		assertThat(TestUtils.<Integer>getPropertyValue(this.simpleClientWebSocketContainer, "sendBufferSizeLimit"))
 				.isEqualTo(512 * 1024);
-		assertThat(TestUtils.getPropertyValue(this.simpleClientWebSocketContainer, "sendBufferOverflowStrategy"))
-				.isNull();
-		assertThat(TestUtils.getPropertyValue(this.simpleClientWebSocketContainer, "connectionManager.uri", URI.class))
+		assertThat(TestUtils.<Object>getPropertyValue(this.simpleClientWebSocketContainer,
+				"sendBufferOverflowStrategy")).isNull();
+		assertThat(TestUtils.<URI>getPropertyValue(this.simpleClientWebSocketContainer, "connectionManager.uri"))
 				.isEqualTo(new URI("ws://foo.bar"));
-		assertThat(TestUtils.getPropertyValue(this.simpleClientWebSocketContainer, "connectionManager.client"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.simpleClientWebSocketContainer, "connectionManager.client"))
 				.isSameAs(this.webSocketClient);
-		assertThat(TestUtils.getPropertyValue(this.simpleClientWebSocketContainer, "connectionManager.phase"))
+		assertThat(TestUtils.<Integer>getPropertyValue(this.simpleClientWebSocketContainer, "connectionManager.phase"))
 				.isEqualTo(Integer.MAX_VALUE);
-		assertThat(TestUtils.getPropertyValue(this.simpleClientWebSocketContainer,
-				"connectionManager.autoStartup", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.simpleClientWebSocketContainer, "headers",
-				WebSocketHttpHeaders.class).isEmpty()).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.simpleClientWebSocketContainer, "connectionManager.autoStartup"))
+				.isFalse();
+		assertThat(TestUtils.<WebSocketHttpHeaders>getPropertyValue(this.simpleClientWebSocketContainer, "headers").isEmpty()).isTrue();
 	}
 
 	@Test
 	public void testDefaultOutboundChannelAdapter() {
-		assertThat(TestUtils.getPropertyValue(this.defaultOutboundAdapter, "webSocketContainer"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultOutboundAdapter, "webSocketContainer"))
 				.isSameAs(this.serverWebSocketContainer);
-		assertThat(TestUtils.getPropertyValue(this.defaultOutboundAdapter, "messageConverters")).isNull();
-		assertThat(TestUtils.getPropertyValue(this.defaultOutboundAdapter, "defaultConverters"))
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultOutboundAdapter, "messageConverters")).isNull();
+		assertThat(TestUtils.<Object>getPropertyValue(this.defaultOutboundAdapter, "defaultConverters"))
 				.isEqualTo(TestUtils.getPropertyValue(this.defaultOutboundAdapter, "messageConverter.converters"));
-		SubProtocolHandlerRegistry subProtocolHandlerRegistry = TestUtils.getPropertyValue(this.defaultOutboundAdapter,
-				"subProtocolHandlerRegistry", SubProtocolHandlerRegistry.class);
-		assertThat(TestUtils.getPropertyValue(subProtocolHandlerRegistry, "defaultProtocolHandler"))
+		SubProtocolHandlerRegistry subProtocolHandlerRegistry =
+				TestUtils.getPropertyValue(this.defaultOutboundAdapter, "subProtocolHandlerRegistry");
+		assertThat(TestUtils.<PassThruSubProtocolHandler>getPropertyValue(subProtocolHandlerRegistry, "defaultProtocolHandler"))
 				.isInstanceOf(PassThruSubProtocolHandler.class);
-		assertThat(TestUtils.getPropertyValue(subProtocolHandlerRegistry, "protocolHandlers", Map.class).isEmpty())
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(subProtocolHandlerRegistry, "protocolHandlers").isEmpty())
 				.isTrue();
-		assertThat(TestUtils.getPropertyValue(this.defaultOutboundAdapter, "client", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.defaultOutboundAdapter, "client")).isFalse();
 	}
 
 	@Test
 	public void testCustomOutboundChannelAdapter() throws URISyntaxException {
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapter, "webSocketContainer"))
-				.isSameAs(this.clientWebSocketContainer);
+		assertThat(TestUtils.<IntegrationWebSocketContainer>getPropertyValue(this.customOutboundAdapter,
+				"webSocketContainer")).isSameAs(this.clientWebSocketContainer);
 
 		SubProtocolHandlerRegistry subProtocolHandlerRegistry = TestUtils.getPropertyValue(this.customOutboundAdapter,
-				"subProtocolHandlerRegistry", SubProtocolHandlerRegistry.class);
-		assertThat(TestUtils.getPropertyValue(subProtocolHandlerRegistry,
+				"subProtocolHandlerRegistry");
+		assertThat(TestUtils.<StompSubProtocolHandler>getPropertyValue(subProtocolHandlerRegistry,
 				"defaultProtocolHandler")).isSameAs(this.stompSubProtocolHandler);
-		Map<?, ?> protocolHandlers =
-				TestUtils.getPropertyValue(subProtocolHandlerRegistry, "protocolHandlers", Map.class);
+		Map<?, ?> protocolHandlers = TestUtils.getPropertyValue(subProtocolHandlerRegistry, "protocolHandlers");
 		assertThat(protocolHandlers.size()).isEqualTo(3);
 		//PassThruSubProtocolHandler is ignored because it doesn't provide any 'protocol' by default.
 		//See warn log message.
@@ -312,16 +313,16 @@ public class WebSocketParserTests {
 			assertThat(handler).isSameAs(this.stompSubProtocolHandler);
 		}
 
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapter, "mergeWithDefaultConverters", Boolean.class))
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customOutboundAdapter, "mergeWithDefaultConverters"))
 				.isTrue();
-		CompositeMessageConverter compositeMessageConverter = TestUtils.getPropertyValue(this.customOutboundAdapter,
-				"messageConverter", CompositeMessageConverter.class);
+		CompositeMessageConverter compositeMessageConverter =
+				TestUtils.getPropertyValue(this.customOutboundAdapter, "messageConverter");
 		List<MessageConverter> converters = compositeMessageConverter.getConverters();
 		assertThat(converters.size()).isEqualTo(5);
 		assertThat(converters.get(0)).isSameAs(this.simpleMessageConverter);
 		assertThat(converters.get(1)).isSameAs(this.mapMessageConverter);
 		assertThat(converters.get(2)).isInstanceOf(StringMessageConverter.class);
-		assertThat(TestUtils.getPropertyValue(this.customOutboundAdapter, "client", Boolean.class)).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.customOutboundAdapter, "client")).isTrue();
 	}
 
 	private static class TestWebSocketHandlerDecoratorFactory implements WebSocketHandlerDecoratorFactory {

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapterTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/inbound/WebSocketInboundChannelAdapterTests.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.1
  */
@@ -87,7 +88,7 @@ public class WebSocketInboundChannelAdapterTests {
 		assertThat(session.getAcceptedProtocol()).isEqualTo("v10.stomp");
 
 		Map<String, WebSocketSession> sessions =
-				TestUtils.getPropertyValue(this.subProtocolWebSocketHandler, "sessions", Map.class);
+				TestUtils.getPropertyValue(this.subProtocolWebSocketHandler, "sessions");
 
 		assertThat(sessions.size()).isEqualTo(1);
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/DefaultConfigurationTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/DefaultConfigurationTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -65,14 +66,13 @@ public class DefaultConfigurationTests {
 	public void verifyTaskScheduler() {
 		Object taskScheduler = context.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME);
 		assertThat(taskScheduler.getClass()).isEqualTo(ThreadPoolTaskScheduler.class);
-		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler", ErrorHandler.class);
+		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler");
 		assertThat(errorHandler.getClass()).isEqualTo(MessagePublishingErrorHandler.class);
-		MessageChannel defaultErrorChannel = TestUtils.getPropertyValue(errorHandler,
-				"messagingTemplate.defaultDestination", MessageChannel.class);
+		MessageChannel defaultErrorChannel =
+				TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNull();
 		errorHandler.handleError(new Throwable());
-		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination",
-				MessageChannel.class);
+		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNotNull();
 		assertThat(defaultErrorChannel).isEqualTo(context.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME));
 	}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/UriVariableTests.java
@@ -70,6 +70,7 @@ import static org.mockito.Mockito.doAnswer;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Andy Wilkinson
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -111,8 +112,8 @@ public class UriVariableTests {
 	@Test
 	@SuppressWarnings("unchecked")
 	public void testHttpUriVariables() {
-		WebServiceTemplate webServiceTemplate = TestUtils.getPropertyValue(this.httpOutboundGateway,
-				"webServiceTemplate", WebServiceTemplate.class);
+		WebServiceTemplate webServiceTemplate =
+				TestUtils.getPropertyValue(this.httpOutboundGateway, "webServiceTemplate");
 		webServiceTemplate = Mockito.spy(webServiceTemplate);
 		final AtomicReference<String> uri = new AtomicReference<>();
 		doAnswer(invocation -> {
@@ -199,7 +200,7 @@ public class UriVariableTests {
 		}
 		WebServiceConnection webServiceConnection = this.emailInterceptor.getLastWebServiceConnection();
 		assertThat(TestUtils.getPropertyValue(webServiceConnection, "to").toString()).isEqualTo(testEmailTo);
-		assertThat(TestUtils.getPropertyValue(webServiceConnection, "subject")).isEqualTo(testEmailSubject);
+		assertThat(TestUtils.<Object>getPropertyValue(webServiceConnection, "subject")).isEqualTo(testEmailSubject);
 		assertThat(this.emailInterceptor.getLastUri().toString())
 				.isEqualTo("mailto:user@example.com?subject=Test%20subject");
 	}

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceInboundGatewayParserTests.java
@@ -54,6 +54,7 @@ import static org.mockito.Mockito.when;
  * @author Gunnar Hillert
  * @author Stephane Nicoll
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -103,7 +104,7 @@ public class WebServiceInboundGatewayParserTests {
 
 	@Test
 	public void extractPayloadSet() {
-		assertThat(TestUtils.getPropertyValue(this.payloadExtractingGateway, "extractPayload", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.payloadExtractingGateway, "extractPayload")).isFalse();
 	}
 
 	@Test
@@ -117,13 +118,11 @@ public class WebServiceInboundGatewayParserTests {
 
 		assertThat(this.marshallingGateway.getErrorChannel()).isSameAs(this.customErrorChannel);
 
-		AbstractHeaderMapper.HeaderMatcher requestHeaderMatcher = TestUtils.getPropertyValue(marshallingGateway,
-				"headerMapper.requestHeaderMatcher", AbstractHeaderMapper.HeaderMatcher.class);
+		AbstractHeaderMapper.HeaderMatcher requestHeaderMatcher = TestUtils.getPropertyValue(marshallingGateway, "headerMapper.requestHeaderMatcher");
 		assertThat(requestHeaderMatcher.matchHeader("testRequest")).isTrue();
 		assertThat(requestHeaderMatcher.matchHeader("testReply")).isFalse();
 
-		AbstractHeaderMapper.HeaderMatcher replyHeaderMatcher = TestUtils.getPropertyValue(marshallingGateway,
-				"headerMapper.replyHeaderMatcher", AbstractHeaderMapper.HeaderMatcher.class);
+		AbstractHeaderMapper.HeaderMatcher replyHeaderMatcher = TestUtils.getPropertyValue(marshallingGateway, "headerMapper.replyHeaderMatcher");
 		assertThat(replyHeaderMatcher.matchHeader("testRequest")).isFalse();
 		assertThat(replyHeaderMatcher.matchHeader("testReply")).isTrue();
 	}
@@ -163,7 +162,8 @@ public class WebServiceInboundGatewayParserTests {
 
 	@Test
 	public void testHeaderMapperReference() {
-		assertThat(TestUtils.getPropertyValue(this.headerMappingGateway, "headerMapper")).isSameAs(testHeaderMapper);
+		assertThat(TestUtils.<Object>getPropertyValue(this.headerMappingGateway, "headerMapper"))
+				.isSameAs(testHeaderMapper);
 	}
 
 	@Autowired
@@ -172,7 +172,8 @@ public class WebServiceInboundGatewayParserTests {
 
 	@Test
 	public void testReplyTimeout() {
-		assertThat(TestUtils.getPropertyValue(replyTimeoutGateway, "messagingTemplate.receiveTimeout")).isEqualTo(1234L);
+		assertThat(TestUtils.<Long>getPropertyValue(replyTimeoutGateway, "messagingTemplate.receiveTimeout"))
+				.isEqualTo(1234L);
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayParserTests.java
@@ -70,6 +70,7 @@ import static org.mockito.Mockito.verify;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -91,20 +92,18 @@ public class WebServiceOutboundGatewayParserTests {
 		assertThat(accessor.getPropertyValue("outputChannel")).isEqualTo(expected);
 		assertThat(accessor.getPropertyValue("requiresReply")).isEqualTo(Boolean.FALSE);
 
-		AbstractHeaderMapper.HeaderMatcher requestHeaderMatcher = TestUtils.getPropertyValue(endpoint,
-				"handler.headerMapper.requestHeaderMatcher", AbstractHeaderMapper.HeaderMatcher.class);
+		AbstractHeaderMapper.HeaderMatcher requestHeaderMatcher = TestUtils.getPropertyValue(endpoint, "handler.headerMapper.requestHeaderMatcher");
 		assertThat(requestHeaderMatcher.matchHeader("testRequest")).isTrue();
 		assertThat(requestHeaderMatcher.matchHeader("testReply")).isFalse();
 
-		AbstractHeaderMapper.HeaderMatcher replyHeaderMatcher = TestUtils.getPropertyValue(endpoint,
-				"handler.headerMapper.replyHeaderMatcher", AbstractHeaderMapper.HeaderMatcher.class);
+		AbstractHeaderMapper.HeaderMatcher replyHeaderMatcher = TestUtils.getPropertyValue(endpoint, "handler.headerMapper.replyHeaderMatcher");
 		assertThat(replyHeaderMatcher.matchHeader("testRequest")).isFalse();
 		assertThat(replyHeaderMatcher.matchHeader("testReply")).isTrue();
 
-		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout", Long.class);
+		Long sendTimeout = TestUtils.getPropertyValue(gateway, "messagingTemplate.sendTimeout");
 		assertThat(sendTimeout).isEqualTo(Long.valueOf(777));
 
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "webServiceTemplate"))
 				.isSameAs(this.context.getBean("webServiceTemplate"));
 	}
 
@@ -294,9 +293,9 @@ public class WebServiceOutboundGatewayParserTests {
 		assertThat(endpoint.getClass()).isEqualTo(EventDrivenConsumer.class);
 		Object gateway = TestUtils.getPropertyValue(endpoint, "handler");
 		Marshaller marshaller = context.getBean("marshallerAndUnmarshaller", Marshaller.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class))
+		assertThat(TestUtils.<Marshaller>getPropertyValue(gateway, "webServiceTemplate.marshaller"))
 				.isSameAs(marshaller);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class))
+		assertThat(TestUtils.<Unmarshaller>getPropertyValue(gateway, "webServiceTemplate.unmarshaller"))
 				.isSameAs(marshaller);
 		context.close();
 	}
@@ -310,9 +309,9 @@ public class WebServiceOutboundGatewayParserTests {
 		Object gateway = TestUtils.getPropertyValue(endpoint, "handler");
 		Marshaller marshaller = context.getBean("marshaller", Marshaller.class);
 		Unmarshaller unmarshaller = context.getBean("unmarshaller", Unmarshaller.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class))
+		assertThat(TestUtils.<Marshaller>getPropertyValue(gateway, "webServiceTemplate.marshaller"))
 				.isSameAs(marshaller);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class))
+		assertThat(TestUtils.<Unmarshaller>getPropertyValue(gateway, "webServiceTemplate.unmarshaller"))
 				.isSameAs(unmarshaller);
 		context.close();
 	}
@@ -340,13 +339,14 @@ public class WebServiceOutboundGatewayParserTests {
 		assertThat(endpoint.getClass()).isEqualTo(EventDrivenConsumer.class);
 		Object gateway = TestUtils.getPropertyValue(endpoint, "handler");
 		Marshaller marshaller = context.getBean("marshallerAndUnmarshaller", Marshaller.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class))
+		assertThat(TestUtils.<Marshaller>getPropertyValue(gateway, "webServiceTemplate.marshaller"))
 				.isSameAs(marshaller);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class))
+		assertThat(TestUtils.<Unmarshaller>getPropertyValue(gateway, "webServiceTemplate.unmarshaller"))
 				.isSameAs(marshaller);
 
 		WebServiceMessageFactory messageFactory = (WebServiceMessageFactory) context.getBean("messageFactory");
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory")).isEqualTo(messageFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "webServiceTemplate.messageFactory"))
+				.isEqualTo(messageFactory);
 		context.close();
 	}
 
@@ -363,13 +363,14 @@ public class WebServiceOutboundGatewayParserTests {
 		Marshaller marshaller = context.getBean("marshaller", Marshaller.class);
 		Unmarshaller unmarshaller = context.getBean("unmarshaller", Unmarshaller.class);
 
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller", Marshaller.class))
+		assertThat(TestUtils.<Marshaller>getPropertyValue(gateway, "webServiceTemplate.marshaller"))
 				.isSameAs(marshaller);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller", Unmarshaller.class))
+		assertThat(TestUtils.<Unmarshaller>getPropertyValue(gateway, "webServiceTemplate.unmarshaller"))
 				.isSameAs(unmarshaller);
 
 		WebServiceMessageFactory messageFactory = context.getBean("messageFactory", WebServiceMessageFactory.class);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory")).isEqualTo(messageFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "webServiceTemplate.messageFactory"))
+				.isEqualTo(messageFactory);
 		context.close();
 	}
 
@@ -394,7 +395,7 @@ public class WebServiceOutboundGatewayParserTests {
 		adviceCalled = 0;
 		AbstractEndpoint endpoint = this.context.getBean("gatewayWithAdvice", AbstractEndpoint.class);
 		assertThat(endpoint.getClass()).isEqualTo(EventDrivenConsumer.class);
-		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler");
 		handler.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}
@@ -411,15 +412,13 @@ public class WebServiceOutboundGatewayParserTests {
 	public void jmsUri() {
 		AbstractEndpoint endpoint = this.context.getBean("gatewayWithJmsUri", AbstractEndpoint.class);
 		assertThat(endpoint.getClass()).isEqualTo(EventDrivenConsumer.class);
-		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler", MessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(handler, "destinationProvider")).isNull();
+		MessageHandler handler = TestUtils.getPropertyValue(endpoint, "handler");
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "destinationProvider")).isNull();
 		assertThat(
-				TestUtils.getPropertyValue(handler, "uriFactory.encodingMode",
-						DefaultUriBuilderFactory.EncodingMode.class))
+				TestUtils.<DefaultUriBuilderFactory.EncodingMode>getPropertyValue(handler, "uriFactory.encodingMode"))
 				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.NONE);
 
-		WebServiceTemplate webServiceTemplate = TestUtils.getPropertyValue(handler, "webServiceTemplate",
-				WebServiceTemplate.class);
+		WebServiceTemplate webServiceTemplate = TestUtils.getPropertyValue(handler, "webServiceTemplate");
 		webServiceTemplate = spy(webServiceTemplate);
 
 		doReturn(null).when(webServiceTemplate).sendAndReceive(anyString(),

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/config/WebServiceOutboundGatewayWithHeaderMapperTests.java
@@ -68,6 +68,7 @@ import static org.mockito.Mockito.mock;
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -94,14 +95,12 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 	@Test
 	public void headerMapperParserTest() {
 		SimpleWebServiceOutboundGateway gateway =
-				TestUtils.getPropertyValue(this.context.getBean("withHeaderMapper"),
-						"handler", SimpleWebServiceOutboundGateway.class);
-		DefaultSoapHeaderMapper headerMapper = TestUtils.getPropertyValue(gateway, "headerMapper",
-				DefaultSoapHeaderMapper.class);
+				TestUtils.<SimpleWebServiceOutboundGateway>getPropertyValue(this.context.getBean("withHeaderMapper"), "handler");
+		DefaultSoapHeaderMapper headerMapper = TestUtils.getPropertyValue(gateway, "headerMapper");
 		assertThat(headerMapper).isNotNull();
 
-		AbstractHeaderMapper.HeaderMatcher requestHeaderMatcher = TestUtils.getPropertyValue(headerMapper,
-				"requestHeaderMatcher", AbstractHeaderMapper.HeaderMatcher.class);
+		AbstractHeaderMapper.HeaderMatcher requestHeaderMatcher =
+				TestUtils.getPropertyValue(headerMapper, "requestHeaderMatcher");
 		assertThat(requestHeaderMatcher.matchHeader("foo")).isTrue();
 		assertThat(requestHeaderMatcher.matchHeader("foo123")).isTrue();
 		assertThat(requestHeaderMatcher.matchHeader("baz")).isTrue();
@@ -109,8 +108,8 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 		assertThat(requestHeaderMatcher.matchHeader("bar")).isFalse();
 		assertThat(requestHeaderMatcher.matchHeader("bar123")).isFalse();
 
-		AbstractHeaderMapper.HeaderMatcher replyHeaderMatcher = TestUtils.getPropertyValue(headerMapper,
-				"replyHeaderMatcher", AbstractHeaderMapper.HeaderMatcher.class);
+		AbstractHeaderMapper.HeaderMatcher replyHeaderMatcher =
+				TestUtils.getPropertyValue(headerMapper, "replyHeaderMatcher");
 		assertThat(replyHeaderMatcher.matchHeader("foo")).isFalse();
 		assertThat(replyHeaderMatcher.matchHeader("foo123")).isFalse();
 		assertThat(replyHeaderMatcher.matchHeader("baz")).isFalse();
@@ -206,12 +205,11 @@ public class WebServiceOutboundGatewayWithHeaderMapperTests {
 			throws Exception {
 
 		AbstractWebServiceOutboundGateway gateway =
-				TestUtils.getPropertyValue(this.context.getBean(gatewayName), "handler",
-						AbstractWebServiceOutboundGateway.class);
+				TestUtils.<AbstractWebServiceOutboundGateway>getPropertyValue(this.context.getBean(gatewayName), "handler");
 
 		if (!soap) {
 			WebServiceTemplate template =
-					TestUtils.getPropertyValue(gateway, "webServiceTemplate", WebServiceTemplate.class);
+					TestUtils.<WebServiceTemplate>getPropertyValue(gateway, "webServiceTemplate");
 			template.setMessageFactory(new DomPoxMessageFactory());
 		}
 

--- a/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
+++ b/spring-integration-ws/src/test/java/org/springframework/integration/ws/dsl/WsDslTests.java
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.3
  *
@@ -61,13 +62,13 @@ public class WsDslTests {
 		MarshallingWebServiceInboundGateway gateway = Ws.marshallingInboundGateway(marshaller)
 				.unmarshaller(unmarshaller)
 				.getObject();
-		assertThat(TestUtils.getPropertyValue(gateway, "marshaller")).isSameAs(marshaller);
-		assertThat(TestUtils.getPropertyValue(gateway, "unmarshaller")).isSameAs(unmarshaller);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "marshaller")).isSameAs(marshaller);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "unmarshaller")).isSameAs(unmarshaller);
 
 		marshaller = mock(Both.class);
 		gateway = Ws.marshallingInboundGateway(marshaller).getObject();
-		assertThat(TestUtils.getPropertyValue(gateway, "marshaller")).isSameAs(marshaller);
-		assertThat(TestUtils.getPropertyValue(gateway, "unmarshaller")).isSameAs(marshaller);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "marshaller")).isSameAs(marshaller);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "unmarshaller")).isSameAs(marshaller);
 	}
 
 	@Test
@@ -79,9 +80,9 @@ public class WsDslTests {
 						.headerMapper(testHeaderMapper)
 						.errorChannel("myErrorChannel")
 						.getObject();
-		assertThat(TestUtils.getPropertyValue(gateway, "extractPayload", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(gateway, "headerMapper")).isSameAs(testHeaderMapper);
-		assertThat(TestUtils.getPropertyValue(gateway, "errorChannelName")).isEqualTo("myErrorChannel");
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "extractPayload")).isFalse();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "headerMapper")).isSameAs(testHeaderMapper);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "errorChannelName")).isEqualTo("myErrorChannel");
 	}
 
 	@Test
@@ -112,19 +113,21 @@ public class WsDslTests {
 						.requestCallback(requestCallback)
 						.uriVariableExpressions(uriVariableExpressions)
 						.getObject();
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.marshaller")).isSameAs(marshaller);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.unmarshaller")).isSameAs(unmarshaller);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory")).isSameAs(messageFactory);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.faultMessageResolver"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "webServiceTemplate.marshaller")).isSameAs(marshaller);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "webServiceTemplate.unmarshaller"))
+				.isSameAs(unmarshaller);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "webServiceTemplate.messageFactory"))
+				.isSameAs(messageFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "webServiceTemplate.faultMessageResolver"))
 				.isSameAs(faultMessageResolver);
-		assertThat(TestUtils.getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.interceptors", ClientInterceptor[].class)[0])
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
+		assertThat(TestUtils.<ClientInterceptor[]>getPropertyValue(gateway, "webServiceTemplate.interceptors")[0])
 				.isSameAs(interceptor);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageSenders",
-				WebServiceMessageSender[].class)[0])
+		assertThat(TestUtils.<WebServiceMessageSender[]>getPropertyValue(gateway, "webServiceTemplate.messageSenders")[0])
 				.isSameAs(messageSender);
-		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
-		assertThat(TestUtils.getPropertyValue(gateway, "uriVariableExpressions")).isEqualTo(uriVariableExpressions);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "uriVariableExpressions"))
+				.isEqualTo(uriVariableExpressions);
 	}
 
 	@Test
@@ -155,18 +158,19 @@ public class WsDslTests {
 						.uriVariableExpressions(uriVariableExpressions)
 						.extractPayload(false)
 						.getObject();
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageFactory")).isSameAs(messageFactory);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.faultMessageResolver"))
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "webServiceTemplate.messageFactory"))
+				.isSameAs(messageFactory);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "webServiceTemplate.faultMessageResolver"))
 				.isSameAs(faultMessageResolver);
-		assertThat(TestUtils.getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.interceptors", ClientInterceptor[].class)[0])
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
+		assertThat(TestUtils.<ClientInterceptor[]>getPropertyValue(gateway, "webServiceTemplate.interceptors")[0])
 				.isSameAs(interceptor);
-		assertThat(TestUtils.getPropertyValue(gateway, "webServiceTemplate.messageSenders",
-				WebServiceMessageSender[].class)[0])
+		assertThat(TestUtils.<WebServiceMessageSender[]>getPropertyValue(gateway, "webServiceTemplate.messageSenders")[0])
 				.isSameAs(messageSender);
-		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
-		assertThat(TestUtils.getPropertyValue(gateway, "uriVariableExpressions")).isEqualTo(uriVariableExpressions);
-		assertThat(TestUtils.getPropertyValue(gateway, "extractPayload", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "uriVariableExpressions"))
+				.isEqualTo(uriVariableExpressions);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "extractPayload")).isFalse();
 	}
 
 	@Test
@@ -187,13 +191,13 @@ public class WsDslTests {
 						.requestCallback(requestCallback)
 						.uriVariableExpressions(uriVariableExpressions)
 						.getObject();
-		assertThat(TestUtils.getPropertyValue(gateway, "uri")).isSameAs(uri);
-		assertThat(TestUtils.getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
-		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
-		assertThat(TestUtils.getPropertyValue(gateway, "uriVariableExpressions")).isEqualTo(uriVariableExpressions);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "uri")).isSameAs(uri);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "uriVariableExpressions"))
+				.isEqualTo(uriVariableExpressions);
 		assertThat(
-				TestUtils.getPropertyValue(gateway, "uriFactory.encodingMode",
-						DefaultUriBuilderFactory.EncodingMode.class))
+				TestUtils.<DefaultUriBuilderFactory.EncodingMode>getPropertyValue(gateway, "uriFactory.encodingMode"))
 				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.TEMPLATE_AND_VALUES);
 	}
 
@@ -217,13 +221,13 @@ public class WsDslTests {
 						.uriVariableExpressions(uriVariableExpressions)
 						.extractPayload(false)
 						.getObject();
-		assertThat(TestUtils.getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
-		assertThat(TestUtils.getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
-		assertThat(TestUtils.getPropertyValue(gateway, "uriVariableExpressions")).isEqualTo(uriVariableExpressions);
-		assertThat(TestUtils.getPropertyValue(gateway, "extractPayload", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "headerMapper")).isSameAs(headerMapper);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "requestCallback")).isSameAs(requestCallback);
+		assertThat(TestUtils.<Object>getPropertyValue(gateway, "uriVariableExpressions"))
+				.isEqualTo(uriVariableExpressions);
+		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "extractPayload")).isFalse();
 		assertThat(
-				TestUtils.getPropertyValue(gateway, "uriFactory.encodingMode",
-						DefaultUriBuilderFactory.EncodingMode.class))
+				TestUtils.<DefaultUriBuilderFactory.EncodingMode>getPropertyValue(gateway, "uriFactory.encodingMode"))
 				.isEqualTo(DefaultUriBuilderFactory.EncodingMode.VALUES_ONLY);
 	}
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/DefaultConfigurationTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/DefaultConfigurationTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 1.0.3
  */
@@ -65,14 +66,13 @@ public class DefaultConfigurationTests {
 	public void verifyTaskScheduler() {
 		Object taskScheduler = context.getBean(IntegrationContextUtils.TASK_SCHEDULER_BEAN_NAME);
 		assertThat(taskScheduler.getClass()).isEqualTo(ThreadPoolTaskScheduler.class);
-		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler", ErrorHandler.class);
+		ErrorHandler errorHandler = TestUtils.getPropertyValue(taskScheduler, "errorHandler");
 		assertThat(errorHandler.getClass()).isEqualTo(MessagePublishingErrorHandler.class);
-		MessageChannel defaultErrorChannel = TestUtils.getPropertyValue(errorHandler,
-				"messagingTemplate.defaultDestination", MessageChannel.class);
+		MessageChannel defaultErrorChannel =
+				TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNull();
 		errorHandler.handleError(new Throwable());
-		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination",
-				MessageChannel.class);
+		defaultErrorChannel = TestUtils.getPropertyValue(errorHandler, "messagingTemplate.defaultDestination");
 		assertThat(defaultErrorChannel).isNotNull();
 		assertThat(defaultErrorChannel).isEqualTo(context.getBean(IntegrationContextUtils.ERROR_CHANNEL_BEAN_NAME));
 	}

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/MarshallingTransformerParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/MarshallingTransformerParserTests.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -60,14 +61,14 @@ public class MarshallingTransformerParserTests {
 	@Test
 	public void testParse() {
 		EventDrivenConsumer consumer = (EventDrivenConsumer) appContext.getBean("parseOnly");
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(consumer, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "handler.order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "autoStartup")).isFalse();
 		SmartLifecycleRoleController roleController = appContext.getBean(SmartLifecycleRoleController.class);
 		@SuppressWarnings("unchecked")
-		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.getPropertyValue(roleController, "lifecycles",
-				MultiValueMap.class).get("foo");
+		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.<MultiValueMap<?, ?>>getPropertyValue(
+				roleController, "lifecycles").get("foo");
 		assertThat(list).containsExactly(consumer);
 	}
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/UnmarshallingTransformerParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/UnmarshallingTransformerParserTests.java
@@ -47,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -61,14 +62,14 @@ public class UnmarshallingTransformerParserTests {
 	@Test
 	public void testParse() {
 		EventDrivenConsumer consumer = (EventDrivenConsumer) appContext.getBean("parseOnly");
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(consumer, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "handler.order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "autoStartup")).isFalse();
 		SmartLifecycleRoleController roleController = appContext.getBean(SmartLifecycleRoleController.class);
 		@SuppressWarnings("unchecked")
-		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.getPropertyValue(roleController, "lifecycles",
-				MultiValueMap.class).get("foo");
+		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.<MultiValueMap<?, ?>>getPropertyValue(
+				roleController, "lifecycles").get("foo");
 		assertThat(list).containsExactly(consumer);
 	}
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathFilterParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathFilterParserTests.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.1
  */
@@ -56,14 +57,14 @@ public class XPathFilterParserTests {
 	@Test
 	public void testParse() {
 		EventDrivenConsumer consumer = (EventDrivenConsumer) context.getBean("parseOnly");
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(consumer, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "handler.order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "autoStartup")).isFalse();
 		SmartLifecycleRoleController roleController = context.getBean(SmartLifecycleRoleController.class);
 		@SuppressWarnings("unchecked")
-		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.getPropertyValue(roleController, "lifecycles",
-				MultiValueMap.class).get("foo");
+		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.<MultiValueMap<?, ?>>getPropertyValue(
+				roleController, "lifecycles").get("foo");
 		assertThat(list).containsExactly(consumer);
 	}
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathHeaderEnricherParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathHeaderEnricherParserTests.java
@@ -46,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -68,14 +69,14 @@ public class XPathHeaderEnricherParserTests {
 	@Test
 	public void testParse() {
 		EventDrivenConsumer consumer = (EventDrivenConsumer) context.getBean("parseOnly");
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(consumer, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "handler.order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "autoStartup")).isFalse();
 		SmartLifecycleRoleController roleController = context.getBean(SmartLifecycleRoleController.class);
 		@SuppressWarnings("unchecked")
-		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.getPropertyValue(roleController, "lifecycles",
-				MultiValueMap.class).get("foo");
+		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.<MultiValueMap<?, ?>>getPropertyValue(
+				roleController, "lifecycles").get("foo");
 		assertThat(list).containsExactly(consumer);
 	}
 
@@ -136,11 +137,11 @@ public class XPathHeaderEnricherParserTests {
 		assertThat(getEnricherProperty("customHeaderEnricher", "shouldSkipNulls")).isFalse();
 		Map<String, ? extends HeaderValueMessageProcessor<?>> headersToAdd =
 				TestUtils.getPropertyValue(this.context.getBean("customHeaderEnricher"),
-						"handler.transformer.headersToAdd", Map.class);
+						"handler.transformer.headersToAdd");
 		HeaderValueMessageProcessor<?> headerValueMessageProcessor = headersToAdd.get("foo");
 		assertThat(headerValueMessageProcessor)
 				.isInstanceOf(XPathExpressionEvaluatingHeaderValueMessageProcessor.class);
-		assertThat(TestUtils.getPropertyValue(headerValueMessageProcessor, "converter"))
+		assertThat(TestUtils.<Object>getPropertyValue(headerValueMessageProcessor, "converter"))
 				.isSameAs(this.context.getBean("xmlPayloadConverter"));
 	}
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathMessageSplitterParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathMessageSplitterParserTests.java
@@ -39,6 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Jonas Partner
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @ContextConfiguration
 @DirtiesContext
@@ -82,10 +83,10 @@ public class XPathMessageSplitterParserTests {
 						</si-xml:xpath-splitter>
 						""");
 		EventDrivenConsumer consumer = (EventDrivenConsumer) ctx.getBean("splitter");
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(consumer, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "handler.order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "autoStartup")).isFalse();
 		consumer.start();
 		ctx.getAutowireCapableBeanFactory()
 				.autowireBeanProperties(this, AutowireCapableBeanFactory.AUTOWIRE_BY_TYPE, false);

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathRouterParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathRouterParserTests.java
@@ -54,6 +54,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @ContextConfiguration
 @DirtiesContext
@@ -103,14 +104,14 @@ public class XPathRouterParserTests {
 		ClassPathXmlApplicationContext context =
 				new ClassPathXmlApplicationContext("XPathRouterTests-context.xml", this.getClass());
 		EventDrivenConsumer consumer = (EventDrivenConsumer) context.getBean("parseOnly");
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(consumer, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "handler.order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "autoStartup")).isFalse();
 		SmartLifecycleRoleController roleController = context.getBean(SmartLifecycleRoleController.class);
 		@SuppressWarnings("unchecked")
 		List<SmartLifecycle> list =
-				(List<SmartLifecycle>) TestUtils.getPropertyValue(roleController, "lifecycles", MultiValueMap.class)
+				(List<SmartLifecycle>) TestUtils.<MultiValueMap<?, ?>>getPropertyValue(roleController, "lifecycles")
 						.get("foo");
 		assertThat(list).containsExactly(consumer);
 		context.close();
@@ -249,7 +250,7 @@ public class XPathRouterParserTests {
 		assertThat(channelB.receive(10)).isNull();
 
 		EventDrivenConsumer routerEndpoint = ac.getBean("xpathRouterEmpty", EventDrivenConsumer.class);
-		var xpathRouter = TestUtils.getPropertyValue(routerEndpoint, "handler", AbstractMappingMessageRouter.class);
+		var xpathRouter = TestUtils.<AbstractMappingMessageRouter>getPropertyValue(routerEndpoint, "handler");
 		xpathRouter.setChannelMapping("channelA", "channelB");
 		inputChannel.send(docMessage);
 		assertThat(channelB.receive(10)).isNotNull();
@@ -271,7 +272,7 @@ public class XPathRouterParserTests {
 		assertThat(channelB.receive(10)).isNotNull();
 
 		EventDrivenConsumer routerEndpoint = ac.getBean("xpathRouterWithMapping", EventDrivenConsumer.class);
-		var xpathRouter = TestUtils.getPropertyValue(routerEndpoint, "handler", AbstractMappingMessageRouter.class);
+		var xpathRouter = TestUtils.<AbstractMappingMessageRouter>getPropertyValue(routerEndpoint, "handler");
 		xpathRouter.removeChannelMapping("channelA");
 		inputChannel.send(docMessage);
 		assertThat(channelA.receive(10)).isNotNull();
@@ -299,7 +300,7 @@ public class XPathRouterParserTests {
 		assertThat(channelB.receive(10)).isNull();
 
 		EventDrivenConsumer routerEndpoint = ac.getBean("xpathRouterWithMappingMultiChannel", EventDrivenConsumer.class);
-		var xpathRouter = TestUtils.getPropertyValue(routerEndpoint, "handler", AbstractMappingMessageRouter.class);
+		var xpathRouter = TestUtils.<AbstractMappingMessageRouter>getPropertyValue(routerEndpoint, "handler");
 		xpathRouter.removeChannelMapping("channelA");
 		xpathRouter.removeChannelMapping("channelB");
 		inputChannel.send(docMessage);

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathSplitterParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathSplitterParserTests.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -59,20 +60,22 @@ public class XPathSplitterParserTests {
 
 	@Test
 	public void testXpathSplitterConfig() {
-		assertThat(TestUtils.getPropertyValue(this.xpathSplitter, "createDocuments", Boolean.class)).isTrue();
-		assertThat(TestUtils.getPropertyValue(this.xpathSplitter, "applySequence", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.xpathSplitter, "returnIterator", Boolean.class)).isFalse();
-		assertThat(TestUtils.getPropertyValue(this.xpathSplitter, "outputProperties")).isSameAs(this.outputProperties);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.xpathSplitter, "createDocuments")).isTrue();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.xpathSplitter, "applySequence")).isFalse();
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.xpathSplitter, "returnIterator")).isFalse();
+		assertThat(TestUtils.<Object>getPropertyValue(this.xpathSplitter, "outputProperties"))
+				.isSameAs(this.outputProperties);
 		assertThat(TestUtils.getPropertyValue(this.xpathSplitter, "xpathExpression").toString())
 				.isEqualTo("/orders/order");
-		assertThat(TestUtils.getPropertyValue(xpathSplitter, "order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(xpathSplitter, "messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(this.xpathSplitter, "discardChannelName")).isEqualTo("nullChannel");
-		assertThat(TestUtils.getPropertyValue(consumer, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(xpathSplitter, "order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(xpathSplitter, "messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<String>getPropertyValue(this.xpathSplitter, "discardChannelName"))
+				.isEqualTo("nullChannel");
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "autoStartup")).isFalse();
 		@SuppressWarnings("unchecked")
-		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.getPropertyValue(roleController, "lifecycles",
-				MultiValueMap.class).get("foo");
+		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.<MultiValueMap<?, ?>>getPropertyValue(
+				roleController, "lifecycles").get("foo");
 		assertThat(list).containsExactly(consumer);
 	}
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathTransformerParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XPathTransformerParserTests.java
@@ -49,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -94,13 +95,14 @@ public class XPathTransformerParserTests {
 
 	@Test
 	public void testParse() {
-		assertThat(TestUtils.getPropertyValue(this.parseOnly, "handler.order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(this.parseOnly, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(this.parseOnly, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(this.parseOnly, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(this.parseOnly, "handler.order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(this.parseOnly, "handler.messagingTemplate.sendTimeout"))
+				.isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(this.parseOnly, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(this.parseOnly, "autoStartup")).isFalse();
 		@SuppressWarnings("unchecked")
-		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.getPropertyValue(roleController, "lifecycles",
-				MultiValueMap.class).get("foo");
+		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.<MultiValueMap<?, ?>>getPropertyValue(
+				roleController, "lifecycles").get("foo");
 		assertThat(list).containsExactly(this.parseOnly);
 	}
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XmlPayloadValidatingFilterParserTests.java
@@ -54,6 +54,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Jooyoung Pyoung
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -91,14 +92,15 @@ public class XmlPayloadValidatingFilterParserTests {
 	@Test
 	public void testParse() {
 		EventDrivenConsumer consumer = (EventDrivenConsumer) ac.getBean("parseOnly");
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(consumer, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "handler.order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "autoStartup")).isFalse();
 		SmartLifecycleRoleController roleController = ac.getBean(SmartLifecycleRoleController.class);
 		@SuppressWarnings("unchecked")
-		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.getPropertyValue(roleController, "lifecycles",
-				MultiValueMap.class).get("foo");
+		List<SmartLifecycle> list =
+				(List<SmartLifecycle>) TestUtils.<MultiValueMap<?, ?>>getPropertyValue(roleController,
+						"lifecycles").get("foo");
 		assertThat(list).containsExactly(consumer);
 	}
 

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XsltPayloadTransformerParserTests.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/XsltPayloadTransformerParserTests.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -71,14 +72,14 @@ public class XsltPayloadTransformerParserTests {
 	@Test
 	public void testParse() {
 		EventDrivenConsumer consumer = (EventDrivenConsumer) applicationContext.getBean("parseOnly");
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.order")).isEqualTo(2);
-		assertThat(TestUtils.getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
-		assertThat(TestUtils.getPropertyValue(consumer, "phase")).isEqualTo(-1);
-		assertThat(TestUtils.getPropertyValue(consumer, "autoStartup", Boolean.class)).isFalse();
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "handler.order")).isEqualTo(2);
+		assertThat(TestUtils.<Long>getPropertyValue(consumer, "handler.messagingTemplate.sendTimeout")).isEqualTo(123L);
+		assertThat(TestUtils.<Integer>getPropertyValue(consumer, "phase")).isEqualTo(-1);
+		assertThat(TestUtils.<Boolean>getPropertyValue(consumer, "autoStartup")).isFalse();
 		SmartLifecycleRoleController roleController = applicationContext.getBean(SmartLifecycleRoleController.class);
 		@SuppressWarnings("unchecked")
-		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.getPropertyValue(roleController, "lifecycles",
-				MultiValueMap.class).get("foo");
+		List<SmartLifecycle> list = (List<SmartLifecycle>) TestUtils.<MultiValueMap<?, ?>>getPropertyValue(
+				roleController, "lifecycles").get("foo");
 		assertThat(list).containsExactly(consumer);
 	}
 
@@ -91,7 +92,7 @@ public class XsltPayloadTransformerParserTests {
 		assertThat(result.getPayload()).as("Payload was not a DOMResult").isInstanceOf(DOMResult.class);
 		Document doc = (Document) ((DOMResult) result.getPayload()).getNode();
 		assertThat(doc.getDocumentElement().getTextContent()).as("Wrong payload").isEqualTo("test");
-		assertThat(TestUtils.getPropertyValue(applicationContext.getBean("xsltTransformerWithResource.handler"),
+		assertThat(TestUtils.<Object>getPropertyValue(applicationContext.getBean("xsltTransformerWithResource.handler"),
 				"transformer.evaluationContext.beanResolver")).isNotNull();
 	}
 

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests.java
@@ -48,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Florian Schmaus
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext(classMode = ClassMode.AFTER_EACH_TEST_METHOD)
@@ -70,21 +71,21 @@ public class ChatMessageInboundChannelAdapterParserTests {
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	public void testInboundAdapter() {
 		ChatMessageListeningEndpoint adapter = context.getBean("xmppInboundAdapter", ChatMessageListeningEndpoint.class);
-		MessageChannel errorChannel = (MessageChannel) TestUtils.getPropertyValue(adapter, "errorChannel");
+		MessageChannel errorChannel = TestUtils.getPropertyValue(adapter, "errorChannel");
 		assertThat(errorChannel).isEqualTo(context.getBean("errorChannel"));
 		assertThat(adapter.isAutoStartup()).isFalse();
-		QueueChannel channel = (QueueChannel) TestUtils.getPropertyValue(adapter, "outputChannel");
+		QueueChannel channel = TestUtils.getPropertyValue(adapter, "outputChannel");
 		assertThat(channel.getComponentName()).isEqualTo("xmppInbound");
-		XMPPConnection connection = (XMPPConnection) TestUtils.getPropertyValue(adapter, "xmppConnection");
+		XMPPConnection connection = TestUtils.getPropertyValue(adapter, "xmppConnection");
 		assertThat(context.getBean("testConnection")).isSameAs(connection);
 		Object stanzaFilter = context.getBean("stanzaFilter");
-		assertThat(TestUtils.getPropertyValue(adapter, "stanzaFilter")).isSameAs(stanzaFilter);
-		assertThat(TestUtils.getPropertyValue(adapter, "payloadExpression.expression")).isEqualTo("#root");
+		assertThat(TestUtils.<Object>getPropertyValue(adapter, "stanzaFilter")).isSameAs(stanzaFilter);
+		assertThat(TestUtils.<String>getPropertyValue(adapter, "payloadExpression.expression")).isEqualTo("#root");
 		adapter.start();
-		Map asyncRecvListeners = TestUtils.getPropertyValue(connection, "asyncRecvListeners", Map.class);
+		Map asyncRecvListeners = TestUtils.getPropertyValue(connection, "asyncRecvListeners");
 		assertThat(asyncRecvListeners.size()).isEqualTo(5);
 		Object lastListener = asyncRecvListeners.values().stream().reduce((first, second) -> second).get();
-		assertThat(TestUtils.getPropertyValue(lastListener, "packetFilter")).isSameAs(stanzaFilter);
+		assertThat(TestUtils.<Object>getPropertyValue(lastListener, "packetFilter")).isSameAs(stanzaFilter);
 		adapter.stop();
 	}
 
@@ -98,7 +99,7 @@ public class ChatMessageInboundChannelAdapterParserTests {
 		xmppConnectionField.setAccessible(true);
 		ReflectionUtils.setField(xmppConnectionField, adapter, xmppConnection);
 
-		StanzaListener stanzaListener = TestUtils.getPropertyValue(adapter, "stanzaListener", StanzaListener.class);
+		StanzaListener stanzaListener = TestUtils.getPropertyValue(adapter, "stanzaListener");
 
 		MessageBuilder message = StanzaBuilder.buildMessage();
 		message.setBody("hello");
@@ -113,7 +114,8 @@ public class ChatMessageInboundChannelAdapterParserTests {
 
 	@Test
 	public void testAutoChannel() {
-		assertThat(TestUtils.getPropertyValue(autoChannelAdapter, "outputChannel")).isSameAs(autoChannel);
+		assertThat(TestUtils.<MessageChannel>getPropertyValue(autoChannelAdapter, "outputChannel"))
+				.isSameAs(autoChannel);
 	}
 
 }

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageOutboundChannelAdapterParserTests.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.verify;
  * @author Artem Bilan
  * @author Gunnar Hillert
  * @author Florian Schmaus
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -72,7 +73,7 @@ public class ChatMessageOutboundChannelAdapterParserTests {
 	@Test
 	public void testPollingConsumer() {
 		Object pollingConsumer = context.getBean("withHeaderMapper");
-		QueueChannel channel = (QueueChannel) TestUtils.getPropertyValue(pollingConsumer, "inputChannel");
+		QueueChannel channel = TestUtils.getPropertyValue(pollingConsumer, "inputChannel");
 		assertThat(channel.getComponentName()).isEqualTo("outboundPollingChannel");
 		assertThat(pollingConsumer).isInstanceOf(PollingConsumer.class);
 	}
@@ -85,8 +86,7 @@ public class ChatMessageOutboundChannelAdapterParserTests {
 
 	@Test
 	public void advised() {
-		MessageHandler handler = TestUtils.getPropertyValue(context.getBean("advised"),
-				"handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(context.getBean("advised"), "handler");
 		handler.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}
@@ -94,11 +94,10 @@ public class ChatMessageOutboundChannelAdapterParserTests {
 	@Test
 	public void testEventConsumer() {
 		Object eventConsumer = context.getBean("outboundEventAdapter");
-		DefaultXmppHeaderMapper headerMapper =
-				TestUtils.getPropertyValue(eventConsumer, "handler.headerMapper", DefaultXmppHeaderMapper.class);
+		DefaultXmppHeaderMapper headerMapper = TestUtils.getPropertyValue(eventConsumer, "handler.headerMapper");
 
 		AbstractHeaderMapper.HeaderMatcher requestHeaderMatcher = TestUtils.getPropertyValue(headerMapper,
-				"requestHeaderMatcher", AbstractHeaderMapper.HeaderMatcher.class);
+				"requestHeaderMatcher");
 		assertThat(requestHeaderMatcher.matchHeader("foo")).isTrue();
 		assertThat(requestHeaderMatcher.matchHeader("foo123")).isTrue();
 		assertThat(requestHeaderMatcher.matchHeader("bar")).isTrue();
@@ -109,7 +108,7 @@ public class ChatMessageOutboundChannelAdapterParserTests {
 
 		MessageHandler outboundEventAdapterHandle =
 				context.getBean("outboundEventAdapter.handler", MessageHandler.class);
-		assertThat(TestUtils.getPropertyValue(outboundEventAdapterHandle, "extensionProvider"))
+		assertThat(TestUtils.<Object>getPropertyValue(outboundEventAdapterHandle, "extensionProvider"))
 				.isSameAs(this.extensionElementProvider);
 	}
 
@@ -117,7 +116,8 @@ public class ChatMessageOutboundChannelAdapterParserTests {
 	public void withHeaderMapper() throws Exception {
 		Object pollingConsumer = context.getBean("withHeaderMapper");
 		assertThat(pollingConsumer instanceof PollingConsumer).isTrue();
-		assertThat(TestUtils.getPropertyValue(pollingConsumer, "handler.headerMapper")).isEqualTo(headerMapper);
+		assertThat(TestUtils.<DefaultXmppHeaderMapper>getPropertyValue(pollingConsumer, "handler.headerMapper"))
+				.isEqualTo(headerMapper);
 		MessageChannel channel = context.getBean("outboundEventChannel", MessageChannel.class);
 		Message<?> message = MessageBuilder.withPayload("hello").setHeader(XmppHeaders.TO, "oleg").
 				setHeader("foobar", "foobar").build();

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/PresenceOutboundChannelAdapterParserTests.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -57,25 +58,23 @@ public class PresenceOutboundChannelAdapterParserTests {
 	public void testRosterEventOutboundChannelAdapterParserAsPollingConsumer() {
 		Object pollingConsumer = context.getBean("pollingOutboundRosterAdapter");
 		assertThat(pollingConsumer instanceof PollingConsumer).isTrue();
-		AbstractXmppConnectionAwareMessageHandler handler = (AbstractXmppConnectionAwareMessageHandler) TestUtils
-				.getPropertyValue(pollingConsumer, "handler");
-		assertThat(TestUtils.getPropertyValue(handler, "order")).isEqualTo(23);
+		AbstractXmppConnectionAwareMessageHandler handler = TestUtils.getPropertyValue(pollingConsumer, "handler");
+		assertThat(TestUtils.<Integer>getPropertyValue(handler, "order")).isEqualTo(23);
 	}
 
 	@Test
 	public void testRosterEventOutboundChannelAdapterParserEventConsumer() {
 		Object eventConsumer = context.getBean("eventOutboundRosterAdapter");
 		assertThat(eventConsumer instanceof EventDrivenConsumer).isTrue();
-		AbstractXmppConnectionAwareMessageHandler handler = (AbstractXmppConnectionAwareMessageHandler) TestUtils
-				.getPropertyValue(eventConsumer, "handler");
-		assertThat(TestUtils.getPropertyValue(handler, "order")).isEqualTo(34);
+		AbstractXmppConnectionAwareMessageHandler handler = TestUtils.getPropertyValue(eventConsumer, "handler");
+		assertThat(TestUtils.<Integer>getPropertyValue(handler, "order")).isEqualTo(34);
 	}
 
 	@Test
 	public void advised() {
 		Object eventConsumer = context.getBean("advised");
 		assertThat(eventConsumer instanceof EventDrivenConsumer).isTrue();
-		MessageHandler handler = TestUtils.getPropertyValue(eventConsumer, "handler", MessageHandler.class);
+		MessageHandler handler = TestUtils.getPropertyValue(eventConsumer, "handler");
 		handler.handleMessage(new GenericMessage<>("foo"));
 		assertThat(adviceCalled).isEqualTo(1);
 	}
@@ -84,12 +83,9 @@ public class PresenceOutboundChannelAdapterParserTests {
 	public void testRosterEventOutboundChannel() {
 		Object channel = context.getBean("eventOutboundRosterChannel");
 		assertThat(channel instanceof SubscribableChannel).isTrue();
-		UnicastingDispatcher dispatcher = (UnicastingDispatcher) TestUtils
-				.getPropertyValue(channel, "dispatcher");
-		@SuppressWarnings("unchecked")
-		Set<MessageHandler> handlers = (Set<MessageHandler>) TestUtils
-				.getPropertyValue(dispatcher, "handlers");
-		assertThat(TestUtils.getPropertyValue(handlers.toArray()[0], "order")).isEqualTo(45);
+		UnicastingDispatcher dispatcher = TestUtils.getPropertyValue(channel, "dispatcher");
+		Set<MessageHandler> handlers = TestUtils.getPropertyValue(dispatcher, "handlers");
+		assertThat(TestUtils.<Integer>getPropertyValue(handlers.toArray()[0], "order")).isEqualTo(45);
 	}
 
 	public static class FooAdvice extends AbstractRequestHandlerAdvice {

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/XmppConnectionParserTests.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.xmpp.config;
 
 import org.jivesoftware.smack.XMPPConnection;
+import org.jivesoftware.smack.roster.Roster;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.context.ConfigurableApplicationContext;
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gunnar Hillert
  * @author Florian Schmaus
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class XmppConnectionParserTests {
 
@@ -42,14 +44,15 @@ public class XmppConnectionParserTests {
 		assertThat(connection.getXMPPServiceDomain().toString()).isEqualTo("my.domain");
 		assertThat(connection.isConnected()).isFalse();
 		XmppConnectionFactoryBean xmppFb = ac.getBean("&connection", XmppConnectionFactoryBean.class);
-		assertThat(TestUtils.getPropertyValue(xmppFb, "user")).isEqualTo("happy.user@my.domain");
-		assertThat(TestUtils.getPropertyValue(xmppFb, "password")).isEqualTo("blah");
-		assertThat(TestUtils.getPropertyValue(xmppFb, "resource")).isNull();
-		assertThat(TestUtils.getPropertyValue(xmppFb, "subscriptionMode").toString()).isEqualTo("accept_all");
+		assertThat(TestUtils.<String>getPropertyValue(xmppFb, "user")).isEqualTo("happy.user@my.domain");
+		assertThat(TestUtils.<String>getPropertyValue(xmppFb, "password")).isEqualTo("blah");
+		assertThat(TestUtils.<String>getPropertyValue(xmppFb, "resource")).isNull();
+		assertThat(TestUtils.<Roster.SubscriptionMode>getPropertyValue(xmppFb, "subscriptionMode").toString())
+				.isEqualTo("accept_all");
 
 		xmppFb = ac.getBean("&connectionWithResource", XmppConnectionFactoryBean.class);
-		assertThat(TestUtils.getPropertyValue(xmppFb, "resource")).isEqualTo("Smack");
-		assertThat(TestUtils.getPropertyValue(xmppFb, "subscriptionMode")).isNull();
+		assertThat(TestUtils.<String>getPropertyValue(xmppFb, "resource")).isEqualTo("Smack");
+		assertThat(TestUtils.<Object>getPropertyValue(xmppFb, "subscriptionMode")).isNull();
 		ac.close();
 	}
 
@@ -61,9 +64,9 @@ public class XmppConnectionParserTests {
 		assertThat(connection.getXMPPServiceDomain().toString()).isEqualTo("foogle.com");
 		assertThat(connection.isConnected()).isFalse();
 		XmppConnectionFactoryBean xmppFb = ac.getBean("&connection", XmppConnectionFactoryBean.class);
-		assertThat(TestUtils.getPropertyValue(xmppFb, "user")).isEqualTo("happy.user");
-		assertThat(TestUtils.getPropertyValue(xmppFb, "password")).isEqualTo("blah");
-		assertThat(TestUtils.getPropertyValue(xmppFb, "resource")).isEqualTo("SpringSource");
+		assertThat(TestUtils.<String>getPropertyValue(xmppFb, "user")).isEqualTo("happy.user");
+		assertThat(TestUtils.<String>getPropertyValue(xmppFb, "password")).isEqualTo("blah");
+		assertThat(TestUtils.<String>getPropertyValue(xmppFb, "resource")).isEqualTo("SpringSource");
 		assertThat(TestUtils.getPropertyValue(xmppFb, "subscriptionMode").toString()).isEqualTo("reject_all");
 		ac.close();
 	}

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpointTests.java
@@ -68,6 +68,7 @@ import static org.mockito.Mockito.verify;
  * @author Gunnar Hillert
  * @author Florian Schmaus
  * @author Artem Bilan
+ * @author Glenn Renfro
  */
 public class ChatMessageListeningEndpointTests implements TestApplicationContextAware {
 
@@ -92,14 +93,14 @@ public class ChatMessageListeningEndpointTests implements TestApplicationContext
 		}).given(connection)
 				.removeAsyncStanzaListener(any(StanzaListener.class));
 
-		assertThat(packetListSet.size()).isEqualTo(0);
+		assertThat(packetListSet).isEmpty();
 		endpoint.setOutputChannel(new QueueChannel());
 		endpoint.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		endpoint.afterPropertiesSet();
 		endpoint.start();
 		assertThat(packetListSet.size()).isEqualTo(1);
 		endpoint.stop();
-		assertThat(packetListSet.size()).isEqualTo(0);
+		assertThat(packetListSet).isEmpty();
 	}
 
 	@Test
@@ -116,7 +117,7 @@ public class ChatMessageListeningEndpointTests implements TestApplicationContext
 		endpoint.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		endpoint.setOutputChannel(new QueueChannel());
 		endpoint.afterPropertiesSet();
-		assertThat(TestUtils.getPropertyValue(endpoint, "xmppConnection")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(endpoint, "xmppConnection")).isNotNull();
 	}
 
 	@Test
@@ -182,7 +183,7 @@ public class ChatMessageListeningEndpointTests implements TestApplicationContext
 		assertThat(((Message) payload).getStanzaId()).isEqualTo(smackMessage.getStanzaId());
 		assertThat(((Message) payload).getBody()).isEqualTo(smackMessage.getBody());
 
-		LogAccessor logger = Mockito.spy(TestUtils.getPropertyValue(endpoint, "logger", LogAccessor.class));
+		LogAccessor logger = Mockito.spy(TestUtils.<LogAccessor>getPropertyValue(endpoint, "logger"));
 		given(logger.isInfoEnabled()).willReturn(true);
 		final CountDownLatch logLatch = new CountDownLatch(1);
 		willAnswer(invocation -> {

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpointTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/inbound/PresenceListeningEndpointTests.java
@@ -46,26 +46,26 @@ import static org.mockito.Mockito.mock;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Florian Schmaus
+ * @author Glenn Renfro
  */
 public class PresenceListeningEndpointTests {
 
 	@Test
-	@SuppressWarnings("unchecked")
 	public void testEndpointLifecycle() {
 		XMPPConnection connection = mock(XMPPConnection.class);
 		Roster roster = Roster.getInstanceFor(connection);
 
-		Set<RosterListener> rosterSet = TestUtils.getPropertyValue(roster, "rosterListeners", Set.class);
+		Set<RosterListener> rosterSet = TestUtils.getPropertyValue(roster, "rosterListeners");
 
 		PresenceListeningEndpoint rosterEndpoint = new PresenceListeningEndpoint(connection);
 		rosterEndpoint.setOutputChannel(new QueueChannel());
 		rosterEndpoint.setBeanFactory(mock(BeanFactory.class));
 		rosterEndpoint.afterPropertiesSet();
-		assertThat(rosterSet.size()).isEqualTo(0);
+		assertThat(rosterSet).isEmpty();
 		rosterEndpoint.start();
 		assertThat(rosterSet.size()).isEqualTo(1);
 		rosterEndpoint.stop();
-		assertThat(rosterSet.size()).isEqualTo(0);
+		assertThat(rosterSet).isEmpty();
 	}
 
 	@Test
@@ -103,7 +103,7 @@ public class PresenceListeningEndpointTests {
 		endpoint.setBeanFactory(bf);
 		endpoint.setOutputChannel(new QueueChannel());
 		endpoint.afterPropertiesSet();
-		assertThat(TestUtils.getPropertyValue(endpoint, "xmppConnection")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(endpoint, "xmppConnection")).isNotNull();
 	}
 
 	@Test

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandlerTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/ChatMessageSendingMessageHandlerTests.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.verify;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Florian Schmaus
+ * @author Glenn Renfro
  */
 public class ChatMessageSendingMessageHandlerTests {
 
@@ -204,7 +205,7 @@ public class ChatMessageSendingMessageHandlerTests {
 		ChatMessageSendingMessageHandler handler = new ChatMessageSendingMessageHandler();
 		handler.setBeanFactory(bf);
 		handler.afterPropertiesSet();
-		assertThat(TestUtils.getPropertyValue(handler, "xmppConnection")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "xmppConnection")).isNotNull();
 	}
 
 	@Test

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/PresenceSendingMessageHandlerTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/outbound/PresenceSendingMessageHandlerTests.java
@@ -37,6 +37,7 @@ import static org.mockito.Mockito.mock;
  * @author Gunnar Hillert
  * @author Artem Bilan
  * @author Florian Schmaus
+ * @author Glenn Renfro
  */
 public class PresenceSendingMessageHandlerTests {
 
@@ -64,7 +65,7 @@ public class PresenceSendingMessageHandlerTests {
 		PresenceSendingMessageHandler handler = new PresenceSendingMessageHandler();
 		handler.setBeanFactory(bf);
 		handler.afterPropertiesSet();
-		assertThat(TestUtils.getPropertyValue(handler, "xmppConnection")).isNotNull();
+		assertThat(TestUtils.<Object>getPropertyValue(handler, "xmppConnection")).isNotNull();
 	}
 
 	@Test

--- a/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/channel/ZeroMqChannelTests.java
+++ b/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/channel/ZeroMqChannelTests.java
@@ -44,6 +44,7 @@ import static org.awaitility.Awaitility.await;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 5.4
  */
@@ -76,13 +77,11 @@ public class ZeroMqChannelTests implements TestApplicationContextAware {
 		channel.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		channel.afterPropertiesSet();
 
-		@SuppressWarnings("unchecked")
-		Mono<ZMQ.Socket> sendSocketMono = TestUtils.getPropertyValue(channel, "sendSocket", Mono.class);
+		Mono<ZMQ.Socket> sendSocketMono = TestUtils.getPropertyValue(channel, "sendSocket");
 		ZMQ.Socket sendSocket = sendSocketMono.block(Duration.ofSeconds(10));
 		assertThat(sendSocket.getZapDomain()).isEqualTo("global");
 
-		@SuppressWarnings("unchecked")
-		Mono<ZMQ.Socket> subscribeSocketMono = TestUtils.getPropertyValue(channel, "subscribeSocket", Mono.class);
+		Mono<ZMQ.Socket> subscribeSocketMono = TestUtils.getPropertyValue(channel, "subscribeSocket");
 		ZMQ.Socket subscribeSocket = subscribeSocketMono.block(Duration.ofSeconds(10));
 		assertThat(subscribeSocket.getZapDomain()).isEqualTo("local");
 

--- a/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducerTests.java
+++ b/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/inbound/ZeroMqMessageProducerTests.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Artem Bilan
  * @author Alessio Matricardi
+ * @author Glenn Renfro
  *
  * @since 5.4
  */
@@ -75,7 +76,7 @@ public class ZeroMqMessageProducerTests {
 		messageProducer.start();
 
 		@SuppressWarnings("unchecked")
-		Mono<ZMQ.Socket> socketMono = TestUtils.getPropertyValue(messageProducer, "socketMono", Mono.class);
+		Mono<ZMQ.Socket> socketMono = TestUtils.getPropertyValue(messageProducer, "socketMono");
 		ZMQ.Socket socketInUse = socketMono.block(Duration.ofSeconds(10));
 		assertThat(socketInUse.getZapDomain()).isEqualTo("global");
 

--- a/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandlerTests.java
+++ b/spring-integration-zeromq/src/test/java/org/springframework/integration/zeromq/outbound/ZeroMqMessageHandlerTests.java
@@ -43,6 +43,7 @@ import static org.awaitility.Awaitility.await;
 /**
  * @author Artem Bilan
  * @author Alessio Matricardi
+ * @author Glenn Renfro
  *
  * @since 5.4
  */
@@ -68,7 +69,7 @@ public class ZeroMqMessageHandlerTests implements TestApplicationContextAware {
 		messageHandler.start();
 
 		@SuppressWarnings("unchecked")
-		Mono<ZMQ.Socket> socketMono = TestUtils.getPropertyValue(messageHandler, "socketMono", Mono.class);
+		Mono<ZMQ.Socket> socketMono = TestUtils.getPropertyValue(messageHandler, "socketMono");
 		ZMQ.Socket socketInUse = socketMono.block(Duration.ofSeconds(10));
 		assertThat(socketInUse.getZapDomain()).isEqualTo("global");
 

--- a/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/UnZipTransformerParserTests.java
+++ b/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/UnZipTransformerParserTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 6.1
  */
@@ -52,20 +53,20 @@ public class UnZipTransformerParserTests {
 	public void testUnZipTransformerParserWithDefaults() {
 		EventDrivenConsumer consumer = this.context.getBean("unzipTransformerWithDefaults", EventDrivenConsumer.class);
 
-		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel", AbstractMessageChannel.class);
+		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel");
 		assertThat(inputChannel.getComponentName()).isEqualTo("input");
 
-		final MessageTransformingHandler handler = TestUtils.getPropertyValue(consumer, "handler", MessageTransformingHandler.class);
+		final MessageTransformingHandler handler = TestUtils.getPropertyValue(consumer, "handler");
 
-		assertThat(TestUtils.getPropertyValue(handler, "outputChannelName")).isEqualTo("output");
+		assertThat(TestUtils.<String>getPropertyValue(handler, "outputChannelName")).isEqualTo("output");
 
-		final UnZipTransformer unZipTransformer = TestUtils.getPropertyValue(handler, "transformer", UnZipTransformer.class);
+		final UnZipTransformer unZipTransformer = TestUtils.getPropertyValue(handler, "transformer");
 
-		final Charset charset = TestUtils.getPropertyValue(unZipTransformer, "charset", Charset.class);
-		final ZipResultType zipResultType = TestUtils.getPropertyValue(unZipTransformer, "zipResultType", ZipResultType.class);
-		final File workDirectory = TestUtils.getPropertyValue(unZipTransformer, "workDirectory", File.class);
-		final Boolean deleteFiles = TestUtils.getPropertyValue(unZipTransformer, "deleteFiles", Boolean.class);
-		final Boolean expectSingleResult = TestUtils.getPropertyValue(unZipTransformer, "expectSingleResult", Boolean.class);
+		final Charset charset = TestUtils.getPropertyValue(unZipTransformer, "charset");
+		final ZipResultType zipResultType = TestUtils.getPropertyValue(unZipTransformer, "zipResultType");
+		final File workDirectory = TestUtils.getPropertyValue(unZipTransformer, "workDirectory");
+		final Boolean deleteFiles = TestUtils.getPropertyValue(unZipTransformer, "deleteFiles");
+		final Boolean expectSingleResult = TestUtils.getPropertyValue(unZipTransformer, "expectSingleResult");
 
 		assertThat(charset).isNotNull();
 		assertThat(zipResultType).isNotNull();
@@ -87,20 +88,20 @@ public class UnZipTransformerParserTests {
 	public void testUnZipTransformerParserWithExplicitSettings() {
 		EventDrivenConsumer consumer = this.context.getBean("unzipTransformer", EventDrivenConsumer.class);
 
-		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel", AbstractMessageChannel.class);
+		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel");
 		assertThat(inputChannel.getComponentName()).isEqualTo("input");
 
-		final MessageTransformingHandler handler = TestUtils.getPropertyValue(consumer, "handler", MessageTransformingHandler.class);
+		final MessageTransformingHandler handler = TestUtils.getPropertyValue(consumer, "handler");
 
-		assertThat(TestUtils.getPropertyValue(handler, "outputChannelName")).isEqualTo("output");
+		assertThat(TestUtils.<String>getPropertyValue(handler, "outputChannelName")).isEqualTo("output");
 
-		final UnZipTransformer unZipTransformer = TestUtils.getPropertyValue(handler, "transformer", UnZipTransformer.class);
+		final UnZipTransformer unZipTransformer = TestUtils.getPropertyValue(handler, "transformer");
 
-		final Charset charset = TestUtils.getPropertyValue(unZipTransformer, "charset", Charset.class);
-		final ZipResultType zipResultType = TestUtils.getPropertyValue(unZipTransformer, "zipResultType", ZipResultType.class);
-		final File workDirectory = TestUtils.getPropertyValue(unZipTransformer, "workDirectory", File.class);
-		final Boolean deleteFiles = TestUtils.getPropertyValue(unZipTransformer, "deleteFiles", Boolean.class);
-		final Boolean expectSingleResult = TestUtils.getPropertyValue(unZipTransformer, "expectSingleResult", Boolean.class);
+		final Charset charset = TestUtils.getPropertyValue(unZipTransformer, "charset");
+		final ZipResultType zipResultType = TestUtils.getPropertyValue(unZipTransformer, "zipResultType");
+		final File workDirectory = TestUtils.getPropertyValue(unZipTransformer, "workDirectory");
+		final Boolean deleteFiles = TestUtils.getPropertyValue(unZipTransformer, "deleteFiles");
+		final Boolean expectSingleResult = TestUtils.getPropertyValue(unZipTransformer, "expectSingleResult");
 
 		assertThat(charset).isNotNull();
 		assertThat(zipResultType).isNotNull();

--- a/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/ZipTransformerParserTests.java
+++ b/spring-integration-zip/src/test/java/org/springframework/integration/zip/config/xml/ZipTransformerParserTests.java
@@ -43,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 /**
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 6.1
  */
@@ -57,21 +58,21 @@ public class ZipTransformerParserTests {
 	public void testZipTransformerParserWithDefaults() {
 		EventDrivenConsumer consumer = this.context.getBean("zipTransformerWithDefaults", EventDrivenConsumer.class);
 
-		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel", AbstractMessageChannel.class);
+		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel");
 		assertThat(inputChannel.getComponentName()).isEqualTo("input");
 
-		final MessageTransformingHandler handler = TestUtils.getPropertyValue(consumer, "handler", MessageTransformingHandler.class);
+		final MessageTransformingHandler handler = TestUtils.getPropertyValue(consumer, "handler");
 
-		assertThat(TestUtils.getPropertyValue(handler, "outputChannelName")).isEqualTo("output");
+		assertThat(TestUtils.<String>getPropertyValue(handler, "outputChannelName")).isEqualTo("output");
 
-		final ZipTransformer zipTransformer = TestUtils.getPropertyValue(handler, "transformer", ZipTransformer.class);
+		final ZipTransformer zipTransformer = TestUtils.getPropertyValue(handler, "transformer");
 
-		final Charset charset = TestUtils.getPropertyValue(zipTransformer, "charset", Charset.class);
-		final FileNameGenerator fileNameGenerator = TestUtils.getPropertyValue(zipTransformer, "fileNameGenerator", FileNameGenerator.class);
-		final ZipResultType zipResultType = TestUtils.getPropertyValue(zipTransformer, "zipResultType", ZipResultType.class);
-		final File workDirectory = TestUtils.getPropertyValue(zipTransformer, "workDirectory", File.class);
-		final Integer compressionLevel = TestUtils.getPropertyValue(zipTransformer, "compressionLevel", Integer.class);
-		final Boolean deleteFiles = TestUtils.getPropertyValue(zipTransformer, "deleteFiles", Boolean.class);
+		final Charset charset = TestUtils.getPropertyValue(zipTransformer, "charset");
+		final FileNameGenerator fileNameGenerator = TestUtils.getPropertyValue(zipTransformer, "fileNameGenerator");
+		final ZipResultType zipResultType = TestUtils.getPropertyValue(zipTransformer, "zipResultType");
+		final File workDirectory = TestUtils.getPropertyValue(zipTransformer, "workDirectory");
+		final Integer compressionLevel = TestUtils.getPropertyValue(zipTransformer, "compressionLevel");
+		final Boolean deleteFiles = TestUtils.getPropertyValue(zipTransformer, "deleteFiles");
 
 		assertThat(charset).isNotNull();
 		assertThat(fileNameGenerator).isNotNull();
@@ -95,21 +96,21 @@ public class ZipTransformerParserTests {
 	public void testZipTransformerParserWithExplicitSettings() {
 		EventDrivenConsumer consumer = this.context.getBean("zipTransformer", EventDrivenConsumer.class);
 
-		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel", AbstractMessageChannel.class);
+		final AbstractMessageChannel inputChannel = TestUtils.getPropertyValue(consumer, "inputChannel");
 		assertThat(inputChannel.getComponentName()).isEqualTo("input");
 
-		final MessageTransformingHandler handler = TestUtils.getPropertyValue(consumer, "handler", MessageTransformingHandler.class);
+		final MessageTransformingHandler handler = TestUtils.getPropertyValue(consumer, "handler");
 
-		assertThat(TestUtils.getPropertyValue(handler, "outputChannelName")).isEqualTo("output");
+		assertThat(TestUtils.<String>getPropertyValue(handler, "outputChannelName")).isEqualTo("output");
 
-		final ZipTransformer zipTransformer = TestUtils.getPropertyValue(handler, "transformer", ZipTransformer.class);
+		final ZipTransformer zipTransformer = TestUtils.getPropertyValue(handler, "transformer");
 
-		final Charset charset = TestUtils.getPropertyValue(zipTransformer, "charset", Charset.class);
-		final FileNameGenerator fileNameGenerator = TestUtils.getPropertyValue(zipTransformer, "fileNameGenerator", FileNameGenerator.class);
-		final ZipResultType zipResultType = TestUtils.getPropertyValue(zipTransformer, "zipResultType", ZipResultType.class);
-		final File workDirectory = TestUtils.getPropertyValue(zipTransformer, "workDirectory", File.class);
-		final Integer compressionLevel = TestUtils.getPropertyValue(zipTransformer, "compressionLevel", Integer.class);
-		final Boolean deleteFiles = TestUtils.getPropertyValue(zipTransformer, "deleteFiles", Boolean.class);
+		final Charset charset = TestUtils.getPropertyValue(zipTransformer, "charset");
+		final FileNameGenerator fileNameGenerator = TestUtils.getPropertyValue(zipTransformer, "fileNameGenerator");
+		final ZipResultType zipResultType = TestUtils.getPropertyValue(zipTransformer, "zipResultType");
+		final File workDirectory = TestUtils.getPropertyValue(zipTransformer, "workDirectory");
+		final Integer compressionLevel = TestUtils.getPropertyValue(zipTransformer, "compressionLevel");
+		final Boolean deleteFiles = TestUtils.getPropertyValue(zipTransformer, "deleteFiles");
 
 		assertThat(charset).isNotNull();
 		assertThat(fileNameGenerator).isNotNull();

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/config/xml/ZookeeperParserTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/config/xml/ZookeeperParserTests.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 4.2
  *
@@ -54,9 +55,9 @@ public class ZookeeperParserTests extends ZookeeperTestSupport {
 	public void test() throws Exception {
 		assertThat(this.initiator.isAutoStartup()).isFalse();
 		assertThat(this.initiator.getPhase()).isEqualTo(1234);
-		assertThat(TestUtils.getPropertyValue(this.initiator, "namespace")).isEqualTo("/siNamespaceTest");
-		assertThat(TestUtils.getPropertyValue(this.initiator, "candidate.role")).isEqualTo("cluster");
-		assertThat(TestUtils.getPropertyValue(this.initiator, "client")).isSameAs(this.client);
+		assertThat(TestUtils.<String>getPropertyValue(this.initiator, "namespace")).isEqualTo("/siNamespaceTest");
+		assertThat(TestUtils.<String>getPropertyValue(this.initiator, "candidate.role")).isEqualTo("cluster");
+		assertThat(TestUtils.<CuratorFramework>getPropertyValue(this.initiator, "client")).isSameAs(this.client);
 
 		this.initiator.start();
 		int n = 0;

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Unseok Kim
+ * @author Glenn Renfro
  *
  * @since 4.2
  *
@@ -53,7 +54,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 			Lock lock = registry.obtain("foo");
 			lock.lock();
 			try {
-				assertThat(TestUtils.getPropertyValue(registry, "locks", Map.class).size()).isEqualTo(1);
+				assertThat(TestUtils.<Map<?, ?>>getPropertyValue(registry, "locks").size()).isEqualTo(1);
 			}
 			finally {
 				lock.unlock();
@@ -62,7 +63,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 
 		Thread.sleep(10);
 		registry.expireUnusedOlderThan(0);
-		assertThat(TestUtils.getPropertyValue(registry, "locks", Map.class).size()).isEqualTo(0);
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(registry, "locks")).isEmpty();
 		registry.destroy();
 	}
 
@@ -73,7 +74,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 			Lock lock = registry.obtain("foo");
 			lock.lockInterruptibly();
 			try {
-				assertThat(TestUtils.getPropertyValue(registry, "locks", Map.class).size()).isEqualTo(1);
+				assertThat(TestUtils.<Map<?, ?>>getPropertyValue(registry, "locks").size()).isEqualTo(1);
 			}
 			finally {
 				lock.unlock();
@@ -279,7 +280,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 			Lock lock = registry.obtain("foo");
 			lock.lock();
 			try {
-				assertThat(TestUtils.getPropertyValue(registry, "locks", Map.class).size()).isEqualTo(1);
+				assertThat(TestUtils.<Map<?, ?>>getPropertyValue(registry, "locks").size()).isEqualTo(1);
 			}
 			finally {
 				lock.unlock();
@@ -290,7 +291,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		assertThatIllegalStateException()
 				.isThrownBy(() -> registry.expireUnusedOlderThan(0))
 				.withMessageContaining("expiry is not supported");
-		assertThat(TestUtils.getPropertyValue(registry, "locks", Map.class).size()).isEqualTo(1);
+		assertThat(TestUtils.<Map<?, ?>>getPropertyValue(registry, "locks").size()).isEqualTo(1);
 		registry.destroy();
 	}
 
@@ -509,9 +510,8 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		registry.destroy();
 	}
 
-	@SuppressWarnings("unchecked")
 	private static Map<String, Lock> getRegistryLocks(ZookeeperLockRegistry registry) {
-		return TestUtils.getPropertyValue(registry, "locks", Map.class);
+		return TestUtils.getPropertyValue(registry, "locks");
 	}
 
 	private static String toKey(String path) {

--- a/src/reference/antora/modules/ROOT/pages/testing.adoc
+++ b/src/reference/antora/modules/ROOT/pages/testing.adoc
@@ -56,7 +56,7 @@ The `TestUtils` class is mostly used for properties assertions in JUnit tests, a
 public void loadBalancerRef() {
     MessageChannel channel = channels.get("lbRefChannel");
     LoadBalancingStrategy lbStrategy = TestUtils.getPropertyValue(channel,
-                 "dispatcher.loadBalancingStrategy", LoadBalancingStrategy.class);
+                 "dispatcher.loadBalancingStrategy");
     assertTrue(lbStrategy instanceof SampleLoadBalancingStrategy);
 }
 ----


### PR DESCRIPTION
Replace three-parameter `TestUtils.getPropertyValue()` calls with the type-safe generic method signature across all Spring Integration test modules. The deprecated method that required an explicit `Class<T>` parameter has been replaced with the generic method that infers the type parameter.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
