### PR TITLE
Not warn that Redis 7 server does not support DELEX

### DIFF
--- a/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
+++ b/spring-integration-redis/src/main/java/org/springframework/integration/redis/util/RedisLockRegistry.java
@@ -657,7 +657,7 @@ public final class RedisLockRegistry
 				}
 				catch (RedisSystemException | InvalidDataAccessApiUsageException ex) {
 					if (isCasCadNotSupportedError(ex)) {
-						LOGGER.warn("CAS/CAD for value operations not supported, falling back to Lua script", ex);
+						LOGGER.info("CAS/CAD for value operations not supported, falling back to Lua script", ex);
 						RedisLockRegistry.this.supportsCasCadOperations = false;
 						res = executeRenewRedisScript(expireAfter);
 					}
@@ -924,7 +924,7 @@ public final class RedisLockRegistry
 				}
 				catch (RedisSystemException | InvalidDataAccessApiUsageException ex) {
 					if (isCasCadNotSupportedError(ex)) {
-						LOGGER.warn("CAS/CAD for value operations not supported, falling back to Lua script", ex);
+						LOGGER.info("CAS/CAD for value operations not supported, falling back to Lua script", ex);
 						RedisLockRegistry.this.supportsCasCadOperations = false;
 						return executeUnlinkUnlockRedisScript();
 					}


### PR DESCRIPTION
Actual: 
RedisLockRegistry print warning that Redis server does not support DELEX Expected:
DELEX is added in Redis 8.4. I use Redis 7. I know progress is forward, new features appear in new software, but log level WARN is not appropriate to remind it. 

Basically, I don't want be warned that I use Redis 7 as long as Redis 7 is officially supported

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
