### PR TITLE
Add redis_command to sensitive-metadata doc

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/security.adoc
+++ b/src/reference/antora/modules/ROOT/pages/security.adoc
@@ -184,6 +184,7 @@ The mentioned above validation and filtering might be applied to them before the
 - `spring-integration-redis`
  * `redis_key`
  * `redis_mapKey`
+ * `redis_command`
 
 - `spring-integration-xmpp`
  * `xmpp_to`


### PR DESCRIPTION
- Specifically to the sensitive-metadata section of the security.adoc

Fixes: https://github.com/spring-projects/spring-integration/issues/11201

`Auto-cherry-pick to 7.0.x`

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
