### PR TITLE
GH-11235: Restore URL-encoded form conversion

### DIFF
--- a/spring-integration-http/src/main/java/org/springframework/integration/http/converter/MultipartAwareFormHttpMessageConverter.java
+++ b/spring-integration-http/src/main/java/org/springframework/integration/http/converter/MultipartAwareFormHttpMessageConverter.java
@@ -20,12 +20,15 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.core.ResolvableType;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
@@ -39,19 +42,32 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 
 /**
- * An {@link HttpMessageConverter} implementation that delegates to an instance of
- * {@link MultipartHttpMessageConverter} while adding the capability to <i>read</i>
- * <code>multipart/form-data</code> content in an HTTP request.
+ * An {@link HttpMessageConverter} implementation that delegates URL-encoded form data
+ * to a {@link FormHttpMessageConverter} and multipart data to a
+ * {@link MultipartHttpMessageConverter}, while adding the capability to <i>read</i>
+ * {@code multipart/form-data} content in an HTTP request.
  *
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Dongliang Xie
  *
  * @since 2.0
  */
 public class MultipartAwareFormHttpMessageConverter implements HttpMessageConverter<MultiValueMap<String, ?>> {
 
-	private final MultipartHttpMessageConverter wrappedConverter = new MultipartHttpMessageConverter();
+	private static final ResolvableType FORM_DATA_TYPE =
+			ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, String.class);
+
+	private final FormHttpMessageConverter formConverter = new FormHttpMessageConverter();
+
+	private final MultipartHttpMessageConverter multipartConverter = new MultipartHttpMessageConverter();
+
+	private final List<MediaType> supportedMediaTypes = Stream
+			.concat(this.formConverter.getSupportedMediaTypes().stream(),
+					this.multipartConverter.getSupportedMediaTypes().stream())
+			.distinct()
+			.toList();
 
 	private MultipartFileReader<?> multipartFileReader = new DefaultMultipartFileReader();
 
@@ -60,7 +76,8 @@ public class MultipartAwareFormHttpMessageConverter implements HttpMessageConver
 	 * @param charset The charset.
 	 */
 	public void setCharset(Charset charset) {
-		this.wrappedConverter.setCharset(charset);
+		this.formConverter.setCharset(charset);
+		this.multipartConverter.setCharset(charset);
 	}
 
 	/**
@@ -74,7 +91,7 @@ public class MultipartAwareFormHttpMessageConverter implements HttpMessageConver
 
 	@Override
 	public List<MediaType> getSupportedMediaTypes() {
-		return this.wrappedConverter.getSupportedMediaTypes();
+		return this.supportedMediaTypes;
 	}
 
 	@Override
@@ -93,7 +110,16 @@ public class MultipartAwareFormHttpMessageConverter implements HttpMessageConver
 
 	@Override
 	public boolean canWrite(Class<?> clazz, @Nullable MediaType mediaType) {
-		return this.wrappedConverter.canWrite(clazz, mediaType);
+		if (!MultiValueMap.class.isAssignableFrom(clazz)) {
+			return false;
+		}
+		if (mediaType == null) {
+			return true;
+		}
+		if (MediaType.APPLICATION_FORM_URLENCODED.includes(mediaType)) {
+			return this.formConverter.canWrite(clazz, mediaType);
+		}
+		return this.multipartConverter.canWrite(clazz, mediaType);
 	}
 
 	@Override
@@ -102,12 +128,17 @@ public class MultipartAwareFormHttpMessageConverter implements HttpMessageConver
 
 		MediaType contentType = inputMessage.getHeaders().getContentType();
 		if (!MediaType.MULTIPART_FORM_DATA.includes(contentType)) {
-			return this.wrappedConverter.read(clazz, inputMessage);
+			return readForm(inputMessage);
 		}
 		Assert.state(inputMessage instanceof MultipartHttpInputMessage,
 				"A request with 'multipart/form-data' Content-Type must be a MultipartHttpInputMessage. "
 						+ "Be sure to provide a 'multipartResolver' bean in the ApplicationContext.");
 		return readMultipart((MultipartHttpInputMessage) inputMessage);
+	}
+
+	@SuppressWarnings("unchecked")
+	private MultiValueMap<String, ?> readForm(HttpInputMessage inputMessage) throws IOException {
+		return (MultiValueMap<String, ?>) this.formConverter.read(FORM_DATA_TYPE, inputMessage, Map.of());
 	}
 
 	private MultiValueMap<String, ?> readMultipart(MultipartHttpInputMessage multipartRequest) throws IOException {
@@ -130,7 +161,36 @@ public class MultipartAwareFormHttpMessageConverter implements HttpMessageConver
 	public void write(MultiValueMap<String, ?> map, @Nullable MediaType contentType, HttpOutputMessage outputMessage)
 			throws IOException, HttpMessageNotWritableException {
 
-		this.wrappedConverter.write(map, contentType, outputMessage);
+		if (isMultipart(map, contentType)) {
+			this.multipartConverter.write(map, contentType, outputMessage);
+		}
+		else if (contentType == null || MediaType.APPLICATION_FORM_URLENCODED.includes(contentType)) {
+			this.formConverter.write(toFormData(map), contentType, outputMessage);
+		}
+		else {
+			throw new HttpMessageNotWritableException("Unsupported Content-Type: " + contentType);
+		}
+	}
+
+	private boolean isMultipart(MultiValueMap<String, ?> map, @Nullable MediaType contentType) {
+		if (contentType != null) {
+			return this.multipartConverter.canWrite(MultiValueMap.class, contentType);
+		}
+		for (List<?> values : map.values()) {
+			for (Object value : values) {
+				if (value != null && !(value instanceof String)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static MultiValueMap<String, String> toFormData(MultiValueMap<String, ?> map) {
+		MultiValueMap<String, String> formData = new LinkedMultiValueMap<>(map.size());
+		map.forEach((name, values) -> values.forEach((value) ->
+				formData.add(name, value != null ? String.valueOf(value) : null)));
+		return formData;
 	}
 
 }

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/converter/MultipartAwareFormHttpMessageConverterTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/converter/MultipartAwareFormHttpMessageConverterTests.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.http.converter;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.integration.http.multipart.MultipartHttpInputMessage;
+import org.springframework.mock.http.MockHttpInputMessage;
+import org.springframework.mock.http.MockHttpOutputMessage;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.mock.web.MockMultipartHttpServletRequest;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dongliang Xie
+ *
+ * @since 7.2
+ */
+public class MultipartAwareFormHttpMessageConverterTests {
+
+	private final MultipartAwareFormHttpMessageConverter converter =
+			new MultipartAwareFormHttpMessageConverter();
+
+	@Test
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public void readUrlEncodedFormForByteArrayTarget() throws Exception {
+		MockHttpInputMessage inputMessage =
+				new MockHttpInputMessage("name=J%FCrgen&tag=first&tag=second".getBytes(StandardCharsets.US_ASCII));
+		inputMessage.getHeaders().setContentType(
+				new MediaType(MediaType.APPLICATION_FORM_URLENCODED, StandardCharsets.ISO_8859_1));
+
+		Object result = ((HttpMessageConverter) this.converter).read(byte[].class, inputMessage);
+
+		assertThat(result).isInstanceOf(MultiValueMap.class);
+		MultiValueMap<String, String> form = (MultiValueMap<String, String>) result;
+		assertThat(form.getFirst("name")).isEqualTo("Jürgen");
+		assertThat(form.get("tag")).containsExactly("first", "second");
+	}
+
+	@Test
+	public void exposeFormAndMultipartMediaTypes() {
+		assertThat(this.converter.getSupportedMediaTypes()).containsExactly(
+				MediaType.APPLICATION_FORM_URLENCODED,
+				MediaType.MULTIPART_FORM_DATA,
+				MediaType.MULTIPART_MIXED,
+				MediaType.MULTIPART_RELATED);
+	}
+
+	@Test
+	public void readAndWriteCapabilitiesMatchSupportedConversions() {
+		assertThat(this.converter.canRead(byte[].class, MediaType.APPLICATION_FORM_URLENCODED)).isTrue();
+		assertThat(this.converter.canRead(MultiValueMap.class, MediaType.MULTIPART_FORM_DATA)).isTrue();
+		assertThat(this.converter.canRead(byte[].class, null)).isTrue();
+		assertThat(this.converter.canRead(MultiValueMap.class, MediaType.APPLICATION_JSON)).isFalse();
+		assertThat(this.converter.canRead(String.class, MediaType.APPLICATION_FORM_URLENCODED)).isFalse();
+		assertThat(this.converter.canWrite(MultiValueMap.class, MediaType.APPLICATION_FORM_URLENCODED)).isTrue();
+		assertThat(this.converter.canWrite(MultiValueMap.class, MediaType.MULTIPART_FORM_DATA)).isTrue();
+		assertThat(this.converter.canWrite(MultiValueMap.class, null)).isTrue();
+		assertThat(this.converter.canWrite(MultiValueMap.class, MediaType.APPLICATION_JSON)).isFalse();
+		assertThat(this.converter.canWrite(Map.class, MediaType.APPLICATION_FORM_URLENCODED)).isFalse();
+	}
+
+	@Test
+	public void writeUrlEncodedFormWithExplicitCharset() throws Exception {
+		MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
+		form.add("name", "Jürgen");
+		form.add("tag", "first");
+		form.add("tag", "second");
+		form.add("count", 42);
+		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+		MediaType contentType =
+				new MediaType(MediaType.APPLICATION_FORM_URLENCODED, StandardCharsets.ISO_8859_1);
+
+		this.converter.write(form, contentType, outputMessage);
+
+		assertThat(outputMessage.getHeaders().getContentType()).isEqualTo(contentType);
+		assertThat(outputMessage.getBodyAsString(StandardCharsets.ISO_8859_1))
+				.isEqualTo("name=J%FCrgen&tag=first&tag=second&count=42");
+	}
+
+	@Test
+	public void useConfiguredCharsetForFormWithNoContentType() throws Exception {
+		this.converter.setCharset(StandardCharsets.ISO_8859_1);
+		MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
+		form.add("name", "Jürgen");
+		form.add("empty", null);
+		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+
+		this.converter.write(form, null, outputMessage);
+
+		assertThat(outputMessage.getHeaders().getContentType()).isEqualTo(MediaType.APPLICATION_FORM_URLENCODED);
+		assertThat(outputMessage.getBodyAsString(StandardCharsets.ISO_8859_1)).isEqualTo("name=J%FCrgen&empty");
+	}
+
+	@Test
+	public void writeMultipartForNonStringValueWithNoContentType() throws Exception {
+		MultiValueMap<String, Object> form = new LinkedMultiValueMap<>();
+		form.add("file", "test".getBytes(StandardCharsets.UTF_8));
+		MockHttpOutputMessage outputMessage = new MockHttpOutputMessage();
+
+		this.converter.write(form, null, outputMessage);
+
+		MediaType contentType = outputMessage.getHeaders().getContentType();
+		assertThat(contentType).isNotNull();
+		assertThat(contentType.isCompatibleWith(MediaType.MULTIPART_FORM_DATA)).isTrue();
+		assertThat(contentType.getParameter("boundary")).isNotBlank();
+		assertThat(outputMessage.getBodyAsString()).contains("name=\"file\"").contains("test");
+	}
+
+	@Test
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public void retainMultipartParametersAndCustomFileReader() throws Exception {
+		MockMultipartHttpServletRequest servletRequest = new MockMultipartHttpServletRequest();
+		servletRequest.setContentType(MediaType.MULTIPART_FORM_DATA_VALUE);
+		servletRequest.addParameter("tag", "first", "second");
+		servletRequest.addFile(
+				new MockMultipartFile("file", "first.txt", "text/plain", "one".getBytes(StandardCharsets.UTF_8)));
+		servletRequest.addFile(new MockMultipartFile("file", "empty.txt", "text/plain", new byte[0]));
+		servletRequest.addFile(
+				new MockMultipartFile("file", "second.txt", "text/plain", "two".getBytes(StandardCharsets.UTF_8)));
+		this.converter.setMultipartFileReader(multipartFile -> multipartFile.getOriginalFilename());
+
+		Object result = ((HttpMessageConverter) this.converter)
+				.read(byte[].class, new MultipartHttpInputMessage(servletRequest));
+
+		MultiValueMap<String, Object> form = (MultiValueMap<String, Object>) result;
+		assertThat(form.get("tag")).containsExactly("first", "second");
+		assertThat(form.get("file")).containsExactly("first.txt", "second.txt");
+	}
+
+}

--- a/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
+++ b/spring-integration-http/src/test/java/org/springframework/integration/http/dsl/HttpDslTests.java
@@ -23,7 +23,6 @@ import java.util.Map;
 
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,7 +48,6 @@ import org.springframework.integration.handler.AbstractReplyProducingMessageHand
 import org.springframework.integration.http.multipart.UploadedMultipartFile;
 import org.springframework.integration.http.outbound.HttpRequestExecutingMessageHandler;
 import org.springframework.integration.scheduling.PollerMetadata;
-import org.springframework.integration.test.util.TestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.PollableChannel;
 import org.springframework.messaging.support.ErrorMessage;
@@ -69,7 +67,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.web.SpringJUnitWebConfig;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.client.RestTestClient;
+import org.springframework.test.web.servlet.client.MockMvcClientHttpRequestFactory;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.Errors;
@@ -99,6 +97,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * @author Oleksii Komlyk
  * @author Glenn Renfro
  * @author Arun Sethumadhavan
+ * @author Dongliang Xie
  *
  * @since 5.0
  */
@@ -126,11 +125,9 @@ public class HttpDslTests {
 	}
 
 	@Test
-	@Disabled("See https://github.com/spring-projects/spring-integration/issues/11235")
 	public void testHttpProxyFlow() throws Exception {
-		RestTestClient restTestClient = RestTestClient.bindTo(this.mockMvc).build();
 		ClientHttpRequestFactory mockRequestFactory =
-				TestUtils.getPropertyValue(restTestClient, "restClient.clientRequestFactory");
+				new MockMvcClientHttpRequestFactory(this.mockMvc);
 		this.serviceInternalGatewayHandler.setRequestFactory(mockRequestFactory);
 		this.serviceInternalGatewayHandler.afterPropertiesSet();
 


### PR DESCRIPTION
Fixes: #11235

Spring Framework 7.1 split URL-encoded form and multipart conversion into separate converters. `MultipartAwareFormHttpMessageConverter` still advertised support for URL-encoded forms, but delegated their reads to the multipart-only converter, causing requests without a multipart boundary to fail.

This change routes URL-encoded data through `FormHttpMessageConverter` while retaining the existing multipart handling and `MultipartFileReader` support. It also re-enables the proxy flow regression test using the public `MockMvcClientHttpRequestFactory` and adds focused converter coverage for read/write routing, charset, repeated values, and multipart behavior.

Validation:

- `./gradlew :spring-integration-http:check`
- Focused proxy and multipart regression tests

A full `./gradlew clean test` was also attempted. The HTTP module passed; the overall run encountered environment-dependent failures in unrelated IP tests and Redis, MQTT, and MySQL Testcontainers.
