### PR TITLE
GH-10906: DefaultLockRepository: Use LocalDateTime directly

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.jdbc.lock;
 
-import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -391,12 +390,12 @@ public class DefaultLockRepository
 		return this.readCommittedTransactionTemplate.<Boolean>execute(
 				transactionStatus -> {
 					if (this.template.update(this.updateQuery, this.id, ttlEpochMillis(ttlDuration),
-							this.region, lock, this.id, epochMillis()) > 0) {
+							this.region, lock, this.id, currentTime()) > 0) {
 						return true;
 					}
 					try {
 						return this.template.update(this.insertQuery, this.region, lock, this.id,
-								epochMillis(), ttlEpochMillis(ttlDuration)) > 0;
+								currentTime(), ttlEpochMillis(ttlDuration)) > 0;
 					}
 					catch (DataIntegrityViolationException ex) {
 						return false;
@@ -410,14 +409,14 @@ public class DefaultLockRepository
 				transactionStatus ->
 						Integer.valueOf(1).equals(
 								this.template.queryForObject(this.countQuery,
-										Integer.class, this.region, lock, this.id, epochMillis())));
+										Integer.class, this.region, lock, this.id, currentTime())));
 	}
 
 	@Override
 	public void deleteExpired() {
 		this.defaultTransactionTemplate.executeWithoutResult(
 				transactionStatus ->
-						this.template.update(this.deleteExpiredQuery, this.region, epochMillis()));
+						this.template.update(this.deleteExpiredQuery, this.region, currentTime()));
 	}
 
 	@Override
@@ -427,12 +426,8 @@ public class DefaultLockRepository
 						this.template.update(this.renewQuery, ttlEpochMillis(ttlDuration), this.region, lock, this.id) == 1);
 	}
 
-	private Timestamp ttlEpochMillis(Duration ttl) {
-		return Timestamp.valueOf(currentTime().plus(ttl));
-	}
-
-	private static Timestamp epochMillis() {
-		return Timestamp.valueOf(currentTime());
+	private static LocalDateTime ttlEpochMillis(Duration ttl) {
+		return currentTime().plus(ttl);
 	}
 
 	private static LocalDateTime currentTime() {


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/10906

The `Timestamp.valueOf()` method uses the system default time zone which may lead to discrepancy when daylight saving happens

According to JDBC 4.2+, we don't need to convert `LocalDateTime` to `Timestamp` anymore

* Fix `DefaultLockRepository` to use `LocalDateTime` as values for SQL statements instead of wrapping them into `Timestamp`

There are no any new tests since this internal change does not affect API logic, and existing working tests prove that everything is still right

**Auto-cherry-pick to `7.0.x` & `6.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
