### PR TITLE
GH-6792: Add headers mapping to JMS channels

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/PollableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/PollableJmsChannel.java
@@ -61,8 +61,7 @@ public class PollableJmsChannel extends AbstractJmsChannel
 	}
 
 	@Override
-	@Nullable
-	public Message<?> receive(long timeout) {
+	public @Nullable Message<?> receive(long timeout) {
 		try {
 			DynamicJmsTemplateProperties.setReceiveTimeout(timeout);
 			return receive();
@@ -73,8 +72,7 @@ public class PollableJmsChannel extends AbstractJmsChannel
 	}
 
 	@Override
-	@Nullable
-	public Message<?> receive() {
+	public @Nullable Message<?> receive() {
 		ChannelInterceptorList interceptorList = getIChannelInterceptorList();
 		Deque<ChannelInterceptor> interceptorStack = null;
 		boolean counted = false;
@@ -109,24 +107,25 @@ public class PollableJmsChannel extends AbstractJmsChannel
 		}
 	}
 
-	@Nullable
-	private Message<?> receiveAndConvertToMessage() {
-		Object object;
+	private @Nullable Message<?> receiveAndConvertToMessage() {
+		jakarta.jms.Message jmsMessage;
 		if (this.messageSelector == null) {
-			object = getJmsTemplate().receiveAndConvert();
+			jmsMessage = this.jmsTemplate.receive();
 		}
 		else {
-			object = getJmsTemplate().receiveSelectedAndConvert(this.messageSelector);
+			jmsMessage = this.jmsTemplate.receiveSelected(this.messageSelector);
 		}
 
-		if (object == null) {
+		if (jmsMessage == null) {
 			logger.trace(() -> "postReceive on channel '" + this + "', message is null");
 			return null;
 		}
-		Message<?> message = object instanceof Message<?> msg
-				? msg
-				: getMessageBuilderFactory().withPayload(object).build();
-		logger.debug(() -> "postReceive on channel '" + this + "', message: " + message);
+
+		Message<?> message = fromJmsMessage(jmsMessage);
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("postReceive on channel '" + this + "', message: " + message);
+		}
 
 		return message;
 	}

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/SubscribableJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/SubscribableJmsChannel.java
@@ -17,25 +17,19 @@
 package org.springframework.integration.jms.channel;
 
 import jakarta.jms.MessageListener;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 import org.springframework.integration.MessageDispatchingException;
 import org.springframework.integration.channel.BroadcastCapableChannel;
 import org.springframework.integration.dispatcher.AbstractDispatcher;
 import org.springframework.integration.dispatcher.BroadcastingDispatcher;
-import org.springframework.integration.dispatcher.MessageDispatcher;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
 import org.springframework.integration.dispatcher.UnicastingDispatcher;
-import org.springframework.integration.support.MessageBuilderFactory;
 import org.springframework.integration.support.management.ManageableSmartLifecycle;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
-import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
-import org.springframework.messaging.MessagingException;
 import org.springframework.util.Assert;
 
 /**
@@ -102,12 +96,8 @@ public class SubscribableJmsChannel extends AbstractJmsChannel
 			return;
 		}
 		super.onInit();
-		boolean isPubSub = isBroadcast();
-		configureDispatcher(isPubSub);
-		MessageListener listener =
-				new DispatchingMessageListener(getJmsTemplate(), this.dispatcher, this, isPubSub,
-						getMessageBuilderFactory());
-		this.container.setMessageListener(listener);
+		configureDispatcher(isBroadcast());
+		this.container.setMessageListener((MessageListener) this::receiveAndDispatch);
 		if (!this.container.isActive()) {
 			this.container.afterPropertiesSet();
 		}
@@ -140,115 +130,54 @@ public class SubscribableJmsChannel extends AbstractJmsChannel
 
 	@Override
 	public boolean isAutoStartup() {
-		return (this.container != null) && this.container.isAutoStartup();
+		return this.container.isAutoStartup();
 	}
 
 	@Override
 	public int getPhase() {
-		return (this.container != null) ? this.container.getPhase() : 0;
+		return this.container.getPhase();
 	}
 
 	@Override
 	public boolean isRunning() {
-		return (this.container != null) && this.container.isRunning();
+		return this.container.isRunning();
 	}
 
 	@Override
 	public void start() {
-		if (this.container != null) {
-			this.container.start();
-		}
+		this.container.start();
 	}
 
 	@Override
 	public void stop() {
-		if (this.container != null) {
-			this.container.stop();
-		}
+		this.container.stop();
 	}
 
 	@Override
 	public void stop(Runnable callback) {
-		if (this.container != null) {
-			this.container.stop(callback);
-		}
-		else {
-			callback.run();
-		}
+		this.container.stop(callback);
 	}
 
 	@Override
 	public void destroy() {
-		if (this.container != null) {
-			this.container.destroy();
-		}
+		this.container.destroy();
 	}
 
-	private static final class DispatchingMessageListener implements MessageListener {
-
-		private final Log logger = LogFactory.getLog(this.getClass());
-
-		private final JmsTemplate jmsTemplate;
-
-		private final MessageDispatcher dispatcher;
-
-		private final SubscribableJmsChannel channel;
-
-		private final boolean isPubSub;
-
-		private final MessageBuilderFactory messageBuilderFactory;
-
-		DispatchingMessageListener(JmsTemplate jmsTemplate,
-				MessageDispatcher dispatcher, SubscribableJmsChannel channel, boolean isPubSub,
-				MessageBuilderFactory messageBuilderFactory) {
-
-			this.jmsTemplate = jmsTemplate;
-			this.dispatcher = dispatcher;
-			this.channel = channel;
-			this.isPubSub = isPubSub;
-			this.messageBuilderFactory = messageBuilderFactory;
+	private void receiveAndDispatch(jakarta.jms.Message message) {
+		Message<?> messageToSend = fromJmsMessage(message);
+		try {
+			this.dispatcher.dispatch(messageToSend);
 		}
-
-		@SuppressWarnings("NullAway") // Dataflow analysis limitation
-		@Override
-		public void onMessage(jakarta.jms.Message message) {
-			Message<?> messageToSend = null;
-			try {
-				MessageConverter converter = this.jmsTemplate.getMessageConverter();
-				Object converted = null;
-				if (converter != null) {
-					converted = converter.fromMessage(message);
-				}
-				if (converted != null) {
-					messageToSend =
-							converted instanceof Message<?> convertedMessage
-									? convertedMessage
-									: this.messageBuilderFactory.withPayload(converted).build();
-					this.dispatcher.dispatch(messageToSend);
-				}
-				else if (this.logger.isWarnEnabled()) {
-					this.logger.warn("No converter found, or converter returned null for: " + message
-							+ ", no Message to dispatch");
-				}
+		catch (MessageDispatchingException ex) {
+			String exceptionMessage = ex.getMessage() + " for jms-channel '" + this.getFullChannelName() + "'.";
+			if (isBroadcast()) {
+				// log only for backwards compatibility with pub/sub
+				this.logger.warn(ex, exceptionMessage);
 			}
-			catch (MessageDispatchingException ex) {
-				String exceptionMessage = ex.getMessage() + " for jms-channel '"
-						+ this.channel.getFullChannelName() + "'.";
-				if (this.isPubSub) {
-					// log only for backwards compatibility with pub/sub
-					if (this.logger.isWarnEnabled()) {
-						this.logger.warn(exceptionMessage, ex);
-					}
-				}
-				else {
-					throw new MessageDeliveryException(messageToSend, exceptionMessage, ex);
-				}
-			}
-			catch (Exception ex) {
-				throw new MessagingException("failed to handle incoming JMS Message", ex);
+			else {
+				throw new MessageDeliveryException(messageToSend, exceptionMessage, ex);
 			}
 		}
-
 	}
 
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
@@ -28,6 +28,7 @@ import jakarta.jms.DeliveryMode;
 import jakarta.jms.Destination;
 import jakarta.jms.TextMessage;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.apache.activemq.artemis.reader.MessageUtil;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -36,6 +37,7 @@ import org.springframework.integration.jms.config.JmsChannelFactoryBean;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.support.JmsHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -55,17 +57,15 @@ import static org.mockito.Mockito.verify;
  */
 public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 
-	private Destination queue;
-
 	@Test
 	public void queueReference() throws Exception {
-		this.queue = new ActiveMQQueue("pollableJmsChannelTestQueue");
+		Destination queue = new ActiveMQQueue("pollableJmsChannelTestQueue");
 
 		JmsChannelFactoryBean factoryBean = new JmsChannelFactoryBean(false);
 		CachingConnectionFactory ccf = new CachingConnectionFactory(connectionFactory);
 		ccf.setCacheConsumers(false);
 		factoryBean.setConnectionFactory(ccf);
-		factoryBean.setDestination(this.queue);
+		factoryBean.setDestination(queue);
 		factoryBean.setBeanFactory(mock());
 		factoryBean.afterPropertiesSet();
 		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
@@ -76,6 +76,9 @@ public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 		Message<?> result1 = channel.receive(10000);
 		assertThat(result1).isNotNull();
 		assertThat(result1.getPayload()).isEqualTo("test1");
+		assertThat(result1.getHeaders())
+				.containsEntry(MessageUtil.JMSXDELIVERYCOUNT, 1)
+				.containsEntry(JmsHeaders.DESTINATION, queue);
 		Message<?> result2 = channel.receive(10000);
 		assertThat(result2).isNotNull();
 		assertThat(result2.getPayload()).isEqualTo("test2");
@@ -152,13 +155,13 @@ public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void qos() throws Exception {
-		this.queue = new ActiveMQQueue("pollableJmsChannelTestQueue");
+		Destination queue = new ActiveMQQueue("pollableJmsChannelTestQueue");
 		CachingConnectionFactory ccf = new CachingConnectionFactory(connectionFactory);
 		ccf.setCacheConsumers(false);
 
 		JmsChannelFactoryBean factoryBean = new JmsChannelFactoryBean(false);
 		factoryBean.setConnectionFactory(ccf);
-		factoryBean.setDestination(this.queue);
+		factoryBean.setDestination(queue);
 		factoryBean.setExplicitQosEnabled(true);
 		factoryBean.setPriority(5);
 		int ttl = 10000;
@@ -200,13 +203,13 @@ public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void selector() throws Exception {
-		this.queue = new ActiveMQQueue("pollableJmsChannelSelectorTestQueue");
+		Destination queue = new ActiveMQQueue("pollableJmsChannelSelectorTestQueue");
 
 		JmsChannelFactoryBean factoryBean = new JmsChannelFactoryBean(false);
 		CachingConnectionFactory ccf = new CachingConnectionFactory(connectionFactory);
 		ccf.setCacheConsumers(false);
 		factoryBean.setConnectionFactory(ccf);
-		factoryBean.setDestination(this.queue);
+		factoryBean.setDestination(queue);
 
 		factoryBean.setMessageSelector("property='value'");
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
@@ -26,6 +26,7 @@ import jakarta.jms.Destination;
 import jakarta.jms.MessageListener;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.jms.client.ActiveMQTopic;
+import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,12 +35,15 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.log.LogAccessor;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.StubTextMessage;
 import org.springframework.integration.jms.config.JmsChannelFactoryBean;
+import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
+import org.springframework.jms.support.JmsHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
@@ -47,7 +51,6 @@ import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
@@ -100,15 +103,22 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 		channel.start();
 		channel.subscribe(handler1);
 		channel.subscribe(handler2);
-		channel.send(new GenericMessage<>("test1"));
+		channel.send(MessageBuilder.withPayload("test1").setHeader("customHeader", "customValue").build());
 		channel.send(new GenericMessage<>("test2"));
-		latch.await(TIMEOUT, TimeUnit.MILLISECONDS);
-		assertThat(receivedList1.size()).isEqualTo(1);
-		assertThat(receivedList1.get(0)).isNotNull();
-		assertThat(receivedList1.get(0).getPayload()).isEqualTo("test1");
-		assertThat(receivedList2.size()).isEqualTo(1);
-		assertThat(receivedList2.get(0)).isNotNull();
-		assertThat(receivedList2.get(0).getPayload()).isEqualTo("test2");
+
+		assertThat(latch.await(TIMEOUT, TimeUnit.MILLISECONDS)).isTrue();
+		assertThat(receivedList1).hasSize(1);
+		assertThat(receivedList1.get(0))
+				.extracting(Message::getPayload)
+				.isEqualTo("test1");
+		assertThat(receivedList1.get(0).getHeaders())
+				.containsEntry(MessageUtil.JMSXDELIVERYCOUNT, 1)
+				.containsEntry(JmsHeaders.DESTINATION, this.queue)
+				.containsEntry("customHeader", "customValue");
+		assertThat(receivedList2).hasSize(1);
+		assertThat(receivedList2.get(0))
+				.extracting(Message::getPayload)
+				.isEqualTo("test2");
 		channel.stop();
 	}
 
@@ -135,12 +145,11 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 		channel.subscribe(handler1);
 		channel.subscribe(handler2);
 		channel.start();
-		if (!waitUntilRegisteredWithDestination(channel, 10000)) {
-			fail("Listener failed to subscribe to topic");
-		}
+		assertThat(waitUntilRegisteredWithDestination(channel, 10000)).isTrue();
 		channel.send(new GenericMessage<>("test1"));
 		channel.send(new GenericMessage<>("test2"));
-		latch.await(TIMEOUT, TimeUnit.MILLISECONDS);
+
+		assertThat(latch.await(TIMEOUT, TimeUnit.MILLISECONDS)).isTrue();
 		assertThat(receivedList1).hasSize(2);
 		assertThat(receivedList1.get(0).getPayload()).isEqualTo("test1");
 		assertThat(receivedList1.get(1).getPayload()).isEqualTo("test2");
@@ -214,14 +223,13 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 		SubscribableJmsChannel channel = (SubscribableJmsChannel) factoryBean.getObject();
 		channel.afterPropertiesSet();
 		channel.start();
-		if (!waitUntilRegisteredWithDestination(channel, 10000)) {
-			fail("Listener failed to subscribe to topic");
-		}
+		assertThat(waitUntilRegisteredWithDestination(channel, 10000)).isTrue();
 		channel.subscribe(handler1);
 		channel.subscribe(handler2);
 		channel.send(new GenericMessage<>("test1"));
 		channel.send(new GenericMessage<>("test2"));
-		latch.await(TIMEOUT, TimeUnit.MILLISECONDS);
+
+		assertThat(latch.await(TIMEOUT, TimeUnit.MILLISECONDS)).isTrue();
 		assertThat(receivedList1).hasSize(2);
 		assertThat(receivedList1.get(0).getPayload()).isEqualTo("test1");
 		assertThat(receivedList1.get(1).getPayload()).isEqualTo("test2");
@@ -289,8 +297,8 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 	}
 
 	private static List<String> insertMockLoggerInListener(SubscribableJmsChannel channel) {
-		AbstractMessageListenerContainer container = TestUtils.getPropertyValue(channel, "container");
-		Log logger = mock(Log.class);
+		LogAccessor logAccessor = TestUtils.getPropertyValue(channel, "logger");
+		Log logger = mock();
 		final ArrayList<String> logList = new ArrayList<>();
 		doAnswer(invocation -> {
 			String message = invocation.getArgument(0);
@@ -300,9 +308,8 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 			return null;
 		}).when(logger).warn(anyString(), any(Exception.class));
 		when(logger.isWarnEnabled()).thenReturn(true);
-		Object listener = container.getMessageListener();
-		DirectFieldAccessor dfa = new DirectFieldAccessor(listener);
-		dfa.setPropertyValue("logger", logger);
+		DirectFieldAccessor dfa = new DirectFieldAccessor(logAccessor);
+		dfa.setPropertyValue("log", logger);
 		return logList;
 	}
 
@@ -323,7 +330,7 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 
 	/**
 	 * Blocks until the listener container has subscribed; if the container does not support
-	 * this test, or the caching mode is incompatible, true is returned. Otherwise blocks
+	 * this test, or the caching mode is incompatible, true is returned. Otherwise, blocks
 	 * until timeout milliseconds have passed, or the consumer has registered.
 	 * @see DefaultMessageListenerContainer#isRegisteredWithDestination()
 	 * @param timeout Timeout in milliseconds.

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelHistoryTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelHistoryTests.java
@@ -16,8 +16,12 @@
 
 package org.springframework.integration.jms.config;
 
+import jakarta.jms.JMSException;
+import jakarta.jms.MessageProducer;
+import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
+import org.mockito.ArgumentCaptor;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
@@ -26,6 +30,8 @@ import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.channel.SubscribableJmsChannel;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.jms.support.converter.SimpleMessageConverter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.SubscribableChannel;
@@ -34,9 +40,9 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 /**
@@ -53,22 +59,34 @@ public class JmsChannelHistoryTests extends ActiveMQMultiContextTests {
 	ApplicationContext context;
 
 	@Test
-	public void testMessageHistory() {
-		AbstractMessageListenerContainer mlContainer = mock(AbstractMessageListenerContainer.class);
-		JmsTemplate template = mock(JmsTemplate.class);
+	public void testMessageHistory() throws JMSException {
+		AbstractMessageListenerContainer mlContainer = mock();
+		JmsTemplate template = new JmsTemplate(connectionFactory) {
+
+			@Override
+			protected void doSend(MessageProducer producer, jakarta.jms.Message message) {
+			}
+
+		};
+		template.setDefaultDestination(new ActiveMQQueue("test_queue"));
+		MessageConverter messageConverter = spy(new SimpleMessageConverter());
+		template.setMessageConverter(messageConverter);
 		SubscribableJmsChannel channel = new SubscribableJmsChannel(mlContainer, template);
 		channel.setShouldTrack(true);
 		channel.setBeanName("jmsChannel");
 		Message<String> message = new GenericMessage<>("hello");
 
-		doAnswer(invocation -> {
-			Message<String> msg = invocation.getArgument(0);
-			MessageHistory history = MessageHistory.read(msg);
-			assertThat(history.get(0).contains("jmsChannel")).isTrue();
-			return null;
-		}).when(template).convertAndSend(Mockito.any(Message.class));
 		channel.send(message);
-		verify(template, times(1)).convertAndSend(Mockito.any(Message.class));
+
+		ArgumentCaptor<Message<?>> messageArgumentCaptor = ArgumentCaptor.captor();
+		verify(messageConverter).toMessage(messageArgumentCaptor.capture(), any());
+
+		Message<?> messageInTheChannel = messageArgumentCaptor.getValue();
+		MessageHistory history = MessageHistory.read(messageInTheChannel);
+		assertThat(history)
+				.first()
+				.asInstanceOf(InstanceOfAssertFactories.MAP)
+				.containsEntry("name", "jmsChannel");
 		channel.stop();
 	}
 
@@ -79,7 +97,10 @@ public class JmsChannelHistoryTests extends ActiveMQMultiContextTests {
 		channel.send(new GenericMessage<>("hello"));
 		Message<?> resultMessage = resultChannel.receive(10000);
 		MessageHistory history = MessageHistory.read(resultMessage);
-		assertThat(history.get(0).contains("jmsChannel")).isTrue();
+		assertThat(history)
+				.first()
+				.asInstanceOf(InstanceOfAssertFactories.MAP)
+				.containsEntry("name", "jmsChannel");
 	}
 
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelParserTests.java
@@ -176,8 +176,6 @@ public class JmsChannelParserTests extends ActiveMQMultiContextTests {
 				"container");
 		assertThat(jmsTemplate.getDefaultDestination()).isEqualTo(topic);
 		assertThat(container.getDestination()).isEqualTo(topic);
-		assertThat(TestUtils.<Object>getPropertyValue(channel, "container.messageListener.messageBuilderFactory"))
-				.isSameAs(this.messageBuilderFactory);
 	}
 
 	@Test

--- a/src/reference/antora/modules/ROOT/pages/jms.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jms.adoc
@@ -190,8 +190,7 @@ Java::
 ----
 @Bean
 public JmsMessageDrivenEndpoint jmsIn() {
-    JmsMessageDrivenEndpoint endpoint = new JmsMessageDrivenEndpoint(container(), listener());
-    return endpoint;
+    return new JmsMessageDrivenEndpoint(container(), listener());
 }
 @Bean
 public AbstractMessageListenerContainer container() {
@@ -822,8 +821,8 @@ Starting with version 5.1, the `DefaultJmsHeaderMapper` can be configured for ma
 @Bean
 public DefaultJmsHeaderMapper jmsHeaderMapper() {
     DefaultJmsHeaderMapper mapper = new DefaultJmsHeaderMapper();
-    mapper.setMapInboundDeliveryMode(true)
-    mapper.setMapInboundExpiration(true)
+    mapper.setMapInboundDeliveryMode(true);
+    mapper.setMapInboundExpiration(true);
     return mapper;
 }
 ----
@@ -925,6 +924,9 @@ The following example provides both a custom instance for resolution of the JMS 
 
 For the `<publish-subscribe-channel />`, set the `durable` attribute to `true` for a durable subscription or `subscription-shared` for a shared subscription (requires a JMS 2.0 broker and has been available since version 4.2).
 Use `subscription` to name the subscription.
+
+Starting with version 7.1, the `AbstractJmsChannel` and its implementations use a `DefaultJmsHeaderMapper` internally to map all headers from the message-to-send to JMS message properties; and on consuming side, map all JMS message properties into message headers.
+The custom header-mapping and payload conversion logic can be done by the `org.springframework.jms.support.converter.MessagingMessageConverter` injection into the `JmsTemplate` used for `AbstractJmsChannel` instances.
 
 [[jms-selectors]]
 == Using JMS Message Selectors

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -51,3 +51,9 @@ See xref:testing.adoc[] for more information.
 
 The `RedisMessageStore.doRemove` now uses `GETDEL` instead of `GET` + `UNLINK` for Redis 6.2+ by default.
 Use `RedisMessageStore.setUseUnlink(true)` to use `GET` + `UNLINK` when atomicity is not required and `GETDEL` causes noticeable Redis latency.
+
+[[x7.1-jms-changes]]
+=== JMS Support Changes
+
+JMS-backed message channels now map headers to JMS message properties and back.
+See xref:jms.adoc[] for more information.


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/6792

Currently, by default `AbstractJmsChannel` implementations use Java serialization for storing `Message<?>` instance into JMS destination. The deserialized message is produced from the channel as is. There might be use-cases when some JMS properties could be useful in downstream flows.

* Add `DefaultJmsHeaderMapper` into the `AbstractJmsChannel` as a conditional logic to map headers to/from JMS when `jmsTemplate.getMessageConverter()` is not a `MessagingMessageConverter`. Otherwise, then conversion of the message and header mapping is done in that converter
* Refactor logic in the `AbstractJmsChannel` to common API
* Fix Nullability formatting in the `PollableJmsChannel`
* Use lambda style for `MessageListener` in the `SubscribableJmsChannel` instead of inner extra class
* Ensure in the `PollableJmsChannelTests` and `SubscribableJmsChannelTests` that header mapper does it job
* Fix `JmsChannelParserTests` to not assert on the `messageBuilderFactory` since now a `MessageListener` in the `SubscribableJmsChannel` is a direct method of the class
* Fix `JmsChannelHistoryTests` verification according to a new internal logic of the `AbstractJmsChannel`
* Document new feature in the `jms.adoc` and `whats-new.adoc`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
