### PR TITLE
Fix multibyte ack-header offset in `DatagramPacketMessageMapper`

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapper.java
@@ -66,6 +66,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Dave Syer
  * @author Artem Bilan
+ * @author Uwez Khan
  *
  * @since 2.0
  */
@@ -243,10 +244,13 @@ public class DatagramPacketMessageMapper implements InboundMessageMapper<Datagra
 				String headersString = new String(packet.getData(), offset, length, this.charset);
 				Matcher matcher = UDP_HEADERS_PATTERN.matcher(headersString);
 				if (matcher.find()) {
-					// Strip off the ack headers and put in Message headers
-					length = length - matcher.end();
+					// Strip off the ack headers and put in Message headers.
+					// 'matcher.end()' is a character index into the decoded string; convert it to the
+					// number of bytes those characters occupy so multibyte charsets keep the payload aligned.
+					int headerLength = headersString.substring(0, matcher.end()).getBytes(this.charset).length;
+					length = length - headerLength;
 					payload = new byte[length];
-					System.arraycopy(packet.getData(), offset + matcher.end(), payload, 0, length);
+					System.arraycopy(packet.getData(), offset + headerLength, payload, 0, length);
 					message = getMessageBuilderFactory().withPayload(payload)
 							.setHeader(IpHeaders.ACK_ID, UUID.fromString(matcher.group(2)))
 							.setHeader(IpHeaders.ACK_ADDRESS, matcher.group(1))

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapperTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/udp/DatagramPacketMessageMapperTests.java
@@ -87,6 +87,34 @@ public class DatagramPacketMessageMapperTests {
 	}
 
 	@Test
+	public void testAckHeaderWithMultibyteAddress() {
+		Message<byte[]> message = MessageBuilder.withPayload("ABCD".getBytes()).build();
+		DatagramPacketMessageMapper mapper = new DatagramPacketMessageMapper();
+		mapper.setAckAddress("café:11111");
+		mapper.setAcknowledge(true);
+		mapper.setBeanFactory(mock());
+		DatagramPacket packet = mapper.fromMessage(message);
+		packet.setSocketAddress(new InetSocketAddress("localhost", 22222));
+		Message<byte[]> messageOut = mapper.toMessage(packet);
+		assertThat(messageOut.getPayload()).isEqualTo(message.getPayload());
+		assertThat(messageOut.getHeaders().get(IpHeaders.ACK_ADDRESS)).isEqualTo("café:11111");
+	}
+
+	@Test
+	public void testAckHeaderWithMultibyteAddressLengthCheck() {
+		Message<byte[]> message = MessageBuilder.withPayload("ABCD".getBytes()).build();
+		DatagramPacketMessageMapper mapper = new DatagramPacketMessageMapper();
+		mapper.setAckAddress("café:11111");
+		mapper.setAcknowledge(true);
+		mapper.setLengthCheck(true);
+		mapper.setBeanFactory(mock());
+		DatagramPacket packet = mapper.fromMessage(message);
+		packet.setSocketAddress(new InetSocketAddress("localhost", 22222));
+		Message<byte[]> messageOut = mapper.toMessage(packet);
+		assertThat(messageOut.getPayload()).isEqualTo(message.getPayload());
+	}
+
+	@Test
 	public void testTruncation() {
 		String test = "ABCD";
 		Message<byte[]> message = MessageBuilder.withPayload(test.getBytes()).build();


### PR DESCRIPTION
Round-tripping a UDP message through `DatagramPacketMessageMapper` with a non-ASCII `ip_ackTo` value:

    ackTo "café:11111" -> payload ";ABCD"   (expected "ABCD")

`toMessage` strips the `ip_ackTo`/`id` prefix using `Matcher.end()`, which is a character index into the decoded header string, but applies it as a byte offset into the packet and as the payload length. For a multibyte charset (UTF-8 is the default) the character count is shorter than the byte count, so the copy starts inside the header and the framing shifts.

Before: payload `";ABCD"`, the body is offset by the stray UTF-8 byte and the separator leaks in.
After: the matched prefix is re-encoded with the configured charset to get its byte length, which drives both the source offset and the remaining payload length, so the payload is `"ABCD"`.

Trade-off: one extra `getBytes(charset)` over the matched header region per ack packet, only on the ack path; ASCII ack addresses behave exactly as before.
