### PR TITLE
Preserve original headers in `DefaultErrorMessageStrategy`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/DefaultErrorMessageStrategy.java
@@ -24,12 +24,13 @@ import org.springframework.messaging.support.ErrorMessage;
 
 /**
  * A simple {@link ErrorMessageStrategy} implementations which produces
- * a error message with original message if the {@link AttributeAccessor} has
+ * an error message with original message if the {@link AttributeAccessor} has
  * {@link ErrorMessageUtils#INPUT_MESSAGE_CONTEXT_KEY} attribute.
- * Otherwise plain {@link ErrorMessage} with the {@code throwable} as {@code payload}.
+ * Otherwise, plain {@link ErrorMessage} with the {@code throwable} as {@code payload}.
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Jiandong Ma
  *
  * @since 4.3.10
  *
@@ -41,8 +42,8 @@ public class DefaultErrorMessageStrategy implements ErrorMessageStrategy {
 	public ErrorMessage buildErrorMessage(Throwable throwable, @Nullable AttributeAccessor attributes) {
 		Object inputMessage = attributes == null ? null
 				: attributes.getAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY);
-		if (inputMessage instanceof Message) {
-			return new ErrorMessage(throwable, (Message<?>) inputMessage);
+		if (inputMessage instanceof Message<?> message) {
+			return new ErrorMessage(throwable, message.getHeaders(), message);
 		}
 		else {
 			return new ErrorMessage(throwable);

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/advice/AdvisedMessageHandlerTests.java
@@ -77,6 +77,7 @@ import static org.mockito.Mockito.when;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Glenn Renfro
+ * @author Jiandong Ma
  *
  * @since 2.2
  */
@@ -550,10 +551,11 @@ public class AdvisedMessageHandlerTests implements TestApplicationContextAware {
 		handler.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		handler.afterPropertiesSet();
 
-		Message<String> message = new GenericMessage<>("Hello, world!");
+		Message<String> message = new GenericMessage<>("Hello, world!", Map.of("source", "upstream"));
 		handler.handleMessage(message);
 		Message<?> error = errors.receive(10000);
 		assertThat(error).isNotNull();
+		assertThat(error.getHeaders()).containsEntry("source", "upstream");
 		assertThat(error.getPayload())
 				.asInstanceOf(InstanceOfAssertFactories.THROWABLE)
 				.isInstanceOf(MessagingException.class)

--- a/src/reference/antora/modules/ROOT/pages/error-handling.adoc
+++ b/src/reference/antora/modules/ROOT/pages/error-handling.adoc
@@ -79,7 +79,7 @@ xref:handler-advice/classes.adoc#retry-advice[`RequestHandlerRetryAdvice`].
 The `ErrorMessageStrategy` is used to build an `ErrorMessage` based on the provided exception and an `AttributeAccessor` context.
 It can be injected into any `MessageProducerSupport` or `MessagingGatewaySupport`.
 The `requestMessage` is stored under `ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY` in the `AttributeAccessor` context.
-The `ErrorMessageStrategy` can use that `requestMessage` as the `originalMessage` property of the `ErrorMessage` it creates.
+The `ErrorMessageStrategy` can use that `requestMessage` as the `originalMessage` property of the `ErrorMessage` it creates, preserving the `requestMessage` headers.
 The `DefaultErrorMessageStrategy` does exactly that.
 
 Starting with version 5.2, all the `MessageHandlingException` instances thrown by the framework components, includes a component `BeanDefinition` resource and source to determine a configuration point form the exception.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -19,3 +19,6 @@ Java 17 is still the baseline, but Java 25 is supported.
 
 [[x7.2-general-changes]]
 === General Changes
+
+The `DefaultErrorMessageStrategy` now preserves the original headers when building the `ErrorMessage`.
+See xref:error-handling.adoc[] for more information.


### PR DESCRIPTION
When setup `RequestHandlerRetryAdvice` with a recover `ErrorMessageSendingRecoverer`,  after retry exhausted,  the `DefaultErrorMessageStrategy` will build a `ErrorMessage`,  however it does not copy the original message headers.

because I need the header values to do the error routing, so I think it is useful to keep it.

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
