### PR TITLE
Add DSL for Redis Queue channel adapters.

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
@@ -56,7 +56,9 @@ public final class Redis {
 	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
 	 * @return the {@link RedisQueueInboundChannelAdapterSpec} instance
 	 */
-	public static RedisQueueInboundChannelAdapterSpec queueInboundChannelAdapter(String queueName, RedisConnectionFactory connectionFactory) {
+	public static RedisQueueInboundChannelAdapterSpec queueInboundChannelAdapter(String queueName,
+			RedisConnectionFactory connectionFactory) {
+
 		return new RedisQueueInboundChannelAdapterSpec(queueName, connectionFactory);
 	}
 
@@ -66,7 +68,9 @@ public final class Redis {
 	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
 	 * @return the {@link RedisQueueOutboundChannelAdapterSpec} instance
 	 */
-	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(String queueName, RedisConnectionFactory connectionFactory) {
+	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(String queueName,
+			RedisConnectionFactory connectionFactory) {
+
 		return new RedisQueueOutboundChannelAdapterSpec(queueName, connectionFactory);
 	}
 
@@ -76,7 +80,9 @@ public final class Redis {
 	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
 	 * @return the {@link RedisQueueOutboundChannelAdapterSpec} instance
 	 */
-	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(Expression queueExpression, RedisConnectionFactory connectionFactory) {
+	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(Expression queueExpression,
+			RedisConnectionFactory connectionFactory) {
+
 		return new RedisQueueOutboundChannelAdapterSpec(queueExpression, connectionFactory);
 	}
 
@@ -86,7 +92,9 @@ public final class Redis {
 	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
 	 * @return the {@link RedisQueueOutboundChannelAdapterSpec} instance
 	 */
-	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(Function<Message<?>, String> queueFunction, RedisConnectionFactory connectionFactory) {
+	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(
+			Function<Message<?>, String> queueFunction, RedisConnectionFactory connectionFactory) {
+
 		return new RedisQueueOutboundChannelAdapterSpec(new FunctionExpression<>(queueFunction), connectionFactory);
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
@@ -16,8 +16,12 @@
 
 package org.springframework.integration.redis.dsl;
 
+import java.util.function.Function;
+
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.expression.Expression;
+import org.springframework.integration.expression.FunctionExpression;
+import org.springframework.messaging.Message;
 
 /**
  * Factory class for Redis components.
@@ -74,6 +78,16 @@ public final class Redis {
 	 */
 	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(Expression queueExpression, RedisConnectionFactory connectionFactory) {
 		return new RedisQueueOutboundChannelAdapterSpec(queueExpression, connectionFactory);
+	}
+
+	/**
+	 * The factory to produce a {@link RedisQueueOutboundChannelAdapterSpec}.
+	 * @param queueFunction The queueExpression of the Redis list to build on
+	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
+	 * @return the {@link RedisQueueOutboundChannelAdapterSpec} instance
+	 */
+	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(Function<Message<?>, String> queueFunction, RedisConnectionFactory connectionFactory) {
+		return new RedisQueueOutboundChannelAdapterSpec(new FunctionExpression<>(queueFunction), connectionFactory);
 	}
 
 	private Redis() {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.redis.dsl;
 
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.expression.Expression;
 
 /**
  * Factory class for Redis components.
@@ -43,6 +44,36 @@ public final class Redis {
 	 */
 	public static RedisOutboundChannelAdapterSpec outboundChannelAdapter(RedisConnectionFactory connectionFactory) {
 		return new RedisOutboundChannelAdapterSpec(connectionFactory);
+	}
+
+	/**
+	 * The factory to produce a {@link RedisQueueInboundChannelAdapterSpec}.
+	 * @param queueName The queueName of the Redis list to build on
+	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
+	 * @return the {@link RedisQueueInboundChannelAdapterSpec} instance
+	 */
+	public static RedisQueueInboundChannelAdapterSpec queueInboundChannelAdapter(String queueName, RedisConnectionFactory connectionFactory) {
+		return new RedisQueueInboundChannelAdapterSpec(queueName, connectionFactory);
+	}
+
+	/**
+	 * The factory to produce a {@link RedisQueueOutboundChannelAdapterSpec}.
+	 * @param queueName The queueName of the Redis list to build on
+	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
+	 * @return the {@link RedisQueueOutboundChannelAdapterSpec} instance
+	 */
+	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(String queueName, RedisConnectionFactory connectionFactory) {
+		return new RedisQueueOutboundChannelAdapterSpec(queueName, connectionFactory);
+	}
+
+	/**
+	 * The factory to produce a {@link RedisQueueOutboundChannelAdapterSpec}.
+	 * @param queueExpression The queueExpression of the Redis list to build on
+	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
+	 * @return the {@link RedisQueueOutboundChannelAdapterSpec} instance
+	 */
+	public static RedisQueueOutboundChannelAdapterSpec queueOutboundChannelAdapter(Expression queueExpression, RedisConnectionFactory connectionFactory) {
+		return new RedisQueueOutboundChannelAdapterSpec(queueExpression, connectionFactory);
 	}
 
 	private Redis() {

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisInboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisInboundChannelAdapterSpec.java
@@ -31,13 +31,15 @@ import org.springframework.messaging.converter.MessageConverter;
  *
  * @since 7.1
  */
-public class RedisInboundChannelAdapterSpec extends MessageProducerSpec<RedisInboundChannelAdapterSpec, RedisInboundChannelAdapter> {
+public class RedisInboundChannelAdapterSpec extends
+		MessageProducerSpec<RedisInboundChannelAdapterSpec, RedisInboundChannelAdapter> {
 
 	protected RedisInboundChannelAdapterSpec(RedisConnectionFactory connectionFactory) {
 		this.target = new RedisInboundChannelAdapter(connectionFactory);
 	}
 
 	/**
+	 * Specify the RedisSerializer to deserialize the body of Redis messages.
 	 * @param serializer the serializer
 	 * @return the spec
 	 * @see RedisInboundChannelAdapter#setSerializer(RedisSerializer)
@@ -48,6 +50,7 @@ public class RedisInboundChannelAdapterSpec extends MessageProducerSpec<RedisInb
 	}
 
 	/**
+	 * Specify the topics to subscribe.
 	 * @param topics the topics
 	 * @return the spec
 	 * @see RedisInboundChannelAdapter#setTopics(String...)
@@ -58,6 +61,7 @@ public class RedisInboundChannelAdapterSpec extends MessageProducerSpec<RedisInb
 	}
 
 	/**
+	 * Specify the topicPatterns to subscribe.
 	 * @param topicPatterns the topicPatterns
 	 * @return the spec
 	 * @see RedisInboundChannelAdapter#setTopicPatterns(String...)
@@ -68,6 +72,7 @@ public class RedisInboundChannelAdapterSpec extends MessageProducerSpec<RedisInb
 	}
 
 	/**
+	 * Specify the messageConverter to convert between Redis messages and Spring message payloads.
 	 * @param messageConverter the messageConverter
 	 * @return the spec
 	 * @see RedisInboundChannelAdapter#setMessageConverter(MessageConverter)
@@ -78,6 +83,7 @@ public class RedisInboundChannelAdapterSpec extends MessageProducerSpec<RedisInb
 	}
 
 	/**
+	 * Specify an {@link Executor} for running the message listeners when messages are received.
 	 * @param taskExecutor the taskExecutor
 	 * @return the spec
 	 * @see RedisInboundChannelAdapter#setTaskExecutor(Executor)

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisInboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisInboundChannelAdapterSpec.java
@@ -25,7 +25,7 @@ import org.springframework.integration.redis.inbound.RedisInboundChannelAdapter;
 import org.springframework.messaging.converter.MessageConverter;
 
 /**
- * A {@link MessageProducerSpec} for a {@link RedisInboundChannelAdapterSpec}.
+ * A {@link MessageProducerSpec} for a {@link RedisInboundChannelAdapter}.
  *
  * @author Jiandong Ma
  *

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisOutboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisOutboundChannelAdapterSpec.java
@@ -34,13 +34,15 @@ import org.springframework.messaging.converter.MessageConverter;
  *
  * @since 7.1
  */
-public class RedisOutboundChannelAdapterSpec extends MessageHandlerSpec<RedisOutboundChannelAdapterSpec, RedisPublishingMessageHandler> {
+public class RedisOutboundChannelAdapterSpec extends
+		MessageHandlerSpec<RedisOutboundChannelAdapterSpec, RedisPublishingMessageHandler> {
 
 	protected RedisOutboundChannelAdapterSpec(RedisConnectionFactory connectionFactory) {
 		this.target = new RedisPublishingMessageHandler(connectionFactory);
 	}
 
 	/**
+	 * Specify the RedisSerializer to serialize data before sending to the Redis.
 	 * @param serializer the serializer
 	 * @return the spec
 	 * @see RedisPublishingMessageHandler#setSerializer(RedisSerializer)
@@ -51,6 +53,7 @@ public class RedisOutboundChannelAdapterSpec extends MessageHandlerSpec<RedisOut
 	}
 
 	/**
+	 * Specify the messageConverter to convert between Redis messages and Spring message payloads.
 	 * @param messageConverter the messageConverter
 	 * @return the spec
 	 * @see RedisPublishingMessageHandler#setMessageConverter(MessageConverter)
@@ -61,6 +64,7 @@ public class RedisOutboundChannelAdapterSpec extends MessageHandlerSpec<RedisOut
 	}
 
 	/**
+	 * Specify the topic to publish messages.
 	 * @param topic the topic
 	 * @return the spec
 	 * @see RedisPublishingMessageHandler#setTopic(String)
@@ -71,6 +75,7 @@ public class RedisOutboundChannelAdapterSpec extends MessageHandlerSpec<RedisOut
 	}
 
 	/**
+	 * Specify the topicExpression to determine the topic.
 	 * @param topicExpression the topicExpression
 	 * @return the spec
 	 * @see RedisPublishingMessageHandler#setTopicExpression(Expression)

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisOutboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisOutboundChannelAdapterSpec.java
@@ -28,7 +28,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.MessageConverter;
 
 /**
- * A {@link MessageHandlerSpec} for a {@link RedisOutboundChannelAdapterSpec}.
+ * A {@link MessageHandlerSpec} for a {@link RedisPublishingMessageHandler}.
  *
  * @author Jiandong Ma
  *

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueInboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueInboundChannelAdapterSpec.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.redis.dsl;
+
+import java.time.Duration;
+import java.util.concurrent.Executor;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.integration.dsl.MessageProducerSpec;
+import org.springframework.integration.redis.inbound.RedisQueueMessageDrivenEndpoint;
+
+/**
+ * A {@link MessageProducerSpec} for a {@link RedisQueueInboundChannelAdapterSpec}.
+ *
+ * @author Jiandong Ma
+ *
+ * @since 7.1
+ */
+public class RedisQueueInboundChannelAdapterSpec extends MessageProducerSpec<RedisQueueInboundChannelAdapterSpec, RedisQueueMessageDrivenEndpoint> {
+
+	protected RedisQueueInboundChannelAdapterSpec(String queueName, RedisConnectionFactory connectionFactory) {
+		this.target = new RedisQueueMessageDrivenEndpoint(queueName, connectionFactory);
+	}
+
+	/**
+	 * @param serializer the serializer
+	 * @return the spec
+	 * @see RedisQueueMessageDrivenEndpoint#setSerializer(RedisSerializer)
+	 */
+	public RedisQueueInboundChannelAdapterSpec serializer(RedisSerializer<?> serializer) {
+		this.target.setSerializer(serializer);
+		return this;
+	}
+
+	/**
+	 * @param expectMessage the expectMessage
+	 * @return the spec
+	 * @see RedisQueueMessageDrivenEndpoint#setExpectMessage(boolean)
+	 */
+	public RedisQueueInboundChannelAdapterSpec expectMessage(boolean expectMessage) {
+		this.target.setExpectMessage(expectMessage);
+		return this;
+	}
+
+	/**
+	 * @param receiveTimeout the receiveTimeout
+	 * @return the spec
+	 * @see RedisQueueMessageDrivenEndpoint#setReceiveDuration(Duration)
+	 */
+	public RedisQueueInboundChannelAdapterSpec receiveDuration(Duration receiveTimeout) {
+		this.target.setReceiveDuration(receiveTimeout);
+		return this;
+	}
+
+	/**
+	 * @param receiveTimeout the receiveTimeout
+	 * @return the spec
+	 * @see RedisQueueMessageDrivenEndpoint#setReceiveTimeout(long)
+	 */
+	public RedisQueueInboundChannelAdapterSpec receiveTimeout(long receiveTimeout) {
+		this.target.setReceiveTimeout(receiveTimeout);
+		return this;
+	}
+
+	/**
+	 * @param taskExecutor the taskExecutor
+	 * @return the spec
+	 * @see RedisQueueMessageDrivenEndpoint#setTaskExecutor(Executor)
+	 */
+	public RedisQueueInboundChannelAdapterSpec taskExecutor(Executor taskExecutor) {
+		this.target.setTaskExecutor(taskExecutor);
+		return this;
+	}
+
+	/**
+	 * @param recoveryInterval the recoveryInterval
+	 * @return the spec
+	 * @see RedisQueueMessageDrivenEndpoint#setRecoveryInterval(long)
+	 */
+	public RedisQueueInboundChannelAdapterSpec recoveryInterval(long recoveryInterval) {
+		this.target.setRecoveryInterval(recoveryInterval);
+		return this;
+	}
+
+	/**
+	 * @param rightPop the rightPop
+	 * @return the spec
+	 * @see RedisQueueMessageDrivenEndpoint#setRightPop(boolean)
+	 */
+	public RedisQueueInboundChannelAdapterSpec rightPop(boolean rightPop) {
+		this.target.setRightPop(rightPop);
+		return this;
+	}
+
+}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueInboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueInboundChannelAdapterSpec.java
@@ -25,7 +25,7 @@ import org.springframework.integration.dsl.MessageProducerSpec;
 import org.springframework.integration.redis.inbound.RedisQueueMessageDrivenEndpoint;
 
 /**
- * A {@link MessageProducerSpec} for a {@link RedisQueueInboundChannelAdapterSpec}.
+ * A {@link MessageProducerSpec} for a {@link RedisQueueMessageDrivenEndpoint}.
  *
  * @author Jiandong Ma
  *

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueInboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueInboundChannelAdapterSpec.java
@@ -31,13 +31,15 @@ import org.springframework.integration.redis.inbound.RedisQueueMessageDrivenEndp
  *
  * @since 7.1
  */
-public class RedisQueueInboundChannelAdapterSpec extends MessageProducerSpec<RedisQueueInboundChannelAdapterSpec, RedisQueueMessageDrivenEndpoint> {
+public class RedisQueueInboundChannelAdapterSpec extends
+		MessageProducerSpec<RedisQueueInboundChannelAdapterSpec, RedisQueueMessageDrivenEndpoint> {
 
 	protected RedisQueueInboundChannelAdapterSpec(String queueName, RedisConnectionFactory connectionFactory) {
 		this.target = new RedisQueueMessageDrivenEndpoint(queueName, connectionFactory);
 	}
 
 	/**
+	 * Specify the RedisSerializer to deserialize the body of Redis messages.
 	 * @param serializer the serializer
 	 * @return the spec
 	 * @see RedisQueueMessageDrivenEndpoint#setSerializer(RedisSerializer)
@@ -48,6 +50,7 @@ public class RedisQueueInboundChannelAdapterSpec extends MessageProducerSpec<Red
 	}
 
 	/**
+	 * Specify whether expects data from the Redis queue to contain entire Message instances.
 	 * @param expectMessage the expectMessage
 	 * @return the spec
 	 * @see RedisQueueMessageDrivenEndpoint#setExpectMessage(boolean)
@@ -58,6 +61,7 @@ public class RedisQueueInboundChannelAdapterSpec extends MessageProducerSpec<Red
 	}
 
 	/**
+	 * Specify the timeout for 'pop' operation to wait for a Redis message from the Redis Queue.
 	 * @param receiveTimeout the receiveTimeout
 	 * @return the spec
 	 * @see RedisQueueMessageDrivenEndpoint#setReceiveDuration(Duration)
@@ -68,6 +72,7 @@ public class RedisQueueInboundChannelAdapterSpec extends MessageProducerSpec<Red
 	}
 
 	/**
+	 * Specify the timeout for 'pop' operation to wait for a Redis message from the Redis Queue.
 	 * @param receiveTimeout the receiveTimeout
 	 * @return the spec
 	 * @see RedisQueueMessageDrivenEndpoint#setReceiveTimeout(long)
@@ -78,6 +83,7 @@ public class RedisQueueInboundChannelAdapterSpec extends MessageProducerSpec<Red
 	}
 
 	/**
+	 * Specify an {@link Executor} for the underlying listening task.
 	 * @param taskExecutor the taskExecutor
 	 * @return the spec
 	 * @see RedisQueueMessageDrivenEndpoint#setTaskExecutor(Executor)
@@ -88,6 +94,8 @@ public class RedisQueueInboundChannelAdapterSpec extends MessageProducerSpec<Red
 	}
 
 	/**
+	 * Specify the time in milliseconds for the underlying listening task should sleep
+	 * after exceptions on the 'pop' operation.
 	 * @param recoveryInterval the recoveryInterval
 	 * @return the spec
 	 * @see RedisQueueMessageDrivenEndpoint#setRecoveryInterval(long)
@@ -98,6 +106,7 @@ public class RedisQueueInboundChannelAdapterSpec extends MessageProducerSpec<Red
 	}
 
 	/**
+	 * Specify use "right pop" or "left pop" to read messages from the Redis Queue.
 	 * @param rightPop the rightPop
 	 * @return the spec
 	 * @see RedisQueueMessageDrivenEndpoint#setRightPop(boolean)

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueOutboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueOutboundChannelAdapterSpec.java
@@ -29,7 +29,8 @@ import org.springframework.integration.redis.outbound.RedisQueueOutboundChannelA
  *
  * @since 7.1
  */
-public class RedisQueueOutboundChannelAdapterSpec extends MessageHandlerSpec<RedisQueueOutboundChannelAdapterSpec, RedisQueueOutboundChannelAdapter> {
+public class RedisQueueOutboundChannelAdapterSpec extends
+		MessageHandlerSpec<RedisQueueOutboundChannelAdapterSpec, RedisQueueOutboundChannelAdapter> {
 
 	protected RedisQueueOutboundChannelAdapterSpec(String queueName, RedisConnectionFactory connectionFactory) {
 		this.target = new RedisQueueOutboundChannelAdapter(queueName, connectionFactory);
@@ -40,6 +41,7 @@ public class RedisQueueOutboundChannelAdapterSpec extends MessageHandlerSpec<Red
 	}
 
 	/**
+	 * Specify send only the payload or the entire Message to the Redis queue.
 	 * @param extractPayload the extractPayload
 	 * @return the spec
 	 * @see RedisQueueOutboundChannelAdapter#setExtractPayload(boolean)
@@ -50,6 +52,7 @@ public class RedisQueueOutboundChannelAdapterSpec extends MessageHandlerSpec<Red
 	}
 
 	/**
+	 * Specify the RedisSerializer to serialize data before sending to the Redis Queue.
 	 * @param serializer the serializer
 	 * @return the spec
 	 * @see RedisQueueOutboundChannelAdapter#setSerializer(RedisSerializer)
@@ -60,6 +63,7 @@ public class RedisQueueOutboundChannelAdapterSpec extends MessageHandlerSpec<Red
 	}
 
 	/**
+	 * Specify use "left push" or "right push" to write messages to the Redis Queue.
 	 * @param leftPush the leftPush
 	 * @return the spec
 	 * @see RedisQueueOutboundChannelAdapter#setLeftPush(boolean)

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueOutboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueOutboundChannelAdapterSpec.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.redis.dsl;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.expression.Expression;
+import org.springframework.integration.dsl.MessageHandlerSpec;
+import org.springframework.integration.redis.outbound.RedisQueueOutboundChannelAdapter;
+
+/**
+ * A {@link MessageHandlerSpec} for a {@link RedisQueueOutboundChannelAdapterSpec}.
+ *
+ * @author Jiandong Ma
+ *
+ * @since 7.1
+ */
+public class RedisQueueOutboundChannelAdapterSpec extends MessageHandlerSpec<RedisQueueOutboundChannelAdapterSpec, RedisQueueOutboundChannelAdapter> {
+
+	protected RedisQueueOutboundChannelAdapterSpec(String queueName, RedisConnectionFactory connectionFactory) {
+		this.target = new RedisQueueOutboundChannelAdapter(queueName, connectionFactory);
+	}
+
+	protected RedisQueueOutboundChannelAdapterSpec(Expression queueExpression, RedisConnectionFactory connectionFactory) {
+		this.target = new RedisQueueOutboundChannelAdapter(queueExpression, connectionFactory);
+	}
+
+	/**
+	 * @param extractPayload the extractPayload
+	 * @return the spec
+	 * @see RedisQueueOutboundChannelAdapter#setExtractPayload(boolean)
+	 */
+	public RedisQueueOutboundChannelAdapterSpec extractPayload(boolean extractPayload) {
+		this.target.setExtractPayload(extractPayload);
+		return this;
+	}
+
+	/**
+	 * @param serializer the serializer
+	 * @return the spec
+	 * @see RedisQueueOutboundChannelAdapter#setSerializer(RedisSerializer)
+	 */
+	public RedisQueueOutboundChannelAdapterSpec serializer(RedisSerializer<?> serializer) {
+		this.target.setSerializer(serializer);
+		return this;
+	}
+
+	/**
+	 * @param leftPush the leftPush
+	 * @return the spec
+	 * @see RedisQueueOutboundChannelAdapter#setLeftPush(boolean)
+	 */
+	public RedisQueueOutboundChannelAdapterSpec leftPush(boolean leftPush) {
+		this.target.setLeftPush(leftPush);
+		return this;
+	}
+
+}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueOutboundChannelAdapterSpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueOutboundChannelAdapterSpec.java
@@ -23,7 +23,7 @@ import org.springframework.integration.dsl.MessageHandlerSpec;
 import org.springframework.integration.redis.outbound.RedisQueueOutboundChannelAdapter;
 
 /**
- * A {@link MessageHandlerSpec} for a {@link RedisQueueOutboundChannelAdapterSpec}.
+ * A {@link MessageHandlerSpec} for a {@link RedisQueueOutboundChannelAdapter}.
  *
  * @author Jiandong Ma
  *

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
@@ -65,6 +65,10 @@ class RedisTests implements RedisContainerTest {
 
 	static final String TOPIC_FOR_OUTBOUND_CHANNEL_ADAPTER = "dslOutboundChannelAdapterTopic";
 
+	static final String QUEUE_NAME_FOR_QUEUE_INBOUND_CHANNEL_ADAPTER = "dslQueueInboundChannelAdapter";
+
+	static final String QUEUE_NAME_FOR_QUEUE_OUTBOUND_CHANNEL_ADAPTER = "dslQueueOutboundChannelAdapter";
+
 	@Autowired
 	RedisConnectionFactory connectionFactory;
 
@@ -77,6 +81,13 @@ class RedisTests implements RedisContainerTest {
 	@Autowired
 	@Qualifier("outboundChannelAdapterFlow.input")
 	MessageChannel outboundChannelAdapterInputChannel;
+
+	@Autowired
+	QueueChannel queueInboundChannelAdapterOutputChannel;
+
+	@Autowired
+	@Qualifier("queueOutboundChannelAdapterFlow.input")
+	MessageChannel queueOutboundChannelAdapterInputChannel;
 
 	@Test
 	void testInboundChannelAdapterFlow() throws Exception {
@@ -147,6 +158,46 @@ class RedisTests implements RedisContainerTest {
 		container.stop();
 	}
 
+	@Test
+	void testQueueInboundChannelAdapterFlow() {
+		// Given
+		int numToTest = 10;
+		StringRedisTemplate redisTemplate = new StringRedisTemplate(connectionFactory);
+		var listOps = redisTemplate.boundListOps(QUEUE_NAME_FOR_QUEUE_INBOUND_CHANNEL_ADAPTER);
+		for (int i = 0; i < numToTest; i++) {
+			listOps.leftPush("queue-inbound-message-" + i);
+		}
+
+		for (int i = 0; i < numToTest; i++) {
+			// When
+			Message<?> message = queueInboundChannelAdapterOutputChannel.receive(10000);
+			// Then
+			assertThat(message).isNotNull()
+					.extracting(Message::getPayload)
+					.isEqualTo("queue-inbound-message-" + i);
+		}
+	}
+
+	@Test
+	void testQueueOutboundChannelAdapterFlow() {
+		// Given
+		int numToTest = 10;
+		for (int i = 0; i < numToTest; i++) {
+			queueOutboundChannelAdapterInputChannel.send(MessageBuilder.withPayload("queue-outbound-message-" + i).build());
+		}
+
+		StringRedisTemplate redisTemplate = new StringRedisTemplate(connectionFactory);
+		var listOps = redisTemplate.boundListOps(QUEUE_NAME_FOR_QUEUE_OUTBOUND_CHANNEL_ADAPTER);
+		for (int i = 0; i < numToTest; i++) {
+			// When
+			String msg = listOps.rightPop();
+			// Then
+			assertThat(msg)
+					.isNotNull()
+					.isEqualTo("queue-outbound-message-" + i);
+		}
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@EnableIntegration
 	static class Config {
@@ -171,6 +222,26 @@ class RedisTests implements RedisContainerTest {
 			return flow -> flow
 					.handle(Redis.outboundChannelAdapter(redisConnectionFactory)
 							.topicExpression(new LiteralExpression(TOPIC_FOR_OUTBOUND_CHANNEL_ADAPTER)));
+		}
+
+		@Bean
+		IntegrationFlow queueInboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory) {
+			return IntegrationFlow.from(Redis
+							.queueInboundChannelAdapter(QUEUE_NAME_FOR_QUEUE_INBOUND_CHANNEL_ADAPTER, redisConnectionFactory)
+							.serializer(RedisSerializer.string())
+							.rightPop(true)
+					)
+					.channel(c -> c.queue("queueInboundChannelAdapterOutputChannel"))
+					.get();
+		}
+
+		@Bean
+		IntegrationFlow queueOutboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory) {
+			return flow -> flow
+					.handle(Redis.queueOutboundChannelAdapter(QUEUE_NAME_FOR_QUEUE_OUTBOUND_CHANNEL_ADAPTER, redisConnectionFactory)
+							.serializer(RedisSerializer.string())
+							.leftPush(true)
+					);
 		}
 
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
@@ -229,7 +229,6 @@ class RedisTests implements RedisContainerTest {
 			return IntegrationFlow.from(Redis
 							.queueInboundChannelAdapter(QUEUE_NAME_FOR_QUEUE_INBOUND_CHANNEL_ADAPTER, redisConnectionFactory)
 							.serializer(RedisSerializer.string())
-							.rightPop(true)
 					)
 					.channel(c -> c.queue("queueInboundChannelAdapterOutputChannel"))
 					.get();
@@ -240,7 +239,6 @@ class RedisTests implements RedisContainerTest {
 			return flow -> flow
 					.handle(Redis.queueOutboundChannelAdapter(QUEUE_NAME_FOR_QUEUE_OUTBOUND_CHANNEL_ADAPTER, redisConnectionFactory)
 							.serializer(RedisSerializer.string())
-							.leftPush(true)
 					);
 		}
 

--- a/src/reference/antora/modules/ROOT/pages/redis.adoc
+++ b/src/reference/antora/modules/ROOT/pages/redis.adoc
@@ -370,6 +370,7 @@ RedisQueueMessageDrivenEndpoint queueInboundChannelAdapter() {
     adapter.setExpectMessage(); <11>
     adapter.setTaskExecutor(); <12>
     adapter.setRightPop(); <13>
+    return adapter;
 }
 ----
 
@@ -476,6 +477,7 @@ RedisQueueOutboundChannelAdapter queueOutboundChannelAdapter() {
     adapter.setSerializer(); <6>
     adapter.setExtractPayload(); <7>
     adapter.setLeftPush(); <8>
+    return adapter;
 }
 ----
 

--- a/src/reference/antora/modules/ROOT/pages/redis.adoc
+++ b/src/reference/antora/modules/ROOT/pages/redis.adoc
@@ -148,13 +148,17 @@ Java DSL::
 RedisConnectionFactory connectionFactory() {
     return RedisContainerTest.connectionFactory();
 }
-
+@Bean
+MessageConverter testConverter() {
+    return new SimpleMessageConverter();
+}
 @Bean
 IntegrationFlow inboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory) {
 
     return IntegrationFlow.from(Redis
                     .inboundChannelAdapter(redisConnectionFactory)
-                    .topics(TOPIC_FOR_INBOUND_CHANNEL_ADAPTER))
+                    .topics(TOPIC_FOR_INBOUND_CHANNEL_ADAPTER)
+                    .messageConverter(testConverter()))
             .channel(c -> c.queue("inboundChannelAdapterQueueChannel"))
             .get();
 }
@@ -169,12 +173,16 @@ Java::
 RedisConnectionFactory connectionFactory() {
     return RedisContainerTest.connectionFactory();
 }
-
+@Bean
+MessageConverter testConverter() {
+    return new SimpleMessageConverter();
+}
 @Bean
 RedisInboundChannelAdapter inboundChannelAdapter(RedisConnectionFactory connectionFactory) {
 	var adapter = new RedisInboundChannelAdapter(connectionFactory);
 	adapter.setTopics(redisChannelName);
 	adapter.setOutputChannel(channel);
+	adapter.setMessageConverter(testConverter());
 	return adapter;
 }
 ----
@@ -241,10 +249,16 @@ RedisConnectionFactory connectionFactory() {
 }
 
 @Bean
+MessageConverter testConverter() {
+    return new SimpleMessageConverter();
+}
+
+@Bean
 IntegrationFlow outboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory) {
     return flow -> flow
             .handle(Redis.outboundChannelAdapter(redisConnectionFactory)
-                    .topicExpression(new LiteralExpression(TOPIC_FOR_OUTBOUND_CHANNEL_ADAPTER)));
+                    .topicExpression(new LiteralExpression(TOPIC_FOR_OUTBOUND_CHANNEL_ADAPTER))
+                    .messageConverter(testConverter()));
 }
 ----
 
@@ -258,9 +272,15 @@ RedisConnectionFactory connectionFactory() {
 }
 
 @Bean
+MessageConverter testConverter() {
+    return new SimpleMessageConverter();
+}
+
+@Bean
 RedisPublishingMessageHandler outboundChannelAdapter(RedisConnectionFactory connectionFactory) {
 	var handler = new RedisPublishingMessageHandler(connectionFactory);
 	handler.setTopicExpression(new LiteralExpression(topic));
+    handler.setMessageConverter(testConverter());
 	return handler;
 }
 ----
@@ -301,7 +321,61 @@ It uses an internal listener thread and does not use a poller.
 
 The following listing shows all the available attributes for `queue-inbound-channel-adapter`:
 
-[source,xml]
+[tabs]
+======
+Java DSL::
++
+[source, java, role="primary"]
+----
+@Bean
+IntegrationFlow queueInboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory) {
+    return IntegrationFlow.from(Redis
+                    .queueInboundChannelAdapter(
+							queueName, <6>
+                            redisConnectionFactory) <5>
+                    .id() <1>
+                    .outputChannel() <2>
+                    .autoStartup() <3>
+                    .phase()   <4>
+                    .errorChannel() <7>
+                    .serializer() <8>
+                    .receiveTimeout() <9>
+                    .recoveryInterval() <10>
+                    .expectMessage() <11>
+                    .taskExecutor() <12>
+                    .rightPop() <13>
+            )
+            .get();
+}
+----
+
+Java::
++
+[source, java, role="secondary"]
+----
+@Bean
+RedisQueueMessageDrivenEndpoint queueInboundChannelAdapter() {
+    var adapter = new RedisQueueMessageDrivenEndpoint(
+            queueName, <6>
+            redisConnectionFactory <5>
+    );
+    adapter.setBeanName(); <1>
+    adapter.setOutputChannel(); <2>
+    adapter.setAutoStartup(); <3>
+    adapter.setPhase(); <4>
+    adapter.setErrorChannel(); <7>
+    adapter.setSerializer(); <8>
+    adapter.setReceiveTimeout(); <9>
+    adapter.setRecoveryInterval(); <10>
+    adapter.setExpectMessage(); <11>
+    adapter.setTaskExecutor(); <12>
+    adapter.setRightPop(); <13>
+}
+----
+
+XML::
++
+[source,xml, role="secondary"]
 ----
 <int-redis:queue-inbound-channel-adapter id=""  <1>
                     channel=""  <2>
@@ -318,6 +392,8 @@ The following listing shows all the available attributes for `queue-inbound-chan
                     right-pop=""/>  <13>
 
 ----
+
+======
 
 <1> The component bean name.
 If `channel` attribute not provided, a `DirectChannel` is created and registered in the application context with this `id` attribute as the bean name.
@@ -363,7 +439,49 @@ Spring Integration 3.0 introduced a queue outbound channel adapter to "`push`" t
 By default, it uses "`left push`", but "`right push`" can be configured instead.
 The following listing shows all the available attributes for a Redis `queue-outbound-channel-adapter`:
 
-[source,xml]
+[tabs]
+======
+Java DSL::
++
+[source, java, role="primary"]
+----
+@Bean
+IntegrationFlow queueOutboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory) {
+    return IntegrationFlow.from("inputChannel") <2>
+            .handle(Redis.queueOutboundChannelAdapter(
+					    queueName <4>
+                        or queueExpression, <5>
+                        redisConnectionFactory) <3>
+                    .serializer(RedisSerializer.string()) <6>
+                    .extractPayload() <7>
+                    .leftPush() <8>
+            , e->e.id()) <1>
+            .get();
+}
+----
+
+Java::
++
+[source, Java, role="secondary"]
+----
+@Bean
+@ServiceActivator(inputChannel = "channel") <2>
+RedisQueueOutboundChannelAdapter queueOutboundChannelAdapter() {
+	var adapter = new RedisQueueOutboundChannelAdapter(
+		queueName   <4>
+        or queueExpression,  <5>
+        redisConnectionFactory  <3>
+    );
+    adapter.setBeanName(); <1>
+    adapter.setSerializer(); <6>
+    adapter.setExtractPayload(); <7>
+    adapter.setLeftPush(); <8>
+}
+----
+
+XML::
++
+[source, xml, role="secondary"]
 ----
 <int-redis:queue-outbound-channel-adapter id=""  <1>
                     channel=""  <2>
@@ -375,6 +493,8 @@ The following listing shows all the available attributes for a Redis `queue-outb
                     left-push=""/>  <8>
 
 ----
+
+======
 
 <1> The component bean name.
 If the `channel` attribute is not provided, a `DirectChannel` is created and registered in the application context with this `id` attribute as the bean name.

--- a/src/reference/antora/modules/ROOT/pages/redis.adoc
+++ b/src/reference/antora/modules/ROOT/pages/redis.adoc
@@ -453,7 +453,7 @@ IntegrationFlow queueOutboundChannelAdapterFlow(RedisConnectionFactory redisConn
 					    queueName <4>
                         or queueExpression, <5>
                         redisConnectionFactory) <3>
-                    .serializer(RedisSerializer.string()) <6>
+                    .serializer() <6>
                     .extractPayload() <7>
                     .leftPush() <8>
             , e->e.id()) <1>


### PR DESCRIPTION
Related to: #8108

Also add respective Java DSL and Java usage in redis.adoc.

Additionally, add missing MessageConverter sample for channel adapters in redis.adoc.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
