### PR TITLE
GH-10853: Fix MQTTv5 for any shared subscription pattern

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -405,22 +405,22 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 	}
 
 	@Override
-	public void removeTopic(String... topic) {
+	public void removeTopic(String... topics) {
 		this.topicLock.lock();
 		try {
-			super.removeTopic(topic);
-			for (String topicToRemove : topic) {
+			super.removeTopic(topics);
+			for (String topicToRemove : topics) {
 				this.topicsWithoutSharedSubscriptionPrefix.remove(topicToRemove);
 			}
 			if (this.mqttClient != null && this.mqttClient.isConnected()) {
-				unsubscribe(topic);
+				unsubscribe(topics);
 			}
 			if (!CollectionUtils.isEmpty(this.subscriptions)) {
-				this.subscriptions.removeIf((sub) -> ObjectUtils.containsElement(topic, sub.getTopic()));
+				this.subscriptions.removeIf((sub) -> ObjectUtils.containsElement(topics, sub.getTopic()));
 			}
 		}
 		catch (MqttException ex) {
-			throw new MessagingException("Failed to unsubscribe from topic(s) " + Arrays.toString(topic), ex);
+			throw new MessagingException("Failed to unsubscribe from topics(s) " + Arrays.toString(topics), ex);
 		}
 		finally {
 			this.topicLock.unlock();

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -20,10 +20,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.ConcurrentModificationException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import org.eclipse.paho.mqttv5.client.IMqttAsyncClient;
@@ -92,6 +95,9 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 		extends AbstractMqttMessageDrivenChannelAdapter<IMqttAsyncClient, MqttConnectionOptions>
 		implements MqttCallback, MqttComponent<MqttConnectionOptions> {
 
+	private static final Pattern SHARED_SUBSCRIPTION_PATTERN =
+			Pattern.compile("^\\$(?:share|SharedSubscription)/[^/]*/(.*)$");
+
 	private final Lock lock = new ReentrantLock();
 
 	/**
@@ -100,6 +106,8 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 	private final ClientManager.DefaultMessageHandler<MqttMessage> defaultMessageHandler = this::messageArrivedIfMatched;
 
 	private final MqttConnectionOptions connectionOptions;
+
+	private final Map<String, String> topicsWithoutSharedSubscriptionPrefix = new HashMap<>();
 
 	private @Nullable List<MqttSubscription> subscriptions;
 
@@ -137,6 +145,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 		this.connectionOptions = new MqttConnectionOptions();
 		this.connectionOptions.setServerURIs(new String[] {url});
 		this.connectionOptions.setAutomaticReconnect(true);
+		populateTopicsWithoutSharedSubscriptionPrefix(topic);
 	}
 
 	/**
@@ -165,6 +174,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 					"Otherwise the current channel adapter restart should be used explicitly, " +
 					"e.g. via handling 'MqttConnectionFailedEvent' on client disconnection.");
 		}
+		populateTopicsWithoutSharedSubscriptionPrefix(topic);
 	}
 
 	/**
@@ -193,6 +203,18 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 
 		super(clientManager, topic);
 		this.connectionOptions = clientManager.getConnectionInfo();
+		populateTopicsWithoutSharedSubscriptionPrefix(topic);
+	}
+
+	private void populateTopicsWithoutSharedSubscriptionPrefix(String... topics) {
+		for (String topic : topics) {
+			String topicWithoutPrefix = topic;
+			Matcher matcher = SHARED_SUBSCRIPTION_PATTERN.matcher(topic);
+			if (matcher.find()) {
+				topicWithoutPrefix = matcher.group(1);
+			}
+			this.topicsWithoutSharedSubscriptionPrefix.put(topic, topicWithoutPrefix);
+		}
 	}
 
 	@Override
@@ -301,7 +323,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 			if (this.mqttClient != null && this.mqttClient.isConnected()) {
 				if (this.connectionOptions.isCleanStart()) {
 					unsubscribe(topics);
-					// Have to re-subscribe on next start if connection is not lost.
+					// Have to re-subscribe on the next start if the connection is not lost.
 					this.readyToSubscribeOnStart = true;
 
 				}
@@ -360,6 +382,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 		this.topicLock.lock();
 		try {
 			super.addTopic(topic, qos);
+			populateTopicsWithoutSharedSubscriptionPrefix(topic);
 			MqttSubscription subscription = new MqttSubscription(topic, qos);
 			if (this.subscriptions != null) {
 				this.subscriptions.add(subscription);
@@ -386,6 +409,9 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 		this.topicLock.lock();
 		try {
 			super.removeTopic(topic);
+			for (String topicToRemove : topic) {
+				this.topicsWithoutSharedSubscriptionPrefix.remove(topicToRemove);
+			}
 			if (this.mqttClient != null && this.mqttClient.isConnected()) {
 				unsubscribe(topic);
 			}
@@ -467,7 +493,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 	@Override
 	public void connectComplete(boolean reconnect, @Nullable String serverURI) {
 		// The 'running' flag is set after 'doStart()', so possible a race condition
-		// when start is not finished yet, but server answers with successful connection.
+		// when start is not finished yet, but the server answers with a successful connection.
 		if (isActive()) {
 			subscribe();
 		}
@@ -531,10 +557,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 	}
 
 	private void messageArrivedIfMatched(String topic, MqttMessage mqttMessage) {
-		for (String subscribedTopic : getTopic()) {
-			if (subscribedTopic.startsWith("$") && subscribedTopic.contains("/")) {
-				subscribedTopic = subscribedTopic.split("/", 3)[2];
-			}
+		for (String subscribedTopic : this.topicsWithoutSharedSubscriptionPrefix.values()) {
 			if (MqttTopicValidator.isMatched(subscribedTopic, topic)) {
 				messageArrived(topic, mqttMessage);
 				return;

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -532,7 +532,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 
 	private void messageArrivedIfMatched(String topic, MqttMessage mqttMessage) {
 		for (String subscribedTopic : getTopic()) {
-			if (subscribedTopic.startsWith("$share/")) {
+			if (subscribedTopic.startsWith("$") && subscribedTopic.contains("/")) {
 				subscribedTopic = subscribedTopic.split("/", 3)[2];
 			}
 			if (MqttTopicValidator.isMatched(subscribedTopic, topic)) {

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -107,7 +107,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		try (var ctx = new AnnotationConfigApplicationContext(Mqttv5Config.class)) {
 			var input = ctx.getBean("mqttOutFlow.input", MessageChannel.class);
 			var mqttv5MessageDrivenChannelAdapter = ctx.getBean(Mqttv5PahoMessageDrivenChannelAdapter.class);
-			mqttv5MessageDrivenChannelAdapter.addTopic("$SharedSubscription/group/testTopic");
+			mqttv5MessageDrivenChannelAdapter.addTopic("$share/group/testTopic");
 			var output = ctx.getBean("fromMqttChannel", PollableChannel.class);
 
 			String testPayload = "shared topic payload";

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/ClientManagerBackToBackTests.java
@@ -107,7 +107,7 @@ class ClientManagerBackToBackTests implements MosquittoContainerTest {
 		try (var ctx = new AnnotationConfigApplicationContext(Mqttv5Config.class)) {
 			var input = ctx.getBean("mqttOutFlow.input", MessageChannel.class);
 			var mqttv5MessageDrivenChannelAdapter = ctx.getBean(Mqttv5PahoMessageDrivenChannelAdapter.class);
-			mqttv5MessageDrivenChannelAdapter.addTopic("$share/group/testTopic");
+			mqttv5MessageDrivenChannelAdapter.addTopic("$SharedSubscription/group/testTopic");
 			var output = ctx.getBean("fromMqttChannel", PollableChannel.class);
 
 			String testPayload = "shared topic payload";

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5AdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5AdapterTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.mqtt;
 
+import java.util.Map;
+
 import org.eclipse.paho.mqttv5.client.IMqttAsyncClient;
 import org.eclipse.paho.mqttv5.client.IMqttMessageListener;
 import org.eclipse.paho.mqttv5.client.IMqttToken;
@@ -28,8 +30,10 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.integration.channel.NullChannel;
 import org.springframework.integration.mqtt.inbound.Mqttv5PahoMessageDrivenChannelAdapter;
+import org.springframework.integration.test.util.TestUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -73,6 +77,25 @@ public class Mqttv5AdapterTests {
 		verify(client).connect(any(MqttConnectionOptions.class));
 		verify(client).subscribe(any(MqttSubscription[].class), any(), any(), any(IMqttMessageListener.class), any());
 		verify(client, never()).unsubscribe(any(String[].class));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void sharedSubscriptionsPopulation() throws Exception {
+		IMqttAsyncClient client = mock();
+		Mqttv5PahoMessageDrivenChannelAdapter adapter = buildAdapterIn(client, false);
+
+		adapter.addTopic("$share/group/testTopic", "$SharedSubscription/myGroup/test/#", "some_other_topic",
+				"$SYS/broker/#");
+
+		Map<String, String> topicsWithoutSharedSubscriptionPrefix =
+				(Map<String, String>) TestUtils.getPropertyValue(adapter, "topicsWithoutSharedSubscriptionPrefix");
+
+		assertThat(topicsWithoutSharedSubscriptionPrefix)
+				.containsEntry("$share/group/testTopic", "testTopic")
+				.containsEntry("$SharedSubscription/myGroup/test/#", "test/#")
+				.containsEntry("some_other_topic", "some_other_topic")
+				.containsEntry("$SYS/broker/#", "$SYS/broker/#");
 	}
 
 	private static Mqttv5PahoMessageDrivenChannelAdapter buildAdapterIn(final IMqttAsyncClient client,


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10853

Apparently, not all MQTT brokers come with `$share/` pattern on shared subscription topics.

* Fix `Mqttv5PahoMessageDrivenChannelAdapter` to check `subscribedTopic` for starting `$` symbol and having `/`
* Adjust `ClientManagerBackToBackTests.sharedTopicWithClientManager()` for IBM MessageSight and Eclipse Amlen pattern with `$SharedSubscription/`

**Auto-cherry-pick to `7.0.x` & `6.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
