### PR TITLE
IntegrationFlowBuilder falls back to outputChannelName

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
@@ -341,13 +341,7 @@ public interface IntegrationFlow {
 			@Nullable IntegrationFlowBuilder integrationFlowBuilderArg) {
 
 		IntegrationFlowBuilder integrationFlowBuilder = integrationFlowBuilderArg;
-		MessageChannel outputChannel;
-		try {
-			outputChannel = messageProducer.getOutputChannel();
-		}
-		catch (IllegalArgumentException argumentException) {
-			outputChannel = null;
-		}
+		MessageChannel outputChannel = messageProducer.getOutputChannel();
 
 		if (outputChannel == null) {
 			String outputChannelName = messageProducer.getOutputChannelName();
@@ -490,13 +484,7 @@ public interface IntegrationFlow {
 			@Nullable IntegrationFlowBuilder integrationFlowBuilderArg) {
 
 		IntegrationFlowBuilder integrationFlowBuilder = integrationFlowBuilderArg;
-		MessageChannel outputChannel;
-		try {
-			outputChannel = inboundGateway.getRequestChannel();
-		}
-		catch (IllegalArgumentException argumentException) {
-			outputChannel = null;
-		}
+		MessageChannel outputChannel = inboundGateway.getRequestChannel();
 
 		if (outputChannel == null) {
 			String requestChannelName = inboundGateway.getRequestChannelName();

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
@@ -41,6 +41,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * The main Integration DSL abstraction.
@@ -91,6 +92,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Oleg Zhurakousky
  * @author Artem Vozhdayenko
+ * @author Glenn Renfro
  *
  * @since 5.0
  *
@@ -339,18 +341,24 @@ public interface IntegrationFlow {
 			@Nullable IntegrationFlowBuilder integrationFlowBuilderArg) {
 
 		IntegrationFlowBuilder integrationFlowBuilder = integrationFlowBuilderArg;
-		MessageChannel outputChannel = messageProducer.getOutputChannel();
-		if (outputChannel == null) {
+		MessageChannel outputChannel = null;
+		String outputChannelName = messageProducer.getOutputChannelName();
+		try {
+			outputChannel = messageProducer.getOutputChannel();
+		}
+		catch (IllegalArgumentException argumentException) {
+			if (argumentException.getMessage() != null && !argumentException.getMessage()
+					.contentEquals("'beanFactory' must not be null")) {
+				throw argumentException;
+			}
+		}
+
+		if (!StringUtils.hasText(outputChannelName) && outputChannel == null) {
 			outputChannel = new DirectChannel();
 			messageProducer.setOutputChannel(outputChannel);
 		}
-		if (integrationFlowBuilder == null) {
-			integrationFlowBuilder = from(outputChannel);
-		}
-		else {
-			integrationFlowBuilder.channel(outputChannel);
-		}
-		return integrationFlowBuilder.addComponent(messageProducer);
+		return updateOutputChannelForBuilder(integrationFlowBuilder, outputChannelName, outputChannel)
+				.addComponent(messageProducer);
 	}
 
 	/**
@@ -474,18 +482,49 @@ public interface IntegrationFlow {
 			@Nullable IntegrationFlowBuilder integrationFlowBuilderArg) {
 
 		IntegrationFlowBuilder integrationFlowBuilder = integrationFlowBuilderArg;
-		MessageChannel outputChannel = inboundGateway.getRequestChannel();
-		if (outputChannel == null) {
+		MessageChannel outputChannel = null;
+		String requestChannelName = inboundGateway.getRequestChannelName();
+
+		try {
+			outputChannel = inboundGateway.getRequestChannel();
+		}
+		catch (IllegalArgumentException argumentException) {
+			if (argumentException.getMessage() != null && !argumentException.getMessage()
+					.contentEquals("'beanFactory' must not be null")) {
+				throw argumentException;
+			}
+		}
+
+		if (!StringUtils.hasText(requestChannelName) && outputChannel == null) {
 			outputChannel = new DirectChannel();
 			inboundGateway.setRequestChannel(outputChannel);
 		}
+		return updateOutputChannelForBuilder(integrationFlowBuilder, requestChannelName, outputChannel)
+				.addComponent(inboundGateway);
+	}
+
+	private static IntegrationFlowBuilder updateOutputChannelForBuilder(
+			@Nullable IntegrationFlowBuilder integrationFlowBuilder, @Nullable String channelName,
+			@Nullable MessageChannel outputChannel) {
 		if (integrationFlowBuilder == null) {
-			integrationFlowBuilder = from(outputChannel);
+			if (outputChannel != null) {
+				integrationFlowBuilder = from(outputChannel);
+			}
+			else {
+				Assert.notNull(channelName, "'channelName' must not be null");
+				integrationFlowBuilder = from(channelName);
+			}
 		}
 		else {
-			integrationFlowBuilder.channel(outputChannel);
+			if (outputChannel != null) {
+				integrationFlowBuilder.channel(outputChannel);
+			}
+			else {
+				Assert.notNull(channelName, "'channelName' must not be null");
+				integrationFlowBuilder.channel(channelName);
+			}
 		}
-		return integrationFlowBuilder.addComponent(inboundGateway);
+		return integrationFlowBuilder;
 	}
 
 	@Nullable

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/IntegrationFlow.java
@@ -341,24 +341,32 @@ public interface IntegrationFlow {
 			@Nullable IntegrationFlowBuilder integrationFlowBuilderArg) {
 
 		IntegrationFlowBuilder integrationFlowBuilder = integrationFlowBuilderArg;
-		MessageChannel outputChannel = null;
-		String outputChannelName = messageProducer.getOutputChannelName();
+		MessageChannel outputChannel;
 		try {
 			outputChannel = messageProducer.getOutputChannel();
 		}
 		catch (IllegalArgumentException argumentException) {
-			if (argumentException.getMessage() != null && !argumentException.getMessage()
-					.contentEquals("'beanFactory' must not be null")) {
-				throw argumentException;
+			outputChannel = null;
+		}
+
+		if (outputChannel == null) {
+			String outputChannelName = messageProducer.getOutputChannelName();
+			if (StringUtils.hasText(outputChannelName)) {
+				outputChannel = new MessageChannelReference(outputChannelName);
+			}
+			else {
+				outputChannel = new DirectChannel();
+				messageProducer.setOutputChannel(outputChannel);
 			}
 		}
 
-		if (!StringUtils.hasText(outputChannelName) && outputChannel == null) {
-			outputChannel = new DirectChannel();
-			messageProducer.setOutputChannel(outputChannel);
+		if (integrationFlowBuilder == null) {
+			integrationFlowBuilder = from(outputChannel);
 		}
-		return updateOutputChannelForBuilder(integrationFlowBuilder, outputChannelName, outputChannel)
-				.addComponent(messageProducer);
+		else {
+			integrationFlowBuilder.channel(outputChannel);
+		}
+		return integrationFlowBuilder.addComponent(messageProducer);
 	}
 
 	/**
@@ -482,49 +490,32 @@ public interface IntegrationFlow {
 			@Nullable IntegrationFlowBuilder integrationFlowBuilderArg) {
 
 		IntegrationFlowBuilder integrationFlowBuilder = integrationFlowBuilderArg;
-		MessageChannel outputChannel = null;
-		String requestChannelName = inboundGateway.getRequestChannelName();
-
+		MessageChannel outputChannel;
 		try {
 			outputChannel = inboundGateway.getRequestChannel();
 		}
 		catch (IllegalArgumentException argumentException) {
-			if (argumentException.getMessage() != null && !argumentException.getMessage()
-					.contentEquals("'beanFactory' must not be null")) {
-				throw argumentException;
-			}
+			outputChannel = null;
 		}
 
-		if (!StringUtils.hasText(requestChannelName) && outputChannel == null) {
-			outputChannel = new DirectChannel();
-			inboundGateway.setRequestChannel(outputChannel);
-		}
-		return updateOutputChannelForBuilder(integrationFlowBuilder, requestChannelName, outputChannel)
-				.addComponent(inboundGateway);
-	}
-
-	private static IntegrationFlowBuilder updateOutputChannelForBuilder(
-			@Nullable IntegrationFlowBuilder integrationFlowBuilder, @Nullable String channelName,
-			@Nullable MessageChannel outputChannel) {
-		if (integrationFlowBuilder == null) {
-			if (outputChannel != null) {
-				integrationFlowBuilder = from(outputChannel);
+		if (outputChannel == null) {
+			String requestChannelName = inboundGateway.getRequestChannelName();
+			if (StringUtils.hasText(requestChannelName)) {
+				outputChannel = new MessageChannelReference(requestChannelName);
 			}
 			else {
-				Assert.notNull(channelName, "'channelName' must not be null");
-				integrationFlowBuilder = from(channelName);
+				outputChannel = new DirectChannel();
+				inboundGateway.setRequestChannel(outputChannel);
 			}
+		}
+
+		if (integrationFlowBuilder == null) {
+			integrationFlowBuilder = from(outputChannel);
 		}
 		else {
-			if (outputChannel != null) {
-				integrationFlowBuilder.channel(outputChannel);
-			}
-			else {
-				Assert.notNull(channelName, "'channelName' must not be null");
-				integrationFlowBuilder.channel(channelName);
-			}
+			integrationFlowBuilder.channel(outputChannel);
 		}
-		return integrationFlowBuilder;
+		return integrationFlowBuilder.addComponent(inboundGateway);
 	}
 
 	@Nullable

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -104,8 +104,8 @@ public abstract class MessageProducerSupport extends AbstractEndpoint
 
 	/**
 	 * Return the output channel name.
-	 * @return the output channel name.
-	 * @since 6.5
+	 * @return the output channel name or null if not provided.
+	 * @since 6.5.10
 	 */
 	@Nullable
 	public String getOutputChannelName() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -114,9 +114,11 @@ public abstract class MessageProducerSupport extends AbstractEndpoint
 
 	@Override
 	public @Nullable MessageChannel getOutputChannel() {
-		String channelName = this.outputChannelName;
-		if (channelName != null) {
-			this.outputChannel = getChannelResolver().resolveDestination(channelName);
+		if (this.outputChannelName != null) {
+			if (getBeanFactory() == null) {
+				return null;
+			}
+			this.outputChannel = getChannelResolver().resolveDestination(this.outputChannelName);
 			this.outputChannelName = null;
 		}
 		return this.outputChannel;

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -53,6 +53,7 @@ import org.springframework.util.StringUtils;
  * @author Mark Fisher
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 public abstract class MessageProducerSupport extends AbstractEndpoint
 		implements MessageProducer, TrackableComponent,
@@ -99,6 +100,16 @@ public abstract class MessageProducerSupport extends AbstractEndpoint
 	public void setOutputChannelName(String outputChannelName) {
 		Assert.hasText(outputChannelName, "'outputChannelName' must not be null or empty");
 		this.outputChannelName = outputChannelName;
+	}
+
+	/**
+	 * Return the output channel name.
+	 * @return the output channel name.
+	 * @since 6.5
+	 */
+	@Nullable
+	public String getOutputChannelName() {
+		return this.outputChannelName;
 	}
 
 	@Override

--- a/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/endpoint/MessageProducerSupport.java
@@ -114,11 +114,12 @@ public abstract class MessageProducerSupport extends AbstractEndpoint
 
 	@Override
 	public @Nullable MessageChannel getOutputChannel() {
-		if (this.outputChannelName != null) {
+		String channelName = this.outputChannelName;
+		if (channelName != null) {
 			if (getBeanFactory() == null) {
 				return null;
 			}
-			this.outputChannel = getChannelResolver().resolveDestination(this.outputChannelName);
+			this.outputChannel = getChannelResolver().resolveDestination(channelName);
 			this.outputChannelName = null;
 		}
 		return this.outputChannel;

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -448,13 +448,13 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 	 * @since 4.2
 	 */
 	public @Nullable MessageChannel getRequestChannel() {
-		String requestChannelName = this.requestChannelName;
+		String channelName = this.requestChannelName;
 
-		if (this.requestChannel == null && requestChannelName != null) {
+		if (this.requestChannel == null && channelName != null) {
 			if (getBeanFactory() == null) {
 				return null;
 			}
-			this.requestChannel = getChannelResolver().resolveDestination(requestChannelName);
+			this.requestChannel = getChannelResolver().resolveDestination(channelName);
 		}
 		return this.requestChannel;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -449,6 +449,9 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 	 */
 	public @Nullable MessageChannel getRequestChannel() {
 		if (this.requestChannel == null && this.requestChannelName != null) {
+			if (getBeanFactory() == null) {
+				return null;
+			}
 			this.requestChannel = getChannelResolver().resolveDestination(this.requestChannelName);
 		}
 		return this.requestChannel;

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -209,8 +209,8 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 
 	/**
 	 * Return this gateway's request channel name.
-	 * @return the channel name.
-	 * @since 6.5
+	 * @return the channel name or null if not provided.
+	 * @since 6.5.10
 	 */
 	@Nullable
 	public String getRequestChannelName() {

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -448,11 +448,13 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 	 * @since 4.2
 	 */
 	public @Nullable MessageChannel getRequestChannel() {
-		if (this.requestChannel == null && this.requestChannelName != null) {
+		String requestChannelName = this.requestChannelName;
+
+		if (this.requestChannel == null && requestChannelName != null) {
 			if (getBeanFactory() == null) {
 				return null;
 			}
-			this.requestChannel = getChannelResolver().resolveDestination(this.requestChannelName);
+			this.requestChannel = getChannelResolver().resolveDestination(requestChannelName);
 		}
 		return this.requestChannel;
 	}

--- a/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/gateway/MessagingGatewaySupport.java
@@ -92,6 +92,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Trung Pham
  * @author Christian Tzolov
+ * @author Glenn Renfro
  */
 @IntegrationManagedResource
 public abstract class MessagingGatewaySupport extends AbstractEndpoint
@@ -204,6 +205,16 @@ public abstract class MessagingGatewaySupport extends AbstractEndpoint
 	public void setRequestChannelName(String requestChannelName) {
 		Assert.hasText(requestChannelName, "'requestChannelName' must not be empty");
 		this.requestChannelName = requestChannelName;
+	}
+
+	/**
+	 * Return this gateway's request channel name.
+	 * @return the channel name.
+	 * @since 6.5
+	 */
+	@Nullable
+	public String getRequestChannelName() {
+		return this.requestChannelName;
 	}
 
 	/**

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
@@ -65,6 +65,8 @@ import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.core.GenericTransformer;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.MessageChannels;
+import org.springframework.integration.dsl.MessageProducerSpec;
+import org.springframework.integration.dsl.MessagingGatewaySpec;
 import org.springframework.integration.dsl.PollerSpec;
 import org.springframework.integration.dsl.Pollers;
 import org.springframework.integration.dsl.QueueChannelSpec;
@@ -72,7 +74,9 @@ import org.springframework.integration.dsl.TransformerEndpointSpec;
 import org.springframework.integration.dsl.Transformers;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
+import org.springframework.integration.endpoint.MessageProducerSupport;
 import org.springframework.integration.gateway.GatewayProxyFactoryBean;
+import org.springframework.integration.gateway.MessagingGatewaySupport;
 import org.springframework.integration.handler.AbstractReplyProducingMessageHandler;
 import org.springframework.integration.handler.DelayHandler;
 import org.springframework.integration.handler.LoggingHandler;
@@ -563,6 +567,72 @@ public class IntegrationFlowTests {
 	@AfterEach
 	public void cleanUpList() {
 		outputStringList.clear();
+	}
+
+	@Test
+	public void testMessageProducerSpecWithOutputChannelName() {
+		IntegrationFlow flow = IntegrationFlow.from(new TestMessageProducerSpec()
+				.outputChannel("someChannelName")).get();
+		assertThat(flow).isNotNull();
+	}
+
+	@Test
+	public void testMessageProducerSpecWithOutputNoChannelName() {
+		IntegrationFlow flow = IntegrationFlow.from(new TestMessageProducerSpec()
+				.outputChannel(new QueueChannel())).get();
+		assertThat(flow).isNotNull();
+	}
+
+	@Test
+	public void testMessageProducerSpecWithOutputNullChannel() {
+		IntegrationFlow flow = IntegrationFlow.from(new TestMessageProducerSpec()).get();
+		assertThat(flow).isNotNull();
+	}
+
+	@Test
+	public void testWithChannelName() {
+		IntegrationFlow flow = IntegrationFlow.from("someChannelName").bridge().get();
+		assertThat(flow).isNotNull();
+	}
+
+	@Test
+	public void testMessagingGatewaySpecWithRequestChannelName() {
+		IntegrationFlow flow = IntegrationFlow.from(new TestMessagingGatewaySpec()
+				.requestChannel("someChannelName")).get();
+		assertThat(flow).isNotNull();
+	}
+
+	@Test
+	public void testMessageGatewaySpecWithRequestNoChannelName() {
+		IntegrationFlow flow = IntegrationFlow.from(new TestMessagingGatewaySpec()
+				.requestChannel(new QueueChannel())).get();
+		assertThat(flow).isNotNull();
+	}
+
+	@Test
+	public void testMessageGatewaySpecNullChannel() {
+		IntegrationFlow flow = IntegrationFlow.from(new TestMessagingGatewaySpec()).get();
+		assertThat(flow).isNotNull();
+	}
+
+	private static class TestMessageProducerSpec
+			extends MessageProducerSpec<TestMessageProducerSpec, MessageProducerSupport> {
+
+		TestMessageProducerSpec() {
+			super(new MessageProducerSupport() {
+			});
+		}
+
+	}
+
+	private static class TestMessagingGatewaySpec
+			extends MessagingGatewaySpec<TestMessagingGatewaySpec, MessagingGatewaySupport> {
+
+		TestMessagingGatewaySpec() {
+			super(new MessagingGatewaySupport() {
+			});
+		}
+
 	}
 
 	@MessagingGateway

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/flows/IntegrationFlowTests.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +73,7 @@ import org.springframework.integration.dsl.Pollers;
 import org.springframework.integration.dsl.QueueChannelSpec;
 import org.springframework.integration.dsl.TransformerEndpointSpec;
 import org.springframework.integration.dsl.Transformers;
+import org.springframework.integration.dsl.support.MessageChannelReference;
 import org.springframework.integration.endpoint.AbstractEndpoint;
 import org.springframework.integration.endpoint.EventDrivenConsumer;
 import org.springframework.integration.endpoint.MessageProducerSupport;
@@ -128,6 +130,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 @SpringJUnitConfig
 @DirtiesContext
 public class IntegrationFlowTests {
+
+	public static final String SAMPLE_CHANNEL_NAME = "someChannelName";
 
 	@Autowired
 	private ListableBeanFactory beanFactory;
@@ -572,47 +576,49 @@ public class IntegrationFlowTests {
 	@Test
 	public void testMessageProducerSpecWithOutputChannelName() {
 		IntegrationFlow flow = IntegrationFlow.from(new TestMessageProducerSpec()
-				.outputChannel("someChannelName")).get();
-		assertThat(flow).isNotNull();
+				.outputChannel(SAMPLE_CHANNEL_NAME)).get();
+		Map<Object, String> components = flow.getIntegrationComponents();
+		assertThat(components.keySet()).anyMatch(c -> c instanceof MessageChannelReference channelReference &&
+				SAMPLE_CHANNEL_NAME.equals(channelReference.name()));
 	}
 
 	@Test
 	public void testMessageProducerSpecWithOutputNoChannelName() {
 		IntegrationFlow flow = IntegrationFlow.from(new TestMessageProducerSpec()
 				.outputChannel(new QueueChannel())).get();
-		assertThat(flow).isNotNull();
+		Map<Object, String> components = flow.getIntegrationComponents();
+		assertThat(components.keySet()).hasAtLeastOneElementOfType(QueueChannel.class);
 	}
 
 	@Test
 	public void testMessageProducerSpecWithOutputNullChannel() {
 		IntegrationFlow flow = IntegrationFlow.from(new TestMessageProducerSpec()).get();
-		assertThat(flow).isNotNull();
-	}
-
-	@Test
-	public void testWithChannelName() {
-		IntegrationFlow flow = IntegrationFlow.from("someChannelName").bridge().get();
-		assertThat(flow).isNotNull();
+		Map<Object, String> components = flow.getIntegrationComponents();
+		assertThat(components.keySet()).hasAtLeastOneElementOfType(DirectChannel.class);
 	}
 
 	@Test
 	public void testMessagingGatewaySpecWithRequestChannelName() {
 		IntegrationFlow flow = IntegrationFlow.from(new TestMessagingGatewaySpec()
-				.requestChannel("someChannelName")).get();
-		assertThat(flow).isNotNull();
+				.requestChannel(SAMPLE_CHANNEL_NAME)).get();
+		Map<Object, String> components = flow.getIntegrationComponents();
+		assertThat(components.keySet()).anyMatch(c -> c instanceof MessageChannelReference channelReference &&
+				SAMPLE_CHANNEL_NAME.equals(channelReference.name()));
 	}
 
 	@Test
 	public void testMessageGatewaySpecWithRequestNoChannelName() {
 		IntegrationFlow flow = IntegrationFlow.from(new TestMessagingGatewaySpec()
 				.requestChannel(new QueueChannel())).get();
-		assertThat(flow).isNotNull();
+		Map<Object, String> components = flow.getIntegrationComponents();
+		assertThat(components.keySet()).hasAtLeastOneElementOfType(QueueChannel.class);
 	}
 
 	@Test
-	public void testMessageGatewaySpecNullChannel() {
+	public void testMessageGatewaySpecDirectChannel() {
 		IntegrationFlow flow = IntegrationFlow.from(new TestMessagingGatewaySpec()).get();
-		assertThat(flow).isNotNull();
+		Map<Object, String> components = flow.getIntegrationComponents();
+		assertThat(components.keySet()).hasAtLeastOneElementOfType(DirectChannel.class);
 	}
 
 	private static class TestMessageProducerSpec


### PR DESCRIPTION
- If outputChannel is not available, check if channelName is available.
- If neither are available create a direct channel.

Fixes: https://github.com/spring-projects/spring-integration/issues/11107

**Auto-cherry-pick to `7.0.x` & `6.5.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
