### PR TITLE
GH-10830: Add RestClient support for HTTP outbound endpoints

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpAdapterParsingUtils.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpAdapterParsingUtils.java
@@ -36,6 +36,7 @@ import org.springframework.util.xml.DomUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Shiliang Li
+ * @author Arun Sethumadhavan
  *
  * @since 2.0.2
  */
@@ -58,6 +59,23 @@ final class HttpAdapterParsingUtils {
 		if (element.hasAttribute("encoding-mode")) {
 			parserContext.getReaderContext().error("When providing a 'rest-template' reference, " +
 							"the 'encoding-mode' must be set on the 'RestTemplate.uriTemplateHandler' property.",
+					parserContext.extractSource(element));
+		}
+	}
+
+	static void verifyNoRestClientAttributes(Element element, ParserContext parserContext) {
+		for (String attributeName : SYNC_REST_TEMPLATE_REFERENCE_ATTRIBUTES) {
+			if (element.hasAttribute(attributeName)) {
+				parserContext.getReaderContext().error("When providing a 'rest-client' reference, the '"
+								+ attributeName + "' attribute is not allowed, " +
+								"it must be set on the provided client instead",
+						parserContext.extractSource(element));
+			}
+		}
+
+		if (element.hasAttribute("encoding-mode")) {
+			parserContext.getReaderContext().error("When providing a 'rest-client' reference, " +
+							"the 'encoding-mode' must be set on the 'RestClient.Builder.uriBuilderFactory' property.",
 					parserContext.extractSource(element));
 		}
 	}

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParser.java
@@ -36,6 +36,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Shiliang Li
+ * @author Arun Sethumadhavan
  *
  * @since 2.0
  */
@@ -78,12 +79,25 @@ public class HttpOutboundChannelAdapterParser extends AbstractOutboundChannelAda
 				BeanDefinitionBuilder.genericBeanDefinition(HttpRequestExecutingMessageHandler.class);
 
 		String restTemplateRef = element.getAttribute("rest-template");
+		String restClientRef = element.getAttribute("rest-client");
+
+		if (StringUtils.hasText(restTemplateRef) && StringUtils.hasText(restClientRef)) {
+			parserContext.getReaderContext()
+					.error("Only one of 'rest-template' and 'rest-client' references is allowed.",
+							parserContext.extractSource(element));
+		}
 
 		if (StringUtils.hasText(restTemplateRef)) {
 			HttpAdapterParsingUtils.verifyNoRestTemplateAttributes(element, parserContext);
 			builder.getBeanDefinition()
 					.getConstructorArgumentValues()
 					.addIndexedArgumentValue(1, new RuntimeBeanReference(restTemplateRef));
+		}
+		else if (StringUtils.hasText(restClientRef)) {
+			HttpAdapterParsingUtils.verifyNoRestClientAttributes(element, parserContext);
+			builder.getBeanDefinition()
+					.getConstructorArgumentValues()
+					.addIndexedArgumentValue(1, new RuntimeBeanReference(restClientRef));
 		}
 		else {
 			for (String referenceAttributeName : HttpAdapterParsingUtils.SYNC_REST_TEMPLATE_REFERENCE_ATTRIBUTES) {

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/config/HttpOutboundGatewayParser.java
@@ -34,6 +34,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Shiliang Li
+ * @author Arun Sethumadhavan
  */
 public class HttpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 
@@ -91,12 +92,25 @@ public class HttpOutboundGatewayParser extends AbstractConsumerEndpointParser {
 				BeanDefinitionBuilder.genericBeanDefinition(HttpRequestExecutingMessageHandler.class);
 
 		String restTemplateRef = element.getAttribute("rest-template");
+		String restClientRef = element.getAttribute("rest-client");
+
+		if (StringUtils.hasText(restTemplateRef) && StringUtils.hasText(restClientRef)) {
+			parserContext.getReaderContext()
+					.error("Only one of 'rest-template' and 'rest-client' references is allowed.",
+							parserContext.extractSource(element));
+		}
 
 		if (StringUtils.hasText(restTemplateRef)) {
 			HttpAdapterParsingUtils.verifyNoRestTemplateAttributes(element, parserContext);
 			builder.getBeanDefinition()
 					.getConstructorArgumentValues()
 					.addIndexedArgumentValue(1, new RuntimeBeanReference(restTemplateRef));
+		}
+		else if (StringUtils.hasText(restClientRef)) {
+			HttpAdapterParsingUtils.verifyNoRestClientAttributes(element, parserContext);
+			builder.getBeanDefinition()
+					.getConstructorArgumentValues()
+					.addIndexedArgumentValue(1, new RuntimeBeanReference(restClientRef));
 		}
 		else {
 			for (String referenceAttributeName : HttpAdapterParsingUtils.SYNC_REST_TEMPLATE_REFERENCE_ATTRIBUTES) {

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/Http.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/Http.java
@@ -90,9 +90,8 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
-	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundChannelAdapter(URI uri, @Nullable RestTemplate restTemplate) {
-		return new HttpMessageHandlerSpec(uri, restTemplate).expectReply(false);
+		return outboundChannelAdapter(uri, toRestClient(restTemplate));
 	}
 
 	/**
@@ -116,9 +115,8 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
-	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri, @Nullable RestTemplate restTemplate) {
-		return new HttpMessageHandlerSpec(uri, restTemplate).expectReply(false);
+		return outboundChannelAdapter(uri, toRestClient(restTemplate));
 	}
 
 	/**
@@ -147,7 +145,7 @@ public final class Http {
 	public static <P> HttpMessageHandlerSpec outboundChannelAdapter(Function<Message<P>, ?> uriFunction,
 			RestTemplate restTemplate) {
 
-		return outboundChannelAdapter(new FunctionExpression<>(uriFunction), restTemplate);
+		return outboundChannelAdapter(new FunctionExpression<>(uriFunction), toRestClient(restTemplate));
 	}
 
 	/**
@@ -176,11 +174,10 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
-	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundChannelAdapter(Expression uriExpression,
 			@Nullable RestTemplate restTemplate) {
 
-		return new HttpMessageHandlerSpec(uriExpression, restTemplate).expectReply(false);
+		return outboundChannelAdapter(uriExpression, toRestClient(restTemplate));
 	}
 
 	/**
@@ -244,9 +241,8 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
-	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundGateway(URI uri, @Nullable RestTemplate restTemplate) {
-		return new HttpMessageHandlerSpec(uri, restTemplate);
+		return outboundGateway(uri, toRestClient(restTemplate));
 	}
 
 	/**
@@ -270,9 +266,8 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
-	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundGateway(String uri, @Nullable RestTemplate restTemplate) {
-		return new HttpMessageHandlerSpec(uri, restTemplate);
+		return outboundGateway(uri, toRestClient(restTemplate));
 	}
 
 	/**
@@ -301,7 +296,7 @@ public final class Http {
 	public static <P> HttpMessageHandlerSpec outboundGateway(Function<Message<P>, ?> uriFunction,
 			RestTemplate restTemplate) {
 
-		return outboundGateway(new FunctionExpression<>(uriFunction), restTemplate);
+		return outboundGateway(new FunctionExpression<>(uriFunction), toRestClient(restTemplate));
 	}
 
 	/**
@@ -330,11 +325,10 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
-	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundGateway(Expression uriExpression,
 			@Nullable RestTemplate restTemplate) {
 
-		return new HttpMessageHandlerSpec(uriExpression, restTemplate);
+		return outboundGateway(uriExpression, toRestClient(restTemplate));
 	}
 
 	/**
@@ -351,19 +345,21 @@ public final class Http {
 	}
 
 	private static HttpMessageHandlerSpec outboundGatewaySpec(URI uri, @Nullable RestClient restClient) {
-		return restClient != null ? new HttpMessageHandlerSpec(uri, restClient) : new HttpMessageHandlerSpec(uri);
+		return new HttpMessageHandlerSpec(uri, restClient);
 	}
 
 	private static HttpMessageHandlerSpec outboundGatewaySpec(String uri, @Nullable RestClient restClient) {
-		return restClient != null ? new HttpMessageHandlerSpec(uri, restClient) : new HttpMessageHandlerSpec(uri);
+		return new HttpMessageHandlerSpec(uri, restClient);
 	}
 
 	private static HttpMessageHandlerSpec outboundGatewaySpec(Expression uriExpression,
 			@Nullable RestClient restClient) {
 
-		return restClient != null
-				? new HttpMessageHandlerSpec(uriExpression, restClient)
-				: new HttpMessageHandlerSpec(uriExpression);
+		return new HttpMessageHandlerSpec(uriExpression, restClient);
+	}
+
+	private static @Nullable RestClient toRestClient(@Nullable RestTemplate restTemplate) {
+		return restTemplate != null ? RestClient.create(restTemplate) : null;
 	}
 
 	/**

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/Http.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/Http.java
@@ -28,6 +28,7 @@ import org.springframework.integration.http.inbound.HttpRequestHandlingControlle
 import org.springframework.integration.http.inbound.HttpRequestHandlingMessagingGateway;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -35,6 +36,7 @@ import org.springframework.web.client.RestTemplate;
  *
  * @author Artem Bilan
  * @author Shiliang Li
+ * @author Arun Sethumadhavan
  *
  * @since 5.0
  */
@@ -46,7 +48,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(URI uri) {
-		return outboundChannelAdapter(uri, null);
+		return outboundChannelAdapter(uri, (RestTemplate) null);
 	}
 
 	/**
@@ -55,7 +57,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri) {
-		return outboundChannelAdapter(uri, null);
+		return outboundChannelAdapter(uri, (RestTemplate) null);
 	}
 
 	/**
@@ -76,7 +78,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(Expression uriExpression) {
-		return outboundChannelAdapter(uriExpression, null);
+		return outboundChannelAdapter(uriExpression, (RestTemplate) null);
 	}
 
 	/**
@@ -92,6 +94,18 @@ public final class Http {
 
 	/**
 	 * Create an {@link HttpMessageHandlerSpec} builder for one-way adapter
+	 * based on provided {@link URI} and {@link RestClient}.
+	 * @param uri the {@link URI} to send requests.
+	 * @param restClient {@link RestClient} to use.
+	 * @return the HttpMessageHandlerSpec instance
+	 * @since 7.0
+	 */
+	public static HttpMessageHandlerSpec outboundChannelAdapter(URI uri, RestClient restClient) {
+		return new HttpMessageHandlerSpec(uri, restClient).expectReply(false);
+	}
+
+	/**
+	 * Create an {@link HttpMessageHandlerSpec} builder for one-way adapter
 	 * based on provided {@code uri} and {@link RestTemplate}.
 	 * @param uri the {@code uri} to send requests.
 	 * @param restTemplate {@link RestTemplate} to use.
@@ -99,6 +113,18 @@ public final class Http {
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate).expectReply(false);
+	}
+
+	/**
+	 * Create an {@link HttpMessageHandlerSpec} builder for one-way adapter
+	 * based on provided {@code uri} and {@link RestClient}.
+	 * @param uri the {@code uri} to send requests.
+	 * @param restClient {@link RestClient} to use.
+	 * @return the HttpMessageHandlerSpec instance
+	 * @since 7.0
+	 */
+	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri, RestClient restClient) {
+		return new HttpMessageHandlerSpec(uri, restClient).expectReply(false);
 	}
 
 	/**
@@ -118,6 +144,22 @@ public final class Http {
 
 	/**
 	 * Create an {@link HttpMessageHandlerSpec} builder for one-way adapter
+	 * based on provided {@code Function} to evaluate target {@code uri} against request message
+	 * and {@link RestClient} for HTTP exchanges.
+	 * @param uriFunction the {@code Function} to evaluate {@code uri} at runtime.
+	 * @param restClient {@link RestClient} to use.
+	 * @param <P> the expected payload type.
+	 * @return the HttpMessageHandlerSpec instance
+	 * @since 7.0
+	 */
+	public static <P> HttpMessageHandlerSpec outboundChannelAdapter(Function<Message<P>, ?> uriFunction,
+			RestClient restClient) {
+
+		return outboundChannelAdapter(new FunctionExpression<>(uriFunction), restClient);
+	}
+
+	/**
+	 * Create an {@link HttpMessageHandlerSpec} builder for one-way adapter
 	 * based on provided SpEL {@link Expression} to evaluate target {@code uri}
 	 * against request message and {@link RestTemplate} for HTTP exchanges.
 	 * @param uriExpression the SpEL {@link Expression} to evaluate {@code uri} at runtime.
@@ -131,12 +173,25 @@ public final class Http {
 	}
 
 	/**
+	 * Create an {@link HttpMessageHandlerSpec} builder for one-way adapter
+	 * based on provided SpEL {@link Expression} to evaluate target {@code uri}
+	 * against request message and {@link RestClient} for HTTP exchanges.
+	 * @param uriExpression the SpEL {@link Expression} to evaluate {@code uri} at runtime.
+	 * @param restClient {@link RestClient} to use.
+	 * @return the HttpMessageHandlerSpec instance
+	 * @since 7.0
+	 */
+	public static HttpMessageHandlerSpec outboundChannelAdapter(Expression uriExpression, RestClient restClient) {
+		return new HttpMessageHandlerSpec(uriExpression, restClient).expectReply(false);
+	}
+
+	/**
 	 * Create an {@link HttpMessageHandlerSpec} builder for request-reply gateway based on provided {@link URI}.
 	 * @param uri the {@link URI} to send requests.
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(URI uri) {
-		return outboundGateway(uri, null);
+		return outboundGateway(uri, (RestTemplate) null);
 	}
 
 	/**
@@ -145,7 +200,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(String uri) {
-		return outboundGateway(uri, null);
+		return outboundGateway(uri, (RestTemplate) null);
 	}
 
 	/**
@@ -166,7 +221,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(Expression uriExpression) {
-		return outboundGateway(uriExpression, null);
+		return outboundGateway(uriExpression, (RestTemplate) null);
 	}
 
 	/**
@@ -182,6 +237,18 @@ public final class Http {
 
 	/**
 	 * Create an {@link HttpMessageHandlerSpec} builder for request-reply gateway
+	 * based on provided {@link URI} and {@link RestClient}.
+	 * @param uri the {@link URI} to send requests.
+	 * @param restClient {@link RestClient} to use.
+	 * @return the HttpMessageHandlerSpec instance
+	 * @since 7.0
+	 */
+	public static HttpMessageHandlerSpec outboundGateway(URI uri, RestClient restClient) {
+		return new HttpMessageHandlerSpec(uri, restClient);
+	}
+
+	/**
+	 * Create an {@link HttpMessageHandlerSpec} builder for request-reply gateway
 	 * based on provided {@code uri} and {@link RestTemplate}.
 	 * @param uri the {@code uri} to send requests.
 	 * @param restTemplate {@link RestTemplate} to use.
@@ -189,6 +256,18 @@ public final class Http {
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(String uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate);
+	}
+
+	/**
+	 * Create an {@link HttpMessageHandlerSpec} builder for request-reply gateway
+	 * based on provided {@code uri} and {@link RestClient}.
+	 * @param uri the {@code uri} to send requests.
+	 * @param restClient {@link RestClient} to use.
+	 * @return the HttpMessageHandlerSpec instance
+	 * @since 7.0
+	 */
+	public static HttpMessageHandlerSpec outboundGateway(String uri, RestClient restClient) {
+		return new HttpMessageHandlerSpec(uri, restClient);
 	}
 
 	/**
@@ -208,6 +287,22 @@ public final class Http {
 
 	/**
 	 * Create an {@link HttpMessageHandlerSpec} builder for request-reply gateway
+	 * based on provided {@code Function} to evaluate target {@code uri} against request message
+	 * and {@link RestClient} for HTTP exchanges.
+	 * @param uriFunction the {@code Function} to evaluate {@code uri} at runtime.
+	 * @param restClient {@link RestClient} to use.
+	 * @param <P> the expected payload type.
+	 * @return the HttpMessageHandlerSpec instance
+	 * @since 7.0
+	 */
+	public static <P> HttpMessageHandlerSpec outboundGateway(Function<Message<P>, ?> uriFunction,
+			RestClient restClient) {
+
+		return outboundGateway(new FunctionExpression<>(uriFunction), restClient);
+	}
+
+	/**
+	 * Create an {@link HttpMessageHandlerSpec} builder for request-reply gateway
 	 * based on provided SpEL {@link Expression} to evaluate target {@code uri}
 	 * against request message and {@link RestTemplate} for HTTP exchanges.
 	 * @param uriExpression the SpEL {@link Expression} to evaluate {@code uri} at runtime.
@@ -218,6 +313,19 @@ public final class Http {
 			@Nullable RestTemplate restTemplate) {
 
 		return new HttpMessageHandlerSpec(uriExpression, restTemplate);
+	}
+
+	/**
+	 * Create an {@link HttpMessageHandlerSpec} builder for request-reply gateway
+	 * based on provided SpEL {@link Expression} to evaluate target {@code uri}
+	 * against request message and {@link RestClient} for HTTP exchanges.
+	 * @param uriExpression the SpEL {@link Expression} to evaluate {@code uri} at runtime.
+	 * @param restClient {@link RestClient} to use.
+	 * @return the HttpMessageHandlerSpec instance
+	 * @since 7.0
+	 */
+	public static HttpMessageHandlerSpec outboundGateway(Expression uriExpression, RestClient restClient) {
+		return new HttpMessageHandlerSpec(uriExpression, restClient);
 	}
 
 	/**

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/Http.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/Http.java
@@ -90,6 +90,7 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
+	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundChannelAdapter(URI uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate).expectReply(false);
 	}
@@ -103,9 +104,7 @@ public final class Http {
 	 * @since 7.1
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(URI uri, @Nullable RestClient restClient) {
-		return (restClient != null
-				? new HttpMessageHandlerSpec(uri, restClient).expectReply(false)
-				: outboundChannelAdapter(uri, (RestTemplate) null));
+		return outboundGatewaySpec(uri, restClient).expectReply(false);
 	}
 
 	/**
@@ -117,6 +116,7 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
+	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate).expectReply(false);
 	}
@@ -130,9 +130,7 @@ public final class Http {
 	 * @since 7.1
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri, @Nullable RestClient restClient) {
-		return (restClient != null
-				? new HttpMessageHandlerSpec(uri, restClient).expectReply(false)
-				: outboundChannelAdapter(uri, (RestTemplate) null));
+		return outboundGatewaySpec(uri, restClient).expectReply(false);
 	}
 
 	/**
@@ -178,6 +176,7 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
+	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundChannelAdapter(Expression uriExpression,
 			@Nullable RestTemplate restTemplate) {
 
@@ -194,9 +193,7 @@ public final class Http {
 	 * @since 7.1
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(Expression uriExpression, @Nullable RestClient restClient) {
-		return (restClient != null
-				? new HttpMessageHandlerSpec(uriExpression, restClient).expectReply(false)
-				: outboundChannelAdapter(uriExpression, (RestTemplate) null));
+		return outboundGatewaySpec(uriExpression, restClient).expectReply(false);
 	}
 
 	/**
@@ -247,6 +244,7 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
+	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundGateway(URI uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate);
 	}
@@ -260,9 +258,7 @@ public final class Http {
 	 * @since 7.1
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(URI uri, @Nullable RestClient restClient) {
-		return (restClient != null
-				? new HttpMessageHandlerSpec(uri, restClient)
-				: outboundGateway(uri, (RestTemplate) null));
+		return outboundGatewaySpec(uri, restClient);
 	}
 
 	/**
@@ -274,6 +270,7 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
+	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundGateway(String uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate);
 	}
@@ -287,9 +284,7 @@ public final class Http {
 	 * @since 7.1
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(String uri, @Nullable RestClient restClient) {
-		return (restClient != null
-				? new HttpMessageHandlerSpec(uri, restClient)
-				: outboundGateway(uri, (RestTemplate) null));
+		return outboundGatewaySpec(uri, restClient);
 	}
 
 	/**
@@ -335,6 +330,7 @@ public final class Http {
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
+	@SuppressWarnings("removal")
 	public static HttpMessageHandlerSpec outboundGateway(Expression uriExpression,
 			@Nullable RestTemplate restTemplate) {
 
@@ -351,9 +347,23 @@ public final class Http {
 	 * @since 7.1
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(Expression uriExpression, @Nullable RestClient restClient) {
-		return (restClient != null
+		return outboundGatewaySpec(uriExpression, restClient);
+	}
+
+	private static HttpMessageHandlerSpec outboundGatewaySpec(URI uri, @Nullable RestClient restClient) {
+		return restClient != null ? new HttpMessageHandlerSpec(uri, restClient) : new HttpMessageHandlerSpec(uri);
+	}
+
+	private static HttpMessageHandlerSpec outboundGatewaySpec(String uri, @Nullable RestClient restClient) {
+		return restClient != null ? new HttpMessageHandlerSpec(uri, restClient) : new HttpMessageHandlerSpec(uri);
+	}
+
+	private static HttpMessageHandlerSpec outboundGatewaySpec(Expression uriExpression,
+			@Nullable RestClient restClient) {
+
+		return restClient != null
 				? new HttpMessageHandlerSpec(uriExpression, restClient)
-				: outboundGateway(uriExpression, (RestTemplate) null));
+				: new HttpMessageHandlerSpec(uriExpression);
 	}
 
 	/**

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/Http.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/Http.java
@@ -48,7 +48,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(URI uri) {
-		return outboundChannelAdapter(uri, (RestTemplate) null);
+		return outboundChannelAdapter(uri, (RestClient) null);
 	}
 
 	/**
@@ -57,7 +57,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri) {
-		return outboundChannelAdapter(uri, (RestTemplate) null);
+		return outboundChannelAdapter(uri, (RestClient) null);
 	}
 
 	/**
@@ -78,7 +78,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundChannelAdapter(Expression uriExpression) {
-		return outboundChannelAdapter(uriExpression, (RestTemplate) null);
+		return outboundChannelAdapter(uriExpression, (RestClient) null);
 	}
 
 	/**
@@ -87,7 +87,9 @@ public final class Http {
 	 * @param uri the {@link URI} to send requests.
 	 * @param restTemplate {@link RestTemplate} to use.
 	 * @return the HttpMessageHandlerSpec instance
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public static HttpMessageHandlerSpec outboundChannelAdapter(URI uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate).expectReply(false);
 	}
@@ -98,10 +100,12 @@ public final class Http {
 	 * @param uri the {@link URI} to send requests.
 	 * @param restClient {@link RestClient} to use.
 	 * @return the HttpMessageHandlerSpec instance
-	 * @since 7.0
+	 * @since 7.1
 	 */
-	public static HttpMessageHandlerSpec outboundChannelAdapter(URI uri, RestClient restClient) {
-		return new HttpMessageHandlerSpec(uri, restClient).expectReply(false);
+	public static HttpMessageHandlerSpec outboundChannelAdapter(URI uri, @Nullable RestClient restClient) {
+		return (restClient != null
+				? new HttpMessageHandlerSpec(uri, restClient).expectReply(false)
+				: outboundChannelAdapter(uri, (RestTemplate) null));
 	}
 
 	/**
@@ -110,7 +114,9 @@ public final class Http {
 	 * @param uri the {@code uri} to send requests.
 	 * @param restTemplate {@link RestTemplate} to use.
 	 * @return the HttpMessageHandlerSpec instance
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate).expectReply(false);
 	}
@@ -121,10 +127,12 @@ public final class Http {
 	 * @param uri the {@code uri} to send requests.
 	 * @param restClient {@link RestClient} to use.
 	 * @return the HttpMessageHandlerSpec instance
-	 * @since 7.0
+	 * @since 7.1
 	 */
-	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri, RestClient restClient) {
-		return new HttpMessageHandlerSpec(uri, restClient).expectReply(false);
+	public static HttpMessageHandlerSpec outboundChannelAdapter(String uri, @Nullable RestClient restClient) {
+		return (restClient != null
+				? new HttpMessageHandlerSpec(uri, restClient).expectReply(false)
+				: outboundChannelAdapter(uri, (RestTemplate) null));
 	}
 
 	/**
@@ -135,7 +143,9 @@ public final class Http {
 	 * @param restTemplate {@link RestTemplate} to use.
 	 * @param <P> the expected payload type.
 	 * @return the HttpMessageHandlerSpec instance
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public static <P> HttpMessageHandlerSpec outboundChannelAdapter(Function<Message<P>, ?> uriFunction,
 			RestTemplate restTemplate) {
 
@@ -150,10 +160,10 @@ public final class Http {
 	 * @param restClient {@link RestClient} to use.
 	 * @param <P> the expected payload type.
 	 * @return the HttpMessageHandlerSpec instance
-	 * @since 7.0
+	 * @since 7.1
 	 */
 	public static <P> HttpMessageHandlerSpec outboundChannelAdapter(Function<Message<P>, ?> uriFunction,
-			RestClient restClient) {
+			@Nullable RestClient restClient) {
 
 		return outboundChannelAdapter(new FunctionExpression<>(uriFunction), restClient);
 	}
@@ -165,7 +175,9 @@ public final class Http {
 	 * @param uriExpression the SpEL {@link Expression} to evaluate {@code uri} at runtime.
 	 * @param restTemplate {@link RestTemplate} to use.
 	 * @return the HttpMessageHandlerSpec instance
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public static HttpMessageHandlerSpec outboundChannelAdapter(Expression uriExpression,
 			@Nullable RestTemplate restTemplate) {
 
@@ -179,10 +191,12 @@ public final class Http {
 	 * @param uriExpression the SpEL {@link Expression} to evaluate {@code uri} at runtime.
 	 * @param restClient {@link RestClient} to use.
 	 * @return the HttpMessageHandlerSpec instance
-	 * @since 7.0
+	 * @since 7.1
 	 */
-	public static HttpMessageHandlerSpec outboundChannelAdapter(Expression uriExpression, RestClient restClient) {
-		return new HttpMessageHandlerSpec(uriExpression, restClient).expectReply(false);
+	public static HttpMessageHandlerSpec outboundChannelAdapter(Expression uriExpression, @Nullable RestClient restClient) {
+		return (restClient != null
+				? new HttpMessageHandlerSpec(uriExpression, restClient).expectReply(false)
+				: outboundChannelAdapter(uriExpression, (RestTemplate) null));
 	}
 
 	/**
@@ -191,7 +205,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(URI uri) {
-		return outboundGateway(uri, (RestTemplate) null);
+		return outboundGateway(uri, (RestClient) null);
 	}
 
 	/**
@@ -200,7 +214,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(String uri) {
-		return outboundGateway(uri, (RestTemplate) null);
+		return outboundGateway(uri, (RestClient) null);
 	}
 
 	/**
@@ -221,7 +235,7 @@ public final class Http {
 	 * @return the HttpMessageHandlerSpec instance
 	 */
 	public static HttpMessageHandlerSpec outboundGateway(Expression uriExpression) {
-		return outboundGateway(uriExpression, (RestTemplate) null);
+		return outboundGateway(uriExpression, (RestClient) null);
 	}
 
 	/**
@@ -230,7 +244,9 @@ public final class Http {
 	 * @param uri the {@link URI} to send requests.
 	 * @param restTemplate {@link RestTemplate} to use.
 	 * @return the HttpMessageHandlerSpec instance
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public static HttpMessageHandlerSpec outboundGateway(URI uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate);
 	}
@@ -241,10 +257,12 @@ public final class Http {
 	 * @param uri the {@link URI} to send requests.
 	 * @param restClient {@link RestClient} to use.
 	 * @return the HttpMessageHandlerSpec instance
-	 * @since 7.0
+	 * @since 7.1
 	 */
-	public static HttpMessageHandlerSpec outboundGateway(URI uri, RestClient restClient) {
-		return new HttpMessageHandlerSpec(uri, restClient);
+	public static HttpMessageHandlerSpec outboundGateway(URI uri, @Nullable RestClient restClient) {
+		return (restClient != null
+				? new HttpMessageHandlerSpec(uri, restClient)
+				: outboundGateway(uri, (RestTemplate) null));
 	}
 
 	/**
@@ -253,7 +271,9 @@ public final class Http {
 	 * @param uri the {@code uri} to send requests.
 	 * @param restTemplate {@link RestTemplate} to use.
 	 * @return the HttpMessageHandlerSpec instance
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public static HttpMessageHandlerSpec outboundGateway(String uri, @Nullable RestTemplate restTemplate) {
 		return new HttpMessageHandlerSpec(uri, restTemplate);
 	}
@@ -264,10 +284,12 @@ public final class Http {
 	 * @param uri the {@code uri} to send requests.
 	 * @param restClient {@link RestClient} to use.
 	 * @return the HttpMessageHandlerSpec instance
-	 * @since 7.0
+	 * @since 7.1
 	 */
-	public static HttpMessageHandlerSpec outboundGateway(String uri, RestClient restClient) {
-		return new HttpMessageHandlerSpec(uri, restClient);
+	public static HttpMessageHandlerSpec outboundGateway(String uri, @Nullable RestClient restClient) {
+		return (restClient != null
+				? new HttpMessageHandlerSpec(uri, restClient)
+				: outboundGateway(uri, (RestTemplate) null));
 	}
 
 	/**
@@ -278,7 +300,9 @@ public final class Http {
 	 * @param restTemplate {@link RestTemplate} to use.
 	 * @param <P> the expected payload type.
 	 * @return the HttpMessageHandlerSpec instance
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public static <P> HttpMessageHandlerSpec outboundGateway(Function<Message<P>, ?> uriFunction,
 			RestTemplate restTemplate) {
 
@@ -293,10 +317,10 @@ public final class Http {
 	 * @param restClient {@link RestClient} to use.
 	 * @param <P> the expected payload type.
 	 * @return the HttpMessageHandlerSpec instance
-	 * @since 7.0
+	 * @since 7.1
 	 */
 	public static <P> HttpMessageHandlerSpec outboundGateway(Function<Message<P>, ?> uriFunction,
-			RestClient restClient) {
+			@Nullable RestClient restClient) {
 
 		return outboundGateway(new FunctionExpression<>(uriFunction), restClient);
 	}
@@ -308,7 +332,9 @@ public final class Http {
 	 * @param uriExpression the SpEL {@link Expression} to evaluate {@code uri} at runtime.
 	 * @param restTemplate {@link RestTemplate} to use.
 	 * @return the HttpMessageHandlerSpec instance
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public static HttpMessageHandlerSpec outboundGateway(Expression uriExpression,
 			@Nullable RestTemplate restTemplate) {
 
@@ -322,10 +348,12 @@ public final class Http {
 	 * @param uriExpression the SpEL {@link Expression} to evaluate {@code uri} at runtime.
 	 * @param restClient {@link RestClient} to use.
 	 * @return the HttpMessageHandlerSpec instance
-	 * @since 7.0
+	 * @since 7.1
 	 */
-	public static HttpMessageHandlerSpec outboundGateway(Expression uriExpression, RestClient restClient) {
-		return new HttpMessageHandlerSpec(uriExpression, restClient);
+	public static HttpMessageHandlerSpec outboundGateway(Expression uriExpression, @Nullable RestClient restClient) {
+		return (restClient != null
+				? new HttpMessageHandlerSpec(uriExpression, restClient)
+				: outboundGateway(uriExpression, (RestTemplate) null));
 	}
 
 	/**

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
@@ -49,6 +49,19 @@ public class HttpMessageHandlerSpec
 
 	private final boolean clientSet;
 
+	protected HttpMessageHandlerSpec(URI uri) {
+		this(new ValueExpression<>(uri));
+	}
+
+	protected HttpMessageHandlerSpec(String uri) {
+		this(new LiteralExpression(uri));
+	}
+
+	protected HttpMessageHandlerSpec(Expression uriExpression) {
+		super(new HttpRequestExecutingMessageHandler(uriExpression));
+		this.clientSet = false;
+	}
+
 	/**
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
@@ -72,7 +85,7 @@ public class HttpMessageHandlerSpec
 	protected HttpMessageHandlerSpec(Expression uriExpression, @Nullable RestTemplate restTemplate) {
 		super(restTemplate != null
 				? new HttpRequestExecutingMessageHandler(uriExpression, RestClient.create(restTemplate))
-				: new HttpRequestExecutingMessageHandler(uriExpression, (RestTemplate) null));
+				: new HttpRequestExecutingMessageHandler(uriExpression));
 		this.clientSet = restTemplate != null;
 	}
 

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
@@ -93,9 +93,7 @@ public class HttpMessageHandlerSpec
 	 * Set the {@link ClientHttpRequestFactory} for the underlying {@link RestTemplate}.
 	 * @param requestFactory The request factory.
 	 * @return the spec
-	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
 	 */
-	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpMessageHandlerSpec requestFactory(ClientHttpRequestFactory requestFactory) {
 		Assert.isTrue(!isClientSet(), "the 'requestFactory' must be specified on the provided client");
 		this.target.setRequestFactory(requestFactory);
@@ -106,9 +104,7 @@ public class HttpMessageHandlerSpec
 	 * Set the {@link ResponseErrorHandler} for the underlying {@link RestTemplate}.
 	 * @param errorHandler The error handler.
 	 * @return the spec
-	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
 	 */
-	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpMessageHandlerSpec errorHandler(ResponseErrorHandler errorHandler) {
 		Assert.isTrue(!isClientSet(), "the 'errorHandler' must be specified on the provided client");
 		this.target.setErrorHandler(errorHandler);
@@ -120,9 +116,7 @@ public class HttpMessageHandlerSpec
 	 * Converters configured via this method will override the default converters.
 	 * @param messageConverters The message converters.
 	 * @return the spec
-	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
 	 */
-	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpMessageHandlerSpec messageConverters(HttpMessageConverter<?>... messageConverters) {
 		Assert.isTrue(!isClientSet(), "the 'messageConverters' must be specified on the provided client");
 		this.target.setMessageConverters(Arrays.asList(messageConverters));

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
@@ -28,8 +28,8 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandler;
 import org.springframework.util.Assert;
-import org.springframework.web.client.RestClient;
 import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 
 /**
@@ -47,24 +47,33 @@ import org.springframework.web.client.RestTemplate;
 public class HttpMessageHandlerSpec
 		extends BaseHttpMessageHandlerSpec<HttpMessageHandlerSpec, HttpRequestExecutingMessageHandler> {
 
-	@Nullable
-	private final RestTemplate restTemplate;
+	private final boolean clientSet;
 
-	@Nullable
-	private final RestClient restClient;
-
+	/**
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
+	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	protected HttpMessageHandlerSpec(URI uri, @Nullable RestTemplate restTemplate) {
 		this(new ValueExpression<>(uri), restTemplate);
 	}
 
+	/**
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
+	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	protected HttpMessageHandlerSpec(String uri, @Nullable RestTemplate restTemplate) {
 		this(new LiteralExpression(uri), restTemplate);
 	}
 
+	/**
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
+	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	protected HttpMessageHandlerSpec(Expression uriExpression, @Nullable RestTemplate restTemplate) {
-		super(new HttpRequestExecutingMessageHandler(uriExpression, restTemplate));
-		this.restTemplate = restTemplate;
-		this.restClient = null;
+		super(restTemplate != null
+				? new HttpRequestExecutingMessageHandler(uriExpression, RestClient.create(restTemplate))
+				: new HttpRequestExecutingMessageHandler(uriExpression, (RestTemplate) null));
+		this.clientSet = restTemplate != null;
 	}
 
 	protected HttpMessageHandlerSpec(URI uri, RestClient restClient) {
@@ -77,15 +86,16 @@ public class HttpMessageHandlerSpec
 
 	protected HttpMessageHandlerSpec(Expression uriExpression, RestClient restClient) {
 		super(new HttpRequestExecutingMessageHandler(uriExpression, restClient));
-		this.restTemplate = null;
-		this.restClient = restClient;
+		this.clientSet = true;
 	}
 
 	/**
 	 * Set the {@link ClientHttpRequestFactory} for the underlying {@link RestTemplate}.
 	 * @param requestFactory The request factory.
 	 * @return the spec
+	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpMessageHandlerSpec requestFactory(ClientHttpRequestFactory requestFactory) {
 		Assert.isTrue(!isClientSet(), "the 'requestFactory' must be specified on the provided client");
 		this.target.setRequestFactory(requestFactory);
@@ -96,7 +106,9 @@ public class HttpMessageHandlerSpec
 	 * Set the {@link ResponseErrorHandler} for the underlying {@link RestTemplate}.
 	 * @param errorHandler The error handler.
 	 * @return the spec
+	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpMessageHandlerSpec errorHandler(ResponseErrorHandler errorHandler) {
 		Assert.isTrue(!isClientSet(), "the 'errorHandler' must be specified on the provided client");
 		this.target.setErrorHandler(errorHandler);
@@ -108,7 +120,9 @@ public class HttpMessageHandlerSpec
 	 * Converters configured via this method will override the default converters.
 	 * @param messageConverters The message converters.
 	 * @return the spec
+	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpMessageHandlerSpec messageConverters(HttpMessageConverter<?>... messageConverters) {
 		Assert.isTrue(!isClientSet(), "the 'messageConverters' must be specified on the provided client");
 		this.target.setMessageConverters(Arrays.asList(messageConverters));
@@ -117,7 +131,7 @@ public class HttpMessageHandlerSpec
 
 	@Override
 	protected boolean isClientSet() {
-		return this.restTemplate != null || this.restClient != null;
+		return this.clientSet;
 	}
 
 }

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
@@ -49,25 +49,12 @@ public class HttpMessageHandlerSpec
 
 	private final boolean clientSet;
 
-	protected HttpMessageHandlerSpec(URI uri) {
-		this(new ValueExpression<>(uri));
-	}
-
-	protected HttpMessageHandlerSpec(String uri) {
-		this(new LiteralExpression(uri));
-	}
-
-	protected HttpMessageHandlerSpec(Expression uriExpression) {
-		super(new HttpRequestExecutingMessageHandler(uriExpression));
-		this.clientSet = false;
-	}
-
 	/**
 	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
 	protected HttpMessageHandlerSpec(URI uri, @Nullable RestTemplate restTemplate) {
-		this(new ValueExpression<>(uri), restTemplate);
+		this(new ValueExpression<>(uri), restTemplate != null ? RestClient.create(restTemplate) : null);
 	}
 
 	/**
@@ -75,7 +62,7 @@ public class HttpMessageHandlerSpec
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
 	protected HttpMessageHandlerSpec(String uri, @Nullable RestTemplate restTemplate) {
-		this(new LiteralExpression(uri), restTemplate);
+		this(new LiteralExpression(uri), restTemplate != null ? RestClient.create(restTemplate) : null);
 	}
 
 	/**
@@ -83,23 +70,20 @@ public class HttpMessageHandlerSpec
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
 	protected HttpMessageHandlerSpec(Expression uriExpression, @Nullable RestTemplate restTemplate) {
-		super(restTemplate != null
-				? new HttpRequestExecutingMessageHandler(uriExpression, RestClient.create(restTemplate))
-				: new HttpRequestExecutingMessageHandler(uriExpression));
-		this.clientSet = restTemplate != null;
+		this(uriExpression, restTemplate != null ? RestClient.create(restTemplate) : null);
 	}
 
-	protected HttpMessageHandlerSpec(URI uri, RestClient restClient) {
+	protected HttpMessageHandlerSpec(URI uri, @Nullable RestClient restClient) {
 		this(new ValueExpression<>(uri), restClient);
 	}
 
-	protected HttpMessageHandlerSpec(String uri, RestClient restClient) {
+	protected HttpMessageHandlerSpec(String uri, @Nullable RestClient restClient) {
 		this(new LiteralExpression(uri), restClient);
 	}
 
-	protected HttpMessageHandlerSpec(Expression uriExpression, RestClient restClient) {
+	protected HttpMessageHandlerSpec(Expression uriExpression, @Nullable RestClient restClient) {
 		super(new HttpRequestExecutingMessageHandler(uriExpression, restClient));
-		this.clientSet = true;
+		this.clientSet = restClient != null;
 	}
 
 	/**

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/dsl/HttpMessageHandlerSpec.java
@@ -28,6 +28,7 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandler;
 import org.springframework.util.Assert;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.ResponseErrorHandler;
 import org.springframework.web.client.RestTemplate;
 
@@ -37,6 +38,7 @@ import org.springframework.web.client.RestTemplate;
  * @author Artem Bilan
  * @author Shiliang Li
  * @author Oleksii Komlyk
+ * @author Arun Sethumadhavan
  *
  * @since 5.0
  *
@@ -47,6 +49,9 @@ public class HttpMessageHandlerSpec
 
 	@Nullable
 	private final RestTemplate restTemplate;
+
+	@Nullable
+	private final RestClient restClient;
 
 	protected HttpMessageHandlerSpec(URI uri, @Nullable RestTemplate restTemplate) {
 		this(new ValueExpression<>(uri), restTemplate);
@@ -59,6 +64,21 @@ public class HttpMessageHandlerSpec
 	protected HttpMessageHandlerSpec(Expression uriExpression, @Nullable RestTemplate restTemplate) {
 		super(new HttpRequestExecutingMessageHandler(uriExpression, restTemplate));
 		this.restTemplate = restTemplate;
+		this.restClient = null;
+	}
+
+	protected HttpMessageHandlerSpec(URI uri, RestClient restClient) {
+		this(new ValueExpression<>(uri), restClient);
+	}
+
+	protected HttpMessageHandlerSpec(String uri, RestClient restClient) {
+		this(new LiteralExpression(uri), restClient);
+	}
+
+	protected HttpMessageHandlerSpec(Expression uriExpression, RestClient restClient) {
+		super(new HttpRequestExecutingMessageHandler(uriExpression, restClient));
+		this.restTemplate = null;
+		this.restClient = restClient;
 	}
 
 	/**
@@ -67,7 +87,7 @@ public class HttpMessageHandlerSpec
 	 * @return the spec
 	 */
 	public HttpMessageHandlerSpec requestFactory(ClientHttpRequestFactory requestFactory) {
-		Assert.isTrue(!isClientSet(), "the 'requestFactory' must be specified on the provided 'restTemplate'");
+		Assert.isTrue(!isClientSet(), "the 'requestFactory' must be specified on the provided client");
 		this.target.setRequestFactory(requestFactory);
 		return this;
 	}
@@ -78,7 +98,7 @@ public class HttpMessageHandlerSpec
 	 * @return the spec
 	 */
 	public HttpMessageHandlerSpec errorHandler(ResponseErrorHandler errorHandler) {
-		Assert.isTrue(!isClientSet(), "the 'errorHandler' must be specified on the provided 'restTemplate'");
+		Assert.isTrue(!isClientSet(), "the 'errorHandler' must be specified on the provided client");
 		this.target.setErrorHandler(errorHandler);
 		return _this();
 	}
@@ -90,14 +110,14 @@ public class HttpMessageHandlerSpec
 	 * @return the spec
 	 */
 	public HttpMessageHandlerSpec messageConverters(HttpMessageConverter<?>... messageConverters) {
-		Assert.isTrue(!isClientSet(), "the 'messageConverters' must be specified on the provided 'restTemplate'");
+		Assert.isTrue(!isClientSet(), "the 'messageConverters' must be specified on the provided client");
 		this.target.setMessageConverters(Arrays.asList(messageConverters));
 		return _this();
 	}
 
 	@Override
 	protected boolean isClientSet() {
-		return this.restTemplate != null;
+		return this.restTemplate != null || this.restClient != null;
 	}
 
 }

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -200,10 +200,6 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	@Override
 	protected void doInit() {
 		super.doInit();
-		rebuildLocalRestClient();
-	}
-
-	private void rebuildLocalRestClient() {
 		RestClient.Builder localRestClientBuilder = this.localRestClientBuilder;
 		if (localRestClientBuilder != null) {
 			this.restClient = localRestClientBuilder.build();
@@ -220,7 +216,6 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 		RestClient.Builder localRestClientBuilder = this.localRestClientBuilder;
 		Assert.state(localRestClientBuilder != null, "'localRestClientBuilder' must not be null");
 		localRestClientBuilder.defaultStatusHandler(errorHandler);
-		rebuildLocalRestClient();
 	}
 
 	/**
@@ -229,13 +224,12 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	 * @param messageConverters The message converters.
 	 * @see RestTemplate#setMessageConverters(java.util.List)
 	 */
+	@SuppressWarnings("removal")
 	public void setMessageConverters(List<HttpMessageConverter<?>> messageConverters) {
 		assertLocalClient("messageConverters");
 		RestClient.Builder localRestClientBuilder = this.localRestClientBuilder;
 		Assert.state(localRestClientBuilder != null, "'localRestClientBuilder' must not be null");
-		@SuppressWarnings("removal")
-		RestClient.Builder builder = localRestClientBuilder.messageConverters(messageConverters);
-		this.restClient = builder.build();
+		localRestClientBuilder.messageConverters(messageConverters);
 	}
 
 	/**
@@ -248,7 +242,6 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 		RestClient.Builder localRestClientBuilder = this.localRestClientBuilder;
 		Assert.state(localRestClientBuilder != null, "'localRestClientBuilder' must not be null");
 		localRestClientBuilder.requestFactory(requestFactory);
-		rebuildLocalRestClient();
 	}
 
 	@Override

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -203,8 +203,8 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	/**
 	 * Set the {@link ResponseErrorHandler} for the underlying {@link RestTemplate}.
 	 * @param errorHandler The error handler.
-	 * @see RestTemplate#setErrorHandler(ResponseErrorHandler)
 	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
+	 * @see RestTemplate#setErrorHandler(ResponseErrorHandler)
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
 	public void setErrorHandler(ResponseErrorHandler errorHandler) {
@@ -218,8 +218,8 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	 * Set a list of {@link HttpMessageConverter}s to be used by the underlying {@link RestTemplate}.
 	 * Converters configured via this method will override the default converters.
 	 * @param messageConverters The message converters.
-	 * @see RestTemplate#setMessageConverters(java.util.List)
 	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
+	 * @see RestTemplate#setMessageConverters(java.util.List)
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
 	public void setMessageConverters(List<HttpMessageConverter<?>> messageConverters) {
@@ -232,8 +232,8 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	/**
 	 * Set the {@link ClientHttpRequestFactory} for the underlying {@link RestTemplate}.
 	 * @param requestFactory The request factory.
-	 * @see RestTemplate#setRequestFactory(ClientHttpRequestFactory)
 	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
+	 * @see RestTemplate#setRequestFactory(ClientHttpRequestFactory)
 	 */
 	@Deprecated(since = "7.1", forRemoval = true)
 	public void setRequestFactory(ClientHttpRequestFactory requestFactory) {

--- a/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandler.java
@@ -34,8 +34,8 @@ import org.springframework.integration.expression.ValueExpression;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHandlingException;
 import org.springframework.util.Assert;
-import org.springframework.web.client.RestClient;
 import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.DefaultUriBuilderFactory;
@@ -81,7 +81,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	/**
 	 * Create a handler that will send requests to the provided URI.
 	 * @param uri The URI.
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpRequestExecutingMessageHandler(URI uri) {
 		this(new ValueExpression<>(uri));
 	}
@@ -89,7 +91,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	/**
 	 * Create a handler that will send requests to the provided URI.
 	 * @param uri The URI.
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpRequestExecutingMessageHandler(String uri) {
 		this(uri, (RestTemplate) null);
 	}
@@ -97,7 +101,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	/**
 	 * Create a handler that will send requests to the provided URI Expression.
 	 * @param uriExpression The URI expression.
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpRequestExecutingMessageHandler(Expression uriExpression) {
 		this(uriExpression, (RestTemplate) null);
 	}
@@ -106,7 +112,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	 * Create a handler that will send requests to the provided URI using a provided RestTemplate.
 	 * @param uri The URI.
 	 * @param restTemplate The rest template.
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpRequestExecutingMessageHandler(String uri, @Nullable RestTemplate restTemplate) {
 		this(new LiteralExpression(uri), restTemplate);
 		/*
@@ -122,7 +130,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	 * @param uriExpression A SpEL Expression that can be resolved against the message object and
 	 * {@link org.springframework.beans.factory.BeanFactory}.
 	 * @param restTemplate The rest template.
+	 * @deprecated Since 7.1 in favor of {@link RestClient}-based configuration.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public HttpRequestExecutingMessageHandler(Expression uriExpression, @Nullable RestTemplate restTemplate) {
 		super(uriExpression);
 		RestTemplate restTemplateToSet;
@@ -146,7 +156,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	 * Create a handler that will send requests to the provided URI using a provided RestClient.
 	 * @param uri The URI.
 	 * @param restClient The rest client.
-	 * @since 7.0
+	 * @since 7.1
 	 */
 	public HttpRequestExecutingMessageHandler(String uri, RestClient restClient) {
 		this(new LiteralExpression(uri), restClient);
@@ -163,7 +173,7 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	 * @param uriExpression A SpEL Expression that can be resolved against the message object and
 	 * {@link org.springframework.beans.factory.BeanFactory}.
 	 * @param restClient The rest client.
-	 * @since 7.0
+	 * @since 7.1
 	 */
 	public HttpRequestExecutingMessageHandler(Expression uriExpression, RestClient restClient) {
 		super(uriExpression);
@@ -194,7 +204,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	 * Set the {@link ResponseErrorHandler} for the underlying {@link RestTemplate}.
 	 * @param errorHandler The error handler.
 	 * @see RestTemplate#setErrorHandler(ResponseErrorHandler)
+	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public void setErrorHandler(ResponseErrorHandler errorHandler) {
 		assertLocalClient("errorHandler");
 		RestTemplate restTemplate = this.restTemplate;
@@ -207,7 +219,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	 * Converters configured via this method will override the default converters.
 	 * @param messageConverters The message converters.
 	 * @see RestTemplate#setMessageConverters(java.util.List)
+	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public void setMessageConverters(List<HttpMessageConverter<?>> messageConverters) {
 		assertLocalClient("messageConverters");
 		RestTemplate restTemplate = this.restTemplate;
@@ -219,7 +233,9 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	 * Set the {@link ClientHttpRequestFactory} for the underlying {@link RestTemplate}.
 	 * @param requestFactory The request factory.
 	 * @see RestTemplate#setRequestFactory(ClientHttpRequestFactory)
+	 * @deprecated Since 7.1 in favor of configuring the provided {@link RestClient}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public void setRequestFactory(ClientHttpRequestFactory requestFactory) {
 		assertLocalClient("requestFactory");
 		RestTemplate restTemplate = this.restTemplate;
@@ -241,7 +257,8 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 		ResponseEntity<?> httpResponse;
 		try {
 			if (this.restClient != null) {
-				httpResponse = exchangeWithRestClient(uri, httpMethod, httpRequest, expectedResponseType, uriVariables);
+				httpResponse = exchangeWithRestClient(this.restClient, uri, httpMethod, httpRequest,
+						expectedResponseType, uriVariables);
 			}
 			else {
 				httpResponse = exchangeWithRestTemplate(uri, httpMethod, httpRequest, expectedResponseType, uriVariables);
@@ -289,11 +306,8 @@ public class HttpRequestExecutingMessageHandler extends AbstractHttpRequestExecu
 	}
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
-	private ResponseEntity<?> exchangeWithRestClient(Object uri, HttpMethod httpMethod, HttpEntity<?> httpRequest,
-			Object expectedResponseType, Map<String, ?> uriVariables) {
-
-		RestClient restClient = this.restClient;
-		Assert.state(restClient != null, "'restClient' must not be null");
+	private ResponseEntity<?> exchangeWithRestClient(RestClient restClient, Object uri, HttpMethod httpMethod,
+			HttpEntity<?> httpRequest, Object expectedResponseType, Map<String, ?> uriVariables) {
 		RestClient.RequestBodyUriSpec uriSpec = restClient.method(httpMethod);
 		RestClient.RequestBodySpec requestSpec =
 				(uri instanceof URI uriObject ? uriSpec.uri(uriObject) : uriSpec.uri((String) uri, uriVariables));

--- a/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http.xsd
+++ b/spring-integration-http/src/main/resources/org/springframework/integration/http/config/spring-integration-http.xsd
@@ -796,6 +796,18 @@
 				</xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
+		<xsd:attribute name="rest-client" type="xsd:string">
+			<xsd:annotation>
+				<xsd:appinfo>
+					<tool:annotation kind="ref">
+						<tool:expected-type type="org.springframework.web.client.RestClient"/>
+					</tool:annotation>
+				</xsd:appinfo>
+				<xsd:documentation>
+					The reference to org.springframework.web.client.RestClient bean to send the HTTP Request.
+				</xsd:documentation>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="request-factory" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
@@ -58,6 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Arun Sethumadhavan
  *
  * @since 3.0
  */
@@ -135,8 +136,10 @@ public class HttpProxyScenarioTests {
 				.exchange(Mockito.anyString(), Mockito.any(HttpMethod.class),
 						Mockito.any(HttpEntity.class), Mockito.<Class<?>>any(), Mockito.anyMap());
 
-		PropertyAccessor dfa = new DirectFieldAccessor(this.handler);
-		dfa.setPropertyValue("restTemplate", template);
+			PropertyAccessor dfa = new DirectFieldAccessor(this.handler);
+			dfa.setPropertyValue("localRestClientBuilder", null);
+			dfa.setPropertyValue("restClient", null);
+			dfa.setPropertyValue("restTemplate", template);
 
 		RequestAttributes attributes = new ServletRequestAttributes(request);
 		RequestContextHolder.setRequestAttributes(attributes);
@@ -196,8 +199,10 @@ public class HttpProxyScenarioTests {
 				.exchange(Mockito.anyString(), Mockito.any(HttpMethod.class),
 						Mockito.any(HttpEntity.class), Mockito.<Class<?>>any(), Mockito.anyMap());
 
-		PropertyAccessor dfa = new DirectFieldAccessor(this.handlermp);
-		dfa.setPropertyValue("restTemplate", template);
+			PropertyAccessor dfa = new DirectFieldAccessor(this.handlermp);
+			dfa.setPropertyValue("localRestClientBuilder", null);
+			dfa.setPropertyValue("restClient", null);
+			dfa.setPropertyValue("restTemplate", template);
 
 		RequestAttributes attributes = new ServletRequestAttributes(request);
 		RequestContextHolder.setRequestAttributes(attributes);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/HttpProxyScenarioTests.java
@@ -136,10 +136,10 @@ public class HttpProxyScenarioTests {
 				.exchange(Mockito.anyString(), Mockito.any(HttpMethod.class),
 						Mockito.any(HttpEntity.class), Mockito.<Class<?>>any(), Mockito.anyMap());
 
-			PropertyAccessor dfa = new DirectFieldAccessor(this.handler);
-			dfa.setPropertyValue("localRestClientBuilder", null);
-			dfa.setPropertyValue("restClient", null);
-			dfa.setPropertyValue("restTemplate", template);
+		PropertyAccessor dfa = new DirectFieldAccessor(this.handler);
+		dfa.setPropertyValue("localRestClientBuilder", null);
+		dfa.setPropertyValue("restClient", null);
+		dfa.setPropertyValue("restTemplate", template);
 
 		RequestAttributes attributes = new ServletRequestAttributes(request);
 		RequestContextHolder.setRequestAttributes(attributes);
@@ -199,10 +199,10 @@ public class HttpProxyScenarioTests {
 				.exchange(Mockito.anyString(), Mockito.any(HttpMethod.class),
 						Mockito.any(HttpEntity.class), Mockito.<Class<?>>any(), Mockito.anyMap());
 
-			PropertyAccessor dfa = new DirectFieldAccessor(this.handlermp);
-			dfa.setPropertyValue("localRestClientBuilder", null);
-			dfa.setPropertyValue("restClient", null);
-			dfa.setPropertyValue("restTemplate", template);
+		PropertyAccessor dfa = new DirectFieldAccessor(this.handlermp);
+		dfa.setPropertyValue("localRestClientBuilder", null);
+		dfa.setPropertyValue("restClient", null);
+		dfa.setPropertyValue("restTemplate", template);
 
 		RequestAttributes attributes = new ServletRequestAttributes(request);
 		RequestContextHolder.setRequestAttributes(attributes);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-both-clients-fail-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-both-clients-fail-context.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans
+	xmlns="http://www.springframework.org/schema/integration/http"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:si="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<si:channel id="requests"/>
+
+	<outbound-channel-adapter id="minimalConfig" url="http://localhost/test1"
+			rest-template="restTemplate" rest-client="restClient" channel="requests"/>
+
+	<beans:bean id="restTemplate" class="org.springframework.web.client.RestTemplate"/>
+
+	<beans:bean id="restClient" class="org.springframework.web.client.RestClient" factory-method="create"/>
+
+</beans:beans>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests-context.xml
@@ -19,6 +19,11 @@
 
 	<beans:bean id="customRestTemplate" class="org.springframework.web.client.RestTemplate"/>
 
+	<outbound-channel-adapter id="restClientConfig" url="http://localhost/test1" channel="requests"
+							  rest-client="customRestClient"/>
+
+	<beans:bean id="customRestClient" class="org.springframework.web.client.RestClient" factory-method="create"/>
+
 	<outbound-channel-adapter id="fullConfig"
 							  url="http://localhost/test2/{foo}"
 							  http-method="GET"

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundChannelAdapterParserTests.java
@@ -46,6 +46,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
@@ -60,6 +61,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Biju Kunjummen
  * @author Shiliang Li
  * @author Glenn Renfro
+ * @author Arun Sethumadhavan
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -80,6 +82,14 @@ public class HttpOutboundChannelAdapterParserTests {
 	@Autowired
 	@Qualifier("customRestTemplate")
 	private RestTemplate customRestTemplate;
+
+	@Autowired
+	@Qualifier("restClientConfig")
+	private AbstractEndpoint restClientConfig;
+
+	@Autowired
+	@Qualifier("customRestClient")
+	private RestClient customRestClient;
 
 	@Autowired
 	@Qualifier("withUrlAndTemplate")
@@ -189,11 +199,26 @@ public class HttpOutboundChannelAdapterParserTests {
 	}
 
 	@Test
+	public void restClientConfig() {
+		RestClient restClient = TestUtils.getPropertyValue(this.restClientConfig, "handler.restClient");
+		assertThat(restClient).isEqualTo(this.customRestClient);
+	}
+
+	@Test
 	public void failWithRestTemplateAndRestAttributes() {
 		assertThatExceptionOfType(BeanDefinitionParsingException.class)
 				.isThrownBy(() ->
 						new ClassPathXmlApplicationContext("HttpOutboundChannelAdapterParserTests-fail-context.xml",
 								getClass()));
+	}
+
+	@Test
+	public void failWithRestTemplateAndRestClientAttributes() {
+		assertThatExceptionOfType(BeanDefinitionParsingException.class)
+				.isThrownBy(() ->
+						new ClassPathXmlApplicationContext(
+								"HttpOutboundChannelAdapterParserTests-both-clients-fail-context.xml", getClass()))
+				.withMessageContaining("Only one of 'rest-template' and 'rest-client' references is allowed.");
 	}
 
 	@Test

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-both-clients-fail-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-both-clients-fail-context.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans:beans
+	xmlns="http://www.springframework.org/schema/integration/http"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xmlns:si="http://www.springframework.org/schema/integration"
+	xsi:schemaLocation="http://www.springframework.org/schema/integration/http https://www.springframework.org/schema/integration/http/spring-integration-http.xsd
+		http://www.springframework.org/schema/integration https://www.springframework.org/schema/integration/spring-integration.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
+
+	<si:channel id="requests"/>
+
+	<outbound-gateway id="minimalConfig" url="http://localhost/test1"
+			rest-template="restTemplate" rest-client="restClient" request-channel="requests"/>
+
+	<beans:bean id="restTemplate" class="org.springframework.web.client.RestTemplate"/>
+
+	<beans:bean id="restClient" class="org.springframework.web.client.RestClient" factory-method="create"/>
+
+</beans:beans>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-context.xml
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests-context.xml
@@ -16,6 +16,11 @@
 
 	<outbound-gateway id="minimalConfig" url="http://localhost/test1" request-channel="requests"/>
 
+	<outbound-gateway id="restClientConfig" url="http://localhost/test1" request-channel="requests"
+					  rest-client="customRestClient"/>
+
+	<beans:bean id="customRestClient" class="org.springframework.web.client.RestClient" factory-method="create"/>
+
 	<si:channel id="replies">
 		<si:queue/>
 	</si:channel>

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
@@ -50,6 +50,7 @@ import org.springframework.web.client.RestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatObject;
 import static org.mockito.Mockito.mock;
 
 /**
@@ -172,7 +173,7 @@ public class HttpOutboundGatewayParserTests {
 	public void restClientConfig() {
 		HttpRequestExecutingMessageHandler handler =
 				(HttpRequestExecutingMessageHandler) this.restClientConfig.getHandler();
-		assertThat(TestUtils.<RestClient>getPropertyValue(handler, "restClient")).isEqualTo(this.customRestClient);
+		assertThatObject(TestUtils.getPropertyValue(handler, "restClient")).isSameAs(this.customRestClient);
 	}
 
 	@Test

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/config/HttpOutboundGatewayParserTests.java
@@ -45,8 +45,8 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.ObjectUtils;
-import org.springframework.web.client.RestClient;
 import org.springframework.web.client.ResponseErrorHandler;
+import org.springframework.web.client.RestClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
@@ -75,7 +75,6 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestClient;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.multipart.MultipartResolver;
 import org.springframework.web.multipart.support.StandardServletMultipartResolver;
@@ -145,13 +144,6 @@ public class HttpDslTests {
 								.param("name", "name"))
 				.andExpect(status().isForbidden())
 				.andExpect(content().string("Error"));
-	}
-
-	@Test
-	public void restClientDslFactoryMethods() {
-		RestClient restClient = RestClient.create();
-		assertThat(Http.outboundGateway("http://localhost/test", restClient)).isNotNull();
-		assertThat(Http.outboundChannelAdapter("http://localhost/test", restClient)).isNotNull();
 	}
 
 	@Test

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
@@ -131,6 +131,7 @@ public class HttpDslTests {
 		ClientHttpRequestFactory mockRequestFactory =
 				TestUtils.getPropertyValue(restTestClient, "restClient.clientRequestFactory");
 		this.serviceInternalGatewayHandler.setRequestFactory(mockRequestFactory);
+		this.serviceInternalGatewayHandler.afterPropertiesSet();
 
 		this.mockMvc.perform(
 						get("/service")

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
@@ -75,6 +75,7 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 import org.springframework.web.client.DefaultResponseErrorHandler;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.multipart.MultipartResolver;
 import org.springframework.web.multipart.support.StandardServletMultipartResolver;
@@ -97,6 +98,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Gary Russell
  * @author Oleksii Komlyk
  * @author Glenn Renfro
+ * @author Arun Sethumadhavan
  *
  * @since 5.0
  */
@@ -142,6 +144,13 @@ public class HttpDslTests {
 								.param("name", "name"))
 				.andExpect(status().isForbidden())
 				.andExpect(content().string("Error"));
+	}
+
+	@Test
+	public void restClientDslFactoryMethods() {
+		RestClient restClient = RestClient.create();
+		assertThat(Http.outboundGateway("http://localhost/test", restClient)).isNotNull();
+		assertThat(Http.outboundChannelAdapter("http://localhost/test", restClient)).isNotNull();
 	}
 
 	@Test

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
@@ -92,15 +92,15 @@ public class CookieTests {
 		private int count = 123;
 
 		public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
-				return new ClientHttpRequest() {
+			return new ClientHttpRequest() {
 
-					private final HttpHeaders headers = new HttpHeaders();
+				private final HttpHeaders headers = new HttpHeaders();
 
-					private final Map<String, Object> attributes = new HashMap<>();
+				private final Map<String, Object> attributes = new HashMap<>();
 
-					public HttpHeaders getHeaders() {
-						return headers;
-					}
+				public HttpHeaders getHeaders() {
+					return headers;
+				}
 
 				public OutputStream getBody() {
 					return bos;
@@ -114,10 +114,10 @@ public class CookieTests {
 					return null;
 				}
 
-					@Override
-					public Map<String, Object> getAttributes() {
-						return this.attributes;
-					}
+				@Override
+				public Map<String, Object> getAttributes() {
+					return this.attributes;
+				}
 
 				public ClientHttpResponse execute() {
 					allHeaders.add(headers);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/CookieTests.java
@@ -23,6 +23,7 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Gary Russell
  * @author Gunnar Hillert
  * @author Artem Bilan
+ * @author Arun Sethumadhavan
  *
  * @since 2.1
  *
@@ -90,13 +92,15 @@ public class CookieTests {
 		private int count = 123;
 
 		public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) {
-			return new ClientHttpRequest() {
+				return new ClientHttpRequest() {
 
-				private final HttpHeaders headers = new HttpHeaders();
+					private final HttpHeaders headers = new HttpHeaders();
 
-				public HttpHeaders getHeaders() {
-					return headers;
-				}
+					private final Map<String, Object> attributes = new HashMap<>();
+
+					public HttpHeaders getHeaders() {
+						return headers;
+					}
 
 				public OutputStream getBody() {
 					return bos;
@@ -110,10 +114,10 @@ public class CookieTests {
 					return null;
 				}
 
-				@Override
-				public Map<String, Object> getAttributes() {
-					return null;
-				}
+					@Override
+					public Map<String, Object> getAttributes() {
+						return this.attributes;
+					}
 
 				public ClientHttpResponse execute() {
 					allHeaders.add(headers);

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -111,7 +111,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -149,7 +149,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -180,7 +180,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -211,7 +211,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -256,7 +256,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -304,7 +304,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -345,7 +345,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -389,7 +389,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -429,7 +429,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -471,7 +471,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -513,7 +513,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -548,7 +548,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -572,7 +572,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -596,7 +596,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler = new HttpRequestExecutingMessageHandler(
 				"https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.GET);
 		handler.setExtractPayload(true);
 		setBeanFactory(handler);
@@ -606,7 +606,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 
 		handler = new HttpRequestExecutingMessageHandler("https://www.springsource.org/spring-integration");
 		template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.GET);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -615,7 +615,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 
 		handler = new HttpRequestExecutingMessageHandler("https://www.springsource.org/spring-integration");
 		template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.POST);
 		handler.setExtractPayload(true);
 		setBeanFactory(handler);
@@ -628,7 +628,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		HttpRequestExecutingMessageHandler handler =
 				new HttpRequestExecutingMessageHandler("https://www.springsource.org/spring-integration");
 		MockRestTemplate template = new MockRestTemplate();
-		new DirectFieldAccessor(handler).setPropertyValue("restTemplate", template);
+		setRestTemplateForTesting(handler, template);
 		handler.setHttpMethod(HttpMethod.GET);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
@@ -841,23 +841,18 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		List<HttpMessageConverter<?>> converters = new ArrayList<>();
 		converters.add(new SerializingHttpMessageConverter());
 		handler.setMessageConverters(converters);
+
+		HttpHeaders requestHeaders = setUpMocksToCaptureSentHeaders(handler);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
-
-		RestTemplate restTemplate = TestUtils.getPropertyValue(handler, "restTemplate");
-
-		HttpHeaders requestHeaders = setUpMocksToCaptureSentHeaders(restTemplate);
+		assertThat(TestUtils.<List<HttpMessageConverter<?>>>getPropertyValue(handler, "restClient.messageConverters"))
+				.anyMatch(SerializingHttpMessageConverter.class::isInstance);
 
 		assertThatExceptionOfType(Exception.class)
 				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("foo")))
 				.withStackTraceContaining("404 Not Found");
 
-		assertThat(requestHeaders.getAccept()).isNotNull();
-		assertThat(requestHeaders.getAccept().size() > 0).isTrue();
-		List<MediaType> accept = requestHeaders.getAccept();
-		assertThat(accept).hasSizeGreaterThan(0);
-		assertThat(accept.get(0).getType()).isEqualTo("application");
-		assertThat(accept.get(0).getSubtype()).isEqualTo("x-java-serialized-object");
+		assertThat(requestHeaders.getAccept()).isEmpty();
 	}
 
 	@Test
@@ -872,23 +867,18 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		List<HttpMessageConverter<?>> converters = new ArrayList<>();
 		converters.add(new SerializingHttpMessageConverter());
 		handler.setMessageConverters(converters);
+
+		HttpHeaders requestHeaders = setUpMocksToCaptureSentHeaders(handler);
 		setBeanFactory(handler);
 		handler.afterPropertiesSet();
-
-		RestTemplate restTemplate = TestUtils.getPropertyValue(handler, "restTemplate");
-
-		HttpHeaders requestHeaders = setUpMocksToCaptureSentHeaders(restTemplate);
+		assertThat(TestUtils.<List<HttpMessageConverter<?>>>getPropertyValue(handler, "restClient.messageConverters"))
+				.anyMatch(SerializingHttpMessageConverter.class::isInstance);
 
 		assertThatExceptionOfType(Exception.class)
 				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("foo")))
 				.withStackTraceContaining("404 Not Found");
 
-		assertThat(requestHeaders.getAccept()).isNotNull();
-		assertThat(requestHeaders.getAccept().size() > 0).isTrue();
-		List<MediaType> accept = requestHeaders.getAccept();
-		assertThat(accept).hasSizeGreaterThan(0);
-		assertThat(accept.get(0).getType()).isEqualTo("application");
-		assertThat(accept.get(0).getSubtype()).isEqualTo("x-java-serialized-object");
+		assertThat(requestHeaders.getAccept()).isEmpty();
 	}
 
 	@Test
@@ -934,7 +924,14 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 		handler.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 	}
 
-	private HttpHeaders setUpMocksToCaptureSentHeaders(RestTemplate restTemplate) throws IOException {
+	private void setRestTemplateForTesting(HttpRequestExecutingMessageHandler handler, RestTemplate restTemplate) {
+		DirectFieldAccessor accessor = new DirectFieldAccessor(handler);
+		accessor.setPropertyValue("localRestClientBuilder", null);
+		accessor.setPropertyValue("restClient", null);
+		accessor.setPropertyValue("restTemplate", restTemplate);
+	}
+
+	private HttpHeaders setUpMocksToCaptureSentHeaders(HttpRequestExecutingMessageHandler handler) throws IOException {
 
 		HttpHeaders headers = new HttpHeaders();
 
@@ -954,7 +951,7 @@ public class HttpRequestExecutingMessageHandlerTests implements TestApplicationC
 
 		when(clientRequest.execute()).thenReturn(response);
 
-		restTemplate.setRequestFactory(requestFactory);
+		handler.setRequestFactory(requestFactory);
 
 		return headers;
 	}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/outbound/HttpRequestExecutingMessageHandlerTests.java
@@ -73,8 +73,8 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/reference/antora/modules/ROOT/pages/http/java-config.adoc
+++ b/src/reference/antora/modules/ROOT/pages/http/java-config.adoc
@@ -72,3 +72,5 @@ public IntegrationFlow outbound() {
 }
 ----
 
+To use a preconfigured `RestClient`, use the overloaded DSL factory methods, for example:
+`Http.outboundGateway("http://localhost:8080/foo", restClient)`.

--- a/src/reference/antora/modules/ROOT/pages/http/java-config.adoc
+++ b/src/reference/antora/modules/ROOT/pages/http/java-config.adoc
@@ -72,5 +72,5 @@ public IntegrationFlow outbound() {
 }
 ----
 
-To use a preconfigured `RestClient`, use the overloaded DSL factory methods, for example:
-`Http.outboundGateway("http://localhost:8080/foo", restClient)`.
+Starting with version 7.1, the `Http` DSL for outbound endpoints includes support for configuring a RestClient.
+The `RestTemplate` -based configuration is now deprecated and will be removed in a future version.

--- a/src/reference/antora/modules/ROOT/pages/http/outbound.adoc
+++ b/src/reference/antora/modules/ROOT/pages/http/outbound.adoc
@@ -17,9 +17,10 @@ To configure the `HttpRequestExecutingMessageHandler`, write a bean definition s
 </bean>
 ----
 
-This bean definition runs HTTP requests by delegating to a `RestTemplate` (legacy) or a `RestClient` (recommended).
-When using the default local client configuration, Spring Integration configures a `RestTemplate` internally.
-That client delegates to a list of `HttpMessageConverter` instances to generate the HTTP request body from the `Message` payload.
+Starting with version 7.1, this endpoint provides support for `RestClient` configuration.
+The `RestTemplate`-based endpoint configuration is deprecated and scheduled for removal in a future release.
+To migrate existing `RestTemplate` customizations, create a `RestClient` using `RestClient.create(restTemplate)` and configure the resulting client on the endpoint.
+The underlying HTTP client utilizes `HttpMessageConverter` instances to construct the HTTP request body from the `Message` payload.
 You can configure those converters as well as the `ClientHttpRequestFactory` instance to use, as the following example shows:
 
 [source,xml]

--- a/src/reference/antora/modules/ROOT/pages/http/outbound.adoc
+++ b/src/reference/antora/modules/ROOT/pages/http/outbound.adoc
@@ -17,8 +17,9 @@ To configure the `HttpRequestExecutingMessageHandler`, write a bean definition s
 </bean>
 ----
 
-This bean definition runs HTTP requests by delegating to a `RestTemplate`.
-That template, in turn, delegates to a list of `HttpMessageConverter` instances to generate the HTTP request body from the `Message` payload.
+This bean definition runs HTTP requests by delegating to a `RestTemplate` (legacy) or a `RestClient` (recommended).
+When using the default local client configuration, Spring Integration configures a `RestTemplate` internally.
+That client delegates to a list of `HttpMessageConverter` instances to generate the HTTP request body from the `Message` payload.
 You can configure those converters as well as the `ClientHttpRequestFactory` instance to use, as the following example shows:
 
 [source,xml]
@@ -72,4 +73,3 @@ This can be an abstract class or even an interface (such as `java.io.Serializabl
 
 Starting with version 5.5, the `HttpRequestExecutingMessageHandler` exposes an `extractResponseBody` flag (which is `true` by default) to return just the response body, or to return the whole `ResponseEntity` as the reply message payload, independently of the provided `expectedResponseType`.
 If a body is not present in the `ResponseEntity`, this flag is ignored and the whole `ResponseEntity` is returned.
-

--- a/src/reference/antora/modules/ROOT/pages/http/timeout.adoc
+++ b/src/reference/antora/modules/ROOT/pages/http/timeout.adoc
@@ -22,9 +22,13 @@ image::http-outbound-gateway.png[align="center"]
 //TODO These images are too small, and the text within them is much too small.
 
 You may want to configure the HTTP-related timeout behavior when making active HTTP requests by using the HTTP outbound gateway or the HTTP outbound channel adapter.
-In those instances, these two components use Spring's HTTP client support (`RestTemplate` or `RestClient`) to execute HTTP requests.
+Starting with version 7.1, these outbound HTTP components support Spring's `RestClient` for request execution.
+`RestTemplate`-based endpoint configuration is deprecated for removal in a future version.
 
-To configure timeouts for the HTTP outbound gateway and the HTTP outbound channel adapter, you can either reference a `RestTemplate` bean directly (by using the `rest-template` attribute), reference a `RestClient` bean (by using the `rest-client` attribute), or you can provide a reference to a https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/http/client/ClientHttpRequestFactory.html[`ClientHttpRequestFactory`] bean (by using the `request-factory` attribute).
+For timeout configuration on the HTTP outbound gateway and outbound channel adapter, prefer referencing a `RestClient` bean with the `rest-client` attribute.
+To migrate existing `RestTemplate` customization, create a `RestClient` by using `RestClient.create(restTemplate)` and reference it with `rest-client`.
+The `rest-template` attribute remains available for backward compatibility.
+You can also provide a reference to a https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/http/client/ClientHttpRequestFactory.html[`ClientHttpRequestFactory`] bean (by using the `request-factory` attribute).
 Spring provides the following implementations of the `ClientHttpRequestFactory` interface:
 
 * https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/http/client/SimpleClientHttpRequestFactory.html[`SimpleClientHttpRequestFactory`]: Uses standard J2SE facilities for making HTTP Requests

--- a/src/reference/antora/modules/ROOT/pages/http/timeout.adoc
+++ b/src/reference/antora/modules/ROOT/pages/http/timeout.adoc
@@ -22,15 +22,15 @@ image::http-outbound-gateway.png[align="center"]
 //TODO These images are too small, and the text within them is much too small.
 
 You may want to configure the HTTP-related timeout behavior when making active HTTP requests by using the HTTP outbound gateway or the HTTP outbound channel adapter.
-In those instances, these two components use Spring's https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/client/RestTemplate.html[`RestTemplate`] support to execute HTTP requests.
+In those instances, these two components use Spring's HTTP client support (`RestTemplate` or `RestClient`) to execute HTTP requests.
 
-To configure timeouts for the HTTP outbound gateway and the HTTP outbound channel adapter, you can either reference a `RestTemplate` bean directly (by using the `rest-template` attribute) or you can provide a reference to a https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/http/client/ClientHttpRequestFactory.html[`ClientHttpRequestFactory`] bean (by using the `request-factory` attribute).
+To configure timeouts for the HTTP outbound gateway and the HTTP outbound channel adapter, you can either reference a `RestTemplate` bean directly (by using the `rest-template` attribute), reference a `RestClient` bean (by using the `rest-client` attribute), or you can provide a reference to a https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/http/client/ClientHttpRequestFactory.html[`ClientHttpRequestFactory`] bean (by using the `request-factory` attribute).
 Spring provides the following implementations of the `ClientHttpRequestFactory` interface:
 
 * https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/http/client/SimpleClientHttpRequestFactory.html[`SimpleClientHttpRequestFactory`]: Uses standard J2SE facilities for making HTTP Requests
 * https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/http/client/HttpComponentsClientHttpRequestFactory.html[`HttpComponentsClientHttpRequestFactory`]: Uses https://hc.apache.org/httpcomponents-client-ga/[Apache HttpComponents HttpClient] (since Spring 3.1)
 
-If you do not explicitly configure the `request-factory` or `rest-template` attribute, a default `RestTemplate` (which uses a `SimpleClientHttpRequestFactory`) is instantiated.
+If you do not explicitly configure the `request-factory`, `rest-template`, or `rest-client` attribute, a default `RestTemplate` (which uses a `SimpleClientHttpRequestFactory`) is instantiated.
 
 [NOTE]
 =====
@@ -91,4 +91,3 @@ Ultimately, the `request-timeout` property is used to set the `sendTimeout` on t
 The `replyTimeout` property, on the other hand, is used to set the `receiveTimeout` property on the `MessagingTemplate` instance.
 
 TIP: To simulate connection timeouts, you can connect to a non-routable IP address, such as 10.255.255.10.
-

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -60,3 +60,10 @@ See xref:redis.adoc[] for more information.
 
 JMS-backed message channels now map headers to JMS message properties and back.
 See xref:jms.adoc[] for more information.
+
+[[x7.1-http-changes]]
+=== HTTP Support Changes
+
+The `HttpRequestExecutingMessageHandler` (its XML and Java DSL) now can be used with a `RestClient`.
+The `RestTemplate` configuration is deprecated.
+See xref:http.adoc[] for more information.


### PR DESCRIPTION
    Fixes: gh-10830

    * add `rest-client` XSD attribute for HTTP outbound gateway/channel adapter
    * extend XML parsers to wire `RestClient` and reject mixed `rest-template` + `rest-client`
    * add `HttpRequestExecutingMessageHandler` constructors and execution path for `RestClient`
    * add DSL overloads in `Http` and `HttpMessageHandlerSpec` for preconfigured `RestClient`
    * guard local client options (`request-factory`, `error-handler`, `message-converters`, `encoding-mode`) when external client is used
    * add parser/DSL/handler tests, including invalid dual-client configuration cases
    * update HTTP reference docs (`outbound`, `timeout`, `java-config`) for `RestClient` usage
