### PR TITLE
GH-11049: Block unlock until key is removed

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -29,6 +29,7 @@ import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -37,6 +38,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -586,15 +588,40 @@ public final class RedisLockRegistry
 				return;
 			}
 			try {
-				if (Thread.currentThread().isInterrupted()) {
-					RedisLockRegistry.this.executor.execute(this::removeLockKey);
+				CountDownLatch latch = new CountDownLatch(1);
+				AtomicReference<RuntimeException> exceptionHolder = new AtomicReference<>();
+				RedisLockRegistry.this.executor.execute(() -> {
+					try {
+						removeLockKey();
+					}
+					catch (RuntimeException ex) {
+						exceptionHolder.set(ex);
+					}
+					finally {
+						latch.countDown();
+					}
+				});
+
+				boolean interrupted = false;
+				try {
+					while (true) {
+						try {
+							latch.await();
+							break;
+						}
+						catch (InterruptedException e) {
+							interrupted = true;
+						}
+					}
 				}
-				else {
-					removeLockKey();
+				finally {
+					if (interrupted) {
+						Thread.currentThread().interrupt();
+					}
 				}
 
-				if (LOGGER.isDebugEnabled()) {
-					LOGGER.debug("Released lock; " + this);
+				if (exceptionHolder.get() != null) {
+					throw exceptionHolder.get();
 				}
 			}
 			catch (Exception e) {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
@@ -1121,10 +1121,11 @@ class RedisLockRegistryTests implements RedisContainerTest {
 		CountDownLatch removalStarted = new CountDownLatch(1);
 		CountDownLatch allowRemovalToFinish = new CountDownLatch(1);
 
+		// Create an executor to freeze the removal process
 		registry.setExecutor(runnable -> new Thread(() -> {
 			try {
 				removalStarted.countDown();
-				allowRemovalToFinish.await(); // Hold the Redis delete hostage
+				allowRemovalToFinish.await();
 				runnable.run();
 			}
 			catch (InterruptedException e) {
@@ -1134,6 +1135,7 @@ class RedisLockRegistryTests implements RedisContainerTest {
 
 		Lock lock = registry.obtain("test");
 
+		// Spawn worker thread with error logging
 		Thread testThread = new Thread(() -> {
 			lock.lock();
 			try {
@@ -1146,28 +1148,26 @@ class RedisLockRegistryTests implements RedisContainerTest {
 
 		testThread.start();
 
-		// Wait until the background thread reaches the removal phase
+		// Wait until the background thread reaches the frozen state
 		boolean started = removalStarted.await(5, TimeUnit.SECONDS);
 		assertThat(started).isTrue();
 
-		// The unlocking thread is still blocked
+		// Verify thread state - it should still be blocked in unlock()
 		assertThat(testThread.isAlive()).isTrue();
 
-		// Try to acquire the lock from a fresh registry instance.
-		RedisLockRegistry freshRegistry = new RedisLockRegistry(redisConnectionFactory, this.registryKey);
-		Lock freshLock = freshRegistry.obtain("test");
-		assertThat(freshLock.tryLock()).isFalse();
+		// Since testThread is blocked in unlock(), it still holds the local lock
+		Lock localUserLock = registry.obtain("test");
+		assertThat(localUserLock.tryLock()).isFalse();
 
-		// Release the thread
+		// Allow executor thread to continue
 		allowRemovalToFinish.countDown();
 
-		// Verify the unlocking thread terminates normally
 		testThread.join(1000);
 		assertThat(testThread.isAlive()).isFalse();
 
-		// Now that the key is deleted, the fresh instance can acquire it
-		assertThat(freshLock.tryLock()).isTrue();
-		freshLock.unlock();
+		// Final check
+		assertThat(localUserLock.tryLock()).isTrue();
+		localUserLock.unlock();
 	}
 
 	private Long getExpire(RedisLockRegistry registry, String lockKey) {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
@@ -1118,14 +1118,14 @@ class RedisLockRegistryTests implements RedisContainerTest {
 	void testUnlockWhenInterruptedBlocksUntilKeyRemoved() throws Exception {
 		RedisLockRegistry registry = new RedisLockRegistry(redisConnectionFactory, this.registryKey);
 
-		AtomicBoolean backgroundTaskFinished = new AtomicBoolean(false);
+		CountDownLatch removalStarted = new CountDownLatch(1);
+		CountDownLatch allowRemovalToFinish = new CountDownLatch(1);
 
-		// Inject an executor that takes 200ms to run the key removal
 		registry.setExecutor(runnable -> new Thread(() -> {
 			try {
-				Thread.sleep(200);
+				removalStarted.countDown();
+				allowRemovalToFinish.await(); // Hold the Redis delete hostage
 				runnable.run();
-				backgroundTaskFinished.set(true); // Marks completion
 			}
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
@@ -1145,11 +1145,29 @@ class RedisLockRegistryTests implements RedisContainerTest {
 		});
 
 		testThread.start();
-		testThread.join();
 
-		// UNMODIFIED: FAILS (Expected: true, Actual: false) because unlock() leaked out early.
-		// FIXED: PASSES (true) because the latch forced the thread to wait for the background task.
-		assertThat(backgroundTaskFinished.get()).isTrue();
+		// Wait until the background thread reaches the removal phase
+		boolean started = removalStarted.await(5, TimeUnit.SECONDS);
+		assertThat(started).isTrue();
+
+		// The unlocking thread is still blocked
+		assertThat(testThread.isAlive()).isTrue();
+
+		// Try to acquire the lock from a fresh registry instance.
+		RedisLockRegistry freshRegistry = new RedisLockRegistry(redisConnectionFactory, this.registryKey);
+		Lock freshLock = freshRegistry.obtain("test");
+		assertThat(freshLock.tryLock()).isFalse();
+
+		// Release the thread
+		allowRemovalToFinish.countDown();
+
+		// Verify the unlocking thread terminates normally
+		testThread.join(1000);
+		assertThat(testThread.isAlive()).isFalse();
+
+		// Now that the key is deleted, the fresh instance can acquire it
+		assertThat(freshLock.tryLock()).isTrue();
+		freshLock.unlock();
 	}
 
 	private Long getExpire(RedisLockRegistry registry, String lockKey) {

--- a/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
+++ b/spring-integration-redis/src/test/java/org/springframework/integration/redis/util/RedisLockRegistryTests.java
@@ -1114,6 +1114,44 @@ class RedisLockRegistryTests implements RedisContainerTest {
 		});
 	}
 
+	@Test
+	void testUnlockWhenInterruptedBlocksUntilKeyRemoved() throws Exception {
+		RedisLockRegistry registry = new RedisLockRegistry(redisConnectionFactory, this.registryKey);
+
+		AtomicBoolean backgroundTaskFinished = new AtomicBoolean(false);
+
+		// Inject an executor that takes 200ms to run the key removal
+		registry.setExecutor(runnable -> new Thread(() -> {
+			try {
+				Thread.sleep(200);
+				runnable.run();
+				backgroundTaskFinished.set(true); // Marks completion
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+		}).start());
+
+		Lock lock = registry.obtain("test");
+
+		Thread testThread = new Thread(() -> {
+			lock.lock();
+			try {
+				Thread.currentThread().interrupt();
+			}
+			finally {
+				lock.unlock();
+			}
+		});
+
+		testThread.start();
+		testThread.join();
+
+		// UNMODIFIED: FAILS (Expected: true, Actual: false) because unlock() leaked out early.
+		// FIXED: PASSES (true) because the latch forced the thread to wait for the background task.
+		assertThat(backgroundTaskFinished.get()).isTrue();
+	}
+
 	private Long getExpire(RedisLockRegistry registry, String lockKey) {
 		StringRedisTemplate template = createTemplate();
 		String registryKey = TestUtils.getPropertyValue(registry, "registryKey");


### PR DESCRIPTION
- Block the unlock operation until the lock key is actually removed.
- Prevent early return when the current thread is interrupted.
- Propagate any exceptions from the removal task to the caller.
- Add a test to verify blocking behavior on interrupted threads.

Fixes: https://github.com/spring-projects/spring-integration/issues/11049

**Auto-cherry-pick to `7.0.x` & `6.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
