### PR TITLE
GH-11121: Fix SftpSession.listNames() for root directory wildcard paths

### DIFF
--- a/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
+++ b/spring-integration-sftp/src/main/java/org/springframework/integration/sftp/session/SftpSession.java
@@ -46,6 +46,7 @@ import org.springframework.util.StringUtils;
  * @author Oleg Zhurakousky
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Adam Yang
  * @since 2.0
  */
 public class SftpSession implements Session<SftpClient.DirEntry> {
@@ -80,10 +81,10 @@ public class SftpSession implements Session<SftpClient.DirEntry> {
 		String remotePath = StringUtils.trimTrailingCharacter(path, '/');
 		String remoteDir = remotePath;
 		int lastIndex = remotePath.lastIndexOf('/');
-		if (lastIndex > 0) {
+		if (lastIndex >= 0) {
 			remoteDir = remoteDir.substring(0, lastIndex);
 		}
-		String remoteFile = lastIndex > 0 ? remotePath.substring(lastIndex + 1) : null;
+		String remoteFile = lastIndex >= 0 ? remotePath.substring(lastIndex + 1) : null;
 		boolean isPattern = remoteFile != null && remoteFile.contains("*");
 
 		if (!isPattern && remoteFile != null) {

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/session/SftpRemoteFileTemplateTests.java
@@ -138,6 +138,14 @@ public class SftpRemoteFileTemplateTests extends SftpTestSupport {
 	}
 
 	@Test
+	public void lsRootWildCard() throws IOException {
+		try (Session<SftpClient.DirEntry> session = this.sessionFactory.getSession()) {
+			String[] entries = session.listNames("/*");
+			assertThat(entries).contains(".", "sftpSource", "sftpTarget");
+		}
+	}
+
+	@Test
 	public void renameWithOldSftpVersion() {
 		DefaultSftpSessionFactory factory = new DefaultSftpSessionFactory(false);
 		factory.setHost("localhost");


### PR DESCRIPTION
## Summary

`SftpSession.listNames("/*")` throws `SftpException: SSH_FX_NO_SUCH_FILE` when listing files in the root directory using a wildcard pattern.

In `SftpSession.doList()`, the path parsing uses `lastIndexOf('/')` to split the directory and file parts. For root-level paths like `/*`, `lastIndexOf('/')` returns `0`, but the condition checks `lastIndex > 0`, which excludes index `0`. This means the path is never split — `remoteDir` stays as `/*` and `remoteFile` stays `null`, causing the SFTP client to try to open `/*` as a literal directory name.

## Changes

- Changed `lastIndex > 0` to `lastIndex >= 0` in `SftpSession.doList()` so root directory paths are correctly parsed
- Added test `lsRootWildCard()` that reproduces the issue and verifies the fix

This bug was introduced in 6.0.0, so the fix targets `6.0.x` for forward-merging through newer release branches.

Fixes: gh-11121