### PR TITLE
Add JmsTemplate overloads to JMS DSL channel specs

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.jms.config;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -70,6 +71,10 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 	private final boolean messageDriven;
 
 	private JmsTemplate jmsTemplate = new DynamicJmsTemplate();
+
+	private boolean jmsTemplateExplicitlySet;
+
+	private final List<String> templateDelegatingOptions = new ArrayList<>();
 
 	private @Nullable Class<? extends AbstractMessageListenerContainer> containerType;
 
@@ -165,30 +170,37 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 	 */
 
 	public void setDeliveryPersistent(boolean deliveryPersistent) {
+		recordJmsTemplateOption("deliveryPersistent");
 		this.jmsTemplate.setDeliveryPersistent(deliveryPersistent);
 	}
 
 	public void setExplicitQosEnabled(boolean explicitQosEnabled) {
+		recordJmsTemplateOption("explicitQosEnabled");
 		this.jmsTemplate.setExplicitQosEnabled(explicitQosEnabled);
 	}
 
 	public void setMessageConverter(MessageConverter messageConverter) {
+		recordJmsTemplateOption("messageConverter");
 		this.jmsTemplate.setMessageConverter(messageConverter);
 	}
 
 	public void setMessageIdEnabled(boolean messageIdEnabled) {
+		recordJmsTemplateOption("messageIdEnabled");
 		this.jmsTemplate.setMessageIdEnabled(messageIdEnabled);
 	}
 
 	public void setMessageTimestampEnabled(boolean messageTimestampEnabled) {
+		recordJmsTemplateOption("messageTimestampEnabled");
 		this.jmsTemplate.setMessageTimestampEnabled(messageTimestampEnabled);
 	}
 
 	public void setPriority(int priority) {
+		recordJmsTemplateOption("priority");
 		this.jmsTemplate.setPriority(priority);
 	}
 
 	public void setTimeToLive(long timeToLive) {
+		recordJmsTemplateOption("timeToLive");
 		this.jmsTemplate.setTimeToLive(timeToLive);
 	}
 
@@ -237,6 +249,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	public void setConnectionFactory(ConnectionFactory connectionFactory) {
 		this.connectionFactory = connectionFactory;
+		recordJmsTemplateOption("connectionFactory");
 		this.jmsTemplate.setConnectionFactory(this.connectionFactory);
 	}
 
@@ -255,6 +268,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	public void setDestinationResolver(DestinationResolver destinationResolver) {
 		this.destinationResolver = destinationResolver;
+		recordJmsTemplateOption("destinationResolver");
 		this.jmsTemplate.setDestinationResolver(destinationResolver);
 	}
 
@@ -303,16 +317,19 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	public void setPubSubDomain(boolean pubSubDomain) {
 		this.pubSubDomain = pubSubDomain;
+		recordJmsTemplateOption("pubSubDomain");
 		this.jmsTemplate.setPubSubDomain(pubSubDomain);
 	}
 
 	public void setPubSubNoLocal(boolean pubSubNoLocal) {
 		this.pubSubNoLocal = pubSubNoLocal;
+		recordJmsTemplateOption("pubSubNoLocal");
 		this.jmsTemplate.setPubSubNoLocal(pubSubNoLocal);
 	}
 
 	public void setReceiveTimeout(long receiveTimeout) {
 		this.receiveTimeout = receiveTimeout;
+		recordJmsTemplateOption("receiveTimeout");
 		this.jmsTemplate.setReceiveTimeout(receiveTimeout);
 	}
 
@@ -323,15 +340,30 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	public void setSessionAcknowledgeMode(int sessionAcknowledgeMode) {
 		this.sessionAcknowledgeMode = sessionAcknowledgeMode;
+		recordJmsTemplateOption("sessionAcknowledgeMode");
 		this.jmsTemplate.setSessionAcknowledgeMode(sessionAcknowledgeMode);
 	}
 
+	/**
+	 * The template to be used by the Factory.
+	 * When an external {@link JmsTemplate} is provided, none of the individual template options
+	 * (e.g. {@code deliveryPersistent}, {@code connectionFactory}, {@code receiveTimeout}, etc.)
+	 * may be set on this factory bean — configure them directly on the provided template instead.
+	 * @param jmsTemplate the {@link JmsTemplate} to build on
+	 * @since 7.1
+	 */
 	public void setJmsTemplate(JmsTemplate jmsTemplate) {
 		this.jmsTemplate = jmsTemplate;
+		this.jmsTemplateExplicitlySet = true;
+	}
+
+	private void recordJmsTemplateOption(String option) {
+		this.templateDelegatingOptions.add(option);
 	}
 
 	public void setSessionTransacted(boolean sessionTransacted) {
 		this.sessionTransacted = sessionTransacted;
+		recordJmsTemplateOption("sessionTransacted");
 		this.jmsTemplate.setSessionTransacted(sessionTransacted);
 	}
 
@@ -411,6 +443,15 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 	private void initializeJmsTemplate() {
 		Assert.isTrue(this.destination != null ^ this.destinationName != null,
 				"Exactly one of destination or destinationName is required.");
+		Assert.isTrue(!this.jmsTemplateExplicitlySet || this.templateDelegatingOptions.isEmpty(),
+				() -> {
+					String quoted = this.templateDelegatingOptions.stream()
+							.map(opt -> "'" + opt + "'")
+							.reduce((a, b) -> a + ", " + b)
+							.orElse("");
+					return "The following options must be provided on the externally configured JmsTemplate " +
+							"instead of on this factory bean: " + quoted;
+				});
 		JavaUtils.INSTANCE
 				.acceptIfNotNull(this.destination, this.jmsTemplate::setDefaultDestination)
 				.acceptIfNotNull(this.destinationName, this.jmsTemplate::setDefaultDestinationName);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -55,6 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 2.0
  */
@@ -68,7 +69,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	private final boolean messageDriven;
 
-	private final JmsTemplate jmsTemplate = new DynamicJmsTemplate();
+	private JmsTemplate jmsTemplate = new DynamicJmsTemplate();
 
 	private @Nullable Class<? extends AbstractMessageListenerContainer> containerType;
 
@@ -323,6 +324,10 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 	public void setSessionAcknowledgeMode(int sessionAcknowledgeMode) {
 		this.sessionAcknowledgeMode = sessionAcknowledgeMode;
 		this.jmsTemplate.setSessionAcknowledgeMode(sessionAcknowledgeMode);
+	}
+
+	public void setJmsTemplate(JmsTemplate jmsTemplate) {
+		this.jmsTemplate = jmsTemplate;
 	}
 
 	public void setSessionTransacted(boolean sessionTransacted) {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/config/JmsChannelFactoryBean.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.jms.config;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executor;
 
@@ -74,7 +73,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	private boolean jmsTemplateExplicitlySet;
 
-	private final List<String> templateDelegatingOptions = new ArrayList<>();
+	private boolean defaultTemplatePropertySet;
 
 	private @Nullable Class<? extends AbstractMessageListenerContainer> containerType;
 
@@ -170,37 +169,37 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 	 */
 
 	public void setDeliveryPersistent(boolean deliveryPersistent) {
-		recordJmsTemplateOption("deliveryPersistent");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setDeliveryPersistent(deliveryPersistent);
 	}
 
 	public void setExplicitQosEnabled(boolean explicitQosEnabled) {
-		recordJmsTemplateOption("explicitQosEnabled");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setExplicitQosEnabled(explicitQosEnabled);
 	}
 
 	public void setMessageConverter(MessageConverter messageConverter) {
-		recordJmsTemplateOption("messageConverter");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setMessageConverter(messageConverter);
 	}
 
 	public void setMessageIdEnabled(boolean messageIdEnabled) {
-		recordJmsTemplateOption("messageIdEnabled");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setMessageIdEnabled(messageIdEnabled);
 	}
 
 	public void setMessageTimestampEnabled(boolean messageTimestampEnabled) {
-		recordJmsTemplateOption("messageTimestampEnabled");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setMessageTimestampEnabled(messageTimestampEnabled);
 	}
 
 	public void setPriority(int priority) {
-		recordJmsTemplateOption("priority");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setPriority(priority);
 	}
 
 	public void setTimeToLive(long timeToLive) {
-		recordJmsTemplateOption("timeToLive");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setTimeToLive(timeToLive);
 	}
 
@@ -249,7 +248,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	public void setConnectionFactory(ConnectionFactory connectionFactory) {
 		this.connectionFactory = connectionFactory;
-		recordJmsTemplateOption("connectionFactory");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setConnectionFactory(this.connectionFactory);
 	}
 
@@ -268,7 +267,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	public void setDestinationResolver(DestinationResolver destinationResolver) {
 		this.destinationResolver = destinationResolver;
-		recordJmsTemplateOption("destinationResolver");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setDestinationResolver(destinationResolver);
 	}
 
@@ -317,19 +316,19 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	public void setPubSubDomain(boolean pubSubDomain) {
 		this.pubSubDomain = pubSubDomain;
-		recordJmsTemplateOption("pubSubDomain");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setPubSubDomain(pubSubDomain);
 	}
 
 	public void setPubSubNoLocal(boolean pubSubNoLocal) {
 		this.pubSubNoLocal = pubSubNoLocal;
-		recordJmsTemplateOption("pubSubNoLocal");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setPubSubNoLocal(pubSubNoLocal);
 	}
 
 	public void setReceiveTimeout(long receiveTimeout) {
 		this.receiveTimeout = receiveTimeout;
-		recordJmsTemplateOption("receiveTimeout");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setReceiveTimeout(receiveTimeout);
 	}
 
@@ -340,7 +339,7 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 
 	public void setSessionAcknowledgeMode(int sessionAcknowledgeMode) {
 		this.sessionAcknowledgeMode = sessionAcknowledgeMode;
-		recordJmsTemplateOption("sessionAcknowledgeMode");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setSessionAcknowledgeMode(sessionAcknowledgeMode);
 	}
 
@@ -357,13 +356,13 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 		this.jmsTemplateExplicitlySet = true;
 	}
 
-	private void recordJmsTemplateOption(String option) {
-		this.templateDelegatingOptions.add(option);
+	private void recordJmsTemplateOption() {
+		this.defaultTemplatePropertySet = true;
 	}
 
 	public void setSessionTransacted(boolean sessionTransacted) {
 		this.sessionTransacted = sessionTransacted;
-		recordJmsTemplateOption("sessionTransacted");
+		recordJmsTemplateOption();
 		this.jmsTemplate.setSessionTransacted(sessionTransacted);
 	}
 
@@ -443,15 +442,9 @@ public class JmsChannelFactoryBean extends AbstractFactoryBean<AbstractJmsChanne
 	private void initializeJmsTemplate() {
 		Assert.isTrue(this.destination != null ^ this.destinationName != null,
 				"Exactly one of destination or destinationName is required.");
-		Assert.isTrue(!this.jmsTemplateExplicitlySet || this.templateDelegatingOptions.isEmpty(),
-				() -> {
-					String quoted = this.templateDelegatingOptions.stream()
-							.map(opt -> "'" + opt + "'")
-							.reduce((a, b) -> a + ", " + b)
-							.orElse("");
-					return "The following options must be provided on the externally configured JmsTemplate " +
-							"instead of on this factory bean: " + quoted;
-				});
+		Assert.isTrue(!this.jmsTemplateExplicitlySet || !this.defaultTemplatePropertySet,
+				() -> "JmsTemplate properties must be configured on the externally supplied JmsTemplate, " +
+						"not on the factory bean.");
 		JavaUtils.INSTANCE
 				.acceptIfNotNull(this.destination, this.jmsTemplate::setDefaultDestination)
 				.acceptIfNotNull(this.destinationName, this.jmsTemplate::setDefaultDestinationName);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
@@ -48,7 +48,7 @@ public final class Jms {
 	}
 
 	/**
-	 * The template to produce a {@link JmsPollableMessageChannelSpec}.
+	 * The factory to produce a {@link JmsPollableMessageChannelSpec}.
 	 * @param jmsTemplate the {@link JmsTemplate} to build on
 	 * @return the {@link JmsPollableMessageChannelSpec} instance
 	 * @since 7.1

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/Jms.java
@@ -30,6 +30,7 @@ import org.springframework.jms.listener.DefaultMessageListenerContainer;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -47,6 +48,18 @@ public final class Jms {
 	}
 
 	/**
+	 * The template to produce a {@link JmsPollableMessageChannelSpec}.
+	 * @param jmsTemplate the {@link JmsTemplate} to build on
+	 * @return the {@link JmsPollableMessageChannelSpec} instance
+	 * @since 7.1
+	 */
+	public static JmsPollableMessageChannelSpec<?, PollableJmsChannel> pollableChannel(
+			JmsTemplate jmsTemplate) {
+
+		return new JmsPollableMessageChannelSpec<>(jmsTemplate);
+	}
+
+	/**
 	 * The factory to produce a {@link JmsPollableMessageChannelSpec}.
 	 * @param id                the bean name for the target {@code PollableChannel} component
 	 * @param connectionFactory the JMS ConnectionFactory to build on
@@ -61,12 +74,36 @@ public final class Jms {
 	}
 
 	/**
+	 * The template to produce a {@link JmsPollableMessageChannelSpec}.
+	 * @param id the bean name for the target {@code PollableChannel} component
+	 * @param jmsTemplate the {@link JmsTemplate} to build on
+	 * @return the {@link JmsPollableMessageChannelSpec} instance
+	 * @since 7.1
+	 */
+	public static JmsPollableMessageChannelSpec<?, PollableJmsChannel> pollableChannel(String id,
+			JmsTemplate jmsTemplate) {
+
+		JmsPollableMessageChannelSpec<?, PollableJmsChannel> spec = new JmsPollableMessageChannelSpec<>(jmsTemplate);
+		return spec.id(id);
+	}
+
+	/**
 	 * The factory to produce a {@link JmsMessageChannelSpec}.
 	 * @param connectionFactory the JMS ConnectionFactory to build on
 	 * @return the {@link JmsMessageChannelSpec} instance
 	 */
 	public static JmsMessageChannelSpec<?, ?> channel(ConnectionFactory connectionFactory) {
 		return new JmsMessageChannelSpec<>(connectionFactory);
+	}
+
+	/**
+	 * The factory to produce a {@link JmsMessageChannelSpec}.
+	 * @param jmsTemplate the {@link JmsTemplate} to build on
+	 * @return the {@link JmsMessageChannelSpec} instance
+	 * @since 7.1
+	 */
+	public static JmsMessageChannelSpec<?, ?> channel(JmsTemplate jmsTemplate) {
+		return new JmsMessageChannelSpec<>(jmsTemplate);
 	}
 
 	/**

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageChannelSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsMessageChannelSpec.java
@@ -23,6 +23,7 @@ import jakarta.jms.ConnectionFactory;
 import org.springframework.integration.jms.channel.AbstractJmsChannel;
 import org.springframework.integration.jms.channel.SubscribableJmsChannel;
 import org.springframework.integration.jms.config.JmsChannelFactoryBean;
+import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.ErrorHandler;
@@ -37,6 +38,7 @@ import org.springframework.util.ErrorHandler;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -45,6 +47,10 @@ public class JmsMessageChannelSpec<S extends JmsMessageChannelSpec<S, T>, T
 
 	protected JmsMessageChannelSpec(ConnectionFactory connectionFactory) {
 		super(new JmsChannelFactoryBean(true), connectionFactory);
+	}
+
+	protected JmsMessageChannelSpec(JmsTemplate jmsTemplate) {
+		super(new JmsChannelFactoryBean(true), jmsTemplate);
 	}
 
 	/**

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsPollableMessageChannelSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsPollableMessageChannelSpec.java
@@ -59,8 +59,6 @@ public class JmsPollableMessageChannelSpec<S extends JmsPollableMessageChannelSp
 
 		this.jmsChannelFactoryBean = jmsChannelFactoryBean;
 		this.jmsChannelFactoryBean.setConnectionFactory(connectionFactory);
-		this.jmsChannelFactoryBean.setSingleton(false);
-		this.jmsChannelFactoryBean.setBeanFactory(new DefaultListableBeanFactory());
 	}
 
 	protected JmsPollableMessageChannelSpec(JmsChannelFactoryBean jmsChannelFactoryBean,
@@ -68,8 +66,6 @@ public class JmsPollableMessageChannelSpec<S extends JmsPollableMessageChannelSp
 
 		this.jmsChannelFactoryBean = jmsChannelFactoryBean;
 		this.jmsChannelFactoryBean.setJmsTemplate(jmsTemplate);
-		this.jmsChannelFactoryBean.setSingleton(false);
-		this.jmsChannelFactoryBean.setBeanFactory(new DefaultListableBeanFactory());
 	}
 
 	@Override
@@ -235,6 +231,8 @@ public class JmsPollableMessageChannelSpec<S extends JmsPollableMessageChannelSp
 	@SuppressWarnings("unchecked")
 	protected T doGet() {
 		try {
+			this.jmsChannelFactoryBean.setSingleton(false);
+			this.jmsChannelFactoryBean.setBeanFactory(new DefaultListableBeanFactory());
 			this.channel = (T) this.jmsChannelFactoryBean.getObject();
 		}
 		catch (Exception e) {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsPollableMessageChannelSpec.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/dsl/JmsPollableMessageChannelSpec.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.integration.dsl.MessageChannelSpec;
 import org.springframework.integration.jms.channel.AbstractJmsChannel;
 import org.springframework.integration.jms.config.JmsChannelFactoryBean;
+import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.destination.DestinationResolver;
 
@@ -36,6 +37,7 @@ import org.springframework.jms.support.destination.DestinationResolver;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  *
  * @since 5.0
  */
@@ -48,11 +50,24 @@ public class JmsPollableMessageChannelSpec<S extends JmsPollableMessageChannelSp
 		this(new JmsChannelFactoryBean(false), connectionFactory);
 	}
 
+	protected JmsPollableMessageChannelSpec(JmsTemplate jmsTemplate) {
+		this(new JmsChannelFactoryBean(false), jmsTemplate);
+	}
+
 	protected JmsPollableMessageChannelSpec(JmsChannelFactoryBean jmsChannelFactoryBean,
 			ConnectionFactory connectionFactory) {
 
 		this.jmsChannelFactoryBean = jmsChannelFactoryBean;
 		this.jmsChannelFactoryBean.setConnectionFactory(connectionFactory);
+		this.jmsChannelFactoryBean.setSingleton(false);
+		this.jmsChannelFactoryBean.setBeanFactory(new DefaultListableBeanFactory());
+	}
+
+	protected JmsPollableMessageChannelSpec(JmsChannelFactoryBean jmsChannelFactoryBean,
+			JmsTemplate jmsTemplate) {
+
+		this.jmsChannelFactoryBean = jmsChannelFactoryBean;
+		this.jmsChannelFactoryBean.setJmsTemplate(jmsTemplate);
 		this.jmsChannelFactoryBean.setSingleton(false);
 		this.jmsChannelFactoryBean.setBeanFactory(new DefaultListableBeanFactory());
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelFactoryBeanTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelFactoryBeanTests.java
@@ -37,11 +37,12 @@ class JmsChannelFactoryBeanTests {
 		fb.setDestinationName("testQueue");
 		fb.setSessionTransacted(true);
 		fb.setJmsTemplate(new JmsTemplate());
+		fb.setBeanFactory(new StaticListableBeanFactory());
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(fb::createInstance)
-				.withMessageContaining("'sessionTransacted'")
-				.withMessageContaining("must be provided on the externally configured JmsTemplate");
+				.withMessageContaining("JmsTemplate properties must be configured on the externally supplied " +
+						"JmsTemplate, not on the factory bean.");
 	}
 
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelFactoryBeanTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/JmsChannelFactoryBeanTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.jms.config;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.jms.core.JmsTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * @author Glenn Renfro
+ */
+
+class JmsChannelFactoryBeanTests {
+
+	@Test
+	void optionSetBeforeExternalTemplateAlsoThrows() {
+		JmsChannelFactoryBean fb = new JmsChannelFactoryBean(false);
+		fb.setBeanName("testChannel");
+		fb.setDestinationName("testQueue");
+		fb.setSessionTransacted(true);
+		fb.setJmsTemplate(new JmsTemplate());
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(fb::createInstance)
+				.withMessageContaining("'sessionTransacted'")
+				.withMessageContaining("must be provided on the externally configured JmsTemplate");
+	}
+
+	@Test
+	void externalTemplateAloneDoesNotThrowGuard() {
+		JmsChannelFactoryBean fb = new JmsChannelFactoryBean(false);
+		fb.setBeanName("testChannel");
+		fb.setJmsTemplate(new JmsTemplate());
+		fb.setDestinationName("testQueue");
+		fb.setBeanFactory(new StaticListableBeanFactory());
+		assertThat(fb.createInstance()).isNotNull();
+	}
+
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/dsl/JmsTests.java
@@ -110,6 +110,10 @@ public class JmsTests extends ActiveMQMultiContextTests {
 	private PollableChannel outputChannel;
 
 	@Autowired
+	@Qualifier("flow2QueueChannel")
+	private PollableChannel flow2OutputChannel;
+
+	@Autowired
 	@Qualifier("jmsOutboundFlow.input")
 	private MessageChannel jmsOutboundInboundChannel;
 
@@ -126,6 +130,9 @@ public class JmsTests extends ActiveMQMultiContextTests {
 
 	@Autowired
 	private TestChannelInterceptor testChannelInterceptor;
+
+	@Autowired
+	private TestChannelInterceptor testChannelInterceptorTemplate;
 
 	@Autowired
 	private PollableChannel jmsPubSubBridgeChannel;
@@ -158,7 +165,7 @@ public class JmsTests extends ActiveMQMultiContextTests {
 	private CountDownLatch redeliveryLatch;
 
 	@Autowired
-	JmsTemplate jmsTemplate;
+	private JmsTemplate jmsTemplate;
 
 	@Autowired
 	TestObservationRegistry observationRegistry;
@@ -182,6 +189,23 @@ public class JmsTests extends ActiveMQMultiContextTests {
 		assertThat(((InterceptableChannel) this.outputChannel).getInterceptors())
 				.contains(this.testChannelInterceptor);
 		assertThat(this.testChannelInterceptor.invoked.get()).isGreaterThanOrEqualTo(5);
+
+	}
+
+	@Test
+	public void testPollingFlowWithTemplate() {
+		this.controlBus.send("'integerMessageSourceForTemplate.inboundChannelAdapter'.start");
+		assertThat(this.beanFactory.getBean("integerChannelFlow2")).isInstanceOf(FixedSubscriberChannel.class);
+		for (int i = 0; i < 5; i++) {
+			Message<?> message = this.flow2OutputChannel.receive(20000);
+			assertThat(message).isNotNull();
+			assertThat(message.getPayload()).isEqualTo("" + i);
+		}
+		this.controlBus.send("'integerMessageSourceForTemplate.inboundChannelAdapter'.stop");
+
+		assertThat(((InterceptableChannel) this.flow2OutputChannel).getInterceptors())
+				.contains(this.testChannelInterceptorTemplate);
+		assertThat(this.testChannelInterceptorTemplate.invoked.get()).isGreaterThanOrEqualTo(5);
 
 	}
 
@@ -373,12 +397,30 @@ public class JmsTests extends ActiveMQMultiContextTests {
 		}
 
 		@Bean
+		@InboundChannelAdapter(value = "flow2.input", autoStartup = "false", poller = @Poller(fixedRate = "100"))
+		public MessageSource<?> integerMessageSourceForTemplate() {
+			MethodInvokingMessageSource source = new MethodInvokingMessageSource();
+			source.setObject(new AtomicInteger());
+			source.setMethodName("getAndIncrement");
+			return source;
+		}
+
+		@Bean
 		public IntegrationFlow flow1() {
 			return f -> f
 					.fixedSubscriberChannel("integerChannel")
 					.transform("payload.toString()")
 					.channel(Jms.pollableChannel("flow1QueueChannel", amqFactory)
 							.destination("flow1QueueChannel"));
+		}
+
+		@Bean
+		public IntegrationFlow flow2(JmsTemplate jmsTemplate) {
+			return f -> f
+					.fixedSubscriberChannel("integerChannelFlow2")
+					.transform("payload.toString()")
+					.channel(Jms.pollableChannel("flow2QueueChannel", jmsTemplate)
+							.destination("flow2QueueChannel"));
 		}
 
 		@Bean
@@ -570,6 +612,12 @@ public class JmsTests extends ActiveMQMultiContextTests {
 		@Bean
 		@GlobalChannelInterceptor(patterns = "flow1QueueChannel")
 		ChannelInterceptor testChannelInterceptor() {
+			return new TestChannelInterceptor();
+		}
+
+		@Bean
+		@GlobalChannelInterceptor(patterns = "flow2QueueChannel")
+		ChannelInterceptor testChannelInterceptorTemplate() {
 			return new TestChannelInterceptor();
 		}
 

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -64,7 +64,7 @@ See xref:jms.adoc[] for more information.
 
 JMS DSL now allows the user to set the `JmsTemplate`.
 When using an external `JmsTemplate` it must be configured prior to when it is set, because the DSL can only set the
-configurations for the default `JMSTemplate`.
+configurations for the default `JmsTemplate`.
 
 [[x7.1-http-changes]]
 === HTTP Support Changes

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -62,6 +62,10 @@ See xref:redis.adoc[] for more information.
 JMS-backed message channels now map headers to JMS message properties and back.
 See xref:jms.adoc[] for more information.
 
+JMS DSL now allows the user to set the `JmsTemplate`.
+When using an external `JmsTemplate` it must be configured prior to when it is set, because the DSL can only set the
+configurations for the default `JMSTemplate`.
+
 [[x7.1-http-changes]]
 === HTTP Support Changes
 


### PR DESCRIPTION
Fixes: #6656

- Allow `JmsChannelFactoryBean` to accept an externally provided `JmsTemplate`
- Add `Jms.pollableChannel(JmsTemplate)` and `Jms.pollableChannel(String, JmsTemplate)` factory methods
- Add `Jms.channel(JmsTemplate)` factory method
- Add protected constructors to `JmsPollableMessageChannelSpec` and `JmsMessageChannelSpec` accepting `JmsTemplate`
- Add integration test verifying the polling flow with a `JmsTemplate`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
