### PR TITLE
GH-11121: Fix SftpSession.listNames() for root directory wildcard paths

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -50,6 +50,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Christian Tzolov
  * @author Darryl Smith
+ * @author Adam Yang
  * @since 2.0
  */
 public class SftpSession implements Session<SftpClient.DirEntry> {
@@ -113,7 +114,10 @@ public class SftpSession implements Session<SftpClient.DirEntry> {
 		if (lastIndex > 0) {
 			remoteDir = remoteDir.substring(0, lastIndex);
 		}
-		String remoteFile = lastIndex > 0 ? remotePath.substring(lastIndex + 1) : null;
+		else if (lastIndex == 0) {
+			remoteDir = "/";
+		}
+		String remoteFile = lastIndex >= 0 ? remotePath.substring(lastIndex + 1) : null;
 		boolean isPattern = remoteFile != null && remoteFile.contains("*");
 
 		if (!isPattern && remoteFile != null) {

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpOutboundTests.java
@@ -78,6 +78,7 @@ import static org.mockito.Mockito.when;
  * @author Artem Bilan
  * @author Darryl Smith
  * @author Glenn Renfro
+ * @author Adam Yang
  */
 public class SftpOutboundTests implements TestApplicationContextAware {
 
@@ -328,6 +329,10 @@ public class SftpOutboundTests implements TestApplicationContextAware {
 								.map((file) -> new SftpClient.DirEntry(file, file, new SftpClient.Attributes()))
 								.toList();
 				when(sftpClient.readDir("/remote-test-dir")).thenReturn(dirEntries);
+
+				SftpClient.Attributes dirAttributes = new SftpClient.Attributes();
+				dirAttributes.setPermissions(SftpConstants.S_IFDIR);
+				willReturn(dirAttributes).given(sftpClient).stat("/remote-test-dir/");
 
 				return SftpTestSessionFactory.createSftpSession(sftpClient);
 			}

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
@@ -55,6 +55,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
  * @author Artem Bilan
  * @author Darryl Smith
  * @author Glenn Renfro
+ * @author Adam Yang
  *
  * @since 4.1
  */
@@ -135,6 +136,22 @@ public class SftpRemoteFileTemplateTests extends SftpTestSupport implements Test
 	public void lsUserHome() throws IOException {
 		try (Session<SftpClient.DirEntry> session = this.sessionFactory.getSession()) {
 			String[] entries = session.listNames("");
+			assertThat(entries).contains(".", "sftpSource", "sftpTarget");
+		}
+	}
+
+	@Test
+	public void lsRootWildcard() throws IOException {
+		try (Session<SftpClient.DirEntry> session = this.sessionFactory.getSession()) {
+			String[] entries = session.listNames("/*");
+			assertThat(entries).contains(".", "sftpSource", "sftpTarget");
+		}
+	}
+
+	@Test
+	public void lsRoot() throws IOException {
+		try (Session<SftpClient.DirEntry> session = this.sessionFactory.getSession()) {
+			String[] entries = session.listNames("/");
 			assertThat(entries).contains(".", "sftpSource", "sftpTarget");
 		}
 	}


### PR DESCRIPTION
## Summary

`SftpSession.listNames("/*")` throws `SftpException: SSH_FX_NO_SUCH_FILE` because the path parsing in `SftpSession.list()` uses `lastIndex > 0` to detect the `/` separator. For root-level paths like `/*`, `lastIndexOf('/')` returns `0`, which is excluded by the `> 0` check. This causes the entire path `/*` to be treated as a literal directory name instead of being split into directory `/` and file pattern `*`.

## Changes

- Changed `lastIndex > 0` to `lastIndex >= 0` in `SftpSession.list()` so root directory paths are correctly parsed
- Added test `lsRootWildcard()` that reproduces the issue and verifies the fix

Fixes: gh-11121

Signed-off-by: Adam Yang <yangadam@users.noreply.github.com>