### PR TITLE
Add stored proc to security doc

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/security.adoc
+++ b/src/reference/antora/modules/ROOT/pages/security.adoc
@@ -162,6 +162,15 @@ The mentioned above validation and filtering might be applied to them before the
 
 - `spring-integration-file`
  * `file_name`
+ * `delete_source_files`
+ * `destination_directory`
+ * `destination_directory_expression`
+ * `original_file`
+ * `relative_path`
+ * `rename_to`
+ * `remote_diretory`
+ * `remote_file`
+
 
 - `spring-integration-ip`
  * `ip_ackTo`


### PR DESCRIPTION
Add `storeProcedureNameExpression` to Sensitive Metadata section

Fixes: https://github.com/spring-projects/spring-integration/issues/11200

**Auto-cherry-pick to `7.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
