### PR TITLE
GH-11183: Fix batch mode message ID generation in KafkaMessageDrivenChannelAdapter

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -78,6 +78,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Urs Keller
  * @author Jooyoung Pyoung
+ * @author Zernov Oleksii
  *
  * @since 5.4
  */
@@ -144,7 +145,6 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 					JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
 							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
-			this.recordListener.setMessageConverter(messageConverter);
 		}
 		else if (JacksonPresent.isJackson2Present()) {
 			var headerMapper = new org.springframework.kafka.support.DefaultKafkaHeaderMapper();
@@ -152,8 +152,9 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 					org.springframework.integration.support.json.JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES
 							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
-			this.recordListener.setMessageConverter(messageConverter);
 		}
+
+		this.recordListener.setMessageConverter(messageConverter);
 
 		if (this.mode.equals(ListenerMode.batch)) {
 			var batchMessagingMessageConverter = new BatchMessagingMessageConverter(messageConverter);

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -57,6 +57,7 @@ import org.springframework.kafka.support.JacksonPresent;
 import org.springframework.kafka.support.JsonKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.converter.BatchMessageConverter;
+import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
 import org.springframework.kafka.support.converter.ConversionException;
 import org.springframework.kafka.support.converter.KafkaMessageHeaders;
 import org.springframework.kafka.support.converter.MessageConverter;
@@ -144,7 +145,6 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
 			this.recordListener.setMessageConverter(messageConverter);
-			this.batchListener.setMessageConverter(messageConverter);
 		}
 		else if (JacksonPresent.isJackson2Present()) {
 			var headerMapper = new org.springframework.kafka.support.DefaultKafkaHeaderMapper();
@@ -153,7 +153,13 @@ public class KafkaMessageDrivenChannelAdapter<K, V> extends MessageProducerSuppo
 							.toArray(new String[0]));
 			messageConverter.setHeaderMapper(headerMapper);
 			this.recordListener.setMessageConverter(messageConverter);
-			this.batchListener.setMessageConverter(messageConverter);
+		}
+
+		if (this.mode.equals(ListenerMode.batch)) {
+			var batchMessagingMessageConverter = new BatchMessagingMessageConverter(messageConverter);
+			batchMessagingMessageConverter.setGenerateMessageId(true);
+			batchMessagingMessageConverter.setGenerateTimestamp(true);
+			this.batchListener.setBatchMessageConverter(batchMessagingMessageConverter);
 		}
 	}
 

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaMessageDrivenChannelAdapter.java
@@ -78,7 +78,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Urs Keller
  * @author Jooyoung Pyoung
- * @author Zernov Oleksii
+ * @author Oleksii Zernov
  *
  * @since 5.4
  */

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
@@ -97,7 +97,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Anshul Mehra
  * @author Jooyoung Pyoung
  * @author Glenn Renfro
- * @author Zernov Oleksii
+ * @author Oleksii Zernov
  *
  * @since 5.4
  */
@@ -282,11 +282,11 @@ public class KafkaDslTests {
 
 	@Test
 	void testBatchListener() {
-		this.kafkaTemplate.send(TEST_TOPIC10, "foo");
+		this.kafkaTemplate.send(TEST_TOPIC10, "testData");
 
 		Message<?> receive = this.listeningFromKafkaResults3.receive(20000);
 		assertThat(receive).isNotNull();
-		assertThat(receive.getPayload()).isEqualTo("foo");
+		assertThat(receive.getPayload()).isEqualTo("testData");
 		MessageHeaders headers = receive.getHeaders();
 		assertThat(headers.get(MessageHeaders.ID)).isNotNull();
 	}
@@ -368,10 +368,7 @@ public class KafkaDslTests {
 			return IntegrationFlow
 					.from(Kafka
 							.messageDrivenChannelAdapter(consumerFactory(),
-									KafkaMessageDrivenChannelAdapter.ListenerMode.batch, TEST_TOPIC10)
-							.configureListenerContainer(c ->
-									c.ackMode(ContainerProperties.AckMode.MANUAL)
-											.id("topic10ListenerContainer")))
+									KafkaMessageDrivenChannelAdapter.ListenerMode.batch, TEST_TOPIC10))
 					.split()
 					.channel(c -> c.queue("listeningFromKafkaResults3"))
 					.get();

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
@@ -97,6 +97,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Anshul Mehra
  * @author Jooyoung Pyoung
  * @author Glenn Renfro
+ * @author Zernov Oleksii
  *
  * @since 5.4
  */

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaDslTests.java
@@ -123,6 +123,8 @@ public class KafkaDslTests {
 
 	static final String TEST_TOPIC8 = "test-topic8";
 
+	static final String TEST_TOPIC10 = "test-topic10";
+
 	@Autowired
 	@Qualifier("sendToKafkaFlow.input")
 	private MessageChannel sendToKafkaFlowInput;
@@ -132,6 +134,9 @@ public class KafkaDslTests {
 
 	@Autowired
 	private PollableChannel listeningFromKafkaResults2;
+
+	@Autowired
+	private PollableChannel listeningFromKafkaResults3;
 
 	@Autowired
 	@Qualifier("kafkaProducer1.handler")
@@ -154,6 +159,9 @@ public class KafkaDslTests {
 	@Autowired(required = false)
 	@Qualifier("kafkaTemplate:" + TEST_TOPIC2)
 	private KafkaTemplate<?, ?> kafkaTemplateTopic2;
+
+	@Autowired
+	private KafkaTemplate<Integer, String> kafkaTemplate;
 
 	@Autowired
 	private JsonKafkaHeaderMapper mapper;
@@ -195,6 +203,7 @@ public class KafkaDslTests {
 			assertThat(headers.containsKey(KafkaHeaders.ACKNOWLEDGMENT)).isTrue();
 			Acknowledgment acknowledgment = headers.get(KafkaHeaders.ACKNOWLEDGMENT, Acknowledgment.class);
 			acknowledgment.acknowledge();
+			assertThat(headers.get(MessageHeaders.ID)).isNotNull();
 			assertThat(headers.get(KafkaHeaders.RECEIVED_TOPIC)).isEqualTo(TEST_TOPIC1);
 			assertThat(headers.get(KafkaHeaders.RECEIVED_KEY)).isEqualTo(i + 1);
 			assertThat(headers.get(KafkaHeaders.RECEIVED_PARTITION)).isEqualTo(0);
@@ -211,6 +220,7 @@ public class KafkaDslTests {
 			assertThat(headers.containsKey(KafkaHeaders.ACKNOWLEDGMENT)).isTrue();
 			Acknowledgment acknowledgment = headers.get(KafkaHeaders.ACKNOWLEDGMENT, Acknowledgment.class);
 			acknowledgment.acknowledge();
+			assertThat(headers.get(MessageHeaders.ID)).isNotNull();
 			assertThat(headers.get(KafkaHeaders.RECEIVED_TOPIC)).isEqualTo(TEST_TOPIC2);
 			assertThat(headers.get(KafkaHeaders.RECEIVED_KEY)).isEqualTo(i + 1);
 			assertThat(headers.get(KafkaHeaders.RECEIVED_PARTITION)).isEqualTo(0);
@@ -267,6 +277,17 @@ public class KafkaDslTests {
 				.isNotNull()
 				.extracting("payload")
 				.isEqualTo("foo");
+	}
+
+	@Test
+	void testBatchListener() {
+		this.kafkaTemplate.send(TEST_TOPIC10, "foo");
+
+		Message<?> receive = this.listeningFromKafkaResults3.receive(20000);
+		assertThat(receive).isNotNull();
+		assertThat(receive.getPayload()).isEqualTo("foo");
+		MessageHeaders headers = receive.getHeaders();
+		assertThat(headers.get(MessageHeaders.ID)).isNotNull();
 	}
 
 	@Configuration
@@ -338,6 +359,20 @@ public class KafkaDslTests {
 							f -> f.throwExceptionOnRejection(true))
 					.<String, String>transform(String::toUpperCase)
 					.channel(c -> c.queue("listeningFromKafkaResults2"))
+					.get();
+		}
+
+		@Bean
+		public IntegrationFlow batchListenerFromKafkaFlow() {
+			return IntegrationFlow
+					.from(Kafka
+							.messageDrivenChannelAdapter(consumerFactory(),
+									KafkaMessageDrivenChannelAdapter.ListenerMode.batch, TEST_TOPIC10)
+							.configureListenerContainer(c ->
+									c.ackMode(ContainerProperties.AckMode.MANUAL)
+											.id("topic10ListenerContainer")))
+					.split()
+					.channel(c -> c.queue("listeningFromKafkaResults3"))
 					.get();
 		}
 


### PR DESCRIPTION
Fixes #11183

When using `Kafka.messageDrivenChannelAdapter` with `ListenerMode.batch` followed by a `.split()`, the splitter fails because the batch message doesn't have a message ID generated. This is required by the splitter to properly set correlation headers on split messages.

The root cause was that the constructor was setting the same `MessagingMessageConverter` (intended for record mode) on the batch listener instead of creating a proper `BatchMessagingMessageConverter` with message ID generation enabled.

This fix ensures that when in batch mode, a `BatchMessagingMessageConverter` is created with `setGenerateMessageId(true)` and `setGenerateTimestamp(true)`, similar to how it's done for record mode.

## Changes
- Modified `KafkaMessageDrivenChannelAdapter` constructor to properly configure `BatchMessagingMessageConverter` for batch mode
- Added test case `testBatchListener()` in `KafkaDslTests` to verify the fix
- Added assertions for message ID in existing tests to ensure consistency
