### PR TITLE
GH-11041: Revise cache in the `JdbcLockRegistry`

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -185,22 +185,9 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 
 	@Override
 	public void renewLock(Object lockKey, Duration customTtl) {
-		Assert.isInstanceOf(String.class, lockKey);
-		String path = pathFor((String) lockKey);
-		JdbcLock jdbcLock;
-		this.lock.lock();
-		try {
-			jdbcLock = this.locks.get(path);
-		}
-		finally {
-			this.lock.unlock();
-		}
-
-		if (jdbcLock == null) {
-			throw new IllegalStateException("Could not found mutex at " + path);
-		}
+		JdbcLock jdbcLock = (JdbcLock) obtain(lockKey);
 		if (!jdbcLock.renew(customTtl)) {
-			throw new IllegalStateException("Could not renew mutex at " + path);
+			throw new IllegalStateException("Could not renew lock " + lockKey);
 		}
 	}
 

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -30,6 +30,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.TransientDataAccessException;
+import org.springframework.integration.support.locks.DefaultLockRegistry;
 import org.springframework.integration.support.locks.DistributedLock;
 import org.springframework.integration.support.locks.ExpirableLockRegistry;
 import org.springframework.integration.support.locks.RenewableLockRegistry;
@@ -67,7 +68,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 
 	private static final int DEFAULT_IDLE = 100;
 
-	private static final int DEFAULT_CAPACITY = 100_000;
+	private static final int DEFAULT_CAPACITY = 256;
 
 	private final Lock lock = new ReentrantLock();
 
@@ -97,6 +98,8 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 	public static final Duration DEFAULT_TTL = Duration.ofSeconds(10);
 
 	private final Duration ttl;
+
+	private DefaultLockRegistry defaultLockRegistry = new DefaultLockRegistry();
 
 	/**
 	 * Construct an instance based on the provided {@link LockRepository}.
@@ -131,11 +134,15 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 
 	/**
 	 * Set the capacity of cached locks.
-	 * @param cacheCapacity The capacity of cached lock, (default 100_000).
+	 * @param cacheCapacity The capacity of cached lock, (default 256 locks).
 	 * @since 5.5.6
+	 * @see DefaultLockRegistry
 	 */
 	public void setCacheCapacity(int cacheCapacity) {
 		this.cacheCapacity = cacheCapacity;
+		// Find the highest power of 2 for (n + 1), then subtract 1
+		int mask = Integer.highestOneBit(cacheCapacity + 1) - 1;
+		this.defaultLockRegistry = new DefaultLockRegistry(mask);
 	}
 
 	@Override
@@ -212,12 +219,13 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 
 		private volatile long lastUsed = System.currentTimeMillis();
 
-		private final ReentrantLock delegate = new ReentrantLock();
+		private final ReentrantLock delegate;
 
 		JdbcLock(LockRepository client, Duration idleBetweenTries, String path) {
 			this.mutex = client;
 			this.idleBetweenTries = idleBetweenTries;
 			this.path = path;
+			this.delegate = (ReentrantLock) JdbcLockRegistry.this.defaultLockRegistry.obtain(this.path);
 		}
 
 		public long getLastUsed() {

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
@@ -50,6 +50,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author Dave Syer
@@ -621,6 +622,7 @@ class JdbcLockRegistryTests {
 		client.afterPropertiesSet();
 		client.afterSingletonsInstantiated();
 		JdbcLockRegistry registry = new JdbcLockRegistry(client) {
+
 			@Override
 			protected String pathFor(String input) {
 				return input;
@@ -632,6 +634,53 @@ class JdbcLockRegistryTests {
 		String lockPath = TestUtils.getPropertyValue(lock, "path");
 
 		assertThat(lockPath).isEqualTo(lockKey);
+	}
+
+	@Test
+	void noSecondLockOnEviction() throws InterruptedException {
+		DefaultLockRepository client = new DefaultLockRepository(dataSource);
+		client.setApplicationContext(this.context);
+		client.afterPropertiesSet();
+		client.afterSingletonsInstantiated();
+		JdbcLockRegistry registry = new JdbcLockRegistry(client);
+		registry.setCacheCapacity(2);
+
+		CountDownLatch lock1Latch = new CountDownLatch(1);
+		CountDownLatch furtherLocksLatch = new CountDownLatch(1);
+
+		Executors.newSingleThreadExecutor()
+				.execute(() -> {
+					DistributedLock lock1 = registry.obtain("lock1");
+					lock1.lock();
+					try {
+						furtherLocksLatch.countDown();
+						lock1Latch.await(10, TimeUnit.SECONDS);
+					}
+					catch (InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
+					finally {
+						lock1.unlock();
+					}
+				});
+
+		assertThat(furtherLocksLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		// Two new locks to trigger cache eviction for the 'lock1'
+		registry.obtain("lock2");
+		registry.obtain("lock3");
+
+		// Request 'lock1' again: will trigger new JdbcLock instance
+		DistributedLock lock1 = registry.obtain("lock1");
+
+		// Cannot lock because 'lock1' is still locked by another thread
+		assertThat(lock1.tryLock(1, TimeUnit.SECONDS)).isFalse();
+
+		lock1Latch.countDown();
+
+		assertThatNoException().isThrownBy(() -> {
+			lock1.lock();
+			lock1.unlock();
+		});
 	}
 
 	private static Map<String, Lock> getRegistryLocks(JdbcLockRegistry registry) {

--- a/src/reference/antora/modules/ROOT/pages/jdbc/lock-registry.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jdbc/lock-registry.adoc
@@ -45,7 +45,10 @@ So the time to live can be highly reduced, and deployments can retake a lost loc
 NOTE: The lock renewal can be done only if the lock is held by the current thread.
 
 Starting with version 5.5.6, the `JdbcLockRegistry` is support automatically clean-up cache for JdbcLock in `JdbcLockRegistry.locks` via `JdbcLockRegistry.setCacheCapacity()`.
+The default value is `256`.
 See its Javadocs for more information.
+This capacity number is also propagated into the `DefaultLockRegistry` used internally in the `JdbcLockRegistry` for a pool of shared `ReentrantLock` instances.
+So, if higher concurrent access (the number of unique lock keys used in parallel) is expected (or allowed) for the application, the `cacheCapacity` should be increased respectively, with the closest power of 2 in mind (essentially `Integer.highestOneBit(cacheCapacity + 1)`).
 
 Starting with version 6.0, the `DefaultLockRepository` can be supplied with a `PlatformTransactionManager` instead of relying on the primary bean from the application context.
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/11041

**Auto-cherry-pick to `7.0.x` & `6.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
