### PR TITLE
GH-11157: Fix caching logic in the `JdbcLockRegistry`

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/DefaultLockRepository.java
@@ -430,6 +430,14 @@ public class DefaultLockRepository
 						this.template.update(this.renewQuery, ttlEpochMillis(ttlDuration), this.region, lock, this.id) == 1);
 	}
 
+	@Override
+	public String toString() {
+		return "DefaultLockRepository{" +
+				"id='" + this.id + '\'' +
+				", region='" + this.region + '\'' +
+				'}';
+	}
+
 	private static LocalDateTime ttlEpochMillis(Duration ttl) {
 		return currentTime().plus(ttl);
 	}

--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/lock/JdbcLockRegistry.java
@@ -30,7 +30,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.dao.TransientDataAccessException;
-import org.springframework.integration.support.locks.DefaultLockRegistry;
 import org.springframework.integration.support.locks.DistributedLock;
 import org.springframework.integration.support.locks.ExpirableLockRegistry;
 import org.springframework.integration.support.locks.RenewableLockRegistry;
@@ -46,6 +45,13 @@ import org.springframework.util.Assert;
  * {@link org.springframework.integration.support.locks.DefaultLockRegistry}, but the
  * locks taken will be global, as long as the underlying database supports the
  * "serializable" isolation level in its transactions.
+ * <p>
+ * The lock instances are cached by their key for future reuse.
+ * If all the locks in the cache are acquired,
+ * the {@link #obtain(Object)} method throws {@link CannotAcquireLockException}.
+ * Otherwise, the old, unused locks are evicted from the cache.
+ * An attempt to lock such an orphaned {@link JdbcLock} throws another {@link CannotAcquireLockException}
+ * to avoid double locking from different threads on the same key.
  *
  * @author Dave Syer
  * @author Artem Bilan
@@ -68,7 +74,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 
 	private static final int DEFAULT_IDLE = 100;
 
-	private static final int DEFAULT_CAPACITY = 256;
+	private static final int DEFAULT_CAPACITY = 100_000;
 
 	private final Lock lock = new ReentrantLock();
 
@@ -80,7 +86,8 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 
 				@Override
 				protected boolean removeEldestEntry(Entry<String, JdbcLock> eldest) {
-					return size() > JdbcLockRegistry.this.cacheCapacity;
+					return size() > JdbcLockRegistry.this.cacheCapacity
+							&& !eldest.getValue().isAcquiredInThisProcess();
 				}
 
 			};
@@ -98,8 +105,6 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 	public static final Duration DEFAULT_TTL = Duration.ofSeconds(10);
 
 	private final Duration ttl;
-
-	private DefaultLockRegistry defaultLockRegistry = new DefaultLockRegistry();
 
 	/**
 	 * Construct an instance based on the provided {@link LockRepository}.
@@ -134,24 +139,36 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 
 	/**
 	 * Set the capacity of cached locks.
-	 * @param cacheCapacity The capacity of cached lock, (default 256 locks).
+	 * @param cacheCapacity The capacity of cached lock, (default 100_000).
 	 * @since 5.5.6
-	 * @see DefaultLockRegistry
 	 */
 	public void setCacheCapacity(int cacheCapacity) {
 		this.cacheCapacity = cacheCapacity;
-		// Find the highest power of 2 for (n + 1), then subtract 1
-		int mask = Integer.highestOneBit(cacheCapacity + 1) - 1;
-		this.defaultLockRegistry = new DefaultLockRegistry(mask);
 	}
 
 	@Override
 	public DistributedLock obtain(Object lockKey) {
 		Assert.isInstanceOf(String.class, lockKey);
-		String path = pathFor((String) lockKey);
+		String lockKeyToUse = (String) lockKey;
 		this.lock.lock();
 		try {
-			return this.locks.computeIfAbsent(path, key -> new JdbcLock(this.client, this.idleBetweenTries, key));
+			JdbcLock jdbcLock =
+					this.locks.computeIfAbsent(lockKeyToUse, key -> new JdbcLock(lockKeyToUse));
+			if (this.locks.size() > this.cacheCapacity) {
+				long now = System.currentTimeMillis();
+				this.locks.entrySet()
+						.removeIf(entry -> {
+							JdbcLock lock = entry.getValue();
+							return lock != jdbcLock && now - lock.getLastUsed() >= 0 && !lock.isAcquiredInThisProcess();
+						});
+				if (this.locks.size() > this.cacheCapacity) {
+					this.locks.remove(lockKeyToUse);
+					throw new CannotAcquireLockException("There are already " +
+							this.cacheCapacity + " unique JDBC locks acquired in the application " +
+							"from " + this + ". Cannot obtain more at the moment.");
+				}
+			}
+			return jdbcLock;
 		}
 		finally {
 			this.lock.unlock();
@@ -180,41 +197,37 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 
 	@Override
 	public void renewLock(Object lockKey) {
-		this.renewLock(lockKey, this.ttl);
+		renewLock(lockKey, this.ttl);
 	}
 
 	@Override
 	public void renewLock(Object lockKey, Duration customTtl) {
 		JdbcLock jdbcLock = (JdbcLock) obtain(lockKey);
 		if (!jdbcLock.renew(customTtl)) {
-			throw new IllegalStateException("Could not renew lock " + lockKey);
+			throw new IllegalStateException("Could not renew lock for: " + lockKey);
 		}
 	}
 
-	private static Duration convertToDuration(long time, TimeUnit timeUnit) {
-		long timeInMilliseconds = TimeUnit.MILLISECONDS.convert(time, timeUnit);
-		return Duration.ofMillis(timeInMilliseconds);
+	@Override
+	public String toString() {
+		return "JdbcLockRegistry{" +
+				"client=" + this.client +
+				'}';
 	}
 
 	private final class JdbcLock implements DistributedLock {
 
-		private final LockRepository mutex;
-
-		private final Duration idleBetweenTries;
+		private final String key;
 
 		private final String path;
 
+		private final ReentrantLock delegate = new ReentrantLock();
+
 		private volatile long lastUsed = System.currentTimeMillis();
 
-		private final ReentrantLock delegate;
-
-		private int holdCount;
-
-		JdbcLock(LockRepository client, Duration idleBetweenTries, String path) {
-			this.mutex = client;
-			this.idleBetweenTries = idleBetweenTries;
-			this.path = path;
-			this.delegate = (ReentrantLock) JdbcLockRegistry.this.defaultLockRegistry.obtain(this.path);
+		JdbcLock(String key) {
+			this.key = key;
+			this.path = pathFor(key);
 		}
 
 		public long getLastUsed() {
@@ -232,30 +245,29 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 			while (true) {
 				try {
 					while (!doLock(ttl)) {
-						Thread.sleep(this.idleBetweenTries.toMillis());
+						Thread.sleep(JdbcLockRegistry.this.idleBetweenTries.toMillis());
 					}
-					this.holdCount++;
 					break;
 				}
 				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
 					// try again
 				}
-				catch (InterruptedException e) {
+				catch (InterruptedException ex) {
 					/*
 					 * This method must be uninterruptible so catch and ignore
 					 * interrupts and only break out of the while loop when
 					 * we get the lock.
 					 */
 				}
-				catch (Exception e) {
+				catch (Exception ex) {
 					this.delegate.unlock();
-					rethrowAsLockException(e);
+					rethrowAsLockException(ex);
 				}
 			}
 		}
 
-		private void rethrowAsLockException(Exception e) {
-			throw new CannotAcquireLockException("Failed to lock mutex at " + this.path, e);
+		private void rethrowAsLockException(Exception ex) {
+			throw new CannotAcquireLockException("Failed to lock for: " + this.key, ex);
 		}
 
 		@Override
@@ -264,15 +276,14 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 			while (true) {
 				try {
 					while (!doLock(JdbcLockRegistry.this.ttl)) {
-						Thread.sleep(this.idleBetweenTries.toMillis());
+						Thread.sleep(JdbcLockRegistry.this.idleBetweenTries.toMillis());
 						if (Thread.currentThread().isInterrupted()) {
 							throw new InterruptedException();
 						}
 					}
-					this.holdCount++;
 					break;
 				}
-				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
+				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException ex) {
 					// try again
 				}
 				catch (InterruptedException ie) {
@@ -292,7 +303,7 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 			try {
 				return tryLock(0, TimeUnit.MICROSECONDS);
 			}
-			catch (InterruptedException e) {
+			catch (InterruptedException ex) {
 				Thread.currentThread().interrupt();
 				return false;
 			}
@@ -313,29 +324,31 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 			boolean acquired;
 			while (true) {
 				try {
-					while (!(acquired = doLock(ttl)) && System.currentTimeMillis() < expire) { //NOSONAR
-						Thread.sleep(this.idleBetweenTries.toMillis());
+					while (!(acquired = doLock(ttl)) && System.currentTimeMillis() < expire) {
+						Thread.sleep(JdbcLockRegistry.this.idleBetweenTries.toMillis());
 					}
 					if (!acquired) {
 						this.delegate.unlock();
 					}
-					else {
-						this.holdCount++;
-					}
 					return acquired;
 				}
-				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
+				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException ex) {
 					// try again
 				}
-				catch (Exception e) {
+				catch (Exception ex) {
 					this.delegate.unlock();
-					rethrowAsLockException(e);
+					rethrowAsLockException(ex);
 				}
 			}
 		}
 
 		private boolean doLock(Duration ttl) {
-			boolean acquired = this.mutex.acquire(this.path, ttl);
+			if (!JdbcLockRegistry.this.locks.containsKey(this.key)) {
+				throw new IllegalStateException("The lock '" + this.key + "' was evicted from the exhausted cache " +
+						"due to its unused period for " + (System.currentTimeMillis() - this.lastUsed) +
+						" milliseconds. Obtain a fresh one from " + JdbcLockRegistry.this);
+			}
+			boolean acquired = JdbcLockRegistry.this.client.acquire(this.path, ttl);
 			if (acquired) {
 				this.lastUsed = System.currentTimeMillis();
 			}
@@ -345,37 +358,36 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 		@Override
 		public void unlock() {
 			if (!this.delegate.isHeldByCurrentThread()) {
-				throw new IllegalMonitorStateException("The current thread doesn't own mutex at " + this.path);
+				throw new IllegalMonitorStateException("The current thread doesn't own a lock for: " + this.key);
 			}
-			if (this.holdCount > 1) {
-				this.holdCount--;
+			if (this.delegate.getHoldCount() > 1) {
 				this.delegate.unlock();
 				return;
 			}
 			try {
 				while (true) {
 					try {
-						if (this.mutex.delete(this.path)) {
+						if (JdbcLockRegistry.this.client.delete(this.path)) {
 							return;
 						}
 						else {
-							throw new ConcurrentModificationException("Lock was released in the store due to expiration. " +
-									"The integrity of data protected by this lock may have been compromised.");
+							throw new ConcurrentModificationException(
+									"Lock was released in the store due to expiration. " +
+											"The integrity of data protected by this lock may have been compromised.");
 						}
 					}
 					catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
 						// try again
 					}
-					catch (ConcurrentModificationException e) {
-						throw e;
+					catch (ConcurrentModificationException ex) {
+						throw ex;
 					}
-					catch (Exception e) {
-						throw new DataAccessResourceFailureException("Failed to release mutex at " + this.path, e);
+					catch (Exception ex) {
+						throw new DataAccessResourceFailureException("Failed to release lock for: " + this.key, ex);
 					}
 				}
 			}
 			finally {
-				this.holdCount--;
 				this.delegate.unlock();
 			}
 		}
@@ -407,21 +419,21 @@ public class JdbcLockRegistry implements ExpirableLockRegistry<DistributedLock>,
 		 */
 		public boolean renew(Duration ttl) {
 			if (!this.delegate.isHeldByCurrentThread()) {
-				throw new IllegalMonitorStateException("The current thread doesn't own mutex at " + this.path);
+				throw new IllegalMonitorStateException("The current thread doesn't hold a lock for: " + this.key);
 			}
 			while (true) {
 				try {
-					boolean renewed = this.mutex.renew(this.path, ttl);
+					boolean renewed = JdbcLockRegistry.this.client.renew(this.path, ttl);
 					if (renewed) {
 						this.lastUsed = System.currentTimeMillis();
 					}
 					return renewed;
 				}
-				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException e) {
+				catch (TransientDataAccessException | TransactionTimedOutException | TransactionSystemException ex) {
 					// try again
 				}
-				catch (Exception e) {
-					throw new DataAccessResourceFailureException("Failed to renew mutex at " + this.path, e);
+				catch (Exception ex) {
+					throw new DataAccessResourceFailureException("Failed to renew lock for: " + this.key, ex);
 				}
 			}
 		}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/lock/JdbcLockRegistryTests.java
@@ -41,9 +41,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.integration.support.locks.DistributedLock;
 import org.springframework.integration.test.util.TestUtils;
-import org.springframework.integration.util.UUIDConverter;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -466,7 +466,7 @@ class JdbcLockRegistryTests {
 					Thread.currentThread().interrupt();
 				}
 				String keyId = "foo:" + finalI;
-				remainLockCheckQueue.offer(toUUID(keyId));
+				remainLockCheckQueue.offer(keyId);
 				Lock obtain = registry.obtain(keyId);
 				obtain.lock();
 				obtain.unlock();
@@ -503,7 +503,7 @@ class JdbcLockRegistryTests {
 		Lock obtainLock0 = registry.obtain(REMAIN_DUMMY_LOCK_KEY);
 		obtainLock0.lock();
 		obtainLock0.unlock();
-		remainLockCheckQueue.offer(toUUID(REMAIN_DUMMY_LOCK_KEY));
+		remainLockCheckQueue.offer(REMAIN_DUMMY_LOCK_KEY);
 
 		for (int i = dummyLockCnt; i < threadCnt + dummyLockCnt; i++) {
 			int finalI = i;
@@ -516,7 +516,7 @@ class JdbcLockRegistryTests {
 					Thread.currentThread().interrupt();
 				}
 				String keyId = "foo:" + finalI;
-				remainLockCheckQueue.offer(toUUID(keyId));
+				remainLockCheckQueue.offer(keyId);
 				Lock obtain = registry.obtain(keyId);
 				obtain.lock();
 				obtain.unlock();
@@ -544,18 +544,16 @@ class JdbcLockRegistryTests {
 
 		registry.obtain("foo:4");
 
-		assertThat(getRegistryLocks(registry)).hasSize(3);
-		assertThat(getRegistryLocks(registry)).containsKeys(toUUID("foo:2"),
-				toUUID("foo:3"),
-				toUUID("foo:4"));
+		assertThat(getRegistryLocks(registry))
+				.hasSize(3)
+				.containsKeys("foo:2", "foo:3", "foo:4");
 
 		//capacity 3->4
 		registry.setCacheCapacity(capacityCnt);
 		registry.obtain("foo:5");
-		assertThat(getRegistryLocks(registry)).hasSize(4);
-		assertThat(getRegistryLocks(registry)).containsKeys(toUUID("foo:3"),
-				toUUID("foo:4"),
-				toUUID("foo:5"));
+		assertThat(getRegistryLocks(registry))
+				.hasSize(4)
+				.containsKeys("foo:3", "foo:4", "foo:5");
 	}
 
 	@Test
@@ -636,7 +634,7 @@ class JdbcLockRegistryTests {
 	}
 
 	@Test
-	void noSecondLockOnEviction() throws InterruptedException {
+	void notUsedLockIsEvictedOnCacheLimit() throws InterruptedException {
 		DefaultLockRepository client = new DefaultLockRepository(dataSource);
 		client.setApplicationContext(this.context);
 		client.afterPropertiesSet();
@@ -664,11 +662,11 @@ class JdbcLockRegistryTests {
 				});
 
 		assertThat(furtherLocksLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		// Two new locks to trigger cache eviction for the 'lock1'
+		// Two new locks to overcharge the cache.
+		// The 'lock2' is evicted by 'lock3' because it is not locked.
 		registry.obtain("lock2");
 		registry.obtain("lock3");
 
-		// Request 'lock1' again: will trigger new JdbcLock instance
 		DistributedLock lock1 = registry.obtain("lock1");
 
 		// Cannot lock because 'lock1' is still locked by another thread
@@ -683,68 +681,55 @@ class JdbcLockRegistryTests {
 	}
 
 	@Test
-	void sharedDelegateIsDeletedFromDbOnUnlock() throws Exception {
-		DefaultLockRepository client1 = newLockRepository();
-		DefaultLockRepository client2 = newLockRepository();
-
-		JdbcLockRegistry registry1 = new JdbcLockRegistry(client1);
-		// setCacheCapacity(2) gives mask=1 in DefaultLockRegistry → only 2 slots, guaranteed collision in ≤3 keys
-		registry1.setCacheCapacity(2);
-		JdbcLockRegistry registry2 = new JdbcLockRegistry(client2);
-
-		// Find two distinct lock keys that share the same ReentrantLock (same DefaultLockRegistry slot)
-		String keyB = null;
-		DistributedLock lockA = null;
-		DistributedLock lockB = null;
-		outer:
-		for (int i = 0; i < 10; i++) {
-			for (int j = i + 1; j < 10; j++) {
-				keyB = "key-" + j;
-				DistributedLock la = registry1.obtain("key-" + i);
-				DistributedLock lb = registry1.obtain(keyB);
-				if (TestUtils.getPropertyValue(la, "delegate") == TestUtils.getPropertyValue(lb, "delegate")) {
-
-					lockA = la;
-					lockB = lb;
-					break outer;
-				}
-			}
-		}
-		assertThat(lockA)
-				.as("Could not find two lock keys mapping to the same DefaultLockRegistry slot")
-				.isNotNull();
-
-		lockA.lock();
-		// Shared delegate: delegate.holdCount becomes 2 after this call
-		lockB.lock();
-
-		// Unlock B first — before the fix, delegate.getHoldCount()>1 short-circuited and skipped the DB delete
-		lockB.unlock();
-
-		// Another process must be able to acquire keyB immediately (its DB row must be deleted)
-		DistributedLock lockBOtherProcess = registry2.obtain(keyB);
-		assertThat(lockBOtherProcess.tryLock(500, TimeUnit.MILLISECONDS))
-				.as("DB row for '" + keyB + "' was not deleted on unlock — orphaned lock detected")
-				.isTrue();
-		lockBOtherProcess.unlock();
-
-		assertThatNoException().isThrownBy(lockA::unlock);
-	}
-
-	private DefaultLockRepository newLockRepository() {
-		DefaultLockRepository client = new DefaultLockRepository(this.dataSource);
+	void cannotAcquireLockExceptionOnCacheLimit() {
+		DefaultLockRepository client = new DefaultLockRepository(dataSource);
 		client.setApplicationContext(this.context);
 		client.afterPropertiesSet();
 		client.afterSingletonsInstantiated();
-		return client;
+		JdbcLockRegistry registry = new JdbcLockRegistry(client);
+		registry.setCacheCapacity(2);
+
+		DistributedLock lock1 = registry.obtain("lock1");
+		lock1.lock();
+		try {
+			DistributedLock lock2 = registry.obtain("lock2");
+			lock2.lock();
+			try {
+				assertThatExceptionOfType(CannotAcquireLockException.class)
+						.isThrownBy(() -> registry.obtain("lock3"))
+						.withMessageStartingWith("There are already 2 unique JDBC locks acquired in the application")
+						.withMessageEndingWith("Cannot obtain more at the moment.");
+			}
+			finally {
+				lock2.unlock();
+			}
+		}
+		finally {
+			lock1.unlock();
+		}
+	}
+
+	@Test
+	void unusedLockIsStale() {
+		DefaultLockRepository client = new DefaultLockRepository(dataSource);
+		client.setApplicationContext(this.context);
+		client.afterPropertiesSet();
+		client.afterSingletonsInstantiated();
+		JdbcLockRegistry registry = new JdbcLockRegistry(client);
+		registry.setCacheCapacity(1);
+
+		DistributedLock lock1 = registry.obtain("lock1");
+		registry.obtain("lock2");
+
+		assertThatExceptionOfType(CannotAcquireLockException.class)
+				.isThrownBy(lock1::lock)
+				.havingCause()
+				.isInstanceOf(IllegalStateException.class)
+				.withMessageStartingWith("The lock 'lock1' was evicted from the exhausted cache due to its unused period for");
 	}
 
 	private static Map<String, Lock> getRegistryLocks(JdbcLockRegistry registry) {
 		return TestUtils.getPropertyValue(registry, "locks");
-	}
-
-	private static String toUUID(String key) {
-		return UUIDConverter.getUUID(key).toString();
 	}
 
 }

--- a/src/reference/antora/modules/ROOT/pages/jdbc/lock-registry.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jdbc/lock-registry.adoc
@@ -44,11 +44,13 @@ So the time to live can be highly reduced, and deployments can retake a lost loc
 
 NOTE: The lock renewal can be done only if the lock is held by the current thread.
 
-Starting with version 5.5.6, the `JdbcLockRegistry` is support automatically clean-up cache for JdbcLock in `JdbcLockRegistry.locks` via `JdbcLockRegistry.setCacheCapacity()`.
-The default value is `256`.
+Starting with version 5.5.6, the `JdbcLockRegistry` supports automatic cache clean-up for unused `JdbcLock` instances via `JdbcLockRegistry.setCacheCapacity()`.
+The default value is `100_000`.
 See its Javadocs for more information.
-This capacity number is also propagated into the `DefaultLockRegistry` used internally in the `JdbcLockRegistry` for a pool of shared `ReentrantLock` instances.
-So, if higher concurrent access (the number of unique lock keys used in parallel) is expected (or allowed) for the application, the `cacheCapacity` should be increased respectively, with the closest power of 2 in mind (essentially `Integer.highestOneBit(cacheCapacity + 1)`).
+The cache can be also cleaned via `expireUnusedOlderThan(long age)` API.
+When all the cached `JdbcLock` instances are acquired, and neither of them can be evicted, the `obtain(Object lockKey)` method throws a `CannotAcquireLockException`.
+Another `CannotAcquireLockException` is also thrown on an attempt to lock a not cached `JdbcLock`.
+A fresh `obtain(Object lockKey)` for that lock key should be called.
 
 Starting with version 6.0, the `DefaultLockRepository` can be supplied with a `PlatformTransactionManager` instead of relying on the primary bean from the application context.
 

--- a/src/reference/antora/modules/ROOT/pages/jdbc/lock-registry.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jdbc/lock-registry.adoc
@@ -48,7 +48,7 @@ Starting with version 5.5.6, the `JdbcLockRegistry` supports automatic cache cle
 The default value is `100_000`.
 See its Javadocs for more information.
 The cache can be also cleaned via `expireUnusedOlderThan(long age)` API.
-When all the cached `JdbcLock` instances are acquired, and neither of them can be evicted, the `obtain(Object lockKey)` method throws a `CannotAcquireLockException`.
+When all the cached `JdbcLock` instances are acquired, and none of them can be evicted, the `obtain(Object lockKey)` method throws a `CannotAcquireLockException`.
 Another `CannotAcquireLockException` is also thrown on an attempt to lock a not cached `JdbcLock`.
 A fresh `obtain(Object lockKey)` for that lock key should be called.
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/11157

The previous (https://github.com/spring-projects/spring-integration/issues/11041) solution, based on the shared pool of `ReentrantLock` from the `DefaultLockRegistry`, being stable and smooth with the memory, is proven to be inconvenient with keys collision. So, different keys might stumble on the same shared `ReentrantLock` making the application being blocked for nothing.

* Remove `DefaultLockRegistry` logic from the `JdbcLockRegistry`
* Remove local `JdbcLock.holdCount` as we rely on the `delegate` again
* Revert back default `cacheCapacity` to `100_000` as we don't use shared pool of locks anymore
* Do not evict from the cache still in-held locks
* In the `obtain()`, try to remove unused lock when `cacheCapacity` is reached. If it cannot clean up the room, throw a `CannotAcquireLockException`. This is to prevent an out-of-memory error
* Also, throw a `CannotAcquireLockException` on lock calls for orphaned lock. This is to prevent a race condition when two distinct local locks are locked in different threads against the same key
* Add human-readable `toString()` into `DefaultLockRepository` and `JdbcLockRegistry`
* Use provided lock key for logs and exceptions instead of internal uuid
* Some other reasonable code refactoring in the `JdbcLockRegistry`

**Auto-cherry-pick to `7.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
