### PR TITLE
Resolve nullability errors after ver upgrade

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -160,4 +160,4 @@ antora = { id = "org.antora", version = "1.0.0" }
 io-spring-antora-generate-yml = { id = "io.spring.antora.generate-antora-yml", version = "0.0.1" }
 protobuf = { id = "com.google.protobuf", version = "0.9.6" }
 aggregate-javadoc = { id = "io.freefair.aggregate-javadoc", version = "9.2.0" }
-nullability = { id = "io.spring.nullability", version = "0.0.12" }
+nullability = { id = "io.spring.nullability", version = "0.0.13" }

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -1657,7 +1657,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 
 		MethodInvokingRouter methodInvokingRouter =
 				new MethodInvokingRouter(new BeanNameMessageProcessor<>(beanName, method));
-		return route(new RouterSpec<>(methodInvokingRouter), routerConfigurer);
+		return route(new RouterSpec<@Nullable Object, MethodInvokingRouter>(methodInvokingRouter), routerConfigurer);
 	}
 
 	/**
@@ -1702,7 +1702,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 		else {
 			router = new MethodInvokingRouter(service);
 		}
-		return route(new RouterSpec<>(router), routerConfigurer);
+		return route(new RouterSpec<@Nullable Object, MethodInvokingRouter>(router), routerConfigurer);
 	}
 
 	/**
@@ -1831,7 +1831,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 		MessageProcessor<?> processor = messageProcessorSpec.getObject();
 		addComponent(processor);
 
-		return route(new RouterSpec<>(new MethodInvokingRouter(processor)), routerConfigurer);
+		return route(new RouterSpec<@Nullable Object, MethodInvokingRouter>(new MethodInvokingRouter(processor)), routerConfigurer);
 	}
 
 	protected <R extends AbstractMessageRouter, S extends AbstractRouterSpec<? super S, R>> B route(S routerSpec,

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/BaseIntegrationFlowDefinition.java
@@ -1653,11 +1653,11 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 */
 	public B route(String beanName, @Nullable String method,
-			@Nullable Consumer<RouterSpec<@Nullable Object, MethodInvokingRouter>> routerConfigurer) {
+			@Nullable Consumer<RouterSpec<Object, MethodInvokingRouter>> routerConfigurer) {
 
 		MethodInvokingRouter methodInvokingRouter =
 				new MethodInvokingRouter(new BeanNameMessageProcessor<>(beanName, method));
-		return route(new RouterSpec<@Nullable Object, MethodInvokingRouter>(methodInvokingRouter), routerConfigurer);
+		return route(new RouterSpec<>(methodInvokingRouter), routerConfigurer);
 	}
 
 	/**
@@ -1693,7 +1693,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @see MethodInvokingRouter
 	 */
 	public B route(Object service, @Nullable String methodName,
-			@Nullable Consumer<RouterSpec<@Nullable Object, MethodInvokingRouter>> routerConfigurer) {
+			@Nullable Consumer<RouterSpec<Object, MethodInvokingRouter>> routerConfigurer) {
 
 		MethodInvokingRouter router;
 		if (StringUtils.hasText(methodName)) {
@@ -1702,7 +1702,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 		else {
 			router = new MethodInvokingRouter(service);
 		}
-		return route(new RouterSpec<@Nullable Object, MethodInvokingRouter>(router), routerConfigurer);
+		return route(new RouterSpec<>(router), routerConfigurer);
 	}
 
 	/**
@@ -1805,7 +1805,7 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 */
 	public B route(MessageProcessorSpec<?> messageProcessorSpec) {
-		return route(messageProcessorSpec, (Consumer<RouterSpec<@Nullable Object, MethodInvokingRouter>>) null);
+		return route(messageProcessorSpec, (Consumer<RouterSpec<Object, MethodInvokingRouter>>) null);
 	}
 
 	/**
@@ -1825,13 +1825,13 @@ public abstract class BaseIntegrationFlowDefinition<B extends BaseIntegrationFlo
 	 * @return the current {@link BaseIntegrationFlowDefinition}.
 	 */
 	public B route(MessageProcessorSpec<?> messageProcessorSpec,
-			@Nullable Consumer<RouterSpec<@Nullable Object, MethodInvokingRouter>> routerConfigurer) {
+			@Nullable Consumer<RouterSpec<Object, MethodInvokingRouter>> routerConfigurer) {
 
 		Assert.notNull(messageProcessorSpec, MESSAGE_PROCESSOR_SPEC_MUST_NOT_BE_NULL);
 		MessageProcessor<?> processor = messageProcessorSpec.getObject();
 		addComponent(processor);
 
-		return route(new RouterSpec<@Nullable Object, MethodInvokingRouter>(new MethodInvokingRouter(processor)), routerConfigurer);
+		return route(new RouterSpec<>(new MethodInvokingRouter(processor)), routerConfigurer);
 	}
 
 	protected <R extends AbstractMessageRouter, S extends AbstractRouterSpec<? super S, R>> B route(S routerSpec,

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/RouterSpec.java
@@ -44,7 +44,7 @@ import org.springframework.util.StringUtils;
  *
  * @since 5.0
  */
-public class RouterSpec<K extends @Nullable Object, R extends AbstractMappingMessageRouter>
+public class RouterSpec<K extends Object, R extends AbstractMappingMessageRouter>
 		extends AbstractRouterSpec<RouterSpec<K, R>, R> {
 
 	private final RouterMappingProvider mappingProvider;

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinIntegrationFlowDefinition.kt
@@ -139,7 +139,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Inline function for [IntegrationFlowDefinition.route] providing a `route<MyTypeIn>()` variant
 	 * with reified generic type.
 	 */
-	inline fun <reified P : Any> route(crossinline function: (P) -> Any?) {
+	inline fun <reified P : Any> route(crossinline function: (P) -> Any) {
 		route(function) { }
 	}
 
@@ -147,7 +147,7 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 * Inline function for [IntegrationFlowDefinition.route] providing a `route<MyTypeIn>()` variant
 	 * with reified generic type.
 	 */
-	inline fun <reified P : Any, T : Any?> route(
+	inline fun <reified P : Any, T : Any> route(
 		crossinline function: (P) -> T,
 		crossinline configurer: KotlinRouterSpec<T, MethodInvokingRouter>.() -> Unit
 	) {
@@ -724,10 +724,11 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 */
 	fun route(
 		beanName: String, method: String?,
-		routerConfigurer: KotlinRouterSpec<Any?, MethodInvokingRouter>.() -> Unit
+		routerConfigurer: KotlinRouterSpec<Any, MethodInvokingRouter>.() -> Unit
 	) {
 
-		this.delegate.route(beanName, method) { routerConfigurer(KotlinRouterSpec(it)) }
+		@Suppress("UNCHECKED_CAST")
+		this.delegate.route(beanName, method) { routerConfigurer(KotlinRouterSpec(it as RouterSpec<Any, MethodInvokingRouter>)) }
 	}
 
 	/**
@@ -744,17 +745,18 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 */
 	fun route(
 		service: Any, methodName: String?,
-		routerConfigurer: KotlinRouterSpec<Any?, MethodInvokingRouter>.() -> Unit
+		routerConfigurer: KotlinRouterSpec<Any, MethodInvokingRouter>.() -> Unit
 	) {
 
-		this.delegate.route(service, methodName) { routerConfigurer(KotlinRouterSpec(it)) }
+		@Suppress("UNCHECKED_CAST")
+		this.delegate.route(service, methodName) { routerConfigurer(KotlinRouterSpec(it as RouterSpec<Any, MethodInvokingRouter>)) }
 	}
 
 	/**
 	 * Populate the [ExpressionEvaluatingRouter] for provided SpEL expression
 	 * with provided options from [KotlinRouterSpec].
 	 */
-	fun <T : Any?> route(
+	fun <T : Any> route(
 		expression: String,
 		routerConfigurer: KotlinRouterSpec<T, ExpressionEvaluatingRouter>.() -> Unit = {}
 	) {
@@ -768,10 +770,11 @@ class KotlinIntegrationFlowDefinition(@PublishedApi internal val delegate: Integ
 	 */
 	fun route(
 		messageProcessorSpec: MessageProcessorSpec<*>,
-		routerConfigurer: KotlinRouterSpec<Any?, MethodInvokingRouter>.() -> Unit = {}
+		routerConfigurer: KotlinRouterSpec<Any, MethodInvokingRouter>.() -> Unit = {}
 	) {
 
-		this.delegate.route(messageProcessorSpec) { routerConfigurer(KotlinRouterSpec(it)) }
+		@Suppress("UNCHECKED_CAST")
+		this.delegate.route(messageProcessorSpec) { routerConfigurer(KotlinRouterSpec(it as RouterSpec<Any, MethodInvokingRouter>)) }
 	}
 
 	/**

--- a/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRouterSpec.kt
+++ b/spring-integration-core/src/main/kotlin/org/springframework/integration/dsl/KotlinRouterSpec.kt
@@ -28,7 +28,7 @@ import org.springframework.messaging.MessageChannel
  *
  * @since 5.3
  */
-class KotlinRouterSpec<K : Any?, R : AbstractMappingMessageRouter>(override val delegate: RouterSpec<K, R>) :
+class KotlinRouterSpec<K : Any, R : AbstractMappingMessageRouter>(override val delegate: RouterSpec<K, R>) :
 	AbstractKotlinRouterSpec<RouterSpec<K, R>, R>(delegate) {
 
 	fun resolutionRequired(resolutionRequired: Boolean) {

--- a/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
+++ b/spring-integration-core/src/test/kotlin/org/springframework/integration/dsl/KotlinDslTests.kt
@@ -303,8 +303,8 @@ class KotlinDslTests : TestApplicationContextAware {
 			integrationFlow<Function<*, *>> {
 				transform<String> { it.lowercase() }
 				filter(UnexpiredMessageSelector())
-				route<Message<*>, Any?>({ null }) { defaultOutputToParentFlow() }
-				route<Message<*>> { m -> m.headers.replyChannel }
+				route<Message<*>, String>({ "" }) { defaultOutputToParentFlow() }
+				route<Message<*>> { m -> m.headers.replyChannel!! }
 			}
 
 		@Bean

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcMessageStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/store/JdbcMessageStore.java
@@ -712,6 +712,7 @@ public class JdbcMessageStore extends AbstractMessageGroupStore
 	}
 
 	@Override
+	@SuppressWarnings("NullAway")
 	public Iterator<MessageGroup> iterator() {
 		List<String> groupIds =
 				this.jdbcTemplate.query(getQuery(Query.LIST_GROUP_KEYS), new SingleColumnRowMapper<>(), this.region);


### PR DESCRIPTION
- Iterator in JdbcMessageStore was ingored because SingleColumnRowMapper.mapRow() is @Nullable but GROUP_KEY is not null

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
