### PR TITLE
GH-11196: Fix DI for Dynamically Registered Flow Beans

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/IntegrationFlowBeanPostProcessor.java
@@ -41,7 +41,6 @@ import org.springframework.beans.factory.config.EmbeddedValueResolver;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
-import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ApplicationContext;
@@ -266,7 +265,7 @@ public class IntegrationFlowBeanPostProcessor
 					}
 					else if (component instanceof FixedSubscriberChannel fixedSubscriberChannel) {
 						String channelBeanName = fixedSubscriberChannel.getComponentName();
-						if ("Unnamed fixed subscriber channel" .equals(channelBeanName)) {
+						if ("Unnamed fixed subscriber channel".equals(channelBeanName)) {
 							channelBeanName = flowNamePrefix + "channel" +
 									BeanFactoryUtils.GENERATED_BEAN_NAME_SEPARATOR + channelNameIndex++;
 						}
@@ -518,7 +517,8 @@ public class IntegrationFlowBeanPostProcessor
 			this.beanFactory.registerDependentBean(parentName, beanName);
 		}
 
-		((BeanDefinitionRegistry) this.beanFactory).registerBeanDefinition(beanName, beanDefinition);
+		this.beanFactory.registerBeanDefinition(beanName, beanDefinition);
+		// Force early FactoryBean#getObject() resolution, e.g. for ConsumerEndpointFactoryBean et al.
 		this.beanFactory.getBean(beanName);
 	}
 
@@ -535,8 +535,11 @@ public class IntegrationFlowBeanPostProcessor
 			this.beanFactory.registerDependentBean(parentName, beanName);
 		}
 
-		this.beanFactory.registerSingleton(beanName, component);
-		this.beanFactory.initializeBean(component, beanName);
+		this.beanFactory.autowireBean(component);
+		Object initializedComponent = this.beanFactory.initializeBean(component, beanName);
+		// Register the post-processed (e.g. possibly proxied) instance, not the raw one.
+		this.beanFactory.registerSingleton(beanName, initializedComponent);
+		// Force early FactoryBean#getObject() resolution, e.g. for ConsumerEndpointFactoryBean et al.
 		this.beanFactory.getBean(beanName);
 	}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/dsl/context/StandardIntegrationFlowContext.java
@@ -164,8 +164,11 @@ public final class StandardIntegrationFlowContext implements IntegrationFlowCont
 				componentSourceAware.setComponentDescription(description);
 			}
 		}
-		this.beanFactory.registerSingleton(beanName, bean);
-		return (B) this.beanFactory.initializeBean(bean, beanName);
+		this.beanFactory.autowireBean(bean);
+		B initializedBean = (B) this.beanFactory.initializeBean(bean, beanName);
+		// Register the post-processed (e.g. possibly proxied) instance, not the raw one.
+		this.beanFactory.registerSingleton(beanName, initializedBean);
+		return initializedBean;
 	}
 
 	/**
@@ -175,8 +178,7 @@ public final class StandardIntegrationFlowContext implements IntegrationFlowCont
 	 * @return the IntegrationFlowRegistration for provided {@code id} or {@code null}
 	 */
 	@Override
-	@Nullable
-	public IntegrationFlowRegistration getRegistrationById(String flowId) {
+	public @Nullable IntegrationFlowRegistration getRegistrationById(String flowId) {
 		return this.registry.get(flowId);
 	}
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/dsl/manualflow/ManualFlowTests.java
@@ -36,10 +36,13 @@ import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.BeanCreationNotAllowedException;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.support.BeanDefinitionOverrideException;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -54,6 +57,7 @@ import org.springframework.integration.config.EnableIntegrationManagement;
 import org.springframework.integration.config.EnableMessageHistory;
 import org.springframework.integration.core.MessageProducer;
 import org.springframework.integration.core.MessagingTemplate;
+import org.springframework.integration.dsl.BaseIntegrationFlowDefinition;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.IntegrationFlowAdapter;
 import org.springframework.integration.dsl.IntegrationFlowBuilder;
@@ -240,6 +244,37 @@ public class ManualFlowTests {
 		assertThat(n).isLessThan(100);
 
 		assertThat(additionalBean.destroyed).isTrue();
+	}
+
+	@Test
+	void additionalBeanReceivesDependencyInjection() {
+		SupportComponent supportComponent = new SupportComponent();
+		IntegrationFlowRegistration flowRegistration =
+				this.integrationFlowContext.registration(BaseIntegrationFlowDefinition::bridge)
+						.id("dependencyInjectionFlow")
+						.addBean("testSupportComponent", supportComponent)
+						.register();
+
+		assertThat(this.beanFactory.containsBean("testSupportComponent")).isTrue();
+		assertThat(supportComponent.dependency).isNotNull();
+
+		flowRegistration.destroy();
+	}
+
+	@Test
+	void additionalBeanPostProcessorReplacementIsPreserved() {
+		ProxiedComponent proxiedComponent = new ProxiedComponent();
+		IntegrationFlowRegistration flowRegistration =
+				this.integrationFlowContext.registration(BaseIntegrationFlowDefinition::bridge)
+						.id("proxyPreservingFlow")
+						.addBean("testProxiedComponent", proxiedComponent)
+						.register();
+
+		Object registeredBean = this.beanFactory.getBean("testProxiedComponent");
+		assertThat(AopUtils.isAopProxy(registeredBean)).isTrue();
+		assertThat(registeredBean).isNotSameAs(proxiedComponent);
+
+		flowRegistration.destroy();
 	}
 
 	@Test
@@ -536,6 +571,43 @@ public class ManualFlowTests {
 		public MessageChannel doNotOverrideChannel() {
 			return new DirectChannel();
 		}
+
+		@Bean
+		Dependency dependency() {
+			return new Dependency();
+		}
+
+		@Bean
+		static BeanPostProcessor proxyingBeanPostProcessor() {
+			return new BeanPostProcessor() {
+
+				@Override
+				public Object postProcessAfterInitialization(Object bean, String beanName) {
+					if (bean instanceof ProxiedComponent) {
+						ProxyFactory proxyFactory = new ProxyFactory(bean);
+						proxyFactory.setProxyTargetClass(true);
+						return proxyFactory.getProxy();
+					}
+					return bean;
+				}
+
+			};
+		}
+
+	}
+
+	private static class Dependency {
+
+	}
+
+	private static class SupportComponent {
+
+		@Autowired
+		Dependency dependency;
+
+	}
+
+	static class ProxiedComponent {
 
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/11196

Since dynamic `IntegrationFlow` beans and their support components were
switched from `BeanDefinition`-backed registration to direct singleton
registration (to avoid retaining merged bean definitions), such beans
skip the property-population phase of the bean lifecycle, and any
object replacement performed by a `BeanPostProcessor` (e.g. an AOP
proxy) is silently discarded.
As a result:
- `@Autowired` fields/methods on beans added via
`IntegrationFlowContext.registration().addBean()`, or contributed by a
custom `IntegrationFlowExtension.addComponent()`, were never populated
- any proxy or other replacement object returned from
`initializeBean()` was lost because the raw, pre-processed instance had
already been bound in the singleton registry under that bean name

* Call `DefaultListableBeanFactory.autowireBean()` before
`initializeBean()` in `StandardIntegrationFlowContext.registerBean()`
and `IntegrationFlowBeanPostProcessor.registerSingleton()` to restore
`@Autowired` injection for singleton-registered dynamic flow components
* Register the singleton *after* `initializeBean()` completes, using its
return value, so a proxy (or other post-processor replacement) is what
ends up bound in the bean factory
* Add a clarifying comment on the existing `getBean()` calls explaining
they force early `FactoryBean#getObject()` resolution
* Add `ManualFlowTests.additionalBeanReceivesDependencyInjection()` and
`ManualFlowTests.additionalBeanPostProcessorReplacementIsPreserved()`
to verify the fix

**Auto-cherry-pick to `7.0.x`**