### PR TITLE
Correct javadoc grammar

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/aggregator/AbstractCorrelatingMessageHandler.java
@@ -315,7 +315,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 
 	/**
 	 * Expire (completely remove) a group if it is completed due to timeout.
-	 * Default true
+	 * Default is {@code true}.
 	 * @param expireGroupsUponTimeout the expireGroupsUponTimeout to set
 	 * @since 4.1
 	 */
@@ -326,7 +326,7 @@ public abstract class AbstractCorrelatingMessageHandler extends AbstractMessageP
 	/**
 	 * Perform a
 	 * {@link org.springframework.integration.support.MessageBuilder#popSequenceDetails()}
-	 * for output message or not. Default to true. This option removes the sequence
+	 * for output message or not. Default is {@code true}. This option removes the sequence
 	 * information added by the nearest upstream component with {@code applySequence=true}
 	 * (for example splitter).
 	 * @param popSequence the boolean flag to use.

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/DirectChannel.java
@@ -75,7 +75,7 @@ public class DirectChannel extends AbstractSubscribableChannel {
 	 * for the exception thrown.
 	 * Overrides {@link #setFailover(boolean)} option.
 	 * In other words: or this, or that option has to be set.
-	 * @param failoverStrategy The failover boolean.
+	 * @param failoverStrategy The failover strategy predicate.
 	 * @since 6.3
 	 */
 	public void setFailoverStrategy(Predicate<Exception> failoverStrategy) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/ExecutorChannel.java
@@ -97,7 +97,7 @@ public class ExecutorChannel extends AbstractExecutorChannel {
 	 * for the exception thrown.
 	 * Overrides {@link #setFailover(boolean)} option.
 	 * In other words: or this, or that option has to be set.
-	 * @param failoverStrategy The failover boolean.
+	 * @param failoverStrategy The failover strategy predicate.
 	 * @since 6.3
 	 */
 	public void setFailoverStrategy(Predicate<Exception> failoverStrategy) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/channel/PartitionedChannel.java
@@ -63,7 +63,6 @@ public class PartitionedChannel extends AbstractExecutorChannel {
 	 * Instantiate based on a provided number of partitions and function resolving a partition key from
 	 * the {@link IntegrationMessageHeaderAccessor#CORRELATION_ID} message header.
 	 * @param partitionCount the number of partitions in this channel.
-	 * sent to this channel.
 	 */
 	public PartitionedChannel(int partitionCount) {
 		this(partitionCount, (message) ->
@@ -108,7 +107,7 @@ public class PartitionedChannel extends AbstractExecutorChannel {
 	 * for the exception thrown.
 	 * Overrides {@link #setFailover(boolean)} option.
 	 * In other words: or this, or that option has to be set.
-	 * @param failoverStrategy The failover boolean.
+	 * @param failoverStrategy The failover strategy predicate.
 	 * @since 6.3
 	 */
 	public void setFailoverStrategy(Predicate<Exception> failoverStrategy) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/context/IntegrationObjectSupport.java
@@ -123,8 +123,8 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	}
 
 	/**
-	 * Will return the name of this component identified by {@link #componentName} field.
-	 * If {@link #componentName} was not set this method will default to the 'beanName' of this component;
+	 * Return the name of this component identified by {@link #componentName} field.
+	 * If {@link #componentName} is not set, this method defaults to the 'beanName' of this component.
 	 */
 	@Override
 	public String getComponentName() {
@@ -300,7 +300,7 @@ public abstract class IntegrationObjectSupport implements ComponentSourceAware, 
 	}
 
 	/**
-	 * Returns the {@link ApplicationContext#getId()} if the
+	 * Return the {@link ApplicationContext#getId()} if the
 	 * {@link ApplicationContext} is available.
 	 * @return The id, or null if there is no application context.
 	 */

--- a/spring-integration-core/src/main/java/org/springframework/integration/core/MessageSource.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/core/MessageSource.java
@@ -35,7 +35,7 @@ public interface MessageSource<T> extends IntegrationPattern {
 
 	/**
 	 * Retrieve the next available message from this source.
-	 * Returns {@code null} if no message is available.
+	 * Return {@code null} if no message is available.
 	 * @return The message or null.
 	 */
 	@Nullable

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/PartitionedDispatcher.java
@@ -125,7 +125,7 @@ public class PartitionedDispatcher extends AbstractDispatcher {
 	 * for the exception thrown.
 	 * Overrides {@link #setFailover(boolean)} option.
 	 * In other words: or this, or that option has to be set.
-	 * @param failoverStrategy The failover boolean.
+	 * @param failoverStrategy The failover strategy predicate.
 	 * @since 6.3
 	 */
 	public void setFailoverStrategy(Predicate<Exception> failoverStrategy) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dispatcher/UnicastingDispatcher.java
@@ -37,7 +37,7 @@ import org.springframework.util.Assert;
  * {@link Message} to at most one of its handlers. The handlers will be tried
  * as determined by the {@link LoadBalancingStrategy} if one is configured. As
  * soon as <em>one</em> of the handlers accepts the Message, the dispatcher will
- * return <code>true</code> and ignore the rest of its handlers.
+ * return {@code true} and ignore the rest of its handlers.
  * <p>
  * If the dispatcher has no handlers, a {@link MessageDispatchingException} will be
  * thrown. If all handlers throw Exceptions, the dispatcher will throw an
@@ -92,7 +92,7 @@ public class UnicastingDispatcher extends AbstractDispatcher {
 	 * for the exception thrown.
 	 * Overrides {@link #setFailover(boolean)} option.
 	 * In other words: or this, or that option has to be set.
-	 * @param failoverStrategy The failover boolean.
+	 * @param failoverStrategy The failover strategy predicate.
 	 * @since 6.3
 	 */
 	public void setFailoverStrategy(Predicate<Exception> failoverStrategy) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/LoadBalancingChannelSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/LoadBalancingChannelSpec.java
@@ -59,7 +59,7 @@ public abstract class LoadBalancingChannelSpec<S extends MessageChannelSpec<S, C
 	 * for the exception thrown.
 	 * Overrides {@link #failover(boolean)} option.
 	 * In other words: or this, or that option has to be set.
-	 * @param failoverStrategy The failover boolean.
+	 * @param failoverStrategy The failover strategy predicate.
 	 * @since 6.3
 	 */
 	public S failoverStrategy(Predicate<Exception> failoverStrategy) {

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/IdempotentReceiverInterceptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/advice/IdempotentReceiverInterceptor.java
@@ -35,14 +35,14 @@ import org.springframework.util.Assert;
  * This {@link org.aopalliance.intercept.MethodInterceptor} works like a
  * {@code MessageFilter} if {@link #discardChannel}
  * is provided or {@link #throwExceptionOnRejection} is set to {@code true}.
- * However if those properties aren't provided, this interceptor will create an new {@link Message}
+ * However if those properties aren't provided, this interceptor will create a new {@link Message}
  * with a {@link IntegrationMessageHeaderAccessor#DUPLICATE_MESSAGE} header when the
  * {@code requestMessage} isn't accepted by {@link MessageSelector}.
  * <p>
  * The {@code idempotent filtering} logic depends on the provided {@link MessageSelector}.
  * <p>
  * This class is designed to be used only for the
- * {@link org.springframework.messaging.MessageHandler#handleMessage},
+ * {@link org.springframework.messaging.MessageHandler#handleMessage}
  * method.
  *
  * @author Artem Bilan

--- a/spring-integration-core/src/main/java/org/springframework/integration/leader/Candidate.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/leader/Candidate.java
@@ -29,7 +29,7 @@ package org.springframework.integration.leader;
 public interface Candidate {
 
 	/**
-	 * Gets the role.
+	 * Get the role.
 	 *
 	 * @return a string indicating the name of the leadership role
 	 *         this candidate is participating in; other candidates
@@ -39,7 +39,7 @@ public interface Candidate {
 	String getRole();
 
 	/**
-	 * Gets the identifier.
+	 * Get the identifier.
 	 *
 	 * @return a unique ID for this candidate; no other candidate for
 	 *         leader election should return the same id


### PR DESCRIPTION
* Verify javadoc documentation matches the code
* Make sure all javadocs are in imperitive tense
* Make sure we javadoc annotations are used properly


<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
