### PR TITLE
GH-10990: Fix MQTT v5 inbound payload conversion

### DIFF
--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -65,7 +65,6 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.util.Assert;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
@@ -462,7 +461,7 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 							.copyHeaders(headers)
 							.build();
 			Object convertedPayload = this.messageConverter.fromMessage(messageToConvert, this.payloadType);
-			if (convertedPayload == null || !ClassUtils.isAssignableValue(this.payloadType, convertedPayload)) {
+			if (convertedPayload == null) {
 				throw new MessageConversionException(messageToConvert, "Failed to convert from MQTT Message");
 			}
 			message =

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -59,12 +59,13 @@ import org.springframework.integration.mqtt.support.MqttHeaderMapper;
 import org.springframework.integration.mqtt.support.MqttHeaders;
 import org.springframework.integration.mqtt.support.MqttMessageConverter;
 import org.springframework.integration.mqtt.support.MqttUtils;
+import org.springframework.integration.support.MutableMessageBuilder;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.converter.MessageConversionException;
 import org.springframework.messaging.converter.SmartMessageConverter;
-import org.springframework.messaging.support.GenericMessage;
 import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ObjectUtils;
 
@@ -87,6 +88,7 @@ import org.springframework.util.ObjectUtils;
  * @author Artem Vozhdayenko
  * @author Matthias Thoma
  * @author Glenn Renfro
+ * @author Goutam Adwant
  *
  * @since 5.5.5
  *
@@ -448,17 +450,44 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 
 		Message<?> message;
 		if (MqttMessage.class.isAssignableFrom(this.payloadType) || byte[].class.isAssignableFrom(this.payloadType)) {
-			message = new GenericMessage<>(payload, headers);
+			message =
+					getMessageBuilderFactory()
+							.withPayload(payload)
+							.copyHeaders(headers)
+							.build();
 		}
 		else {
-			message = this.messageConverter.toMessage(payload, new MessageHeaders(headers), this.payloadType);
+			Message<?> messageToConvert =
+					MutableMessageBuilder.withPayload(payload, false)
+							.copyHeaders(headers)
+							.build();
+			Object convertedPayload = this.messageConverter.fromMessage(messageToConvert, this.payloadType);
+			if (convertedPayload != null && ClassUtils.isAssignableValue(this.payloadType, convertedPayload)) {
+				message =
+						getMessageBuilderFactory()
+								.withPayload(convertedPayload)
+								.copyHeaders(messageToConvert.getHeaders())
+								.build();
+			}
+			else {
+				message = this.messageConverter.toMessage(payload, messageToConvert.getHeaders(), this.payloadType);
+			}
+			if (message == null || !ClassUtils.isAssignableValue(this.payloadType, message.getPayload())) {
+				throw new MessageConversionException(messageToConvert, "Failed to convert from MQTT Message");
+			}
+			message =
+					getMessageBuilderFactory()
+							.fromMessage(message)
+							.copyHeadersIfAbsent(messageToConvert.getHeaders())
+							.build();
 		}
 
+		Message<?> messageToSend = message;
 		try {
-			sendMessage(message);
+			sendMessage(messageToSend);
 		}
 		catch (RuntimeException ex) {
-			logger.error(ex, () -> "Unhandled exception for " + message);
+			logger.error(ex, () -> "Unhandled exception for " + messageToSend);
 			throw ex;
 		}
 	}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -471,12 +471,11 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 							.build();
 		}
 
-		Message<?> messageToSend = message;
 		try {
-			sendMessage(messageToSend);
+			sendMessage(message);
 		}
 		catch (RuntimeException ex) {
-			logger.error(ex, () -> "Unhandled exception for " + messageToSend);
+			logger.error(ex, () -> "Unhandled exception for " + message);
 			throw ex;
 		}
 	}

--- a/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
+++ b/spring-integration-mqtt/src/main/java/org/springframework/integration/mqtt/inbound/Mqttv5PahoMessageDrivenChannelAdapter.java
@@ -462,23 +462,13 @@ public class Mqttv5PahoMessageDrivenChannelAdapter
 							.copyHeaders(headers)
 							.build();
 			Object convertedPayload = this.messageConverter.fromMessage(messageToConvert, this.payloadType);
-			if (convertedPayload != null && ClassUtils.isAssignableValue(this.payloadType, convertedPayload)) {
-				message =
-						getMessageBuilderFactory()
-								.withPayload(convertedPayload)
-								.copyHeaders(messageToConvert.getHeaders())
-								.build();
-			}
-			else {
-				message = this.messageConverter.toMessage(payload, messageToConvert.getHeaders(), this.payloadType);
-			}
-			if (message == null || !ClassUtils.isAssignableValue(this.payloadType, message.getPayload())) {
+			if (convertedPayload == null || !ClassUtils.isAssignableValue(this.payloadType, convertedPayload)) {
 				throw new MessageConversionException(messageToConvert, "Failed to convert from MQTT Message");
 			}
 			message =
 					getMessageBuilderFactory()
-							.fromMessage(message)
-							.copyHeadersIfAbsent(messageToConvert.getHeaders())
+							.withPayload(convertedPayload)
+							.copyHeaders(messageToConvert.getHeaders())
 							.build();
 		}
 

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5AdapterTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5AdapterTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.mqtt;
 
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.paho.mqttv5.client.IMqttAsyncClient;
@@ -23,14 +24,22 @@ import org.eclipse.paho.mqttv5.client.IMqttMessageListener;
 import org.eclipse.paho.mqttv5.client.IMqttToken;
 import org.eclipse.paho.mqttv5.client.MqttConnectionOptions;
 import org.eclipse.paho.mqttv5.common.MqttException;
+import org.eclipse.paho.mqttv5.common.MqttMessage;
 import org.eclipse.paho.mqttv5.common.MqttSubscription;
+import org.eclipse.paho.mqttv5.common.packet.MqttProperties;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.integration.channel.NullChannel;
+import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.mqtt.inbound.Mqttv5PahoMessageDrivenChannelAdapter;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.converter.ByteArrayMessageConverter;
+import org.springframework.messaging.converter.CompositeMessageConverter;
+import org.springframework.messaging.converter.StringMessageConverter;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -45,6 +54,7 @@ import static org.mockito.Mockito.verify;
  * @author Artem Bilan
  * @author Artem Vozhdayenko
  * @author Matthias Thoma
+ * @author Goutam Adwant
  *
  * @since 5.5.16
  *
@@ -98,8 +108,35 @@ public class Mqttv5AdapterTests {
 				.containsEntry("$SYS/broker/#", "$SYS/broker/#");
 	}
 
+	@Test
+	public void payloadTypeIsUsedForInboundPayloadConversion() throws Exception {
+		IMqttAsyncClient client = mock();
+		QueueChannel outputChannel = new QueueChannel();
+		Mqttv5PahoMessageDrivenChannelAdapter adapter = buildAdapterIn(client, false, outputChannel);
+		adapter.setPayloadType(String.class);
+		adapter.setMessageConverter(new CompositeMessageConverter(List.of(
+				new ByteArrayMessageConverter(),
+				new StringMessageConverter())));
+
+		MqttMessage mqttMessage = new MqttMessage("test payload".getBytes());
+		mqttMessage.setProperties(new MqttProperties());
+
+		adapter.messageArrived("testTopic", mqttMessage);
+
+		Message<?> message = outputChannel.receive(0);
+
+		assertThat(message).isNotNull();
+		assertThat(message.getPayload()).isEqualTo("test payload");
+	}
+
 	private static Mqttv5PahoMessageDrivenChannelAdapter buildAdapterIn(final IMqttAsyncClient client,
 			boolean cleanStart) throws MqttException {
+
+		return buildAdapterIn(client, cleanStart, new NullChannel());
+	}
+
+	private static Mqttv5PahoMessageDrivenChannelAdapter buildAdapterIn(final IMqttAsyncClient client,
+			boolean cleanStart, MessageChannel outputChannel) throws MqttException {
 
 		MqttConnectionOptions connectionOptions = new MqttConnectionOptions();
 		connectionOptions.setServerURIs(new String[] {"tcp://localhost:1883"});
@@ -117,7 +154,7 @@ public class Mqttv5AdapterTests {
 		ReflectionTestUtils.setField(adapter, "mqttClient", client);
 		adapter.setBeanFactory(mock(BeanFactory.class));
 		adapter.setApplicationEventPublisher(mock(ApplicationEventPublisher.class));
-		adapter.setOutputChannel(new NullChannel());
+		adapter.setOutputChannel(outputChannel);
 		adapter.afterPropertiesSet();
 		return adapter;
 	}

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
@@ -59,6 +59,7 @@ import static org.awaitility.Awaitility.await;
  * @author Artem Bilan
  * @author Mikhail Polivakha
  * @author Glenn Renfro
+ * @author Goutam Adwant
  *
  * @since 5.5.5
  *

--- a/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
+++ b/spring-integration-mqtt/src/test/java/org/springframework/integration/mqtt/Mqttv5BackToBackTests.java
@@ -172,7 +172,7 @@ public class Mqttv5BackToBackTests implements MosquittoContainerTest {
 		}
 
 		@Bean
-		public SmartMessageConverter mqttStringToBytesConverter() {
+		public SmartMessageConverter mqttBytesToStringConverter() {
 			return new AbstractMessageConverter() {
 
 				@Override
@@ -184,7 +184,7 @@ public class Mqttv5BackToBackTests implements MosquittoContainerTest {
 				protected Object convertFromInternal(Message<?> message, Class<?> targetClass,
 						Object conversionHint) {
 
-					return message.getPayload().toString().getBytes(StandardCharsets.UTF_8);
+					return new String((byte[]) message.getPayload(), StandardCharsets.UTF_8);
 				}
 
 				@Override
@@ -206,7 +206,7 @@ public class Mqttv5BackToBackTests implements MosquittoContainerTest {
 			messageHandler.setHeaderMapper(mqttHeaderMapper);
 			messageHandler.setAsync(true);
 			messageHandler.setAsyncEvents(true);
-			messageHandler.setConverter(mqttStringToBytesConverter());
+			messageHandler.setConverter(mqttBytesToStringConverter());
 
 			return f -> f.handle(messageHandler);
 		}
@@ -222,7 +222,7 @@ public class Mqttv5BackToBackTests implements MosquittoContainerTest {
 			messageProducer.setPayloadType(String.class);
 			messageProducer.setQuiescentTimeout(QUIESCENT_TIMEOUT);
 			messageProducer.setDisconnectCompletionTimeout(DISCONNECT_COMPLETION_TIMEOUT);
-			messageProducer.setMessageConverter(mqttStringToBytesConverter());
+			messageProducer.setMessageConverter(mqttBytesToStringConverter());
 			messageProducer.setManualAcks(true);
 
 			return IntegrationFlow.from(messageProducer)

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -78,4 +78,6 @@ See xref:http.adoc[] for more information.
 === MQTT Changes
 
 For payloads other than `byte[]` or `String`, the `Mqttv5PahoMessageHandler` now delegates the conversion to the configured `MessageConverter` via `toMessage()`, instead of via `fromMessage()`.
+The `Mqttv5PahoMessageDrivenChannelAdapter` now delegates inbound `payloadType` conversion to the configured `SmartMessageConverter` via `fromMessage()`.
+This is a breaking change for custom MQTT v5 converters that relied on the previous reversed method call, but it aligns both channel adapters with the Spring Messaging converter contract.
 See xref:mqtt.adoc[] for more information.


### PR DESCRIPTION
Fixes #10990.

`Mqttv5PahoMessageDrivenChannelAdapter` used the configured `SmartMessageConverter` in the wrong direction when `payloadType` was set. It now builds an inbound message from the MQTT payload and delegates conversion through `fromMessage(...)`, so the requested target payload type is applied consistently.

Custom MQTT v5 converters that depended on the previous reversed call need to provide inbound payload conversion through `fromMessage(...)`; the 7.1 MQTT changes section documents that behavior change.
