### PR TITLE
Use DefaultLockRegistry to support lock pooling

### DIFF
--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
@@ -32,6 +32,7 @@ import org.apache.curator.framework.recipes.locks.InterProcessMutex;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.integration.support.locks.DefaultLockRegistry;
 import org.springframework.integration.support.locks.ExpirableLockRegistry;
 import org.springframework.messaging.MessagingException;
 import org.springframework.scheduling.concurrent.ExecutorConfigurationSupport;
@@ -59,7 +60,7 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 
 	private final KeyToPathStrategy keyToPath;
 
-	private static final int DEFAULT_CAPACITY = 30_000;
+	private static final int DEFAULT_CAPACITY = 256;
 
 	private final Lock locksLock = new ReentrantLock();
 
@@ -90,6 +91,8 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 	private boolean mutexTaskExecutorExplicitlySet;
 
 	private int cacheCapacity = DEFAULT_CAPACITY;
+
+	private volatile DefaultLockRegistry defaultLockRegistry = new DefaultLockRegistry();
 
 	/**
 	 * Construct a lock registry using the default {@link KeyToPathStrategy} which
@@ -141,11 +144,17 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 
 	/**
 	 * Set the capacity of cached locks.
-	 * @param cacheCapacity The capacity of cached lock, (default 30_000).
+	 * @param cacheCapacity The capacity of cached lock, (default 256 locks).
 	 * @since 5.5.6
+	 *
+	 * @see DefaultLockRegistry
 	 */
 	public void setCacheCapacity(int cacheCapacity) {
 		this.cacheCapacity = cacheCapacity;
+		// Find the highest power of 2 for (n + 1), then subtract 1
+
+		int mask = Integer.highestOneBit(cacheCapacity + 1) - 1;
+		this.defaultLockRegistry = new DefaultLockRegistry(mask);
 	}
 
 	@Override
@@ -155,7 +164,8 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 		ZkLock lock;
 		this.locksLock.lock();
 		try {
-			lock = this.locks.computeIfAbsent(path, p -> new ZkLock(this.client, this.mutexTaskExecutor, p));
+			lock = this.locks.computeIfAbsent(path, p -> new ZkLock(this.client, this.mutexTaskExecutor, p,
+					(ReentrantLock) ZookeeperLockRegistry.this.defaultLockRegistry.obtain(path)));
 		}
 		finally {
 			this.locksLock.unlock();
@@ -263,11 +273,15 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 
 		private long lastUsed;
 
-		ZkLock(CuratorFramework client, AsyncTaskExecutor mutexTaskExecutor, String path) {
+		private final ReentrantLock delegate;
+
+		ZkLock(CuratorFramework client, AsyncTaskExecutor mutexTaskExecutor, String path,
+				ReentrantLock registryDelegate) {
 			this.client = client;
 			this.mutex = new InterProcessMutex(client, path);
 			this.mutexTaskExecutor = mutexTaskExecutor;
 			this.path = path;
+			this.delegate = registryDelegate;
 		}
 
 		public long getLastUsed() {
@@ -280,22 +294,41 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 
 		@Override
 		public void lock() {
+			this.delegate.lock();
 			try {
-				this.mutex.acquire();
+				if (this.delegate.getHoldCount() == 1) {
+					this.mutex.acquire();
+				}
 			}
 			catch (Exception e) {
+				this.delegate.unlock();
 				throw new IllegalStateException("Failed to acquire mutex at " + this.path, e);
 			}
 		}
 
 		@Override
 		public void lockInterruptibly() throws InterruptedException {
-			boolean locked = false;
-			// this is a bit ugly, but...
-			while (!locked) {
-				locked = tryLock(1, TimeUnit.SECONDS);
+			this.delegate.lockInterruptibly();
+			try {
+				if (this.delegate.getHoldCount() == 1) {
+					boolean locked = false;
+					// this is a bit ugly, but...
+					while (!locked) {
+						locked = doTryLock(1, TimeUnit.SECONDS);
+					}
+				}
 			}
-
+			catch (InterruptedException ie) {
+				this.delegate.unlock();
+				throw ie;
+			}
+			catch (Exception e) {
+				this.delegate.unlock();
+				if (e instanceof RuntimeException runtimeException) {
+					throw runtimeException;
+				}
+				throw new RuntimeException(e);
+			}
 		}
 
 		@Override
@@ -311,9 +344,37 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 
 		@Override
 		public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+			long startTime = System.nanoTime();
+			if (!this.delegate.tryLock(time, unit)) {
+				return false;
+			}
+			try {
+				if (this.delegate.getHoldCount() == 1) {
+					long waitTime = unit.toNanos(time) - (System.nanoTime() - startTime);
+					boolean acquired = doTryLock(waitTime, TimeUnit.NANOSECONDS);
+					if (!acquired) {
+						this.delegate.unlock();
+					}
+					return acquired;
+				}
+				return true;
+			}
+			catch (Exception e) {
+				this.delegate.unlock();
+				if (e instanceof InterruptedException interruptedException) {
+					throw interruptedException;
+				}
+				if (e instanceof RuntimeException runtimeException) {
+					throw runtimeException;
+				}
+				throw new RuntimeException(e);
+			}
+		}
+
+		private boolean doTryLock(long time, TimeUnit unit) throws InterruptedException {
 			Future<Boolean> future = null;
 			try {
-				long startTime = System.currentTimeMillis();
+				long startTime = System.nanoTime();
 
 				future = this.mutexTaskExecutor.submit(() -> {
 					try {
@@ -324,21 +385,23 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 					}
 				});
 
-				long waitTime = unit.toMillis(time);
+				long waitTime = unit.toNanos(time);
 
-				boolean connected = future.get(waitTime, TimeUnit.MILLISECONDS);
+				boolean connected = future.get(waitTime, TimeUnit.NANOSECONDS);
 
 				if (!connected) {
 					future.cancel(true);
 					return false;
 				}
 				else {
-					waitTime = waitTime - (System.currentTimeMillis() - startTime);
-					return this.mutex.acquire(waitTime, TimeUnit.MILLISECONDS);
+					waitTime = waitTime - (System.nanoTime() - startTime);
+					return this.mutex.acquire(waitTime, TimeUnit.NANOSECONDS);
 				}
 			}
 			catch (@SuppressWarnings("unused") TimeoutException e) {
-				future.cancel(true);
+				if (future != null) {
+					future.cancel(true);
+				}
 				return false;
 			}
 			catch (InterruptedException e) {
@@ -346,17 +409,27 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 				throw e;
 			}
 			catch (Exception e) {
-				throw new MessagingException("Failed to acquire mutex at " + this.path, e);
+				throw new MessagingException("Failed to acquire lock at " + this.path, e);
 			}
 		}
 
 		@Override
 		public void unlock() {
+			if (!this.delegate.isHeldByCurrentThread()) {
+				throw new IllegalMonitorStateException("You do not own lock at " + this.path);
+			}
+			if (this.delegate.getHoldCount() > 1) {
+				this.delegate.unlock();
+				return;
+			}
 			try {
 				this.mutex.release();
 			}
 			catch (Exception e) {
-				throw new MessagingException("Failed to release mutex at " + this.path, e);
+				throw new MessagingException("Failed to release lock at " + this.path, e);
+			}
+			finally {
+				this.delegate.unlock();
 			}
 		}
 
@@ -366,7 +439,7 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 		}
 
 		public boolean isAcquiredInThisProcess() {
-			return this.mutex.isAcquiredInThisProcess();
+			return this.delegate.isLocked();
 		}
 
 	}

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -31,10 +31,10 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.zookeeper.ZookeeperTestSupport;
-import org.springframework.messaging.MessagingException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * @author Gary Russell
@@ -155,8 +155,8 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 			try {
 				lock2.unlock();
 			}
-			catch (MessagingException e) {
-				return e.getCause();
+			catch (Exception e) {
+				return e;
 			}
 			return null;
 		});
@@ -256,9 +256,9 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 			try {
 				lock.unlock();
 			}
-			catch (Exception e) {
+			catch (IllegalMonitorStateException e) {
 				latch.countDown();
-				return e.getCause();
+				return e;
 			}
 			return null;
 		});
@@ -506,6 +506,55 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		assertThat(getRegistryLocks(registry)).hasSize(4);
 		assertThat(getRegistryLocks(registry)).containsKeys(toKey("foo:3"), toKey("foo:4"), toKey("foo:5"));
 		registry.destroy();
+	}
+
+	@Test
+	public void noSecondLockOnEviction() throws InterruptedException {
+		ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
+		registry.setCacheCapacity(2);
+
+		CountDownLatch lock1Latch = new CountDownLatch(1);
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		CountDownLatch furtherLocksLatch = new CountDownLatch(1);
+		try {
+			executor.execute(() -> {
+				Lock lock1 = registry.obtain("lock1");
+				lock1.lock();
+				try {
+					furtherLocksLatch.countDown();
+					lock1Latch.await(10, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+				}
+				finally {
+					lock1.unlock();
+				}
+			});
+
+			assertThat(furtherLocksLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			// Two new locks to trigger cache eviction for the 'lock1'
+			registry.obtain("lock2");
+			registry.obtain("lock3");
+
+			// Request 'lock1' again: will trigger new ZkLock instance
+			Lock lock1 = registry.obtain("lock1");
+
+			// Cannot lock because 'lock1' is still locked by another thread
+			assertThat(lock1.tryLock(1, TimeUnit.SECONDS)).isFalse();
+
+			lock1Latch.countDown();
+
+			assertThatNoException().isThrownBy(() -> {
+				lock1.lock();
+				lock1.unlock();
+			});
+		}
+		finally {
+			executor.shutdown();
+			registry.destroy();
+		}
+
 	}
 
 	private static Map<String, Lock> getRegistryLocks(ZookeeperLockRegistry registry) {


### PR DESCRIPTION
- verify that we don't aquire InterProcessMutex more than once per lock
- adjust lock capacity to 256

Fixes: https://github.com/spring-projects/spring-integration/issues/11113

**Auto-cherry-pick to 7.0.x & 6.5.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
