### PR TITLE
Fix `AbstractMessageProducingHandler` to treat `Flux` as single output

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -241,7 +241,8 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	}
 
 	protected void sendOutputs(@Nullable Object result, Message<?> requestMessage) {
-		if (result instanceof Iterable<?> iterableResult && shouldSplitOutput(iterableResult)) {
+		if (!(result instanceof Flux<?>) && result instanceof Iterable<?> iterableResult &&
+				shouldSplitOutput(iterableResult)) {
 			for (Object o : iterableResult) {
 				produceOutput(o, requestMessage);
 			}
@@ -510,7 +511,7 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		else {
 			builder = getMessageBuilderFactory().withPayload(output);
 			// Assuming that a message in the payload collection is a copy of the request message.
-			if (output instanceof Iterable<?> iterable) {
+			if (!(output instanceof Flux<?>) && output instanceof Iterable<?> iterable) {
 				Iterator<?> iterator = iterable.iterator();
 				if (iterator.hasNext() && iterator.next() instanceof Message<?>) {
 					builder = builder.cloneMessageHistoryIfAny();

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/AbstractMessageProducingHandler.java
@@ -241,8 +241,10 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 	}
 
 	protected void sendOutputs(@Nullable Object result, Message<?> requestMessage) {
-		if (!(result instanceof Flux<?>) && result instanceof Iterable<?> iterableResult &&
-				shouldSplitOutput(iterableResult)) {
+
+		if (!(result instanceof Flux<?>)
+				&& result instanceof Iterable<?> iterableResult
+				&& shouldSplitOutput(iterableResult)) {
 			for (Object o : iterableResult) {
 				produceOutput(o, requestMessage);
 			}
@@ -511,7 +513,8 @@ public abstract class AbstractMessageProducingHandler extends AbstractMessageHan
 		else {
 			builder = getMessageBuilderFactory().withPayload(output);
 			// Assuming that a message in the payload collection is a copy of the request message.
-			if (!(output instanceof Flux<?>) && output instanceof Iterable<?> iterable) {
+			if (!(output instanceof Flux<?>)
+					&& output instanceof Iterable<?> iterable) {
 				Iterator<?> iterator = iterable.iterator();
 				if (iterator.hasNext() && iterator.next() instanceof Message<?>) {
 					builder = builder.cloneMessageHistoryIfAny();

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractMessageProducingHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractMessageProducingHandlerTests.java
@@ -120,13 +120,12 @@ public class AbstractMessageProducingHandlerTests {
 	}
 
 	@Test
-	void shouldHandleCompletableFutureInAsyncMode() throws Exception {
+	void shouldHandleCompletableFutureInAsyncMode() {
 		QueueChannel outputChannel = new QueueChannel();
 		this.handler.setOutputChannel(outputChannel);
 		this.handler.setAsync(true);
 		CompletableFuture<String> future = new CompletableFuture<>();
-		this.handler.setResult(future);
-		Message<?> inputMessage = MessageBuilder.withPayload("test").build();
+		Message<?> inputMessage = MessageBuilder.withPayload(future).build();
 
 		this.handler.handleMessageInternal(inputMessage);
 
@@ -139,16 +138,9 @@ public class AbstractMessageProducingHandlerTests {
 
 	private static class TestMessageProducingHandler extends AbstractMessageProducingHandler {
 
-		private Object result;
-
-		void setResult(Object result) {
-			this.result = result;
-		}
-
 		@Override
 		protected void handleMessageInternal(Message<?> message) {
-			Object resultToSend = this.result != null ? this.result : message.getPayload();
-			sendOutputs(resultToSend, message);
+			sendOutputs(message.getPayload(), message);
 		}
 
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractMessageProducingHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractMessageProducingHandlerTests.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.handler;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link AbstractMessageProducingHandler}.
+ *
+ * @author Glenn Renfro
+ * @since 7.1
+ */
+public class AbstractMessageProducingHandlerTests {
+
+	private TestMessageProducingHandler handler;
+
+	private BeanFactory beanFactory;
+
+	@BeforeEach
+	void setup() {
+		this.handler = new TestMessageProducingHandler();
+		this.beanFactory = mock(BeanFactory.class);
+		this.handler.setBeanFactory(this.beanFactory);
+		this.handler.afterPropertiesSet();
+	}
+
+	@Test
+	void shouldSendOutputToConfiguredChannel() {
+		QueueChannel outputChannel = new QueueChannel();
+		this.handler.setOutputChannel(outputChannel);
+		Message<?> inputMessage = MessageBuilder.withPayload("test").build();
+
+		this.handler.handleMessageInternal(inputMessage);
+
+		Message<?> outputMessage = outputChannel.receive(0);
+		assertThat(outputMessage).isNotNull();
+		assertThat(outputMessage.getPayload()).isEqualTo("test");
+	}
+
+	@Test
+	void shouldSendNonQueueFluxOutputToConfiguredChannel() {
+		QueueChannel outputChannel = new QueueChannel();
+		this.handler.setOutputChannel(outputChannel);
+
+		Flux<String> flux = Flux.just("Hello", "World");
+		Message<?> inputMessage = MessageBuilder.withPayload(flux).build();
+
+		this.handler.handleMessageInternal(inputMessage);
+		Message<?> outputMessage = outputChannel.receive(0);
+		assertThat(outputMessage).isNotNull();
+		Flux<String> result = (Flux<String>) outputMessage.getPayload();
+		StepVerifier.create(result)
+				.expectNext("Hello")
+				.expectNext("World")
+				.thenCancel()
+				.verify();
+	}
+
+	@Test
+	void shouldSendMonoOutputToConfiguredChannel() {
+		QueueChannel outputChannel = new QueueChannel();
+		this.handler.setOutputChannel(outputChannel);
+
+		Mono<String> mono = Mono.just("Hello");
+		Message<?> inputMessage = MessageBuilder.withPayload(mono).build();
+
+		this.handler.handleMessageInternal(inputMessage);
+		Message<?> outputMessage = outputChannel.receive(0);
+		assertThat(outputMessage).isNotNull();
+		Mono<String> result = (Mono<String>) outputMessage.getPayload();
+		StepVerifier.create(result)
+				.expectNext("Hello")
+				.thenCancel()
+				.verify();
+	}
+
+	@Test
+	void shouldSendQueueFluxOutputToConfiguredChannel() {
+		QueueChannel outputChannel = new QueueChannel();
+		this.handler.setOutputChannel(outputChannel);
+
+		Queue<String> testQueue = new LinkedList<>();
+		testQueue.add("Hello");
+		testQueue.add("World");
+		Sinks.Many<String> sink = Sinks.many().unicast().onBackpressureBuffer();
+		testQueue.forEach(item -> sink.tryEmitNext(item));
+		sink.tryEmitComplete();
+		Message<?> inputMessage = MessageBuilder.withPayload(sink.asFlux()).build();
+
+		this.handler.handleMessageInternal(inputMessage);
+
+		Message<?> outputMessage = outputChannel.receive(0);
+		assertThat(outputMessage).isNotNull();
+		Flux<String> result = (Flux<String>) outputMessage.getPayload();
+
+		StepVerifier.create(result)
+				.expectNext("Hello")
+				.expectNext("World")
+				.thenCancel()
+				.verify();
+	}
+
+	@Test
+	void shouldSendOutputToReplyChannel() {
+		QueueChannel replyChannel = new QueueChannel();
+		Message<?> inputMessage = MessageBuilder.withPayload("test")
+				.setReplyChannel(replyChannel)
+				.build();
+
+		this.handler.handleMessageInternal(inputMessage);
+
+		Message<?> outputMessage = replyChannel.receive(0);
+		assertThat(outputMessage).isNotNull();
+		assertThat(outputMessage.getPayload()).isEqualTo("test");
+	}
+
+	@Test
+	void shouldHandleCompletableFutureInAsyncMode() throws Exception {
+		QueueChannel outputChannel = new QueueChannel();
+		this.handler.setOutputChannel(outputChannel);
+		this.handler.setAsync(true);
+		CompletableFuture<String> future = new CompletableFuture<>();
+		this.handler.setResult(future);
+		Message<?> inputMessage = MessageBuilder.withPayload("test").build();
+
+		this.handler.handleMessageInternal(inputMessage);
+
+		assertThat(outputChannel.receive(0)).isNull();
+
+		future.complete("asyncResult");
+
+		Message<?> output = outputChannel.receive(1000);
+		assertThat(output).isNotNull();
+		assertThat(output.getPayload()).isEqualTo("asyncResult");
+	}
+
+	private static class TestMessageProducingHandler extends AbstractMessageProducingHandler {
+
+		private Object result;
+
+		void setResult(Object result) {
+			this.result = result;
+		}
+
+		@Override
+		protected void handleMessageInternal(Message<?> message) {
+			Object resultToSend = this.result != null ? this.result : message.getPayload();
+			sendOutputs(resultToSend, message);
+		}
+
+	}
+
+}

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractMessageProducingHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/AbstractMessageProducingHandlerTests.java
@@ -39,35 +39,21 @@ import static org.mockito.Mockito.mock;
  * Tests for {@link AbstractMessageProducingHandler}.
  *
  * @author Glenn Renfro
- * @since 7.1
+ * @since 6.5.7
  */
 public class AbstractMessageProducingHandlerTests {
 
 	private TestMessageProducingHandler handler;
 
-	private BeanFactory beanFactory;
-
 	@BeforeEach
 	void setup() {
 		this.handler = new TestMessageProducingHandler();
-		this.beanFactory = mock(BeanFactory.class);
-		this.handler.setBeanFactory(this.beanFactory);
+		BeanFactory beanFactory = mock(BeanFactory.class);
+		this.handler.setBeanFactory(beanFactory);
 		this.handler.afterPropertiesSet();
 	}
 
-	@Test
-	void shouldSendOutputToConfiguredChannel() {
-		QueueChannel outputChannel = new QueueChannel();
-		this.handler.setOutputChannel(outputChannel);
-		Message<?> inputMessage = MessageBuilder.withPayload("test").build();
-
-		this.handler.handleMessageInternal(inputMessage);
-
-		Message<?> outputMessage = outputChannel.receive(0);
-		assertThat(outputMessage).isNotNull();
-		assertThat(outputMessage.getPayload()).isEqualTo("test");
-	}
-
+	@SuppressWarnings("unchecked")
 	@Test
 	void shouldSendNonQueueFluxOutputToConfiguredChannel() {
 		QueueChannel outputChannel = new QueueChannel();
@@ -87,6 +73,7 @@ public class AbstractMessageProducingHandlerTests {
 				.verify();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	void shouldSendMonoOutputToConfiguredChannel() {
 		QueueChannel outputChannel = new QueueChannel();
@@ -105,6 +92,7 @@ public class AbstractMessageProducingHandlerTests {
 				.verify();
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	void shouldSendQueueFluxOutputToConfiguredChannel() {
 		QueueChannel outputChannel = new QueueChannel();
@@ -132,20 +120,6 @@ public class AbstractMessageProducingHandlerTests {
 	}
 
 	@Test
-	void shouldSendOutputToReplyChannel() {
-		QueueChannel replyChannel = new QueueChannel();
-		Message<?> inputMessage = MessageBuilder.withPayload("test")
-				.setReplyChannel(replyChannel)
-				.build();
-
-		this.handler.handleMessageInternal(inputMessage);
-
-		Message<?> outputMessage = replyChannel.receive(0);
-		assertThat(outputMessage).isNotNull();
-		assertThat(outputMessage.getPayload()).isEqualTo("test");
-	}
-
-	@Test
 	void shouldHandleCompletableFutureInAsyncMode() throws Exception {
 		QueueChannel outputChannel = new QueueChannel();
 		this.handler.setOutputChannel(outputChannel);
@@ -155,8 +129,6 @@ public class AbstractMessageProducingHandlerTests {
 		Message<?> inputMessage = MessageBuilder.withPayload("test").build();
 
 		this.handler.handleMessageInternal(inputMessage);
-
-		assertThat(outputChannel.receive(0)).isNull();
 
 		future.complete("asyncResult");
 


### PR DESCRIPTION
Fixes #10793
- Exclude `Flux` from iterable splitting in `sendOutputs` to prevent incorrect iteration over reactive streams
- Exclude `Flux` from iterable message-history cloning check in `produceOutput`
- Add `AbstractMessageProducingHandlerTests` to verify `Flux`, `Mono`, and queue-backed `Flux` payloads pass through as single outputs


**Auto-cherry-pick to `7.0.x` & `6.5.x`**
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
