### PR TITLE
Fix SessionFactory Code example for ftp/sftp.

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/ftp/inbound.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ftp/inbound.adoc
@@ -233,7 +233,6 @@ public class FtpJavaApplication {
         sf.setPort(port);
         sf.setUsername("foo");
         sf.setPassword("foo");
-        sf.setTestSession(true);
         return new CachingSessionFactory<FTPFile>(sf);
     }
 

--- a/src/reference/antora/modules/ROOT/pages/ftp/outbound-gateway.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ftp/outbound-gateway.adoc
@@ -327,7 +327,6 @@ public class FtpJavaApplication {
         sf.setPort(port);
         sf.setUsername("foo");
         sf.setPassword("foo");
-        sf.setTestSession(true);
         return new CachingSessionFactory<FTPFile>(sf);
     }
 
@@ -366,7 +365,6 @@ public class FtpJavaApplication {
         sf.setPort(port);
         sf.setUsername("foo");
         sf.setPassword("foo");
-        sf.setTestSession(true);
         return new CachingSessionFactory<FTPFile>(sf);
     }
 

--- a/src/reference/antora/modules/ROOT/pages/ftp/outbound.adoc
+++ b/src/reference/antora/modules/ROOT/pages/ftp/outbound.adoc
@@ -101,7 +101,6 @@ public class FtpJavaApplication {
         sf.setPort(port);
         sf.setUsername("foo");
         sf.setPassword("foo");
-        sf.setTestSession(true);
         return new CachingSessionFactory<FTPFile>(sf);
     }
 
@@ -158,7 +157,6 @@ public class FtpJavaApplication {
         sf.setPort(port);
         sf.setUsername("foo");
         sf.setPassword("foo");
-        sf.setTestSession(true);
         return new CachingSessionFactory<FTPFile>(sf);
     }
 

--- a/src/reference/antora/modules/ROOT/pages/sftp/inbound.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sftp/inbound.adoc
@@ -204,7 +204,6 @@ public class SftpJavaApplication {
         factory.setUser("foo");
         factory.setPassword("foo");
         factory.setAllowUnknownKeys(true);
-        factory.setTestSession(true);
         return new CachingSessionFactory<>(factory);
     }
 

--- a/src/reference/antora/modules/ROOT/pages/sftp/outbound-gateway.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sftp/outbound-gateway.adoc
@@ -333,7 +333,6 @@ public class SftpJavaApplication {
         sf.setPort(port);
         sf.setUsername("foo");
         sf.setPassword("foo");
-        factory.setTestSession(true);
         return new CachingSessionFactory<>(sf);
     }
 

--- a/src/reference/antora/modules/ROOT/pages/sftp/outbound.adoc
+++ b/src/reference/antora/modules/ROOT/pages/sftp/outbound.adoc
@@ -98,7 +98,6 @@ public class SftpJavaApplication {
         factory.setUser("foo");
         factory.setPassword("foo");
         factory.setAllowUnknownKeys(true);
-        factory.setTestSession(true);
         return new CachingSessionFactory<SftpClient.DirEntry>(factory);
     }
 


### PR DESCRIPTION
The `setTestSession()` method is available in `CachingSessionFactory`, but not in the `DefaultFtpSessionFactory` or `DefaultSftpSessionFactory` implementations.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
