### PR TITLE
GH-11013: Fix ZookeeperMetadataStore replace result

### DIFF
--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStore.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStore.java
@@ -151,8 +151,9 @@ public class ZookeeperMetadataStore implements ListenableMetadataStore, SmartLif
 				byte[] bytes = this.client.getData().storingStatIn(currentStat).forPath(getPath(key));
 				if (oldValue.equals(IntegrationUtils.bytesToString(bytes, this.encoding))) {
 					updateNode(key, newValue, currentStat.getVersion());
+					return true;
 				}
-				return true;
+				return false;
 			}
 			catch (KeeperException.NoNodeException | KeeperException.BadVersionException ex) {
 				// ignore, the node doesn't exist there's nothing to replace

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStoreTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/metadata/ZookeeperMetadataStoreTests.java
@@ -128,12 +128,12 @@ public class ZookeeperMetadataStoreTests extends ZookeeperTestSupport {
 		CuratorFramework otherClient = createNewClient();
 		final ZookeeperMetadataStore otherMetadataStore = new ZookeeperMetadataStore(otherClient);
 		otherMetadataStore.start();
-		otherMetadataStore.replace(testKey, "OtherValue", "Integration-2");
+		assertThat(otherMetadataStore.replace(testKey, "OtherValue", "Integration-2")).isFalse();
 		assertThat(IntegrationUtils.bytesToString(client.getData().forPath(metadataStore.getPath(testKey)), "UTF-8"))
 				.isEqualTo("Integration");
 		assertThat(metadataStore.get(testKey)).isEqualTo("Integration");
 		await().untilAsserted(() -> assertThat("Integration").isEqualTo(otherMetadataStore.get(testKey)));
-		otherMetadataStore.replace(testKey, "Integration", "Integration-2");
+		assertThat(otherMetadataStore.replace(testKey, "Integration", "Integration-2")).isTrue();
 		assertThat(IntegrationUtils.bytesToString(client.getData().forPath(metadataStore.getPath(testKey)), "UTF-8"))
 				.isEqualTo("Integration-2");
 		await().untilAsserted(() -> assertThat("Integration-2").isEqualTo(otherMetadataStore.get(testKey)));


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/11013

`ZookeeperMetadataStore.replace()` is expected to behave as a compare-and-set operation. It was returning `true` after reading the current ZooKeeper value even when that value did not match the supplied `oldValue`.

* Return `false` when the stored value differs from `oldValue` and no replacement is performed.
* Extend `ZookeeperMetadataStoreTests.testReplace()` to verify the failed replacement result and that the stored value is left unchanged.

Tests:

`./gradlew :spring-integration-zookeeper:test`