### PR TITLE
Add message_store pattern in `IntegrationPatternType`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/IntegrationPatternType.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/IntegrationPatternType.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
  * Used to indicate which pattern a target component implements.
  *
  * @author Artem Bilan
+ * @author Jiandong Ma
  *
  * @since 5.3
  */
@@ -84,6 +85,8 @@ public enum IntegrationPatternType { // NOSONAR Initialization circularity is us
 
 	control_bus(IntegrationPatternCategory.system_management),
 
+	message_store(IntegrationPatternCategory.system_management),
+
 	router(IntegrationPatternCategory.message_routing),
 
 	recipient_list_router(IntegrationPatternCategory.message_routing);
@@ -140,7 +143,9 @@ public enum IntegrationPatternType { // NOSONAR Initialization circularity is us
 				claim_check_in,
 				claim_check_out),
 
-		system_management(control_bus);
+		system_management(
+				control_bus,
+				message_store);
 
 		private final IntegrationPatternType[] patternTypes;
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/store/MessageStore.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/store/MessageStore.java
@@ -20,6 +20,8 @@ import java.util.UUID;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.integration.IntegrationPattern;
+import org.springframework.integration.IntegrationPatternType;
 import org.springframework.jmx.export.annotation.ManagedAttribute;
 import org.springframework.messaging.Message;
 
@@ -30,10 +32,11 @@ import org.springframework.messaging.Message;
  * @author Iwein Fuld
  * @author Dave Syer
  * @author Artem Bilan
+ * @author Jiandong Ma
  *
  * @since 2.0
  */
-public interface MessageStore {
+public interface MessageStore extends IntegrationPattern {
 
 	/**
 	 * @param id The message identifier.
@@ -85,5 +88,10 @@ public interface MessageStore {
 	 */
 	@ManagedAttribute
 	long getMessageCount();
+
+	@Override
+	default IntegrationPatternType getIntegrationPatternType() {
+		return IntegrationPatternType.message_store;
+	}
 
 }


### PR DESCRIPTION
Make `MessageStore` extend `IntegrationPattern` with default message_store type.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
