### PR TITLE
GH-10931: Add setAllowedOriginPatterns support to ServerWebSocketContainer

### DIFF
--- a/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/ServerWebSocketContainer.java
+++ b/spring-integration-websocket/src/main/java/org/springframework/integration/websocket/ServerWebSocketContainer.java
@@ -51,6 +51,7 @@ import org.springframework.web.socket.sockjs.transport.TransportHandler;
  * @author Gary Russell
  * @author Christian Tzolov
  * @author Jooyoung Pyoung
+ * @author Marcin Nowicki
  *
  * @since 4.1
  */
@@ -68,6 +69,8 @@ public class ServerWebSocketContainer extends IntegrationWebSocketContainer
 	private @Nullable SockJsServiceOptions sockJsServiceOptions;
 
 	private String[] origins = {};
+
+	private String[] originPatterns = {};
 
 	private boolean autoStartup = true;
 
@@ -121,6 +124,18 @@ public class ServerWebSocketContainer extends IntegrationWebSocketContainer
 		return this;
 	}
 
+	/**
+	 * Specify origin patterns for which cross-origin requests are allowed from a browser.
+	 * @param originPatterns the origin patterns to allow.
+	 * @return the current ServerWebSocketContainer
+	 * @since 7.0.5
+	 * @see WebSocketHandlerRegistration#setAllowedOriginPatterns(String...)
+	 */
+	public ServerWebSocketContainer setAllowedOriginPatterns(String... originPatterns) {
+		this.originPatterns = Arrays.copyOf(originPatterns, originPatterns.length);
+		return this;
+	}
+
 	public ServerWebSocketContainer withSockJs(SockJsServiceOptions... sockJsServiceOptions) {
 		if (ObjectUtils.isEmpty(sockJsServiceOptions)) {
 			setSockJsServiceOptions(new SockJsServiceOptions());
@@ -164,8 +179,14 @@ public class ServerWebSocketContainer extends IntegrationWebSocketContainer
 
 		WebSocketHandlerRegistration registration =
 				registry.addHandler(webSocketHandler, this.paths)
-						.addInterceptors(this.interceptors)
-						.setAllowedOrigins(this.origins);
+						.addInterceptors(this.interceptors);
+
+		if (!ObjectUtils.isEmpty(this.originPatterns)) {
+			registration.setAllowedOriginPatterns(this.originPatterns);
+		}
+		if (!ObjectUtils.isEmpty(this.origins)) {
+			registration.setAllowedOrigins(this.origins);
+		}
 
 		if (this.handshakeHandler != null) {
 			registration.setHandshakeHandler(this.handshakeHandler);

--- a/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/server/ServerWebSocketContainerTests.java
+++ b/spring-integration-websocket/src/test/java/org/springframework/integration/websocket/server/ServerWebSocketContainerTests.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.websocket.server;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Answers;
+
+import org.springframework.integration.websocket.ServerWebSocketContainer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistration;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link ServerWebSocketContainer}.
+ *
+ * @author Marcin Nowicki
+ *
+ * @since 7.0.5
+ */
+public class ServerWebSocketContainerTests {
+
+	@Test
+	public void setAllowedOriginPatternsIsUsedInRegistration() {
+		WebSocketHandlerRegistry registry = mock();
+		WebSocketHandlerRegistration registration = mock(Answers.RETURNS_SELF);
+		given(registry.addHandler(any(), any(String[].class))).willReturn(registration);
+
+		ServerWebSocketContainer container = new ServerWebSocketContainer("/test")
+			.setAllowedOriginPatterns("https://example.com");
+
+		container.registerWebSocketHandlers(registry);
+
+		verify(registration).setAllowedOriginPatterns("https://example.com");
+		verify(registration, never()).setAllowedOrigins(any());
+	}
+
+	@Test
+	public void setAllowedOriginsIsUsedWhenNoPatternsConfigured() {
+		WebSocketHandlerRegistry registry = mock();
+		WebSocketHandlerRegistration registration = mock(Answers.RETURNS_SELF);
+		given(registry.addHandler(any(), any(String[].class))).willReturn(registration);
+
+		ServerWebSocketContainer container = new ServerWebSocketContainer("/test")
+			.setAllowedOrigins("https://example.com");
+
+		container.registerWebSocketHandlers(registry);
+
+		verify(registration).setAllowedOrigins("https://example.com");
+		verify(registration, never()).setAllowedOriginPatterns(any());
+	}
+
+	@Test
+	public void bothOriginsAndOriginPatternsAreUsedWhenBothConfigured() {
+		WebSocketHandlerRegistry registry = mock();
+		WebSocketHandlerRegistration registration = mock(Answers.RETURNS_SELF);
+		given(registry.addHandler(any(), any(String[].class))).willReturn(registration);
+
+		ServerWebSocketContainer container = new ServerWebSocketContainer("/test")
+			.setAllowedOrigins("https://example.com")
+			.setAllowedOriginPatterns("https://*.example.com");
+
+		container.registerWebSocketHandlers(registry);
+
+		verify(registration).setAllowedOriginPatterns("https://*.example.com");
+		verify(registration).setAllowedOrigins("https://example.com");
+	}
+
+}


### PR DESCRIPTION
`ServerWebSocketContainer.registerWebSocketHandlers()` hardcoded the use of
`setAllowedOrigins()`, making it impossible to use wildcard patterns (e.g. `"*"`)
together with `allowCredentials=true` in Spring Framework 7+, which forbids that
combination.

This commit adds a `setAllowedOriginPatterns(String...)` method to
`ServerWebSocketContainer` that, when configured, is preferred over
`setAllowedOrigins()` in `registerWebSocketHandlers()`. The existing
`setAllowedOrigins()` behavior is preserved for backward compatibility.

Fixes: #10931