### PR TITLE
Fix reference link in `FTPS and Shared SSLSession`

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/ftp/advanced-configuration.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ftp/advanced-configuration.adoc
@@ -42,7 +42,7 @@ public class AdvancedFtpSessionFactory extends DefaultFtpSessionFactory {
 
 When using FTP over SSL or TLS, some servers require the same `SSLSession` to be used on the control and data connections.
 This is to prevent "`stealing`" data connections.
-See https://scarybeastsecurity.blogspot.cz/2009/02/vsftpd-210-released.html for more information.
+See https://scarybeastsecurity.blogspot.com/2009/02/vsftpd-210-released.html for more information.
 
 Currently, the Apache FTPSClient does not support this feature.
 See https://issues.apache.org/jira/browse/NET-408[NET-408].


### PR DESCRIPTION
current it uses a regional suffix `.cz` , which can not be opened in my region,  however,  `.com` works for me.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
