### PR TITLE
Fix message loss on stop() for PollableChannel reactive consumer

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/util/IntegrationReactiveUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/IntegrationReactiveUtils.java
@@ -127,11 +127,13 @@ public final class IntegrationReactiveUtils {
 	 * the {@link Mono#doOnError}.
 	 * <p>
 	 * Cancellation while {@link MessageSource#receive()} is in flight (the sink is already
-	 * {@code CANCELLED}) is handled by Reactor's discard hook on this flux. A
-	 * {@link PollableChannel} source is best-effort re-queued via non-blocking
-	 * {@link PollableChannel#send(Message, long)} (interceptor chain is re-entered; FIFO is not
-	 * preserved if the queue is not empty; a full bounded channel is logged and the message is
-	 * not nack'd). Other sources are left unacknowledged so the source's own redelivery
+	 * {@code CANCELLED}) is handled by Reactor's discard hook on this flux. Only a
+	 * {@link PollableChannel} adapted through {@link #messageChannelToFlux(MessageChannel)}
+	 * is best-effort re-queued via non-blocking {@link PollableChannel#send(Message, long)}
+	 * (interceptor chain is re-entered; FIFO is not preserved if the queue is not empty; a
+	 * full bounded channel is logged and the message is not nack'd). A direct
+	 * {@code messageSourceToFlux(() -> channel.receive(0))} lambda is not re-queued.
+	 * Other sources are left unacknowledged so the source's own redelivery
 	 * (broker requeue, uncommitted offset) can recover them. The discard hook only sees drops
 	 * at or upstream of this flux; operators a caller adds afterward
 	 * ({@code ReactiveStreamsConsumer.setReactiveCustomizer}, a {@code flatMap} on the

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/IntegrationReactiveUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/IntegrationReactiveUtils.java
@@ -18,7 +18,6 @@ package org.springframework.integration.util;
 
 import java.time.Duration;
 import java.util.concurrent.locks.LockSupport;
-import java.util.function.Consumer;
 
 import io.micrometer.context.ContextSnapshotFactory;
 import org.apache.commons.logging.Log;
@@ -57,12 +56,6 @@ import org.springframework.util.ClassUtils;
 public final class IntegrationReactiveUtils {
 
 	private static final Log LOGGER = LogFactory.getLog(IntegrationReactiveUtils.class);
-
-	/**
-	 * Reactor context key for a sequence-local {@code onNextDropped} hook.
-	 * @see reactor.core.publisher.Operators#onNextDropped(Object, reactor.util.context.Context)
-	 */
-	private static final String REACTOR_ON_NEXT_DROPPED_CONTEXT_KEY = "reactor.onNextDropped.local";
 
 	/**
 	 * The subscriber context entry for {@link Flux#delayElements}
@@ -130,35 +123,27 @@ public final class IntegrationReactiveUtils {
 	 * or falls back to 1-second duration.
 	 * If a produced message has an
 	 * {@link org.springframework.integration.IntegrationMessageHeaderAccessor#ACKNOWLEDGMENT_CALLBACK} header
-	 * it is ack'ed in the {@link Mono#doOnSuccess} and nack'ed in the {@link Mono#doOnError}.
+	 * it is ack'ed in {@link Flux#doOnNext} when this flux emits to its subscriber, and nack'ed in
+	 * the {@link Mono#doOnError}.
 	 * <p>
-	 * When the subscription is cancelled while a message is in flight (already received from the
-	 * {@link MessageSource} but not yet delivered to a downstream subscriber), Reactor routes the
-	 * value through discard hooks which rescue it here: for a {@link PollableChannel} the message is
-	 * best-effort re-queued via non-blocking {@link PollableChannel#send(Message, long)}; for other
-	 * sources an {@link org.springframework.integration.acks.AcknowledgmentCallback} is nack'd when
-	 * present.
+	 * Cancellation while {@link MessageSource#receive()} is in flight (the sink is already
+	 * {@code CANCELLED}) is handled by Reactor's discard hook on this flux. A
+	 * {@link PollableChannel} source is best-effort re-queued via non-blocking
+	 * {@link PollableChannel#send(Message, long)} (interceptor chain is re-entered; FIFO is not
+	 * preserved if the queue is not empty; a full bounded channel is logged and the message is
+	 * not nack'd). Other sources are left unacknowledged so the source's own redelivery
+	 * (broker requeue, uncommitted offset) can recover them. The discard hook only sees drops
+	 * at or upstream of this flux; operators a caller adds afterward
+	 * ({@code ReactiveStreamsConsumer.setReactiveCustomizer}, a {@code flatMap} on the
+	 * {@code ReactiveMessageHandler} path) use a different context and are not rescued here.
 	 * @param messageSource the {@link MessageSource} to adapt.
 	 * @param <T> the expected payload type.
 	 * @return a {@link Flux} which pulls messages from the {@link MessageSource} on demand.
 	 */
 	@SuppressWarnings("NullAway")
 	public static <T> Flux<Message<T>> messageSourceToFlux(MessageSource<T> messageSource) {
-		Consumer<Object> undeliveredConsumer = createUndeliveredConsumer(messageSource);
-
-		return Mono.<Message<T>>create(monoSink -> monoSink.onRequest(request -> {
-					try {
-						monoSink.success(messageSource.receive());
-					}
-					catch (Exception ex) {
-						monoSink.error(ex);
-					}
-				}))
-				.doOnSuccess((message) -> {
-					if (message != null) {
-						AckUtils.autoAck(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message));
-					}
-				})
+		return Mono.<Message<T>>create(monoSink ->
+						monoSink.onRequest((value) -> monoSink.success(messageSource.receive())))
 				.doOnError(MessagingException.class,
 						(ex) -> {
 							Message<?> failedMessage = ex.getFailedMessage();
@@ -174,9 +159,10 @@ public final class IntegrationReactiveUtils {
 										Mono.delay(ctx.getOrDefault(DELAY_WHEN_EMPTY_KEY,
 												DEFAULT_DELAY_WHEN_EMPTY)))))
 				.repeat()
-				.doOnDiscard(Message.class, message -> handleUndeliveredMessage(messageSource, message))
-				.contextWrite(ctx -> ctx.put(REACTOR_ON_NEXT_DROPPED_CONTEXT_KEY, undeliveredConsumer))
-				.retryWhen(Retry.indefinitely().filter(MessagingException.class::isInstance));
+				.doOnDiscard(Message.class, (message) -> handleUndeliveredMessage(messageSource, message))
+				.retryWhen(Retry.indefinitely().filter(MessagingException.class::isInstance))
+				.doOnNext((message) ->
+						AckUtils.autoAck(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message)));
 	}
 
 	/**
@@ -185,7 +171,8 @@ public final class IntegrationReactiveUtils {
 	 * is returned as is because it is already a {@link Publisher};
 	 * - a {@link SubscribableChannel} is subscribed with a {@link MessageHandler}
 	 * for the {@link Sinks.Many#tryEmitNext(Object)} which is returned from this method;
-	 * - a {@link PollableChannel} is wrapped into a {@link PollableChannelMessageSource} and reuses
+	 * - a {@link PollableChannel} is wrapped into a {@link PollableChannelMessageSource} so
+	 * cancelled in-flight receives can be re-queued, and reuses
 	 * {@link #messageSourceToFlux(MessageSource)}.
 	 * @param messageChannel the {@link MessageChannel} to adapt.
 	 * @param <T> the expected payload type.
@@ -208,23 +195,12 @@ public final class IntegrationReactiveUtils {
 		}
 	}
 
-	private static Consumer<Object> createUndeliveredConsumer(MessageSource<?> messageSource) {
-		return value -> {
-			if (value instanceof Message<?> message) {
-				handleUndeliveredMessage(messageSource, message);
-			}
-		};
-	}
-
 	private static void handleUndeliveredMessage(MessageSource<?> messageSource, @Nullable Message<?> message) {
 		if (message == null) {
 			return;
 		}
 		if (messageSource instanceof PollableChannelMessageSource<?> pollableChannelMessageSource) {
 			pollableChannelMessageSource.returnMessage(message);
-		}
-		else {
-			AckUtils.autoNack(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message));
 		}
 	}
 
@@ -244,9 +220,7 @@ public final class IntegrationReactiveUtils {
 
 		void returnMessage(Message<?> message) {
 			if (!this.channel.send(message, 0)) {
-				LOGGER.warn("Failed to return undelivered message to pollable channel [" + this.channel
-						+ "]; nacking instead");
-				AckUtils.autoNack(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message));
+				LOGGER.warn("Failed to return undelivered message to pollable channel [" + this.channel + "]");
 			}
 		}
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/IntegrationReactiveUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/IntegrationReactiveUtils.java
@@ -18,6 +18,7 @@ package org.springframework.integration.util;
 
 import java.time.Duration;
 import java.util.concurrent.locks.LockSupport;
+import java.util.function.Consumer;
 
 import io.micrometer.context.ContextSnapshotFactory;
 import org.apache.commons.logging.Log;
@@ -49,12 +50,19 @@ import org.springframework.util.ClassUtils;
  * Utilities for adapting integration components to/from reactive types.
  *
  * @author Artem Bilan
+ * @author Fardan An
  *
  * @since 5.3
  */
 public final class IntegrationReactiveUtils {
 
 	private static final Log LOGGER = LogFactory.getLog(IntegrationReactiveUtils.class);
+
+	/**
+	 * Reactor context key for a sequence-local {@code onNextDropped} hook.
+	 * @see reactor.core.publisher.Operators#onNextDropped(Object, reactor.util.context.Context)
+	 */
+	private static final String REACTOR_ON_NEXT_DROPPED_CONTEXT_KEY = "reactor.onNextDropped.local";
 
 	/**
 	 * The subscriber context entry for {@link Flux#delayElements}
@@ -123,15 +131,29 @@ public final class IntegrationReactiveUtils {
 	 * If a produced message has an
 	 * {@link org.springframework.integration.IntegrationMessageHeaderAccessor#ACKNOWLEDGMENT_CALLBACK} header
 	 * it is ack'ed in the {@link Mono#doOnSuccess} and nack'ed in the {@link Mono#doOnError}.
+	 * <p>
+	 * When the subscription is cancelled while a message is in flight (already received from the
+	 * {@link MessageSource} but not yet delivered to a downstream subscriber), Reactor routes the
+	 * value through discard hooks which rescue it here: for a {@link PollableChannel} the message is
+	 * best-effort re-queued via non-blocking {@link PollableChannel#send(Message, long)}; for other
+	 * sources an {@link org.springframework.integration.acks.AcknowledgmentCallback} is nack'd when
+	 * present.
 	 * @param messageSource the {@link MessageSource} to adapt.
 	 * @param <T> the expected payload type.
 	 * @return a {@link Flux} which pulls messages from the {@link MessageSource} on demand.
 	 */
 	@SuppressWarnings("NullAway")
 	public static <T> Flux<Message<T>> messageSourceToFlux(MessageSource<T> messageSource) {
-		return Mono.
-				<Message<T>>create(monoSink ->
-				monoSink.onRequest(value -> monoSink.success(messageSource.receive())))
+		Consumer<Object> undeliveredConsumer = createUndeliveredConsumer(messageSource);
+
+		return Mono.<Message<T>>create(monoSink -> monoSink.onRequest(request -> {
+					try {
+						monoSink.success(messageSource.receive());
+					}
+					catch (Exception ex) {
+						monoSink.error(ex);
+					}
+				}))
 				.doOnSuccess((message) -> {
 					if (message != null) {
 						AckUtils.autoAck(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message));
@@ -152,6 +174,8 @@ public final class IntegrationReactiveUtils {
 										Mono.delay(ctx.getOrDefault(DELAY_WHEN_EMPTY_KEY,
 												DEFAULT_DELAY_WHEN_EMPTY)))))
 				.repeat()
+				.doOnDiscard(Message.class, message -> handleUndeliveredMessage(messageSource, message))
+				.contextWrite(ctx -> ctx.put(REACTOR_ON_NEXT_DROPPED_CONTEXT_KEY, undeliveredConsumer))
 				.retryWhen(Retry.indefinitely().filter(MessagingException.class::isInstance));
 	}
 
@@ -161,7 +185,7 @@ public final class IntegrationReactiveUtils {
 	 * is returned as is because it is already a {@link Publisher};
 	 * - a {@link SubscribableChannel} is subscribed with a {@link MessageHandler}
 	 * for the {@link Sinks.Many#tryEmitNext(Object)} which is returned from this method;
-	 * - a {@link PollableChannel} is wrapped into a {@link MessageSource} lambda and reuses
+	 * - a {@link PollableChannel} is wrapped into a {@link PollableChannelMessageSource} and reuses
 	 * {@link #messageSourceToFlux(MessageSource)}.
 	 * @param messageChannel the {@link MessageChannel} to adapt.
 	 * @param <T> the expected payload type.
@@ -175,13 +199,57 @@ public final class IntegrationReactiveUtils {
 		else if (messageChannel instanceof SubscribableChannel) {
 			return adaptSubscribableChannelToPublisher((SubscribableChannel) messageChannel);
 		}
-		else if (messageChannel instanceof PollableChannel) {
-			return messageSourceToFlux(() -> (Message<T>) ((PollableChannel) messageChannel).receive(0));
+		else if (messageChannel instanceof PollableChannel pollableChannel) {
+			return messageSourceToFlux(new PollableChannelMessageSource<>(pollableChannel));
 		}
 		else {
 			throw new IllegalArgumentException("The 'messageChannel' must be an instance of Publisher, " +
 					"SubscribableChannel or PollableChannel, not: " + messageChannel);
 		}
+	}
+
+	private static Consumer<Object> createUndeliveredConsumer(MessageSource<?> messageSource) {
+		return value -> {
+			if (value instanceof Message<?> message) {
+				handleUndeliveredMessage(messageSource, message);
+			}
+		};
+	}
+
+	private static void handleUndeliveredMessage(MessageSource<?> messageSource, @Nullable Message<?> message) {
+		if (message == null) {
+			return;
+		}
+		if (messageSource instanceof PollableChannelMessageSource<?> pollableChannelMessageSource) {
+			pollableChannelMessageSource.returnMessage(message);
+		}
+		else {
+			AckUtils.autoNack(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message));
+		}
+	}
+
+	private static final class PollableChannelMessageSource<T> implements MessageSource<T> {
+
+		private final PollableChannel channel;
+
+		PollableChannelMessageSource(PollableChannel channel) {
+			this.channel = channel;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public @Nullable Message<T> receive() {
+			return (Message<T>) this.channel.receive(0);
+		}
+
+		void returnMessage(Message<?> message) {
+			if (!this.channel.send(message, 0)) {
+				LOGGER.warn("Failed to return undelivered message to pollable channel [" + this.channel
+						+ "]; nacking instead");
+				AckUtils.autoNack(StaticMessageHeaderAccessor.getAcknowledgmentCallback(message));
+			}
+		}
+
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/IntegrationReactiveUtilsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/IntegrationReactiveUtilsTests.java
@@ -44,7 +44,6 @@ import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 
 /**
  * @author Sergei Egorov
@@ -159,8 +158,9 @@ class IntegrationReactiveUtilsTests {
 	}
 
 	@Test
-	void undeliveredMessageNackedWhenCancelledDuringBlockingReceive() throws InterruptedException {
+	void undeliveredMessageNotAcknowledgedWhenCancelledDuringBlockingReceive() throws InterruptedException {
 		CountDownLatch receiveBlocked = new CountDownLatch(1);
+		CountDownLatch receiveCompleted = new CountDownLatch(1);
 		AtomicBoolean releaseReceive = new AtomicBoolean();
 		AtomicReference<AcknowledgmentCallback.Status> ackStatus = new AtomicReference<>();
 		AtomicReference<Message<?>> delivered = new AtomicReference<>();
@@ -172,27 +172,33 @@ class IntegrationReactiveUtilsTests {
 
 		MessageSource<Object> blockingSource = () -> {
 			receiveBlocked.countDown();
-			while (!releaseReceive.get()) {
-				LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10)); // NOSONAR busy wait
+			try {
+				while (!releaseReceive.get()) {
+					LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10)); // NOSONAR busy wait
+				}
+				@SuppressWarnings("unchecked")
+				Message<Object> message = (Message<Object>) testMessage;
+				return message;
 			}
-			@SuppressWarnings("unchecked")
-			Message<Object> message = (Message<Object>) testMessage;
-			return message;
+			finally {
+				receiveCompleted.countDown();
+			}
 		};
 
 		Disposable subscription = IntegrationReactiveUtils.messageSourceToFlux(blockingSource)
 				.subscribe(delivered::set);
 
-		assertThat(receiveBlocked.await(10, TimeUnit.SECONDS)).isTrue();
+		try {
+			assertThat(receiveBlocked.await(10, TimeUnit.SECONDS)).isTrue();
+			subscription.dispose();
+		}
+		finally {
+			releaseReceive.set(true);
+		}
 
-		subscription.dispose();
-		releaseReceive.set(true);
-
-		await().atMost(Duration.ofSeconds(5))
-				.until(() -> ackStatus.get() == AcknowledgmentCallback.Status.REJECT);
-
+		assertThat(receiveCompleted.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(delivered.get()).isNull();
-		assertThat(ackStatus.get()).isEqualTo(AcknowledgmentCallback.Status.REJECT);
+		assertThat(ackStatus.get()).isNull();
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/IntegrationReactiveUtilsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/IntegrationReactiveUtilsTests.java
@@ -19,8 +19,10 @@ package org.springframework.integration.channel;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
@@ -32,16 +34,22 @@ import reactor.core.scheduler.Schedulers;
 import reactor.test.StepVerifier;
 import reactor.util.concurrent.Queues;
 
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.acks.AcknowledgmentCallback;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.util.IntegrationReactiveUtils;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.messaging.support.MessageBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 /**
  * @author Sergei Egorov
  * @author Artem Bilan
+ * @author Fardan An
  *
  * @since 5.1.9
  */
@@ -148,6 +156,43 @@ class IntegrationReactiveUtilsTests {
 
 		assertThat(retryAttempts.get()).isEqualTo(-1);
 		assertThat(finalException.get()).hasMessage("non-retryable RuntimeException");
+	}
+
+	@Test
+	void undeliveredMessageNackedWhenCancelledDuringBlockingReceive() throws InterruptedException {
+		CountDownLatch receiveBlocked = new CountDownLatch(1);
+		AtomicBoolean releaseReceive = new AtomicBoolean();
+		AtomicReference<AcknowledgmentCallback.Status> ackStatus = new AtomicReference<>();
+		AtomicReference<Message<?>> delivered = new AtomicReference<>();
+
+		Message<?> testMessage = MessageBuilder.withPayload("test")
+				.setHeader(IntegrationMessageHeaderAccessor.ACKNOWLEDGMENT_CALLBACK,
+						(AcknowledgmentCallback) ackStatus::set)
+				.build();
+
+		MessageSource<Object> blockingSource = () -> {
+			receiveBlocked.countDown();
+			while (!releaseReceive.get()) {
+				LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10)); // NOSONAR busy wait
+			}
+			@SuppressWarnings("unchecked")
+			Message<Object> message = (Message<Object>) testMessage;
+			return message;
+		};
+
+		Disposable subscription = IntegrationReactiveUtils.messageSourceToFlux(blockingSource)
+				.subscribe(delivered::set);
+
+		assertThat(receiveBlocked.await(10, TimeUnit.SECONDS)).isTrue();
+
+		subscription.dispose();
+		releaseReceive.set(true);
+
+		await().atMost(Duration.ofSeconds(5))
+				.until(() -> ackStatus.get() == AcknowledgmentCallback.Status.REJECT);
+
+		assertThat(delivered.get()).isNull();
+		assertThat(ackStatus.get()).isEqualTo(AcknowledgmentCallback.Status.REJECT);
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/IntegrationReactiveUtilsTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/IntegrationReactiveUtilsTests.java
@@ -197,6 +197,9 @@ class IntegrationReactiveUtilsTests {
 		}
 
 		assertThat(receiveCompleted.await(10, TimeUnit.SECONDS)).isTrue();
+		CountDownLatch singleIdle = new CountDownLatch(1);
+		Schedulers.single().schedule(singleIdle::countDown);
+		assertThat(singleIdle.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(delivered.get()).isNull();
 		assertThat(ackStatus.get()).isNull();
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveStreamsConsumerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveStreamsConsumerTests.java
@@ -23,7 +23,9 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -65,6 +67,7 @@ import static org.mockito.Mockito.verify;
 
 /**
  * @author Artem Bilan
+ * @author Fardan An
  *
  * @since 5.0
  */
@@ -244,6 +247,71 @@ public class ReactiveStreamsConsumerTests implements TestApplicationContextAware
 		verify(testSubscriber, never()).onComplete();
 
 		assertThat(messages.isEmpty()).isTrue();
+
+		reactiveConsumer.stop();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void messageNotLostWhenStopDuringBlockingReceive() throws InterruptedException {
+		CountDownLatch receiveBlocked = new CountDownLatch(1);
+		AtomicBoolean releaseReceive = new AtomicBoolean();
+
+		QueueChannel testChannel = new QueueChannel(1) {
+
+			@Override
+			public Message<?> receive(long timeout) {
+				Message<?> message = super.receive(timeout);
+				if (message != null) {
+					receiveBlocked.countDown();
+					while (!releaseReceive.get()) {
+						LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(10)); // NOSONAR busy wait
+					}
+				}
+				return message;
+			}
+
+		};
+
+		Subscriber<Message<?>> testSubscriber = (Subscriber<Message<?>>) Mockito.mock(Subscriber.class);
+		AtomicReference<Message<?>> delivered = new AtomicReference<>();
+
+		willAnswer(i -> {
+			delivered.set(i.getArgument(0));
+			return null;
+		}).given(testSubscriber).onNext(any(Message.class));
+
+		ReactiveStreamsConsumer reactiveConsumer = new ReactiveStreamsConsumer(testChannel, testSubscriber);
+		reactiveConsumer.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		reactiveConsumer.afterPropertiesSet();
+		reactiveConsumer.start();
+
+		Message<?> testMessage = new GenericMessage<>("test");
+		testChannel.send(testMessage);
+
+		ArgumentCaptor<Subscription> captor = ArgumentCaptor.forClass(Subscription.class);
+		verify(testSubscriber).onSubscribe(captor.capture());
+		captor.getValue().request(1);
+
+		assertThat(receiveBlocked.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(testChannel.getQueueSize()).isZero();
+
+		reactiveConsumer.stop();
+		releaseReceive.set(true);
+
+		await().atMost(Duration.ofSeconds(5))
+				.until(() -> delivered.get() != null || testChannel.getQueueSize() > 0);
+
+		boolean wasDelivered = delivered.get() != null;
+		boolean wasRequeued = testChannel.getQueueSize() > 0;
+		assertThat(wasDelivered ^ wasRequeued).isTrue();
+
+		if (wasDelivered) {
+			assertThat(delivered.get()).isSameAs(testMessage);
+		}
+		else {
+			assertThat(testChannel.receive(0)).isSameAs(testMessage);
+		}
 
 		reactiveConsumer.stop();
 	}

--- a/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveStreamsConsumerTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/channel/reactive/ReactiveStreamsConsumerTests.java
@@ -293,25 +293,20 @@ public class ReactiveStreamsConsumerTests implements TestApplicationContextAware
 		verify(testSubscriber).onSubscribe(captor.capture());
 		captor.getValue().request(1);
 
-		assertThat(receiveBlocked.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(testChannel.getQueueSize()).isZero();
-
-		reactiveConsumer.stop();
-		releaseReceive.set(true);
+		try {
+			assertThat(receiveBlocked.await(10, TimeUnit.SECONDS)).isTrue();
+			assertThat(testChannel.getQueueSize()).isZero();
+			reactiveConsumer.stop();
+		}
+		finally {
+			releaseReceive.set(true);
+		}
 
 		await().atMost(Duration.ofSeconds(5))
-				.until(() -> delivered.get() != null || testChannel.getQueueSize() > 0);
+				.until(() -> testChannel.getQueueSize() > 0);
 
-		boolean wasDelivered = delivered.get() != null;
-		boolean wasRequeued = testChannel.getQueueSize() > 0;
-		assertThat(wasDelivered ^ wasRequeued).isTrue();
-
-		if (wasDelivered) {
-			assertThat(delivered.get()).isSameAs(testMessage);
-		}
-		else {
-			assertThat(testChannel.receive(0)).isSameAs(testMessage);
-		}
+		assertThat(delivered.get()).isNull();
+		assertThat(testChannel.receive(0)).isSameAs(testMessage);
 
 		reactiveConsumer.stop();
 	}


### PR DESCRIPTION
## Summary

- On cancel during an in-flight `MessageSource.receive()`, do not nack. Kafka/AMQP recover via their own redelivery when the delivery is left unacknowledged.
- `PollableChannel` sources adapted through `messageChannelToFlux` are best-effort re-queued (`send(message, 0)`). A direct `messageSourceToFlux(() -> channel.receive(0))` lambda is not re-queued.
- `autoAck` runs on `Flux.doOnNext` of the returned flux (delivery to this flux), not on `Mono.doOnSuccess`.
- Discard rescue is `doOnDiscard` only (no private `onNextDropped` hook). Coverage is drops at or upstream of this flux.

Fixes #11262

## Test plan

- [x] `./gradlew :spring-integration-core:test --tests "*IntegrationReactiveUtilsTests" --tests "*ReactiveStreamsConsumerTests" --tests "*ReactiveMessageSourceProducerTests"` (JDK 17)