### PR TITLE
GH-10783: Use GETDEL in RedisMessageStore.doRemove() 

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisMessageStore.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/store/RedisMessageStore.java
@@ -154,13 +154,6 @@ public class RedisMessageStore extends AbstractKeyValueMessageStore implements B
 		return doRetrieveAndUnlink(id);
 	}
 
-	private boolean isGetDelNotSupportedError(Exception e) {
-		Throwable cause = e.getCause();
-		return cause != null
-				&& cause.getMessage() != null
-				&& cause.getMessage().contains("ERR unknown command `GETDEL`");
-	}
-
 	private @Nullable Object doRetrieveAndUnlink(Object id) {
 		Object removedObject = doRetrieve(id);
 		if (removedObject != null) {
@@ -185,6 +178,13 @@ public class RedisMessageStore extends AbstractKeyValueMessageStore implements B
 				"(JdkSerializationRedisSerializer) the Object must be Serializable. " +
 				"Either make it Serializable or provide your own implementation of " +
 				"RedisSerializer via 'setValueSerializer(..)'", e);
+	}
+
+	private static boolean isGetDelNotSupportedError(Exception e) {
+		Throwable cause = e.getCause();
+		return cause != null
+				&& cause.getMessage() != null
+				&& cause.getMessage().contains("ERR unknown command `GETDEL`");
 	}
 
 }

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -45,3 +45,8 @@ See xref:grpc.adoc[] for more information.
 The `TestUtils.getPropertyValue()` with a `Class<?>` argument has been deprecated in favor of the change on the overloaded method from an `Object` return type to the generic argument.
 This gives a flexible casting of the extracted value to the expected type in tests logic.
 See xref:testing.adoc[] for more information.
+
+[[x7.1-redis-changes]]
+=== Redis Support Changes
+
+The `RedisMessageStore.doRemove` now uses `GETDEL` instead of `GET` + `UNLINK` for Redis 6.2+.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -49,4 +49,5 @@ See xref:testing.adoc[] for more information.
 [[x7.1-redis-changes]]
 === Redis Support Changes
 
-The `RedisMessageStore.doRemove` now uses `GETDEL` instead of `GET` + `UNLINK` for Redis 6.2+.
+The `RedisMessageStore.doRemove` now uses `GETDEL` instead of `GET` + `UNLINK` for Redis 6.2+ by default.
+Use `RedisMessageStore.setUseUnlink(true)` to use `GET` + `UNLINK` when atomicity is not required and `GETDEL` causes noticeable Redis latency.


### PR DESCRIPTION
Fixes: gh-10783

* Use atomic `getAndDelete()` (GETDEL) for Redis 6.2+
* Fall back to GET + UNLINK for older Redis versions
* Add volatile flag for backwards compatibility detection
