### PR TITLE
Use reflection instead of serialization hints

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/aot/FileRuntimeHints.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/aot/FileRuntimeHints.java
@@ -20,9 +20,10 @@ import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
-import org.springframework.aot.hint.SerializationHints;
 import org.springframework.integration.file.splitter.FileSplitter;
 
 /**
@@ -36,9 +37,12 @@ class FileRuntimeHints implements RuntimeHintsRegistrar {
 
 	@Override
 	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
-		SerializationHints serializationHints = hints.serialization();
+		ReflectionHints reflectionHints = hints.reflection();
+
 		Stream.of(FileSplitter.FileMarker.class, FileSplitter.FileMarker.Mark.class)
-				.forEach(serializationHints::registerType);
+				.forEach(clazz -> reflectionHints.registerType(clazz,
+						MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS,
+						MemberCategory.INVOKE_PUBLIC_METHODS));
 	}
 
 }


### PR DESCRIPTION
Replace `SerializationHints` with `ReflectionHints` for `FileSplitter.FileMarker` and `FileSplitter.FileMarker.Mark` AOT registrations.
- SerializtionHints have been deprecated and scheduled for removal
- Register `INVOKE_PUBLIC_CONSTRUCTORS` and `INVOKE_PUBLIC_METHODS` member categories

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
