### PR TITLE
test: fix unstable batch consumer in `MessageDrivenAdapterTests`.

### DIFF
--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/MessageDrivenAdapterTests.java
@@ -110,6 +110,7 @@ import static org.mockito.Mockito.verify;
  * @author Cameron Mayfield
  * @author Urs Keller
  * @author Jooyoung Pyoung
+ * @author Jiandong Ma
  *
  * @since 5.4
  *
@@ -432,8 +433,6 @@ class MessageDrivenAdapterTests implements TestApplicationContextAware {
 			}
 
 		});
-		adapter.start();
-		ContainerTestUtils.waitForAssignment(container, 1);
 
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
 		senderProps.put(ProducerConfig.LINGER_MS_CONFIG, 0);
@@ -442,6 +441,9 @@ class MessageDrivenAdapterTests implements TestApplicationContextAware {
 		template.setDefaultTopic(topic2);
 		template.sendDefault(0, 1487694048607L, 1, "foo");
 		template.sendDefault(0, 1487694048608L, 1, "bar");
+
+		adapter.start();
+		ContainerTestUtils.waitForAssignment(container, 1);
 
 		Message<?> received = out.receive(10000);
 		assertThat(received).isNotNull();
@@ -460,6 +462,11 @@ class MessageDrivenAdapterTests implements TestApplicationContextAware {
 		assertThat(headers.get("testHeader")).isEqualTo("testValue");
 
 		assertThat(onPartitionsAssignedCalledLatch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		adapter.stop();
+
+		final CountDownLatch restartAssignmentLatch = new CountDownLatch(1);
+		adapter.setOnPartitionsAssignedSeekCallback((map, consumer) -> restartAssignmentLatch.countDown());
 
 		adapter.setMessageConverter(new BatchMessageConverter() {
 
@@ -480,12 +487,17 @@ class MessageDrivenAdapterTests implements TestApplicationContextAware {
 		adapter.setErrorChannel(errors);
 		template.sendDefault(0, 1487694048607L, 1, "foo");
 		template.sendDefault(0, 1487694048608L, 1, "bar");
+
+		adapter.start();
+		ContainerTestUtils.waitForAssignment(container, 1);
+
 		Message<?> error = errors.receive(30000);
 		assertThat(error).isNotNull();
 		assertThat(error.getPayload()).isInstanceOf(ConversionException.class);
 		assertThat(((ConversionException) error.getPayload()).getMessage())
 				.contains("Failed to convert to message");
 		assertThat(((ConversionException) error.getPayload()).getRecords()).hasSize(2);
+		assertThat(restartAssignmentLatch.await(10, TimeUnit.SECONDS)).isTrue();
 
 		adapter.stop();
 		pf.reset();


### PR DESCRIPTION
By starting the adapter after sending messages, ensure a single poll retrieves the full batch messages.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
