### PR TITLE
Do not ship javadoc web fonts for individual modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,6 +153,7 @@ configure(javaProjects) { subproject ->
     tasks.withType(Javadoc) {
         options.addBooleanOption('Xdoclint:syntax', true) // only check syntax with doclint
         options.addBooleanOption('Werror', true) // fail build on Javadoc warnings
+        options.addBooleanOption('-no-fonts', true) // exclude fonts from module javadoc
     }
 
     eclipse {


### PR DESCRIPTION
Web fonts use 4MB of space per "-javadoc.jar" file, for each module shipped by the project. While those are useful when browsing the javadoc, this project aggregates all javadocs under a single JAR and hosts it on doc.spring.io.

This commit skips the inclusion for the individual modules' javadoc since those are mainly used by IDEs.
The web fonts are still available for the aggregated version.

This is worth backporting to any branch building on Java 23+.
