### PR TITLE
Update debug msg when queue null but correlation key set

### DIFF
--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
@@ -1309,9 +1309,9 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler
 				if (this.correlationKey != null) {
 					Log debugLogger = LogFactory.getLog("si.jmsgateway.debug");
 					if (debugLogger.isDebugEnabled()) {
-						Object siMessage = this.messageConverter.fromMessage(message);
-						debugLogger.debug("No pending reply for " + siMessage + " with correlationId: "
-								+ correlationId + " pending replies: " + this.replies.keySet());
+						debugLogger.debug("No pending reply for message of type " + message.getJMSType()
+								+ " with correlationId: " + correlationId
+								+ " pending replies: " + this.replies.keySet());
 					}
 					throw new IllegalStateException("No sender waiting for reply");
 				}


### PR DESCRIPTION
- Just log a correlationId and message type

Fixes: https://github.com/spring-projects/spring-integration/issues/11197

`Auto-cherry-pick to 7.0.x`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
