### PR TITLE
GH-11040: Hide exception in gRPC error message

### DIFF
--- a/spring-integration-grpc/src/main/java/org/springframework/integration/grpc/inbound/GrpcInboundGateway.java
+++ b/spring-integration-grpc/src/main/java/org/springframework/integration/grpc/inbound/GrpcInboundGateway.java
@@ -64,6 +64,7 @@ import org.springframework.util.StringUtils;
  * Such information can be used, for example, in downstream flow for routing.
  *
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 7.1
  */
@@ -237,12 +238,13 @@ public class GrpcInboundGateway extends MessagingGatewaySupport implements Binda
 				.map(Message::getPayload);
 	}
 
-	private static StatusRuntimeException toGrpcStatusException(Throwable throwable) {
-		return toGrpcStatusException(throwable, throwable.getMessage());
+	private StatusRuntimeException toGrpcStatusException(Throwable throwable) {
+		return toGrpcStatusException(throwable, "Internal Server Error");
 	}
 
-	private static StatusRuntimeException toGrpcStatusException(Throwable throwable, @Nullable String description) {
-		return Status.fromThrowable(throwable)
+	private StatusRuntimeException toGrpcStatusException(Throwable throwable, @Nullable String description) {
+		logger.error(throwable, description == null ? "Internal Server Error" : description);
+		return Status.fromCode(Status.Code.INTERNAL)
 				.withDescription(description)
 				.asRuntimeException();
 	}

--- a/spring-integration-grpc/src/main/java/org/springframework/integration/grpc/inbound/GrpcInboundGateway.java
+++ b/spring-integration-grpc/src/main/java/org/springframework/integration/grpc/inbound/GrpcInboundGateway.java
@@ -239,13 +239,17 @@ public class GrpcInboundGateway extends MessagingGatewaySupport implements Binda
 	}
 
 	private StatusRuntimeException toGrpcStatusException(Throwable throwable) {
-		return toGrpcStatusException(throwable, "Internal Server Error");
+		return toGrpcStatusException(throwable, throwable.getMessage());
 	}
 
 	private StatusRuntimeException toGrpcStatusException(Throwable throwable, @Nullable String description) {
-		logger.error(throwable, description == null ? "Internal Server Error" : description);
-		return Status.fromCode(Status.Code.INTERNAL)
-				.withDescription(description)
+		Status status = Status.fromThrowable(throwable);
+		String statusDescription = (description != null) ? description : status.getDescription();
+		if (status.getCode().equals(Status.UNKNOWN.getCode()) || statusDescription == null) {
+			statusDescription = "Internal Server Error";
+		}
+		logger.error(throwable, statusDescription);
+		return status.withDescription(statusDescription)
 				.asRuntimeException();
 	}
 

--- a/spring-integration-grpc/src/main/java/org/springframework/integration/grpc/inbound/GrpcInboundGateway.java
+++ b/spring-integration-grpc/src/main/java/org/springframework/integration/grpc/inbound/GrpcInboundGateway.java
@@ -245,7 +245,7 @@ public class GrpcInboundGateway extends MessagingGatewaySupport implements Binda
 	private StatusRuntimeException toGrpcStatusException(Throwable throwable, @Nullable String description) {
 		Status status = Status.fromThrowable(throwable);
 		String statusDescription = (description != null) ? description : status.getDescription();
-		if (status.getCode().equals(Status.UNKNOWN.getCode()) || statusDescription == null) {
+		if (status.getCode().equals(Status.Code.UNKNOWN) || statusDescription == null) {
 			statusDescription = "Internal Server Error";
 		}
 		logger.error(throwable, statusDescription);

--- a/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/inbound/GrpcInboundGatewayTests.java
+++ b/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/inbound/GrpcInboundGatewayTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.ManagedChannel;
@@ -31,13 +32,17 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.log.LogAccessor;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.grpc.GrpcHeaders;
@@ -52,9 +57,12 @@ import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 7.1
  */
@@ -70,6 +78,8 @@ class GrpcInboundGatewayTests {
 
 	@Autowired
 	TestHelloWorldGrpc.TestHelloWorldStub testHelloWorldStub;
+
+	@Autowired ApplicationContext applicationContext;
 
 	@Test
 	void unary() {
@@ -151,14 +161,36 @@ class GrpcInboundGatewayTests {
 
 	@Test
 	void errorFromServer() {
-		assertThatExceptionOfType(StatusRuntimeException.class)
-				.isThrownBy(() -> this.testHelloWorldBlockingStub.errorOnHello(newHelloRequest("Error")))
-				.satisfies(e -> {
-					assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
-					assertThat(e.getStatus().getDescription())
-							.contains("Failed to transform Message in bean " +
-									"'grpcIntegrationFlow.subFlow#4.method-invoking-transformer#1'");
-				});
+		GrpcInboundGateway gateway = this.applicationContext.getBean(GrpcInboundGateway.class);
+		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
+		LogAccessor originalLog = (LogAccessor) accessor.getPropertyValue("logger");
+		LogAccessor spyLog = spy(originalLog);
+
+		try {
+			accessor.setPropertyValue("logger", spyLog);
+
+			assertThatExceptionOfType(StatusRuntimeException.class)
+					.isThrownBy(() -> this.testHelloWorldBlockingStub.errorOnHello(newHelloRequest("Error")))
+					.satisfies(e -> {
+						assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.INTERNAL);
+						assertThat(e.getStatus().getDescription())
+								.contains("Internal Server Error");
+					});
+
+			verify(spyLog).debug(
+					ArgumentMatchers.<Supplier<? extends CharSequence>>argThat(
+							logMessage -> {
+								String actualLogMessage = logMessage.get().toString();
+								return actualLogMessage.contains("Failed to transform Message in bean " +
+										"'grpcIntegrationFlow.subFlow#4.method-invoking-transformer#1");
+							}
+					)
+			);
+
+		}
+		finally {
+			accessor.setPropertyValue("logger", originalLog);
+		}
 	}
 
 	private static HelloRequest newHelloRequest(String message) {

--- a/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/inbound/GrpcInboundGatewayTests.java
+++ b/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/inbound/GrpcInboundGatewayTests.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import io.grpc.ManagedChannel;
@@ -32,17 +31,14 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.log.LogAccessor;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.grpc.GrpcHeaders;
@@ -57,8 +53,6 @@ import org.springframework.util.StringUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 /**
  * @author Artem Bilan
@@ -161,36 +155,25 @@ class GrpcInboundGatewayTests {
 
 	@Test
 	void errorFromServer() {
-		GrpcInboundGateway gateway = this.applicationContext.getBean(GrpcInboundGateway.class);
-		DirectFieldAccessor accessor = new DirectFieldAccessor(gateway);
-		LogAccessor originalLog = (LogAccessor) accessor.getPropertyValue("logger");
-		LogAccessor spyLog = spy(originalLog);
+		assertThatExceptionOfType(StatusRuntimeException.class)
+				.isThrownBy(() -> this.testHelloWorldBlockingStub.errorOnHello(newHelloRequest("Error")))
+				.satisfies(e -> {
+					assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+					assertThat(e.getStatus().getDescription())
+							.contains("Failed to transform Message in bean " +
+									"'grpcIntegrationFlow.subFlow#4.method-invoking-transformer#1'");
+				});
+	}
 
-		try {
-			accessor.setPropertyValue("logger", spyLog);
-
-			assertThatExceptionOfType(StatusRuntimeException.class)
-					.isThrownBy(() -> this.testHelloWorldBlockingStub.errorOnHello(newHelloRequest("Error")))
-					.satisfies(e -> {
-						assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.INTERNAL);
-						assertThat(e.getStatus().getDescription())
-								.contains("Internal Server Error");
-					});
-
-			verify(spyLog).debug(
-					ArgumentMatchers.<Supplier<? extends CharSequence>>argThat(
-							logMessage -> {
-								String actualLogMessage = logMessage.get().toString();
-								return actualLogMessage.contains("Failed to transform Message in bean " +
-										"'grpcIntegrationFlow.subFlow#4.method-invoking-transformer#1");
-							}
-					)
-			);
-
-		}
-		finally {
-			accessor.setPropertyValue("logger", originalLog);
-		}
+	@Test
+	void unknownErrorFromServer() {
+		assertThatExceptionOfType(StatusRuntimeException.class)
+				.isThrownBy(() -> this.testHelloWorldBlockingStub.unknownErrorOnHello(newHelloRequest("Error")))
+				.satisfies(e -> {
+					assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.UNKNOWN);
+					assertThat(e.getStatus().getDescription())
+							.isEqualTo("Internal Server Error");
+				});
 	}
 
 	private static HelloRequest newHelloRequest(String message) {
@@ -270,6 +253,11 @@ class GrpcInboundGatewayTests {
 											.transform(p -> {
 												throw Status.UNAVAILABLE.withDescription("intentional")
 														.asRuntimeException();
+											}))
+
+									.subFlowMapping("UnknownErrorOnHello", flow -> flow
+											.transform(p -> {
+												throw new RuntimeException("");
 											}))
 					)
 					.get();

--- a/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/inbound/GrpcInboundGatewayTests.java
+++ b/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/inbound/GrpcInboundGatewayTests.java
@@ -264,8 +264,7 @@ class GrpcInboundGatewayTests {
 				throw Status.UNAVAILABLE.withDescription("intentional")
 						.asRuntimeException();
 			}
-			throw Status.UNKNOWN.withDescription("")
-					.asRuntimeException();
+			throw new RuntimeException("should not show");
 		}
 
 		private Flux<HelloReply> streamReply(HelloRequest helloRequest) {

--- a/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/inbound/GrpcInboundGatewayTests.java
+++ b/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/inbound/GrpcInboundGatewayTests.java
@@ -168,7 +168,7 @@ class GrpcInboundGatewayTests {
 	@Test
 	void unknownErrorFromServer() {
 		assertThatExceptionOfType(StatusRuntimeException.class)
-				.isThrownBy(() -> this.testHelloWorldBlockingStub.unknownErrorOnHello(newHelloRequest("Error")))
+				.isThrownBy(() -> this.testHelloWorldBlockingStub.errorOnHello(newHelloRequest("unknown")))
 				.satisfies(e -> {
 					assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.UNKNOWN);
 					assertThat(e.getStatus().getDescription())
@@ -250,21 +250,22 @@ class GrpcInboundGatewayTests {
 											.transform(this::requestReply))
 
 									.subFlowMapping("ErrorOnHello", flow -> flow
-											.transform(p -> {
-												throw Status.UNAVAILABLE.withDescription("intentional")
-														.asRuntimeException();
-											}))
-
-									.subFlowMapping("UnknownErrorOnHello", flow -> flow
-											.transform(p -> {
-												throw new RuntimeException("");
-											}))
+											.transform(this::errorReply))
 					)
 					.get();
 		}
 
 		private HelloReply requestReply(HelloRequest helloRequest) {
 			return newHelloReply("Hello " + helloRequest.getName());
+		}
+
+		private HelloReply errorReply(HelloRequest helloRequest) {
+			if (helloRequest.getName().equals("Error")) {
+				throw Status.UNAVAILABLE.withDescription("intentional")
+						.asRuntimeException();
+			}
+			throw Status.UNKNOWN.withDescription("")
+					.asRuntimeException();
 		}
 
 		private Flux<HelloReply> streamReply(HelloRequest helloRequest) {

--- a/spring-integration-grpc/src/test/proto/test_hello.proto
+++ b/spring-integration-grpc/src/test/proto/test_hello.proto
@@ -27,8 +27,4 @@ service TestHelloWorld {
   // Fail with error
   rpc ErrorOnHello(HelloRequest) returns (HelloReply) {}
 
-  // Fail with unknown error
-  rpc UnknownErrorOnHello(HelloRequest) returns (HelloReply) {}
-
-
 }

--- a/spring-integration-grpc/src/test/proto/test_hello.proto
+++ b/spring-integration-grpc/src/test/proto/test_hello.proto
@@ -27,4 +27,8 @@ service TestHelloWorld {
   // Fail with error
   rpc ErrorOnHello(HelloRequest) returns (HelloReply) {}
 
+  // Fail with unknown error
+  rpc UnknownErrorOnHello(HelloRequest) returns (HelloReply) {}
+
+
 }

--- a/src/reference/antora/modules/ROOT/pages/grpc.adoc
+++ b/src/reference/antora/modules/ROOT/pages/grpc.adoc
@@ -156,7 +156,7 @@ All the downstream transformer business methods are type-safe in regard to gRPC 
 [[grpc-inbound-error-handling]]
 === Error Handling
 
-If an error occurs during downstream processing, the `GrpcInboundGateway` attempts to map the resulting `Throwable` to a gRPC `StatusRuntimeException`.
+If an error occurs during downstream processing, the `GrpcInboundGateway` attempts to map the resulting `Throwable` to a gRPC `StatusException`.
 It does so by utilizing `Status.fromThrowable(throwable)` to retain any specific gRPC status codes (such as `Status.UNAVAILABLE`, `Status.INVALID_ARGUMENT`, etc.).
 If the status code evaluates to `UNKNOWN`, the gateway falls back to a generic description of `"Internal Server Error"`.
 This ensures that the client receives the original gRPC status when one is provided.

--- a/src/reference/antora/modules/ROOT/pages/grpc.adoc
+++ b/src/reference/antora/modules/ROOT/pages/grpc.adoc
@@ -153,6 +153,14 @@ private static HelloReply newHelloReply(String message) {
 The routing is done on the `GrpcHeaders.SERVICE_METHOD` header populated by the `GrpcInboundGateway`.
 All the downstream transformer business methods are type-safe in regard to gRPC messages for the `TestHelloWorldGrpc.TestHelloWorldImplBase` service.
 
+[[grpc-inbound-error-handling]]
+=== Error Handling
+
+If an error occurs during downstream processing, the `GrpcInboundGateway` attempts to map the resulting `Throwable` to a gRPC `StatusRuntimeException`.
+It does so by utilizing `Status.fromThrowable(throwable)` to retain any specific gRPC status codes (such as `Status.UNAVAILABLE`, `Status.INVALID_ARGUMENT`, etc.).
+If the status code evaluates to `UNKNOWN`, the gateway falls back to a generic description of `"Internal Server Error"`.
+This ensures that the client receives the original gRPC status when one is provided.
+
 [[configuration-grpc-inbound-gateway-with-dsl]]
 === Configuration with DSL
 


### PR DESCRIPTION
Prevent internal exceptions from leaking in gRPC error responses.
- Log the actual exception locally instead of sending it over the wire.
- Return a generic internal server error for unhandled exceptions.
- Update GrpcInboundGatewayTests to verify the new error handling.

Fixes: #11040

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
