### PR TITLE
Fix misleading Javadoc for messaging annotation post-processors

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationBeanPostProcessor.java
@@ -50,7 +50,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * An infrastructure {@link BeanPostProcessor} implementation that processes method-level
- * messaging annotations such as @Transformer, @Splitter, @Router, and @Filter.
+ * messaging annotations such as @Transformer, @Splitter, @Router, and @Filter, on regular component methods.
  *
  * @author Artem Bilan
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationBeanPostProcessor.java
@@ -50,7 +50,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * An infrastructure {@link BeanPostProcessor} implementation that processes method-level
- * messaging annotations such as @Transformer, @Splitter, @Router, and @Filter, on regular component methods.
+ * messaging annotations (@Transformer, @Splitter, @Router, @Filter etc.) on bean methods.
  *
  * @author Artem Bilan
  *

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationPostProcessor.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
@@ -51,8 +50,8 @@ import org.springframework.integration.util.MessagingAnnotationUtils;
 import org.springframework.util.CollectionUtils;
 
 /**
- * A {@link BeanPostProcessor} implementation that processes method-level
- * messaging annotations such as @Transformer, @Splitter, @Router, and @Filter.
+ * A {@link BeanDefinitionRegistryPostProcessor} implementation that processes method-level
+ * messaging annotations such as @Transformer, @Splitter, @Router, and @Filter, on @Bean methods.
  *
  * @author Mark Fisher
  * @author Marius Bogoevici

--- a/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/config/MessagingAnnotationPostProcessor.java
@@ -51,7 +51,7 @@ import org.springframework.util.CollectionUtils;
 
 /**
  * A {@link BeanDefinitionRegistryPostProcessor} implementation that processes method-level
- * messaging annotations such as @Transformer, @Splitter, @Router, and @Filter, on @Bean methods.
+ * messaging annotations (@Transformer, @Splitter, @Router, @Filter etc.) on @Bean configuration methods.
  *
  * @author Mark Fisher
  * @author Marius Bogoevici


### PR DESCRIPTION
The `MessagingAnnotationPostProcessor` is really not a `BeanPostProcessor`.

Also, update the Javadocs to describe `MessagingAnnotationPostProcessor` and `MessagingAnnotationBeanPostProcessor` as handling `@Bean` methods and regular component methods, respectively.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
