### PR TITLE
GH-10847: Fix `putIfAbsent()` loop in `JdbcMetadataStore`

### DIFF
--- a/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/metadata/JdbcMetadataStore.java
+++ b/spring-integration-jdbc/src/main/java/org/springframework/integration/jdbc/metadata/JdbcMetadataStore.java
@@ -34,6 +34,7 @@ import org.springframework.jdbc.core.JdbcOperations;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Implementation of {@link ConcurrentMetadataStore} using a relational database via JDBC.
@@ -52,6 +53,7 @@ import org.springframework.util.Assert;
  * @author Bojan Vukasovic
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Sanghun Lee
  *
  * @since 5.0
  */
@@ -117,6 +119,8 @@ public class JdbcMetadataStore implements ConcurrentMetadataStore, InitializingB
 
 	private boolean checkDatabaseOnStart = true;
 
+	private boolean lockHintProvided;
+
 	/**
 	 * Instantiate a {@link JdbcMetadataStore} using provided dataSource {@link DataSource}.
 	 * @param dataSource a {@link DataSource}
@@ -176,6 +180,7 @@ public class JdbcMetadataStore implements ConcurrentMetadataStore, InitializingB
 				this.jdbcTemplate.execute((ConnectionCallback<String>) connection ->
 						connection.getMetaData().getDatabaseProductName());
 		this.getValueQuery = String.format(this.getValueQuery, this.tablePrefix);
+		this.lockHintProvided = StringUtils.hasText(this.lockHint);
 		this.getValueForUpdateQuery = String.format(this.getValueForUpdateQuery, this.tablePrefix, this.lockHint);
 		this.replaceValueQuery = String.format(this.replaceValueQuery, this.tablePrefix);
 		this.replaceValueByKeyQuery = String.format(this.replaceValueByKeyQuery, this.tablePrefix);
@@ -240,7 +245,17 @@ public class JdbcMetadataStore implements ConcurrentMetadataStore, InitializingB
 					return this.jdbcTemplate.queryForObject(this.getValueQuery, String.class, key, this.region);
 				}
 				catch (EmptyResultDataAccessException e) {
-					//somebody deleted it between calls. try to insert again (go to beginning of while loop)
+					//the insert saw the row, so this snapshot is older than its commit. read it under
+					//a lock, which is not served from the snapshot. no point without a lock hint
+					if (this.lockHintProvided) {
+						try {
+							return this.jdbcTemplate.queryForObject(this.getValueForUpdateQuery, String.class, key,
+									this.region);
+						}
+						catch (EmptyResultDataAccessException ex) {
+							//somebody deleted it between calls. try to insert again (go to beginning of while loop)
+						}
+					}
 				}
 			}
 		}

--- a/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlMetadataStoreTests.java
+++ b/spring-integration-jdbc/src/test/java/org/springframework/integration/jdbc/mysql/MySqlMetadataStoreTests.java
@@ -19,6 +19,7 @@ package org.springframework.integration.jdbc.mysql;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import javax.sql.DataSource;
@@ -32,18 +33,22 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.integration.jdbc.metadata.JdbcMetadataStore;
 import org.springframework.integration.metadata.ConcurrentMetadataStore;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.jdbc.datasource.init.DataSourceInitializer;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Artem Bilan
+ * @author Sanghun Lee
  *
  * @since 6.4
  */
@@ -53,6 +58,12 @@ class MySqlMetadataStoreTests implements MySqlContainerTest {
 
 	@Autowired
 	ConcurrentMetadataStore jdbcMetadataStore;
+
+	@Autowired
+	PlatformTransactionManager transactionManager;
+
+	@Autowired
+	DataSource dataSource;
 
 	@Test
 	void verifyJdbcMetadataStoreConcurrency() throws InterruptedException {
@@ -66,6 +77,57 @@ class MySqlMetadataStoreTests implements MySqlContainerTest {
 		}
 		assertThat(successPutIfAbsents.await(10, TimeUnit.SECONDS)).isTrue();
 		executorService.shutdown();
+	}
+
+	@Test
+	void verifyPutIfAbsentSeesConcurrentlyCommittedValue() throws Exception {
+		String key = "concurrentlyCommittedKey";
+		TransactionTemplate transactionTemplate = new TransactionTemplate(this.transactionManager);
+		// The scenario only exists under a snapshot-based isolation level, so pin it here rather
+		// than depending on the server default staying REPEATABLE READ.
+		transactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_REPEATABLE_READ);
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(this.dataSource);
+
+		CountDownLatch snapshotTaken = new CountDownLatch(1);
+		CountDownLatch otherTransactionCommitted = new CountDownLatch(1);
+
+		// Bound the worker transaction so a regression times out instead of looping with its locks
+		// held, which would leave the cleanup below blocking rather than the assertion reporting.
+		TransactionTemplate workerTransactionTemplate = new TransactionTemplate(this.transactionManager);
+		workerTransactionTemplate.setIsolationLevel(TransactionDefinition.ISOLATION_REPEATABLE_READ);
+		workerTransactionTemplate.setTimeout(30);
+
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+		try {
+			Future<String> putIfAbsentResult = executorService.submit(() ->
+					workerTransactionTemplate.execute(status -> {
+						// Establish this transaction's snapshot before the other one inserts
+						// the key, like a channel adapter reading before it records metadata.
+						jdbcTemplate.queryForObject("SELECT COUNT(*) FROM INT_METADATA_STORE", Integer.class);
+						snapshotTaken.countDown();
+						try {
+							assertThat(otherTransactionCommitted.await(10, TimeUnit.SECONDS)).isTrue();
+						}
+						catch (InterruptedException ex) {
+							Thread.currentThread().interrupt();
+							throw new IllegalStateException(ex);
+						}
+						return this.jdbcMetadataStore.putIfAbsent(key, "thisValue");
+					}));
+
+			assertThat(snapshotTaken.await(10, TimeUnit.SECONDS)).isTrue();
+			transactionTemplate.executeWithoutResult(status ->
+					jdbcTemplate.update("INSERT INTO INT_METADATA_STORE(METADATA_KEY, METADATA_VALUE, REGION) "
+							+ "VALUES (?, ?, ?)", key, "otherValue", "DEFAULT"));
+			otherTransactionCommitted.countDown();
+
+			assertThat(putIfAbsentResult.get(10, TimeUnit.SECONDS)).isEqualTo("otherValue");
+		}
+		finally {
+			executorService.shutdownNow();
+			executorService.awaitTermination(10, TimeUnit.SECONDS);
+			this.jdbcMetadataStore.remove(key);
+		}
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Fixes: gh-10847

Follow-up to my [analysis comment](https://github.com/spring-projects/spring-integration/issues/10847#issuecomment-5218258467) on the issue.

## The defect

`putIfAbsent()` mixes a locking statement with a non-locking one inside a single transaction: `INSERT ... SELECT ... HAVING COUNT(*) = 0` to insert, then a plain `SELECT` (`getValueQuery`) to re-read. The MySQL 8.0 manual advises against this under [`REPEATABLE READ`](https://dev.mysql.com/doc/refman/8.0/en/innodb-transaction-isolation-levels.html#isolevel_repeatable-read): a non-locking `SELECT` is served from the transaction's read view, while locking statements use the most recent state of the database.

Whenever the read view was created before the commit that added the row, the insert sees the row and reports 0 affected rows, the re-read cannot see it, and the loop has no branch left that can terminate. Instrumented, every logged pass from 2 to 22,000 of one stuck call reports `INSERT affected=0` with no exception next to `SELECT -> EMPTY`.

`put()` has the same insert-then-re-read shape and is unaffected, because it re-reads with `getValueForUpdateQuery`.

## The change

Re-read with the locking query when, and only when, the non-locking one comes back empty.

Keeping the non-locking query as the first attempt is deliberate. Switching the re-read to `FOR UPDATE` unconditionally was tried in #10980 and breaks `verifyJdbcMetadataStoreConcurrency`: 99 of the 100 threads were never blind to begin with, and making all of them take an exclusive lock serialises them on one key. Applied only on the empty path the lock fires on roughly 5% of re-reads in that same test.

No new SQL is introduced. `getValueForUpdateQuery` is the statement `put()` and `remove()` already issue, so every vendor already executes it in production.

`@Transactional` stays, no isolation level is forced from inside the store, and `tryToPutIfAbsent()` is untouched.

## Tests

- `MySqlMetadataStoreTests.verifyPutIfAbsentSeesConcurrentlyCommittedValue` - the reproducing case. Fails with a `TimeoutException` before the change. It pins `ISOLATION_REPEATABLE_READ` on the `TransactionTemplate` rather than trusting the server default, otherwise it would also pass against unfixed code if that default ever changed.

`./gradlew :spring-integration-jdbc:check` passes; the existing 100-thread test was also run over 50 rounds with no failures.

## Scope and known limitations

Please weigh these; I kept the change narrow rather than deciding them on my own.

**Swallowed deadlocks in `tryToPutIfAbsent()`.** `CannotAcquireLockException` is a `TransientDataAccessException`, so a deadlock is caught there and returned as `0`, which the loop reads as "the row already exists". A deadlock means the whole transaction was rolled back, so the code then keeps working inside a dead transaction and the transaction manager commits it none the wiser. This PR ends the loop; that silent partial rollback stays. It touches the broader transactional unit of work directly, so I left it alone - happy to take it separately.

**The locking re-read can throw.** The old empty path took no locks and could not block. `SELECT ... FOR UPDATE` can, so a lock-wait timeout or deadlock on that read now propagates out of `putIfAbsent()`. I chose propagation over catch-and-retry because `put()` and `remove()` already issue the same locking read without catching, and retrying inside a transaction MySQL has already rolled back is what causes the problem above. Worth confirming this is the behaviour you want.

**Configurations still unbounded.** With `setLockHint("")` the two queries are the same, so the guard skips the second one and MySQL `REPEATABLE READ` loops exactly as before - `PersistentAcceptOnceFileListFilterExternalStoreTests` uses that setting. PostgreSQL under an explicit `REPEATABLE READ` also still loops, since its locking reads stay inside the snapshot. There is no loop bound anywhere; whether a bounded retry that fails with a diagnosable exception would be better than spinning is your call.

**New gap lock.** Under MySQL `REPEATABLE READ` a `SELECT ... FOR UPDATE` matching nothing takes a gap lock held until the caller's transaction commits. Previously this path took no locks. `remove()` already gap-locks a missing key, so it is not a new class of behaviour, but it is new for `putIfAbsent()`.

