### PR TITLE
GH-8108: Add DSL for Redis Queue Gateways.

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
@@ -214,6 +214,30 @@ public final class Redis {
 		return new RedisOutboundGatewaySpec(connectionFactory);
 	}
 
+	/**
+	 * The factory to produce a {@link RedisQueueOutboundGatewaySpec}.
+	 * @param queueName The queueName of the Redis list to build on
+	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
+	 * @return the {@link RedisQueueOutboundGatewaySpec} instance
+	 */
+	public static RedisQueueOutboundGatewaySpec queueOutboundGatewaySpec(String queueName,
+			RedisConnectionFactory connectionFactory) {
+
+		return new RedisQueueOutboundGatewaySpec(queueName, connectionFactory);
+	}
+
+	/**
+	 * The factory to produce a {@link RedisQueueInboundGatewaySpec}.
+	 * @param queueName The queueName of the Redis list to build on
+	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
+	 * @return the {@link RedisQueueInboundGatewaySpec} instance
+	 */
+	public static RedisQueueInboundGatewaySpec queueInboundGatewaySpec(String queueName,
+			RedisConnectionFactory connectionFactory) {
+
+		return new RedisQueueInboundGatewaySpec(queueName, connectionFactory);
+	}
+
 	private Redis() {
 	}
 

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/Redis.java
@@ -108,10 +108,10 @@ public final class Redis {
 	 * @param key The key of the Redis collection to build on
 	 * @return the {@link RedisStoreInboundChannelAdapterSpec} instance
 	 */
-	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapterSpec(
+	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapter(
 			RedisConnectionFactory connectionFactory, String key) {
 
-		return storeInboundChannelAdapterSpec(connectionFactory, new LiteralExpression(key));
+		return storeInboundChannelAdapter(connectionFactory, new LiteralExpression(key));
 	}
 
 	/**
@@ -120,7 +120,7 @@ public final class Redis {
 	 * @param keyExpression The keyExpression of the Redis collection to build on
 	 * @return the {@link RedisStoreInboundChannelAdapterSpec} instance
 	 */
-	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapterSpec(
+	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapter(
 			RedisConnectionFactory connectionFactory, Expression keyExpression) {
 
 		return new RedisStoreInboundChannelAdapterSpec(connectionFactory, keyExpression);
@@ -132,10 +132,10 @@ public final class Redis {
 	 * @param keySupplier The keySupplier of the Redis collection to build on
 	 * @return the {@link RedisStoreInboundChannelAdapterSpec} instance
 	 */
-	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapterSpec(
+	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapter(
 			RedisConnectionFactory connectionFactory, Supplier<Message<?>> keySupplier) {
 
-		return storeInboundChannelAdapterSpec(connectionFactory, new SupplierExpression<>(keySupplier));
+		return storeInboundChannelAdapter(connectionFactory, new SupplierExpression<>(keySupplier));
 	}
 
 	/**
@@ -144,10 +144,10 @@ public final class Redis {
 	 * @param key The key of the Redis collection to build on
 	 * @return the {@link RedisStoreInboundChannelAdapterSpec} instance
 	 */
-	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapterSpec(
+	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapter(
 			RedisTemplate<String, ?> redisTemplate, String key) {
 
-		return storeInboundChannelAdapterSpec(redisTemplate, new LiteralExpression(key));
+		return storeInboundChannelAdapter(redisTemplate, new LiteralExpression(key));
 	}
 
 	/**
@@ -156,7 +156,7 @@ public final class Redis {
 	 * @param keyExpression The keyExpression of the Redis collection to build on
 	 * @return the {@link RedisStoreInboundChannelAdapterSpec} instance
 	 */
-	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapterSpec(
+	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapter(
 			RedisTemplate<String, ?> redisTemplate, Expression keyExpression) {
 
 		return new RedisStoreInboundChannelAdapterSpec(redisTemplate, keyExpression);
@@ -168,10 +168,10 @@ public final class Redis {
 	 * @param keySupplier The keySupplier of the Redis collection to build on
 	 * @return the {@link RedisStoreInboundChannelAdapterSpec} instance
 	 */
-	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapterSpec(
+	public static RedisStoreInboundChannelAdapterSpec storeInboundChannelAdapter(
 			RedisTemplate<String, ?> redisTemplate, Supplier<Message<?>> keySupplier) {
 
-		return storeInboundChannelAdapterSpec(redisTemplate, new SupplierExpression<>(keySupplier));
+		return storeInboundChannelAdapter(redisTemplate, new SupplierExpression<>(keySupplier));
 	}
 
 	/**
@@ -179,7 +179,7 @@ public final class Redis {
 	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
 	 * @return the {@link RedisStoreOutboundChannelAdapterSpec} instance
 	 */
-	public static RedisStoreOutboundChannelAdapterSpec storeOutboundChannelAdapterSpec(
+	public static RedisStoreOutboundChannelAdapterSpec storeOutboundChannelAdapter(
 			RedisConnectionFactory connectionFactory) {
 
 		return new RedisStoreOutboundChannelAdapterSpec(connectionFactory);
@@ -190,7 +190,7 @@ public final class Redis {
 	 * @param redisTemplate the {@link RedisTemplate} to build on
 	 * @return the {@link RedisStoreOutboundChannelAdapterSpec} instance
 	 */
-	public static RedisStoreOutboundChannelAdapterSpec storeOutboundChannelAdapterSpec(
+	public static RedisStoreOutboundChannelAdapterSpec storeOutboundChannelAdapter(
 			RedisTemplate<String, ?> redisTemplate) {
 
 		return new RedisStoreOutboundChannelAdapterSpec(redisTemplate);
@@ -201,7 +201,7 @@ public final class Redis {
 	 * @param redisTemplate the {@link RedisTemplate} to build on
 	 * @return the {@link RedisOutboundGatewaySpec} instance
 	 */
-	public static RedisOutboundGatewaySpec outboundGatewaySpec(RedisTemplate<String, ?> redisTemplate) {
+	public static RedisOutboundGatewaySpec outboundGateway(RedisTemplate<String, ?> redisTemplate) {
 		return new RedisOutboundGatewaySpec(redisTemplate);
 	}
 
@@ -210,7 +210,7 @@ public final class Redis {
 	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
 	 * @return the {@link RedisOutboundGatewaySpec} instance
 	 */
-	public static RedisOutboundGatewaySpec outboundGatewaySpec(RedisConnectionFactory connectionFactory) {
+	public static RedisOutboundGatewaySpec outboundGateway(RedisConnectionFactory connectionFactory) {
 		return new RedisOutboundGatewaySpec(connectionFactory);
 	}
 
@@ -220,7 +220,7 @@ public final class Redis {
 	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
 	 * @return the {@link RedisQueueOutboundGatewaySpec} instance
 	 */
-	public static RedisQueueOutboundGatewaySpec queueOutboundGatewaySpec(String queueName,
+	public static RedisQueueOutboundGatewaySpec queueOutboundGateway(String queueName,
 			RedisConnectionFactory connectionFactory) {
 
 		return new RedisQueueOutboundGatewaySpec(queueName, connectionFactory);
@@ -232,7 +232,7 @@ public final class Redis {
 	 * @param connectionFactory the {@link RedisConnectionFactory} to build on
 	 * @return the {@link RedisQueueInboundGatewaySpec} instance
 	 */
-	public static RedisQueueInboundGatewaySpec queueInboundGatewaySpec(String queueName,
+	public static RedisQueueInboundGatewaySpec queueInboundGateway(String queueName,
 			RedisConnectionFactory connectionFactory) {
 
 		return new RedisQueueInboundGatewaySpec(queueName, connectionFactory);

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueInboundGatewaySpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueInboundGatewaySpec.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.redis.dsl;
+
+import java.time.Duration;
+import java.util.concurrent.Executor;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.integration.dsl.MessagingGatewaySpec;
+import org.springframework.integration.redis.inbound.RedisQueueInboundGateway;
+
+/**
+ * A {@link MessagingGatewaySpec} for a {@link RedisQueueInboundGateway}.
+ *
+ * @author Jiandong Ma
+ *
+ * @since 7.1
+ */
+public class RedisQueueInboundGatewaySpec extends MessagingGatewaySpec<RedisQueueInboundGatewaySpec, RedisQueueInboundGateway> {
+
+	protected RedisQueueInboundGatewaySpec(String queueName, RedisConnectionFactory connectionFactory) {
+		super(new RedisQueueInboundGateway(queueName, connectionFactory));
+	}
+
+	/**
+	 * Specify whether extract payload.
+	 * @param extractPayload the extractPayload
+	 * @return the spec
+	 * @see RedisQueueInboundGateway#setExtractPayload(boolean)
+	 */
+	public RedisQueueInboundGatewaySpec extractPayload(boolean extractPayload) {
+		this.target.setExtractPayload(extractPayload);
+		return this;
+	}
+
+	/**
+	 * Specify the redis serializer.
+	 * @param serializer the serializer
+	 * @return the spec
+	 * @see RedisQueueInboundGateway#setSerializer(RedisSerializer)
+	 */
+	public RedisQueueInboundGatewaySpec serializer(RedisSerializer<?> serializer) {
+		this.target.setSerializer(serializer);
+		return this;
+	}
+
+	/**
+	 * Specify the receiveTimeout.
+	 * @param receiveTimeout the receiveTimeout
+	 * @return the spec
+	 * @see RedisQueueInboundGateway#setReceiveDuration(Duration)
+	 */
+	public RedisQueueInboundGatewaySpec receiveTimeout(Duration receiveTimeout) {
+		this.target.setReceiveDuration(receiveTimeout);
+		return this;
+	}
+
+	/**
+	 * Specify the receiveTimeout.
+	 * @param receiveTimeout the receiveTimeout
+	 * @return the spec
+	 * @see RedisQueueInboundGateway#setReceiveTimeout(long)
+	 */
+	public RedisQueueInboundGatewaySpec receiveTimeout(long receiveTimeout) {
+		this.target.setReceiveTimeout(receiveTimeout);
+		return this;
+	}
+
+	/**
+	 * Specify an {@link Executor} for the underlying listening task.
+	 * @param taskExecutor the taskExecutor
+	 * @return the spec
+	 * @see RedisQueueInboundGateway#setTaskExecutor(Executor)
+	 */
+	public RedisQueueInboundGatewaySpec taskExecutor(Executor taskExecutor) {
+		this.target.setTaskExecutor(taskExecutor);
+		return this;
+	}
+
+	/**
+	 * Specify the time (in milliseconds) for the listener task should sleep after exceptions on
+	 * the "right pop" operation before restarting the listener task.
+	 * @param recoveryInterval the recoveryInterval
+	 * @return the spec
+	 * @see RedisQueueInboundGateway#setRecoveryInterval(long)
+	 */
+	public RedisQueueInboundGatewaySpec recoveryInterval(long recoveryInterval) {
+		this.target.setRecoveryInterval(recoveryInterval);
+		return this;
+	}
+
+}

--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueOutboundGatewaySpec.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/dsl/RedisQueueOutboundGatewaySpec.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.redis.dsl;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.integration.dsl.MessageHandlerSpec;
+import org.springframework.integration.redis.outbound.RedisQueueOutboundGateway;
+
+/**
+ * A {@link MessageHandlerSpec} for a {@link RedisQueueOutboundGateway}.
+ *
+ * @author Jiandong Ma
+ *
+ * @since 7.1
+ */
+public class RedisQueueOutboundGatewaySpec extends
+		MessageHandlerSpec<RedisQueueOutboundGatewaySpec, RedisQueueOutboundGateway> {
+
+	protected RedisQueueOutboundGatewaySpec(String queueName, RedisConnectionFactory connectionFactory) {
+		this.target = new RedisQueueOutboundGateway(queueName, connectionFactory);
+	}
+
+	/**
+	 * Specify the receiveTimeout.
+	 * @param receiveTimeout the receiveTimeout
+	 * @return the spec
+	 * @see RedisQueueOutboundGateway#setReceiveDuration(Duration)
+	 */
+	public RedisQueueOutboundGatewaySpec receiveTimeout(Duration receiveTimeout) {
+		this.target.setReceiveDuration(receiveTimeout);
+		return this;
+	}
+
+	/**
+	 * Specify the receiveTimeout.
+	 * @param receiveTimeout the receiveTimeout
+	 * @return the spec
+	 * @see RedisQueueOutboundGateway#setReceiveTimeout(long)
+	 */
+	public RedisQueueOutboundGatewaySpec receiveTimeout(long receiveTimeout) {
+		this.target.setReceiveTimeout(receiveTimeout);
+		return this;
+	}
+
+	/**
+	 * Specify whether extract payload.
+	 * @param extractPayload the extractPayload
+	 * @return the spec
+	 * @see RedisQueueOutboundGateway#setExtractPayload(boolean)
+	 */
+	public RedisQueueOutboundGatewaySpec extractPayload(boolean extractPayload) {
+		this.target.setExtractPayload(extractPayload);
+		return this;
+	}
+
+	/**
+	 * Specify the redis serializer.
+	 * @param serializer the serializer
+	 * @return the spec
+	 * @see RedisQueueOutboundGateway#setSerializer(RedisSerializer)
+	 */
+	public RedisQueueOutboundGatewaySpec serializer(RedisSerializer<?> serializer) {
+		this.target.setSerializer(serializer);
+		return this;
+	}
+
+}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
@@ -136,9 +136,6 @@ class RedisTests implements RedisContainerTest {
 	@Qualifier("queueOutboundGatewayFlow.input")
 	MessageChannel queueOutboundGatewayFlowInputChannel;
 
-	@Autowired
-	QueueChannel queueOutboundGatewayReplyChannel;
-
 	@Test
 	void testInboundChannelAdapterFlow() throws Exception {
 		StringRedisTemplate redisTemplate = new StringRedisTemplate(connectionFactory);
@@ -317,13 +314,15 @@ class RedisTests implements RedisContainerTest {
 	@Test
 	void testQueueInboundAndOutboundGatewayFlow() {
 		// Given
+		QueueChannel replyChannel = new QueueChannel();
 		String gatewayMessagePayload = "queue-gateway-message";
-		Message<String> gatewayMessage = new GenericMessage<>(gatewayMessagePayload,
-				Map.of(MessageHeaders.REPLY_CHANNEL, queueOutboundGatewayReplyChannel));
+		Message<String> gatewayMessage = MessageBuilder.withPayload(gatewayMessagePayload)
+				.setHeader(MessageHeaders.REPLY_CHANNEL, replyChannel)
+				.build();
 		// When
 		queueOutboundGatewayFlowInputChannel.send(gatewayMessage);
 		// Then
-		Message<?> replyMessage = queueOutboundGatewayReplyChannel.receive(10000);
+		Message<?> replyMessage = replyChannel.receive(10000);
 		assertThat(replyMessage)
 				.isNotNull()
 				.extracting(Message::getPayload)
@@ -436,11 +435,6 @@ class RedisTests implements RedisContainerTest {
 							.extractPayload(true)
 							.receiveTimeout(20000), e -> e
 							.sendTimeout(10000));
-		}
-
-		@Bean
-		QueueChannel queueOutboundGatewayReplyChannel() {
-			return new QueueChannel();
 		}
 
 		@Bean

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.integration.redis.dsl;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -26,7 +25,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.awaitility.Awaitility;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
@@ -63,13 +61,11 @@ import org.springframework.integration.transaction.TransactionSynchronizationFac
 import org.springframework.integration.transaction.TransactionSynchronizationProcessor;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.util.AlternativeJdkIdGenerator;
-import org.springframework.util.IdGenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -94,9 +90,7 @@ class RedisTests implements RedisContainerTest {
 
 	static final String STORE_FOR_OUTBOUND_CHANNEL_ADAPTER = "dslStoreOutboundChannelAdapter";
 
-	static final String QUEUE_NAME_FOR_QUEUE_OUTBOUND_GATEWAY = "dslQueueOutboundGateway";
-
-	static final String QUEUE_NAME_FOR_QUEUE_INBOUND_GATEWAY = "dslQueueInboundGateway";
+	static final String QUEUE_NAME_FOR_QUEUE_GATEWAYS = "dslQueueGateways";
 
 	@Autowired
 	RedisConnectionFactory connectionFactory;
@@ -144,9 +138,6 @@ class RedisTests implements RedisContainerTest {
 
 	@Autowired
 	QueueChannel queueOutboundGatewayReplyChannel;
-
-	@Autowired
-	ThreadPoolTaskScheduler taskScheduler;
 
 	@Test
 	void testInboundChannelAdapterFlow() throws Exception {
@@ -324,65 +315,19 @@ class RedisTests implements RedisContainerTest {
 	}
 
 	@Test
-	void testQueueOutboundGatewayFlow() {
+	void testQueueInboundAndOutboundGatewayFlow() {
 		// Given
-		String gatewayReqMessage = "queue-outbound-gateway-message";
-		// simulate the outbound gateway handler in a separate thread.
-		// which in turn pops the uuid from the provided queue, pops value from uuid queue, send reply to uuid.reply queue
-		taskScheduler.execute(() -> {
-			StringRedisTemplate redisTemplate = new StringRedisTemplate(connectionFactory);
-
-			String uuid = redisTemplate
-					.boundListOps(QUEUE_NAME_FOR_QUEUE_OUTBOUND_GATEWAY)
-					.rightPop(Duration.ofMillis(10000));
-			assertThat(uuid).isNotNull();
-
-			String uuidValue = redisTemplate
-					.boundListOps(uuid)
-					.rightPop(Duration.ofMillis(10000));
-			assertThat(uuidValue)
-					.isNotNull()
-					.isEqualTo(gatewayReqMessage);
-
-			redisTemplate
-					.boundListOps(uuid + ".reply")
-					.leftPush("Acked:" + uuidValue);
-		});
+		String gatewayMessagePayload = "queue-gateway-message";
+		Message<String> gatewayMessage = new GenericMessage<>(gatewayMessagePayload,
+				Map.of(MessageHeaders.REPLY_CHANNEL, queueOutboundGatewayReplyChannel));
 		// When
-		queueOutboundGatewayFlowInputChannel.send(MessageBuilder.withPayload(gatewayReqMessage).build());
+		queueOutboundGatewayFlowInputChannel.send(gatewayMessage);
 		// Then
 		Message<?> replyMessage = queueOutboundGatewayReplyChannel.receive(10000);
 		assertThat(replyMessage)
 				.isNotNull()
 				.extracting(Message::getPayload)
-				.isEqualTo("Acked:" + gatewayReqMessage);
-	}
-
-	@Test
-	void testQueueInboundGatewayFlow() {
-		// Given
-		String redisInboundMessage = "queue-inbound-gateway-message";
-		// simulate the inbound gateway caller in test thread,
-		// which in turn pushes uuid to the provided queue, pushes request message to the uuid queue.
-		IdGenerator idGenerator = new AlternativeJdkIdGenerator();
-		String uuid = idGenerator.generateId().toString();
-		StringRedisTemplate redisTemplate = new StringRedisTemplate(connectionFactory);
-		redisTemplate
-				.boundListOps(QUEUE_NAME_FOR_QUEUE_INBOUND_GATEWAY)
-				.leftPush(uuid);
-		redisTemplate
-				.boundListOps(uuid)
-				.leftPush(redisInboundMessage);
-		// When
-		var redisReplyQueueOps = redisTemplate.boundListOps(uuid + ".reply");
-		Awaitility.await()
-				.atMost(Duration.ofMillis(10000))
-				.until(() -> redisReplyQueueOps.size() > 0);
-		// Then
-		String redisReplyMessage = redisReplyQueueOps.rightPop();
-		assertThat(redisReplyMessage)
-				.isNotNull()
-				.isEqualTo("Acked:" + redisInboundMessage);
+				.isEqualTo("Acked:" + gatewayMessagePayload);
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -486,18 +431,22 @@ class RedisTests implements RedisContainerTest {
 		@Bean
 		IntegrationFlow queueOutboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
 			return flow -> flow
-					.handle(Redis.queueOutboundGatewaySpec(QUEUE_NAME_FOR_QUEUE_OUTBOUND_GATEWAY, redisConnectionFactory)
+					.handle(Redis.queueOutboundGatewaySpec(QUEUE_NAME_FOR_QUEUE_GATEWAYS, redisConnectionFactory)
 							.serializer(RedisSerializer.string())
 							.extractPayload(true)
 							.receiveTimeout(20000), e -> e
-							.sendTimeout(10000))
-					.channel(c -> c.queue("queueOutboundGatewayReplyChannel"));
+							.sendTimeout(10000));
+		}
+
+		@Bean
+		QueueChannel queueOutboundGatewayReplyChannel() {
+			return new QueueChannel();
 		}
 
 		@Bean
 		IntegrationFlow queueInboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
 			return IntegrationFlow.from(Redis
-							.queueInboundGatewaySpec(QUEUE_NAME_FOR_QUEUE_INBOUND_GATEWAY, redisConnectionFactory)
+							.queueInboundGatewaySpec(QUEUE_NAME_FOR_QUEUE_GATEWAYS, redisConnectionFactory)
 							.serializer(RedisSerializer.string())
 							.receiveTimeout(10000))
 					.handle((uuidValue, headers) -> "Acked:" + uuidValue)

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.redis.dsl;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -25,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.awaitility.Awaitility;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
@@ -63,8 +65,11 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.AlternativeJdkIdGenerator;
+import org.springframework.util.IdGenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -88,6 +93,10 @@ class RedisTests implements RedisContainerTest {
 	static final String STORE_FOR_INBOUND_CHANNEL_ADAPTER = "dslStoreInboundChannelAdapter";
 
 	static final String STORE_FOR_OUTBOUND_CHANNEL_ADAPTER = "dslStoreOutboundChannelAdapter";
+
+	static final String QUEUE_NAME_FOR_QUEUE_OUTBOUND_GATEWAY = "dslQueueOutboundGateway";
+
+	static final String QUEUE_NAME_FOR_QUEUE_INBOUND_GATEWAY = "dslQueueInboundGateway";
 
 	@Autowired
 	RedisConnectionFactory connectionFactory;
@@ -128,6 +137,16 @@ class RedisTests implements RedisContainerTest {
 
 	@Autowired
 	QueueChannel outboundGatewayReplyChannel;
+
+	@Autowired
+	@Qualifier("queueOutboundGatewayFlow.input")
+	MessageChannel queueOutboundGatewayFlowInputChannel;
+
+	@Autowired
+	QueueChannel queueOutboundGatewayReplyChannel;
+
+	@Autowired
+	ThreadPoolTaskScheduler taskScheduler;
 
 	@Test
 	void testInboundChannelAdapterFlow() throws Exception {
@@ -304,6 +323,68 @@ class RedisTests implements RedisContainerTest {
 				.isEqualTo(initialValue + 1);
 	}
 
+	@Test
+	void testQueueOutboundGatewayFlow() {
+		// Given
+		String gatewayReqMessage = "queue-outbound-gateway-message";
+		// simulate the outbound gateway handler in a separate thread.
+		// which in turn pops the uuid from the provided queue, pops value from uuid queue, send reply to uuid.reply queue
+		taskScheduler.execute(() -> {
+			StringRedisTemplate redisTemplate = new StringRedisTemplate(connectionFactory);
+
+			String uuid = redisTemplate
+					.boundListOps(QUEUE_NAME_FOR_QUEUE_OUTBOUND_GATEWAY)
+					.rightPop(Duration.ofMillis(10000));
+			assertThat(uuid).isNotNull();
+
+			String uuidValue = redisTemplate
+					.boundListOps(uuid)
+					.rightPop(Duration.ofMillis(10000));
+			assertThat(uuidValue)
+					.isNotNull()
+					.isEqualTo(gatewayReqMessage);
+
+			redisTemplate
+					.boundListOps(uuid + ".reply")
+					.leftPush("Acked:" + uuidValue);
+		});
+		// When
+		queueOutboundGatewayFlowInputChannel.send(MessageBuilder.withPayload(gatewayReqMessage).build());
+		// Then
+		Message<?> replyMessage = queueOutboundGatewayReplyChannel.receive(10000);
+		assertThat(replyMessage)
+				.isNotNull()
+				.extracting(Message::getPayload)
+				.isEqualTo("Acked:" + gatewayReqMessage);
+	}
+
+	@Test
+	void testQueueInboundGatewayFlow() {
+		// Given
+		String redisInboundMessage = "queue-inbound-gateway-message";
+		// simulate the inbound gateway caller in test thread,
+		// which in turn pushes uuid to the provided queue, pushes request message to the uuid queue.
+		IdGenerator idGenerator = new AlternativeJdkIdGenerator();
+		String uuid = idGenerator.generateId().toString();
+		StringRedisTemplate redisTemplate = new StringRedisTemplate(connectionFactory);
+		redisTemplate
+				.boundListOps(QUEUE_NAME_FOR_QUEUE_INBOUND_GATEWAY)
+				.leftPush(uuid);
+		redisTemplate
+				.boundListOps(uuid)
+				.leftPush(redisInboundMessage);
+		// When
+		var redisReplyQueueOps = redisTemplate.boundListOps(uuid + ".reply");
+		Awaitility.await()
+				.atMost(Duration.ofMillis(10000))
+				.until(() -> redisReplyQueueOps.size() > 0);
+		// Then
+		String redisReplyMessage = redisReplyQueueOps.rightPop();
+		assertThat(redisReplyMessage)
+				.isNotNull()
+				.isEqualTo("Acked:" + redisInboundMessage);
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@EnableIntegration
 	static class Config {
@@ -400,6 +481,27 @@ class RedisTests implements RedisContainerTest {
 					.handle(Redis.outboundGatewaySpec(redisConnectionFactory)
 							.command("INCR"))
 					.channel(c -> c.queue("outboundGatewayReplyChannel"));
+		}
+
+		@Bean
+		IntegrationFlow queueOutboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
+			return flow -> flow
+					.handle(Redis.queueOutboundGatewaySpec(QUEUE_NAME_FOR_QUEUE_OUTBOUND_GATEWAY, redisConnectionFactory)
+							.serializer(RedisSerializer.string())
+							.extractPayload(true)
+							.receiveTimeout(20000), e -> e
+							.sendTimeout(10000))
+					.channel(c -> c.queue("queueOutboundGatewayReplyChannel"));
+		}
+
+		@Bean
+		IntegrationFlow queueInboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
+			return IntegrationFlow.from(Redis
+							.queueInboundGatewaySpec(QUEUE_NAME_FOR_QUEUE_INBOUND_GATEWAY, redisConnectionFactory)
+							.serializer(RedisSerializer.string())
+							.receiveTimeout(10000))
+					.handle((uuidValue, headers) -> "Acked:" + uuidValue)
+					.get();
 		}
 
 	}

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/dsl/RedisTests.java
@@ -378,7 +378,7 @@ class RedisTests implements RedisContainerTest {
 		IntegrationFlow storeInboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory,
 				TransactionSynchronizationFactory syncFactory) {
 			return IntegrationFlow.from(Redis
-									.storeInboundChannelAdapterSpec(redisConnectionFactory, STORE_FOR_INBOUND_CHANNEL_ADAPTER)
+									.storeInboundChannelAdapter(redisConnectionFactory, STORE_FOR_INBOUND_CHANNEL_ADAPTER)
 									.collectionType(CollectionType.ZSET),
 							endpointConfigure -> endpointConfigure
 									.poller(Pollers
@@ -415,7 +415,7 @@ class RedisTests implements RedisContainerTest {
 		@Bean
 		IntegrationFlow storeOutboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory) {
 			return flow -> flow
-					.handle(Redis.storeOutboundChannelAdapterSpec(redisConnectionFactory)
+					.handle(Redis.storeOutboundChannelAdapter(redisConnectionFactory)
 							.key(STORE_FOR_OUTBOUND_CHANNEL_ADAPTER)
 							.collectionType(CollectionType.MAP));
 		}
@@ -423,7 +423,7 @@ class RedisTests implements RedisContainerTest {
 		@Bean
 		IntegrationFlow outboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
 			return flow -> flow
-					.handle(Redis.outboundGatewaySpec(redisConnectionFactory)
+					.handle(Redis.outboundGateway(redisConnectionFactory)
 							.command("INCR"))
 					.channel(c -> c.queue("outboundGatewayReplyChannel"));
 		}
@@ -431,7 +431,7 @@ class RedisTests implements RedisContainerTest {
 		@Bean
 		IntegrationFlow queueOutboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
 			return flow -> flow
-					.handle(Redis.queueOutboundGatewaySpec(QUEUE_NAME_FOR_QUEUE_GATEWAYS, redisConnectionFactory)
+					.handle(Redis.queueOutboundGateway(QUEUE_NAME_FOR_QUEUE_GATEWAYS, redisConnectionFactory)
 							.serializer(RedisSerializer.string())
 							.extractPayload(true)
 							.receiveTimeout(20000), e -> e
@@ -446,7 +446,7 @@ class RedisTests implements RedisContainerTest {
 		@Bean
 		IntegrationFlow queueInboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
 			return IntegrationFlow.from(Redis
-							.queueInboundGatewaySpec(QUEUE_NAME_FOR_QUEUE_GATEWAYS, redisConnectionFactory)
+							.queueInboundGateway(QUEUE_NAME_FOR_QUEUE_GATEWAYS, redisConnectionFactory)
 							.serializer(RedisSerializer.string())
 							.receiveTimeout(10000))
 					.handle((uuidValue, headers) -> "Acked:" + uuidValue)

--- a/src/reference/antora/modules/ROOT/pages/redis.adoc
+++ b/src/reference/antora/modules/ROOT/pages/redis.adoc
@@ -1192,7 +1192,8 @@ It is mutually exclusive with the 'redis-template' attribute.
 It can be an empty string, which means "`no serializer`".
 In this case, the raw `byte[]` from the inbound Redis message is sent to the `channel` as the `Message` payload.
 By default, it is a `JdkSerializationRedisSerializer`.
-<9> Specifies whether this endpoint should deal only with the payload or the entire Message against the Redis queue. It defaults to `true`.
+<9> Specifies whether this endpoint should deal only with the payload or the entire Message against the Redis queue.
+It defaults to `true`.
 
 [[redis-queue-inbound-gateway]]
 == Redis Queue Inbound Gateway
@@ -1279,7 +1280,8 @@ It is typically applied for queue-based limited reply-channels.
 It defaults to `redisConnectionFactory`.
 It is mutually exclusive with `redis-template` attribute.
 <6> The name of the Redis list for the conversation `UUID`.
-<7> A `SmartLifecycle` attribute to specify the phase in which this endpoint is started. It defaults to `0`.
+<7> A `SmartLifecycle` attribute to specify the phase in which this endpoint is started.
+It defaults to `0`.
 <8> The `RedisSerializer` bean reference.
 It can be an empty string, which means "`no serializer`".
 In this case, the raw `byte[]` from the inbound Redis message is sent to the `channel` as the `Message` payload.
@@ -1288,7 +1290,8 @@ It defaults to a `JdkSerializationRedisSerializer`.
 To restore that behavior, provide a reference to a `StringRedisSerializer`).
 <9> The timeout (in milliseconds) to wait until the received message is fetched.
 It is typically applied for queue-based limited request-channels.
-<10> Specifies whether this endpoint should deal only with the payload or the entire Message against the Redis queue. It defaults to `true`.
+<10> Specifies whether this endpoint should deal only with the payload or the entire Message against the Redis queue.
+It defaults to `true`.
 <11> The time (in milliseconds) the listener task should sleep after exceptions on the "`right pop`" operation before restarting the listener task.
 
 IMPORTANT: The `task-executor` has to be configured with more than one thread for processing; otherwise there is a possible deadlock when the `RedisQueueMessageDrivenEndpoint` tries to restart the listener task after an error.

--- a/src/reference/antora/modules/ROOT/pages/redis.adoc
+++ b/src/reference/antora/modules/ROOT/pages/redis.adoc
@@ -1113,7 +1113,54 @@ It pushes a conversation `UUID` to the provided `queue`, pushes the value with t
 A different UUID is used for each interaction.
 The following listing shows the available attributes for a Redis outbound gateway:
 
-[source,xml]
+[tabs]
+======
+Java DSL::
++
+[source, java, role="primary"]
+----
+@Bean
+IntegrationFlow queueOutboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
+    return IntegrationFlow.from("requestChannel") <1>
+            .handle(Redis.queueOutboundGatewaySpec(
+                            QUEUE_NAME, <6>
+                            redisConnectionFactory) <5>
+                    .serializer() <8>
+                    .extractPayload() <9>
+                    , e -> e
+                    .requiresReply() <3>
+                    .sendTimeout() <4>
+                    .order()) <7>
+            .channel(c -> c.queue("replyChannel")) <2>
+            .get();
+}
+----
+
+Java::
++
+[source, java, role="secondary"]
+----
+@Bean
+@ServiceActivator(
+        inputChannel = "", <1>
+        outputChannel = "", <2>
+        requiresReply = "", <3>
+        sendTimeout = "" <4>
+)
+MessageHandler queueOutboundGateway(RedisConnectionFactory redisConnectionFactory) {
+    var gateway = new RedisQueueOutboundGateway(
+            QUEUE_NAME, <6>
+            redisConnectionFactory); <5>
+    gateway.setOrder(); <7>
+    gateway.setSerializer(); <8>
+    gateway.setExtractPayload(); <9>
+    return gateway;
+}
+----
+
+XML::
++
+[source, xml, role="secondary"]
 ----
 <int-redis:queue-outbound-gateway
         request-channel=""  <1>
@@ -1126,6 +1173,8 @@ The following listing shows the available attributes for a Redis outbound gatewa
         serializer=""  <8>
         extract-payload=""/>  <9>
 ----
+
+======
 
 <1> The `MessageChannel` from which this endpoint receives `Message` instances.
 <2> The `MessageChannel` where this endpoint sends reply `Message` instances.
@@ -1143,8 +1192,7 @@ It is mutually exclusive with the 'redis-template' attribute.
 It can be an empty string, which means "`no serializer`".
 In this case, the raw `byte[]` from the inbound Redis message is sent to the `channel` as the `Message` payload.
 By default, it is a `JdkSerializationRedisSerializer`.
-<9> Specifies whether this endpoint expects data from the Redis queue to contain entire `Message` instances.
-If this attribute is set to `true`, the `serializer` cannot be an empty string, because messages require some form of deserialization (JDK serialization by default).
+<9> Specifies whether this endpoint should deal only with the payload or the entire Message against the Redis queue. It defaults to `true`.
 
 [[redis-queue-inbound-gateway]]
 == Redis Queue Inbound Gateway
@@ -1153,7 +1201,55 @@ Spring Integration 4.1 introduced the Redis queue inbound gateway to perform req
 It pops a conversation `UUID` from the provided `queue`, pops the value with that `UUID` as its key from the Redis list, and pushes the reply to the Redis list with a key of `UUID` plus `.reply`.
 The following listing shows the available attributes for a Redis queue inbound gateway:
 
-[source,xml]
+[tabs]
+======
+Java DSL::
++
+[source, java, role="primary"]
+----
+@Bean
+IntegrationFlow queueInboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
+    return IntegrationFlow.from("requestChannel") <1>
+            .handle(Redis.queueInboundGatewaySpec(
+                            QUEUE_NAME, <6>
+                            redisConnectionFactory) <5>
+                    .taskExecutor() <3>
+                    .replyTimeout() <4>
+                    .phase() <7>
+                    .serializer() <8>
+                    .receiveTimeout() <9>
+                    .extractPayload() <10>
+                    .recoveryInterval()) <11>
+            .channel(c -> c.queue("replyChannel")) <2>
+            .get();
+}
+----
+
+Java::
++
+[source, java, role="secondary"]
+----
+@Bean
+public RedisQueueInboundGateway queueInboundGateway(RedisConnectionFactory connectionFactory) {
+    var gateway = new RedisQueueInboundGateway(
+            QUEUE_NAME, <6>
+            connectionFactory); <5>
+    gateway.setRequestChannel(); <1>
+    gateway.setReplyChannel(); <2>
+    gateway.setTaskExecutor(); <3>
+    gateway.setReplyTimeout(); <4>
+    gateway.setPhase(); <7>
+    gateway.setSerializer(); <8>
+    gateway.setReceiveTimeout(); <9>
+    gateway.setExtractPayload(); <10>
+    gateway.setRecoveryInterval(); <11>
+    return gateway;
+}
+----
+
+XML::
++
+[source, xml, role="secondary"]
 ----
 <int-redis:queue-inbound-gateway
         request-channel=""  <1>
@@ -1162,12 +1258,14 @@ The following listing shows the available attributes for a Redis queue inbound g
         reply-timeout=""  <4>
         connection-factory=""  <5>
         queue=""  <6>
-        order=""  <7>
+        phase=""  <7>
         serializer=""  <8>
         receive-timeout=""  <9>
-        expect-message=""  <10>
+        extract-payload=""  <10>
         recovery-interval=""/>  <11>
 ----
+
+======
 
 <1> The `MessageChannel` where this endpoint sends `Message` instances created from the Redis data.
 <2> The `MessageChannel` from where this endpoint waits for reply `Message` instances.
@@ -1181,7 +1279,7 @@ It is typically applied for queue-based limited reply-channels.
 It defaults to `redisConnectionFactory`.
 It is mutually exclusive with `redis-template` attribute.
 <6> The name of the Redis list for the conversation `UUID`.
-<7> The order of this inbound gateway when multiple gateways are registered.
+<7> A `SmartLifecycle` attribute to specify the phase in which this endpoint is started. It defaults to `0`.
 <8> The `RedisSerializer` bean reference.
 It can be an empty string, which means "`no serializer`".
 In this case, the raw `byte[]` from the inbound Redis message is sent to the `channel` as the `Message` payload.
@@ -1190,8 +1288,7 @@ It defaults to a `JdkSerializationRedisSerializer`.
 To restore that behavior, provide a reference to a `StringRedisSerializer`).
 <9> The timeout (in milliseconds) to wait until the received message is fetched.
 It is typically applied for queue-based limited request-channels.
-<10> Specifies whether this endpoint expects data from the Redis queue to contain entire `Message` instances.
-If this attribute is set to `true`, the `serializer` cannot be an empty string, because messages require some form of deserialization (JDK serialization by default).
+<10> Specifies whether this endpoint should deal only with the payload or the entire Message against the Redis queue. It defaults to `true`.
 <11> The time (in milliseconds) the listener task should sleep after exceptions on the "`right pop`" operation before restarting the listener task.
 
 IMPORTANT: The `task-executor` has to be configured with more than one thread for processing; otherwise there is a possible deadlock when the `RedisQueueMessageDrivenEndpoint` tries to restart the listener task after an error.

--- a/src/reference/antora/modules/ROOT/pages/redis.adoc
+++ b/src/reference/antora/modules/ROOT/pages/redis.adoc
@@ -654,7 +654,7 @@ Java DSL::
 @Bean
 IntegrationFlow storeInboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory) {
     return IntegrationFlow.from(Redis
-                        .storeInboundChannelAdapterSpec(redisConnectionFactory, STORE_FOR_INBOUND_CHANNEL_ADAPTER)
+                        .storeInboundChannelAdapter(redisConnectionFactory, STORE_FOR_INBOUND_CHANNEL_ADAPTER)
                         .collectionType(CollectionType.LIST),
                 endpointConfigure -> endpointConfigure
                         .poller(Pollers.fixedDelay(2000))
@@ -746,7 +746,7 @@ Java DSL::
 IntegrationFlow storeInboundChannelAdapterFlow(RedisConnectionFactory redisConnectionFactory,
         TransactionSynchronizationFactory syncFactory) {
     return IntegrationFlow.from(Redis
-                            .storeInboundChannelAdapterSpec(redisConnectionFactory, STORE_FOR_INBOUND_CHANNEL_ADAPTER)
+                            .storeInboundChannelAdapter(redisConnectionFactory, STORE_FOR_INBOUND_CHANNEL_ADAPTER)
                             .collectionType(CollectionType.ZSET),
                     endpointConfigure -> endpointConfigure
                             .poller(Pollers
@@ -890,7 +890,7 @@ Java DSL::
 @Bean
 public IntegrationFlow storeOutboundChannelAdapterFlow(RedisConnectionFactory connectionFactory) {
     return IntegrationFlow.from("requestChannel")
-            .handle(Redis.storeOutboundChannelAdapterSpec(connectionFactory)
+            .handle(Redis.storeOutboundChannelAdapter(connectionFactory)
                     .collectionType(CollectionType.LIST)
                     .key("myCollection"))
             .get();
@@ -966,7 +966,7 @@ Java DSL::
 IntegrationFlow outboundGatewayFlow() {
     return IntegrationFlow.from("request-channel") <1>
             .handle(Redis
-                    .outboundGatewaySpec(redisConnectionFactory <5>
+                    .outboundGateway(redisConnectionFactory <5>
                         or redisTemplate)  <6>
                     .argumentsSerializer() <7>
                     .commandExpression("") <8>
@@ -1066,7 +1066,7 @@ Java DSL::
 @Bean
 IntegrationFlow outboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
     return IntegrationFlow.from("requestChannel")
-            .handle(Redis.outboundGatewaySpec(redisConnectionFactory)
+            .handle(Redis.outboundGateway(redisConnectionFactory)
                     .command("INCR"))
             .channel(c -> c.queue("replyChannel"))
             .get();
@@ -1122,7 +1122,7 @@ Java DSL::
 @Bean
 IntegrationFlow queueOutboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
     return IntegrationFlow.from("requestChannel") <1>
-            .handle(Redis.queueOutboundGatewaySpec(
+            .handle(Redis.queueOutboundGateway(
                             QUEUE_NAME, <6>
                             redisConnectionFactory) <5>
                     .serializer() <8>
@@ -1211,7 +1211,7 @@ Java DSL::
 @Bean
 IntegrationFlow queueInboundGatewayFlow(RedisConnectionFactory redisConnectionFactory) {
     return IntegrationFlow.from("requestChannel") <1>
-            .handle(Redis.queueInboundGatewaySpec(
+            .handle(Redis.queueInboundGateway(
                             QUEUE_NAME, <6>
                             redisConnectionFactory) <5>
                     .taskExecutor() <3>


### PR DESCRIPTION
Related to: https://github.com/spring-projects/spring-integration/issues/8108

doc fix: there are no properties named `order` and `expect-message` in queue-inbound-gateway, replaced with `phase` and `extract-payload`, modify the properties explanation respectively.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
