### PR TITLE
Revise tests using `IntegrationRegistrar` to register infra beans

### DIFF
--- a/spring-integration-core/src/test/java/org/springframework/integration/bus/DirectChannelSubscriptionTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/bus/DirectChannelSubscriptionTests.java
@@ -20,12 +20,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.config.IntegrationRegistrar;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.ServiceActivatingHandler;
@@ -37,15 +37,15 @@ import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Jiandong Ma
  */
 public class DirectChannelSubscriptionTests {
 
-	private final GenericApplicationContext context = new GenericApplicationContext();
+	private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
 	private final DirectChannel sourceChannel = new DirectChannel();
 
@@ -53,7 +53,7 @@ public class DirectChannelSubscriptionTests {
 
 	@BeforeEach
 	public void setupChannels() {
-		new IntegrationRegistrar().registerBeanDefinitions(mock(), this.context.getDefaultListableBeanFactory());
+		context.register(Config.class);
 		TestUtils.registerBean("sourceChannel", this.sourceChannel, this.context);
 		TestUtils.registerBean("targetChannel", this.targetChannel, this.context);
 	}
@@ -136,6 +136,11 @@ public class DirectChannelSubscriptionTests {
 		public Message<?> handle(Message<?> message) {
 			throw new RuntimeException("intentional test failure");
 		}
+
+	}
+
+	@EnableIntegration
+	static class Config {
 
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/ServiceActivatorAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/ServiceActivatorAnnotationPostProcessorTests.java
@@ -22,7 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.support.RootBeanDefinition;
-import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.DirectChannel;
@@ -30,19 +30,18 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Jiandong Ma
  */
 public class ServiceActivatorAnnotationPostProcessorTests {
 
 	@Test
 	public void testAnnotatedMethod() throws InterruptedException {
 		CountDownLatch latch = new CountDownLatch(1);
-		try (GenericApplicationContext context = new GenericApplicationContext()) {
-			new IntegrationRegistrar().registerBeanDefinitions(mock(), context.getDefaultListableBeanFactory());
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
 			context.registerBeanDefinition("testChannel", new RootBeanDefinition(DirectChannel.class));
 			RootBeanDefinition beanDefinition = new RootBeanDefinition(SimpleServiceActivatorAnnotationTestBean.class);
 			beanDefinition.getConstructorArgumentValues().addGenericArgumentValue(latch);
@@ -79,6 +78,7 @@ public class ServiceActivatorAnnotationPostProcessorTests {
 
 	}
 
+	@EnableIntegration
 	@MessageEndpoint
 	public static class SimpleServiceActivatorAnnotationTestBean extends AbstractServiceActivatorAnnotationTestBean {
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/FilterAnnotationPostProcessorTests.java
@@ -23,12 +23,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.integration.annotation.Filter;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.config.IntegrationRegistrar;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.config.MessagingAnnotationBeanPostProcessor;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
@@ -38,19 +38,19 @@ import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
  * @author Glenn Renfro
+ * @author Jiandong Ma
  *
  * @since 2.0
  */
 public class FilterAnnotationPostProcessorTests {
 
-	private final GenericApplicationContext context = new GenericApplicationContext();
+	private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
 	private final DirectChannel inputChannel = new DirectChannel();
 
@@ -58,7 +58,7 @@ public class FilterAnnotationPostProcessorTests {
 
 	@BeforeEach
 	public void init() {
-		new IntegrationRegistrar().registerBeanDefinitions(mock(), this.context.getDefaultListableBeanFactory());
+		context.register(Config.class);
 		TestUtils.registerBean("input", inputChannel, this.context);
 		TestUtils.registerBean("output", this.outputChannel, this.context);
 	}
@@ -270,6 +270,11 @@ public class FilterAnnotationPostProcessorTests {
 		protected Object doInvoke(ExecutionCallback callback, Object target, Message<?> message) {
 			return callback.execute();
 		}
+
+	}
+
+	@EnableIntegration
+	static class Config {
 
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/MessagingAnnotationPostProcessorTests.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.support.AbstractApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
@@ -35,7 +36,7 @@ import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.annotation.Transformer;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.config.IntegrationRegistrar;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.config.MessagingAnnotationBeanPostProcessor;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.handler.advice.AbstractRequestHandlerAdvice;
@@ -49,12 +50,12 @@ import org.springframework.messaging.core.DestinationResolver;
 import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Jiandong Ma
  */
 public class MessagingAnnotationPostProcessorTests {
 
@@ -289,8 +290,8 @@ public class MessagingAnnotationPostProcessorTests {
 	}
 
 	private static GenericApplicationContext createTestApplicationContext() {
-		GenericApplicationContext context = new GenericApplicationContext();
-		new IntegrationRegistrar().registerBeanDefinitions(mock(), context.getDefaultListableBeanFactory());
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.register(Config.class);
 		return context;
 	}
 
@@ -383,6 +384,11 @@ public class MessagingAnnotationPostProcessorTests {
 	@Retention(RetentionPolicy.RUNTIME)
 	@ServiceActivator(inputChannel = "eventBus")
 	public @interface EventHandler {
+
+	}
+
+	@EnableIntegration
+	static class Config {
 
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/RouterAnnotationPostProcessorTests.java
@@ -23,26 +23,26 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.Router;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.config.IntegrationRegistrar;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Jiandong Ma
  */
 public class RouterAnnotationPostProcessorTests {
 
-	private final GenericApplicationContext context = new GenericApplicationContext();
+	private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
 	private final DirectChannel inputChannel = new DirectChannel();
 
@@ -56,7 +56,6 @@ public class RouterAnnotationPostProcessorTests {
 
 	@BeforeEach
 	public void init() {
-		new IntegrationRegistrar().registerBeanDefinitions(mock(), this.context.getDefaultListableBeanFactory());
 		TestUtils.registerBean("input", inputChannel, this.context);
 		TestUtils.registerBean("output", outputChannel, this.context);
 		TestUtils.registerBean("routingChannel", routingChannel, this.context);
@@ -95,6 +94,7 @@ public class RouterAnnotationPostProcessorTests {
 		context.stop();
 	}
 
+	@EnableIntegration
 	@MessageEndpoint
 	public static class TestRouter {
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SplitterAnnotationPostProcessorTests.java
@@ -21,27 +21,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.context.Lifecycle;
-import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.Splitter;
 import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.channel.QueueChannel;
-import org.springframework.integration.config.IntegrationRegistrar;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Jiandong Ma
  */
 public class SplitterAnnotationPostProcessorTests {
 
-	private final GenericApplicationContext context = new GenericApplicationContext();
+	private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
 
 	private final DirectChannel inputChannel = new DirectChannel();
 
@@ -49,7 +49,6 @@ public class SplitterAnnotationPostProcessorTests {
 
 	@BeforeEach
 	public void init() {
-		new IntegrationRegistrar().registerBeanDefinitions(mock(), this.context.getDefaultListableBeanFactory());
 		TestUtils.registerBean("input", this.inputChannel, this.context);
 		TestUtils.registerBean("output", this.outputChannel, this.context);
 	}
@@ -90,6 +89,7 @@ public class SplitterAnnotationPostProcessorTests {
 		context.stop();
 	}
 
+	@EnableIntegration
 	@MessageEndpoint
 	public static class TestSplitter implements Lifecycle {
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SubscriberOrderTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/config/annotation/SubscriberOrderTests.java
@@ -23,31 +23,30 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.RootBeanDefinition;
-import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.core.annotation.Order;
 import org.springframework.integration.MessageRejectedException;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
 import org.springframework.integration.channel.DirectChannel;
-import org.springframework.integration.config.IntegrationRegistrar;
+import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dispatcher.RoundRobinLoadBalancingStrategy;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Mark Fisher
  * @author Artem Bilan
+ * @author Jiandong Ma
  */
 public class SubscriberOrderTests {
 
 	@Test
 	public void directChannelAndFailoverDispatcherWithSingleCallPerMethod() {
-		try (GenericApplicationContext context = new GenericApplicationContext()) {
-			new IntegrationRegistrar().registerBeanDefinitions(mock(), context.getDefaultListableBeanFactory());
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
 			RootBeanDefinition channelDefinition = new RootBeanDefinition(DirectChannel.class);
 			context.registerBeanDefinition("input", channelDefinition);
 			RootBeanDefinition testBeanDefinition = new RootBeanDefinition(TestBean.class);
@@ -68,8 +67,7 @@ public class SubscriberOrderTests {
 
 	@Test
 	public void directChannelAndFailoverDispatcherWithMultipleCallsPerMethod() {
-		try (GenericApplicationContext context = new GenericApplicationContext()) {
-			new IntegrationRegistrar().registerBeanDefinitions(mock(), context.getDefaultListableBeanFactory());
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
 			BeanDefinitionBuilder channelBuilder = BeanDefinitionBuilder.rootBeanDefinition(DirectChannel.class);
 			channelBuilder.addConstructorArgValue(null);
 			RootBeanDefinition channelDefinition = (RootBeanDefinition) channelBuilder.getBeanDefinition();
@@ -95,8 +93,7 @@ public class SubscriberOrderTests {
 
 	@Test
 	public void directChannelAndRoundRobinDispatcher() {
-		try (GenericApplicationContext context = new GenericApplicationContext()) {
-			new IntegrationRegistrar().registerBeanDefinitions(mock(), context.getDefaultListableBeanFactory());
+		try (AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext()) {
 			RootBeanDefinition channelDefinition = new RootBeanDefinition(DirectChannel.class);
 			channelDefinition.getConstructorArgumentValues()
 					.addGenericArgumentValue(new RoundRobinLoadBalancingStrategy());
@@ -128,6 +125,7 @@ public class SubscriberOrderTests {
 
 	}
 
+	@EnableIntegration
 	@MessageEndpoint
 	static class TestBean extends AbstractTestBean {
 


### PR DESCRIPTION
Instead, using `@EnableIntegration` approach combined with `AnnotationConfigApplicationContext`.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
