### PR TITLE
GH-10854: Fix remote file long name for SFTP

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -126,16 +126,13 @@ public class SftpSession implements Session<SftpClient.DirEntry> {
 			}
 		}
 		remoteDir = normalizePath(remoteDir);
-		String remoteDirToUse = remoteDir;
-		return StreamSupport.stream(this.sftpClient.readDir(remoteDirToUse).spliterator(), false)
+		String longNameDirPrefix = remoteDir.endsWith("/") ? remoteDir : remoteDir + '/';
+		return StreamSupport.stream(this.sftpClient.readDir(remoteDir).spliterator(), false)
 				.filter((entry) -> !isPattern || PatternMatchUtils.simpleMatch(remoteFile, entry.getFilename()))
 				.map((entry) -> {
-					String longFilename = entry.getLongFilename();
-					if (StringUtils.hasText(longFilename)) {
-						return entry;
-					}
+
 					String filename = entry.getFilename();
-					return new SftpClient.DirEntry(filename, remoteDirToUse + '/' + filename, entry.getAttributes());
+					return new SftpClient.DirEntry(filename, longNameDirPrefix + filename, entry.getAttributes());
 				});
 	}
 

--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -130,7 +130,6 @@ public class SftpSession implements Session<SftpClient.DirEntry> {
 		return StreamSupport.stream(this.sftpClient.readDir(remoteDir).spliterator(), false)
 				.filter((entry) -> !isPattern || PatternMatchUtils.simpleMatch(remoteFile, entry.getFilename()))
 				.map((entry) -> {
-
 					String filename = entry.getFilename();
 					return new SftpClient.DirEntry(filename, longNameDirPrefix + filename, entry.getAttributes());
 				});

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/SftpTestSupport.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/SftpTestSupport.java
@@ -80,8 +80,8 @@ public class SftpTestSupport extends RemoteFileTestSupport {
 		DefaultSftpSessionFactory factory = new DefaultSftpSessionFactory(false);
 		factory.setHost("localhost");
 		factory.setPort(port);
-		factory.setUser("foo");
-		factory.setPassword("foo");
+		factory.setUser("user");
+		factory.setPassword("password");
 		factory.setAllowUnknownKeys(true);
 		CachingSessionFactory<SftpClient.DirEntry> cachingSessionFactory = new CachingSessionFactory<>(factory);
 		cachingSessionFactory.setTestSession(true);

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpServerTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpServerTests.java
@@ -35,6 +35,8 @@ import org.apache.sshd.common.file.virtualfs.VirtualFileSystemFactory;
 import org.apache.sshd.server.SshServer;
 import org.apache.sshd.server.keyprovider.SimpleGeneratorHostKeyProvider;
 import org.apache.sshd.sftp.client.SftpClient;
+import org.apache.sshd.sftp.client.SftpVersionSelector;
+import org.apache.sshd.sftp.common.SftpConstants;
 import org.apache.sshd.sftp.server.SftpSubsystemFactory;
 import org.junit.jupiter.api.Test;
 
@@ -109,6 +111,8 @@ public class SftpServerTests {
 			f.setPort(server.getPort());
 			f.setUser("user");
 			f.setAllowUnknownKeys(true);
+			// See AbstractSftpClient.checkDirResponse() with the respective constant logic
+			f.setSftpVersionSelector(SftpVersionSelector.fixedVersionSelector(SftpConstants.SFTP_V3));
 			InputStream stream = new ClassPathResource(privKey).getInputStream();
 			f.setPrivateKey(new ByteArrayResource(FileCopyUtils.copyToByteArray(stream)));
 			f.setPrivateKeyPassphrase(passphrase);
@@ -159,13 +163,16 @@ public class SftpServerTests {
 			}
 		}
 
-		session.write(new ByteArrayInputStream("foo".getBytes()), "bar");
+		session.write(new ByteArrayInputStream("test data".getBytes()), "test_file");
 		list = session.list(".");
-		assertThat(list[1].getFilename()).isEqualTo("bar");
+		assertThat(list[1].getFilename()).isEqualTo("test_file");
+		// The root dir (.) becomes '/' after sftpClient.canonicalPath()
+		// Plus with the SftpConstants.SFTP_V3 settings, we ensure here that SftpSession overrides file long name
+		assertThat(list[1].getLongFilename()).isEqualTo("/test_file");
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-		session.read("bar", outputStream);
-		assertThat(new String(outputStream.toByteArray())).isEqualTo("foo");
-		session.remove("bar");
+		session.read("test_file", outputStream);
+		assertThat(new String(outputStream.toByteArray())).isEqualTo("test data");
+		session.remove("test_file");
 		session.close();
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10854

The logic in the framework is to use a long file name (preferably, the whole path) for metadata key. This was implemented via: https://github.com/spring-projects/spring-integration/issues/10162

Fix `SftpSession.doList()` not consulting with whatever `SftpClient` returns but rather using a remote dir as long name prefix unconditionally. This would make it exactly what we claim in docs and consistent with FTP

**Auto-cherry-pick to `7.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
