### PR TITLE
Verify that ZKLock is not engaged on capacity clean

### DIFF
--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
@@ -17,6 +17,7 @@
 package org.springframework.integration.zookeeper.lock;
 
 import java.io.Serial;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -47,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Vedran Pavic
  * @author Unseok Kim
  * @author Christian Tzolov
+ * @author Glenn Renfro
  *
  * @since 4.2
  *
@@ -71,7 +73,20 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 
 				@Override
 				protected boolean removeEldestEntry(Entry<String, ZkLock> eldest) {
-					return size() > ZookeeperLockRegistry.this.cacheCapacity;
+					if (size() > ZookeeperLockRegistry.this.cacheCapacity) {
+						if (!eldest.getValue().isAcquiredInThisProcess()) {
+							return true;
+						}
+						Iterator<Entry<String, ZkLock>> iterator = entrySet().iterator();
+						while (iterator.hasNext()) {
+							Entry<String, ZkLock> entry = iterator.next();
+							if (!entry.getValue().isAcquiredInThisProcess()) {
+								iterator.remove();
+								break;
+							}
+						}
+					}
+					return false;
 				}
 
 			};

--- a/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
+++ b/spring-integration-zookeeper/src/main/java/org/springframework/integration/zookeeper/lock/ZookeeperLockRegistry.java
@@ -17,7 +17,6 @@
 package org.springframework.integration.zookeeper.lock;
 
 import java.io.Serial;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -73,22 +72,9 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 
 				@Override
 				protected boolean removeEldestEntry(Entry<String, ZkLock> eldest) {
-					if (size() > ZookeeperLockRegistry.this.cacheCapacity) {
-						if (!eldest.getValue().isAcquiredInThisProcess()) {
-							return true;
-						}
-						Iterator<Entry<String, ZkLock>> iterator = entrySet().iterator();
-						while (iterator.hasNext()) {
-							Entry<String, ZkLock> entry = iterator.next();
-							if (!entry.getValue().isAcquiredInThisProcess()) {
-								iterator.remove();
-								break;
-							}
-						}
-					}
-					return false;
+					return size() > ZookeeperLockRegistry.this.cacheCapacity &&
+							!eldest.getValue().isAcquiredInThisProcess();
 				}
-
 			};
 
 	private final boolean trackingTime;
@@ -257,11 +243,6 @@ public class ZookeeperLockRegistry implements ExpirableLockRegistry<Lock>, Dispo
 		@Override
 		public String pathFor(String key) {
 			return this.root + key;
-		}
-
-		@Override
-		public boolean bounded() {
-			return false;
 		}
 
 	}

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -508,6 +508,36 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		registry.destroy();
 	}
 
+	@Test
+	public void testLockEvictionWithAnotherLockOnTheKey() throws InterruptedException {
+		ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
+		registry.setCacheCapacity(1);
+
+		Lock lock = registry.obtain("test");
+		// cache is full
+		lock.lock();
+		try {
+			registry.obtain("test2");
+
+			Lock lock1 = registry.obtain("test");
+
+			// Attempt to acquire lock with 10-second timeout
+			boolean acquired = lock1.tryLock(10, TimeUnit.SECONDS);
+
+			// Fail the test if the lock was not acquired within the timeframe
+			assertThat(acquired).isTrue();
+			try {
+				// do something
+			}
+			finally {
+				lock1.unlock();
+			}
+		}
+		finally {
+			lock.unlock();
+		}
+	}
+
 	private static Map<String, Lock> getRegistryLocks(ZookeeperLockRegistry registry) {
 		return TestUtils.getPropertyValue(registry, "locks");
 	}

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -49,7 +49,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 
 	@Test
 	public void testLock() throws Exception {
-		ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
+		ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client, new TestKeyToPathStrategy());
 		for (int i = 0; i < 10; i++) {
 			Lock lock = registry.obtain("foo");
 			lock.lock();
@@ -353,7 +353,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 
 		final CountDownLatch maincountDownLatch = new CountDownLatch(KEY_CNT);
 		final CountDownLatch countDownLatch = new CountDownLatch(THREAD_CNT);
-		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client);
+		final ZookeeperLockRegistry registry = new ZookeeperLockRegistry(this.client, new TestKeyToPathStrategy());
 		registry.setCacheCapacity(CAPACITY_CNT);
 		final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_CNT);
 
@@ -547,4 +547,16 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		return DEFAULT_ROOT + "/" + path;
 	}
 
+	private static final class TestKeyToPathStrategy implements ZookeeperLockRegistry.KeyToPathStrategy {
+
+		@Override
+		public String pathFor(String key) {
+			return "/SpringIntegration-LockRegistry" + key;
+		}
+
+		@Override
+		public boolean bounded() {
+			return false;
+		}
+	}
 }

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -527,7 +527,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 
 			try {
 				assertThat(acquired).isTrue();
-				assertThat(lock1).isEqualTo(lock);
+				assertThat(lock1).isSameAs(lock);
 			}
 			finally {
 				lock1.unlock();

--- a/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
+++ b/spring-integration-zookeeper/src/test/java/org/springframework/integration/zookeeper/lock/ZkLockRegistryTests.java
@@ -517,6 +517,7 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 		// cache is full
 		lock.lock();
 		try {
+			// Although cache is full, this does not evict an old entry because it is still locked
 			registry.obtain("test2");
 
 			Lock lock1 = registry.obtain("test");
@@ -524,10 +525,9 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 			// Attempt to acquire lock with 10-second timeout
 			boolean acquired = lock1.tryLock(10, TimeUnit.SECONDS);
 
-			// Fail the test if the lock was not acquired within the timeframe
-			assertThat(acquired).isTrue();
 			try {
-				// do something
+				assertThat(acquired).isTrue();
+				assertThat(lock1).isEqualTo(lock);
 			}
 			finally {
 				lock1.unlock();
@@ -559,4 +559,5 @@ public class ZkLockRegistryTests extends ZookeeperTestSupport {
 			return false;
 		}
 	}
+
 }


### PR DESCRIPTION
- Do not remove entry if it still has a zk lock from cache when cacheCapacity limit has been reached.
- If the oldest entry in the cache can't be removed because it is locked.  Find the next oldest entry and remove it
- Add test that validates the fix

Resolves: https://github.com/spring-projects/spring-integration/issues/11113

**Auto-cherry-pick to 7.0.x & 6.5.x**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
