### PR TITLE
Add file configurations to sensitive metadata

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/security.adoc
+++ b/src/reference/antora/modules/ROOT/pages/security.adoc
@@ -162,6 +162,15 @@ The mentioned above validation and filtering might be applied to them before the
 
 - `spring-integration-file`
  * `file_name`
+ * `delete_source_files`
+ * `destination_directory`
+ * `destination_directory_expression`
+ * `original_file`
+ * `relative_path`
+ * `rename_to`
+ * `remote_diretory`
+ * `remote_file`
+
 
 - `spring-integration-ip`
  * `ip_ackTo`

--- a/src/reference/antora/modules/ROOT/pages/security.adoc
+++ b/src/reference/antora/modules/ROOT/pages/security.adoc
@@ -168,7 +168,7 @@ The mentioned above validation and filtering might be applied to them before the
  * `file_remoteDirectory`
  * `file_remoteFile`
 
-NOTE: The following settings in `FileWritingMessageHandler` are also sensitive: `deleteSourceFiles`, `destinationDirectoryExpression`.
+NOTE: The following setting in `FileWritingMessageHandler` is also sensitive: `destinationDirectoryExpression`.
 
 - `spring-integration-ip`
  * `ip_ackTo`

--- a/src/reference/antora/modules/ROOT/pages/security.adoc
+++ b/src/reference/antora/modules/ROOT/pages/security.adoc
@@ -162,15 +162,14 @@ The mentioned above validation and filtering might be applied to them before the
 
 - `spring-integration-file`
  * `file_name`
- * `delete_source_files`
- * `destination_directory`
- * `destination_directory_expression`
- * `original_file`
- * `relative_path`
- * `rename_to`
- * `remote_diretory`
- * `remote_file`
+ * `file_originalFile`
+ * `file_relativePath`
+ * `file_renameTo`
+ * `file_remoteDirectory`
+ * `file_remoteFile`
+ * `file_setModified`
 
+NOTE: The following settings in `FileWritingMessageHandler` are also sensitive: `deleteSourceFiles`, `destinationDirectory`, `destinationDirectoryExpression`.
 
 - `spring-integration-ip`
  * `ip_ackTo`

--- a/src/reference/antora/modules/ROOT/pages/security.adoc
+++ b/src/reference/antora/modules/ROOT/pages/security.adoc
@@ -167,9 +167,8 @@ The mentioned above validation and filtering might be applied to them before the
  * `file_renameTo`
  * `file_remoteDirectory`
  * `file_remoteFile`
- * `file_setModified`
 
-NOTE: The following settings in `FileWritingMessageHandler` are also sensitive: `deleteSourceFiles`, `destinationDirectory`, `destinationDirectoryExpression`.
+NOTE: The following settings in `FileWritingMessageHandler` are also sensitive: `deleteSourceFiles`, `destinationDirectoryExpression`.
 
 - `spring-integration-ip`
  * `ip_ackTo`


### PR DESCRIPTION
- Add FileHeaders and other configurations from FileWritingMessageHandler to sensitive-metadata section where applicable

Fixes: https://github.com/spring-projects/spring-integration/issues/11199

**Auto-cherry-pick to `7.0.x`**

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
