### PR TITLE
GH-11275: Replace unnecessary fully-qualified type references with im…

### DIFF
--- a/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpMessageSource.java
+++ b/spring-integration-amqp/src/main/java/org/springframework/integration/amqp/inbound/AmqpMessageSource.java
@@ -28,6 +28,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.batch.BatchingStrategy;
 import org.springframework.amqp.rabbit.batch.SimpleBatchingStrategy;
@@ -195,7 +196,7 @@ public class AmqpMessageSource extends AbstractMessageSource<Object> {
 					resp.getEnvelope(), StandardCharsets.UTF_8.name());
 			messageProperties.setConsumerQueue(this.queue);
 			Map<String, @Nullable Object> headers = this.headerMapper.toHeadersFromRequest(messageProperties);
-			var amqpMessage = new org.springframework.amqp.core.Message(resp.getBody(), messageProperties);
+			var amqpMessage = new Message(resp.getBody(), messageProperties);
 			Object payload;
 			if (this.batchingStrategy.canDebatch(messageProperties)) {
 				List<Object> payloads = new ArrayList<>();

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundChannelAdapterParserTests.java
@@ -43,6 +43,7 @@ import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.core.log.LogAccessor;
+import org.springframework.expression.Expression;
 import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
 import org.springframework.integration.amqp.support.AmqpHeaderMapper;
 import org.springframework.integration.channel.DirectChannel;
@@ -118,7 +119,7 @@ public class AmqpOutboundChannelAdapterParserTests {
 		AmqpOutboundEndpoint endpoint = TestUtils.getPropertyValue(eventDrivenConsumer, "handler");
 		assertThat(TestUtils.<Object>getPropertyValue(endpoint, "defaultDeliveryMode")).isNotNull();
 		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "lazyConnect")).isFalse();
-		assertThat(TestUtils.<org.springframework.expression.Expression>getPropertyValue(endpoint, "delayExpression")
+		assertThat(TestUtils.<Expression>getPropertyValue(endpoint, "delayExpression")
 				.getExpressionString()).isEqualTo("42");
 		assertThat(TestUtils.<Boolean>getPropertyValue(endpoint, "headersMappedLast")).isFalse();
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/config/AmqpOutboundGatewayParserTests.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.parsing.BeanDefinitionParsingException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.expression.Expression;
 import org.springframework.integration.amqp.outbound.AmqpOutboundEndpoint;
 import org.springframework.integration.amqp.outbound.AsyncAmqpOutboundGateway;
 import org.springframework.integration.channel.QueueChannel;
@@ -97,7 +98,7 @@ public class AmqpOutboundGatewayParserTests {
 
 		assertThat(sendTimeout).isEqualTo(Long.valueOf(777));
 		assertThat(TestUtils.<Boolean>getPropertyValue(gateway, "lazyConnect")).isTrue();
-		assertThat(TestUtils.<org.springframework.expression.Expression>getPropertyValue(gateway, "delayExpression")
+		assertThat(TestUtils.<Expression>getPropertyValue(gateway, "delayExpression")
 				.getExpressionString()).isEqualTo("42");
 	}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpClientTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/dsl/AmqpClientTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.amqp.dsl;
 
+import com.rabbitmq.client.amqp.Environment;
 import com.rabbitmq.client.amqp.impl.AmqpEnvironmentBuilder;
 import org.junit.jupiter.api.Test;
 
@@ -94,7 +95,7 @@ class AmqpClientTests implements RabbitTestContainer {
 	static class ContextConfiguration {
 
 		@Bean
-		com.rabbitmq.client.amqp.Environment environment() {
+		Environment environment() {
 			return new AmqpEnvironmentBuilder()
 					.connectionSettings()
 					.port(RabbitTestContainer.amqpPort())
@@ -103,7 +104,7 @@ class AmqpClientTests implements RabbitTestContainer {
 		}
 
 		@Bean
-		AmqpConnectionFactory connectionFactory(com.rabbitmq.client.amqp.Environment environment) {
+		AmqpConnectionFactory connectionFactory(Environment environment) {
 			return new SingleAmqpConnectionFactory(environment);
 		}
 

--- a/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpClientInboundGatewayTests.java
+++ b/spring-integration-amqp/src/test/java/org/springframework/integration/amqp/inbound/AmqpClientInboundGatewayTests.java
@@ -27,6 +27,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.amqp.core.Declarables;
+import org.springframework.amqp.core.Message;
 import org.springframework.amqp.core.MessageBuilder;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.rabbitmq.client.AmqpConnectionFactory;
@@ -72,7 +73,7 @@ public class AmqpClientInboundGatewayTests implements RabbitTestContainer {
 
 	@Test
 	void inboundGatewayExchangeWithAck() throws InterruptedException {
-		org.springframework.amqp.core.Message requestMessage =
+		Message requestMessage =
 				MessageBuilder.withBody("test data #2".getBytes())
 						.setMessageId("someMessageId")
 						.setContentType(MimeTypeUtils.TEXT_PLAIN_VALUE)

--- a/spring-integration-camel/src/main/java/org/springframework/integration/camel/support/CamelHeaderMapper.java
+++ b/spring-integration-camel/src/main/java/org/springframework/integration/camel/support/CamelHeaderMapper.java
@@ -37,7 +37,7 @@ import org.springframework.util.PatternMatchUtils;
  *
  * @since 6.0
  */
-public class CamelHeaderMapper implements HeaderMapper<org.apache.camel.Message> {
+public class CamelHeaderMapper implements HeaderMapper<Message> {
 
 	private static final LogAccessor LOGGER = new LogAccessor(CamelHeaderMapper.class);
 

--- a/spring-integration-core/src/main/java/org/springframework/integration/util/CoroutinesUtils.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/util/CoroutinesUtils.java
@@ -16,6 +16,8 @@
 
 package org.springframework.integration.util;
 
+import kotlin.coroutines.Continuation;
+import kotlinx.coroutines.reactor.MonoKt;
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Mono;
 
@@ -38,7 +40,7 @@ public final class CoroutinesUtils {
 	}
 
 	public static boolean isContinuationType(Class<?> candidate) {
-		return KotlinDetector.isKotlinPresent() && kotlin.coroutines.Continuation.class.isAssignableFrom(candidate);
+		return KotlinDetector.isKotlinPresent() && Continuation.class.isAssignableFrom(candidate);
 	}
 
 	@Nullable
@@ -47,8 +49,8 @@ public final class CoroutinesUtils {
 		Assert.state(isContinuation(continuation), () ->
 				"The 'continuation' must be an instance of 'kotlin.coroutines.Continuation', but it is: "
 						+ continuation.getClass());
-		return (T) kotlinx.coroutines.reactor.MonoKt.awaitSingleOrNull(
-				source, (kotlin.coroutines.Continuation<T>) continuation);
+		return (T) MonoKt.awaitSingleOrNull(
+				source, (Continuation<T>) continuation);
 	}
 
 	private CoroutinesUtils() {

--- a/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/outbound/GrpcClientOutboundGatewayMultiMethodTests.java
+++ b/spring-integration-grpc/src/test/java/org/springframework/integration/grpc/outbound/GrpcClientOutboundGatewayMultiMethodTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.grpc.outbound;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import io.grpc.ManagedChannel;
@@ -347,7 +348,7 @@ class GrpcClientOutboundGatewayMultiMethodTests {
 			public StreamObserver<HelloRequest> helloToEveryOne(StreamObserver<HelloReply> responseObserver) {
 				return new StreamObserver<>() {
 
-					private final java.util.List<String> names = new java.util.ArrayList<>();
+					private final List<String> names = new ArrayList<>();
 
 					@Override
 					public void onNext(HelloRequest value) {

--- a/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/util/HazelcastOutboundChannelAdapterTestUtils.java
+++ b/spring-integration-hazelcast/src/test/java/org/springframework/integration/hazelcast/outbound/util/HazelcastOutboundChannelAdapterTestUtils.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import com.hazelcast.multimap.MultiMap;
 import com.hazelcast.replicatedmap.ReplicatedMap;
 import com.hazelcast.topic.ITopic;
+import com.hazelcast.topic.Message;
 import com.hazelcast.topic.MessageListener;
 
 import org.springframework.integration.hazelcast.HazelcastIntegrationTestUser;
@@ -167,7 +168,7 @@ public final class HazelcastOutboundChannelAdapterTestUtils {
 				private int index = 1;
 
 				@Override
-				public void onMessage(com.hazelcast.topic.Message message) {
+				public void onMessage(Message message) {
 					HazelcastIntegrationTestUser user =
 							(HazelcastIntegrationTestUser) message.getMessageObject();
 					verifyHazelcastIntegrationTestUser(user, index);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/DefaultJmsHeaderMapper.java
@@ -152,7 +152,7 @@ public class DefaultJmsHeaderMapper extends JmsHeaderMapper {
 	}
 
 	@Override
-	public void fromHeaders(MessageHeaders headers, jakarta.jms.Message jmsMessage) {
+	public void fromHeaders(MessageHeaders headers, Message jmsMessage) {
 		try {
 			populateCorrelationIdPropertyFromHeaders(headers, jmsMessage);
 			populateReplyToPropertyFromHeaders(headers, jmsMessage);
@@ -177,7 +177,7 @@ public class DefaultJmsHeaderMapper extends JmsHeaderMapper {
 		}
 	}
 
-	private void populateCorrelationIdPropertyFromHeaders(MessageHeaders headers, jakarta.jms.Message jmsMessage) {
+	private void populateCorrelationIdPropertyFromHeaders(MessageHeaders headers, Message jmsMessage) {
 		Object jmsCorrelationId = headers.get(JmsHeaders.CORRELATION_ID);
 		if (jmsCorrelationId instanceof Number) {
 			jmsCorrelationId = jmsCorrelationId.toString();
@@ -192,7 +192,7 @@ public class DefaultJmsHeaderMapper extends JmsHeaderMapper {
 		}
 	}
 
-	private void populateReplyToPropertyFromHeaders(MessageHeaders headers, jakarta.jms.Message jmsMessage) {
+	private void populateReplyToPropertyFromHeaders(MessageHeaders headers, Message jmsMessage) {
 		Object jmsReplyTo = headers.get(JmsHeaders.REPLY_TO);
 		if (jmsReplyTo instanceof Destination destination) {
 			try {
@@ -204,7 +204,7 @@ public class DefaultJmsHeaderMapper extends JmsHeaderMapper {
 		}
 	}
 
-	private void populateTypePropertyFromHeaders(MessageHeaders headers, jakarta.jms.Message jmsMessage) {
+	private void populateTypePropertyFromHeaders(MessageHeaders headers, Message jmsMessage) {
 		Object jmsType = headers.get(JmsHeaders.TYPE);
 		if (jmsType instanceof String jmsTypeStr) {
 			try {
@@ -216,7 +216,7 @@ public class DefaultJmsHeaderMapper extends JmsHeaderMapper {
 		}
 	}
 
-	private void populateArbitraryHeaderToProperty(jakarta.jms.Message jmsMessage, String headerName, Object value)
+	private void populateArbitraryHeaderToProperty(Message jmsMessage, String headerName, Object value)
 			throws JMSException {
 
 		if (SUPPORTED_PROPERTY_TYPES.contains(value.getClass())) {
@@ -244,7 +244,7 @@ public class DefaultJmsHeaderMapper extends JmsHeaderMapper {
 	}
 
 	@Override
-	public Map<String, Object> toHeaders(jakarta.jms.Message jmsMessage) {
+	public Map<String, Object> toHeaders(Message jmsMessage) {
 		Map<String, Object> headers = new HashMap<>();
 		try {
 			mapMessageIdProperty(jmsMessage, headers);

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/ExtractRequestReplyPayloadTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/ExtractRequestReplyPayloadTests.java
@@ -19,6 +19,8 @@ package org.springframework.integration.jms.config;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import jakarta.jms.JMSException;
+import jakarta.jms.ObjectMessage;
+import jakarta.jms.TextMessage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
@@ -240,7 +242,7 @@ public class ExtractRequestReplyPayloadTests extends ActiveMQMultiContextTests {
 			template.setDefaultDestination((MessageChannel) message.getHeaders().getReplyChannel());
 			Message<?> origMessage = null;
 			try {
-				origMessage = (Message<?>) ((jakarta.jms.ObjectMessage) message.getPayload()).getObject();
+				origMessage = (Message<?>) ((ObjectMessage) message.getPayload()).getObject();
 			}
 			catch (JMSException e) {
 				fail("failed to deserialize message");
@@ -251,7 +253,7 @@ public class ExtractRequestReplyPayloadTests extends ActiveMQMultiContextTests {
 
 	private MessageHandler unwrapTextMessageAndEchoHandler() {
 		return message -> {
-			assertThat(message.getPayload()).isInstanceOf(jakarta.jms.TextMessage.class);
+			assertThat(message.getPayload()).isInstanceOf(TextMessage.class);
 			MessagingTemplate template = new MessagingTemplate();
 			template.setDefaultDestination((MessageChannel) message.getHeaders().getReplyChannel());
 			String payload = null;

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/TestMessageConverter.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/config/TestMessageConverter.java
@@ -34,7 +34,7 @@ public class TestMessageConverter implements MessageConverter {
 		return "converted-" + original;
 	}
 
-	public jakarta.jms.Message toMessage(Object object, Session session) throws JMSException, MessageConversionException {
+	public Message toMessage(Object object, Session session) throws JMSException, MessageConversionException {
 		return null;
 	}
 

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/OutboundGatewayConnectionTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/OutboundGatewayConnectionTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.Destination;
+import jakarta.jms.Message;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
 import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
@@ -100,9 +101,9 @@ public class OutboundGatewayConnectionTests {
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(amqConnectionFactory);
 		template.setReceiveTimeout(5000);
-		jakarta.jms.Message request = template.receive(requestQueue1);
+		Message request = template.receive(requestQueue1);
 		assertThat(request).isNotNull();
-		final jakarta.jms.Message jmsReply = request;
+		final Message jmsReply = request;
 		template.send(request.getJMSReplyTo(), session -> jmsReply);
 		assertThat(latch2.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(reply.get()).isNotNull();

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/OutboundGatewayFunctionTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/OutboundGatewayFunctionTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
+import jakarta.jms.Message;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.junit.jupiter.api.Test;
 
@@ -104,9 +105,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(connectionFactory);
 		template.setReceiveTimeout(10000);
-		jakarta.jms.Message request = template.receive(requestQueue1);
+		Message request = template.receive(requestQueue1);
 		assertThat(request).isNotNull();
-		final jakarta.jms.Message jmsReply = request;
+		final Message jmsReply = request;
 		template.send(request.getJMSReplyTo(), session -> jmsReply);
 		assertThat(latch2.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(reply.get()).isNotNull();
@@ -146,9 +147,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(connectionFactory);
 		template.setReceiveTimeout(10000);
-		jakarta.jms.Message request = template.receive(requestQueue2);
+		Message request = template.receive(requestQueue2);
 		assertThat(request).isNotNull();
-		final jakarta.jms.Message jmsReply = request;
+		final Message jmsReply = request;
 		template.send(request.getJMSReplyTo(), session -> {
 			jmsReply.setJMSCorrelationID(jmsReply.getJMSMessageID());
 			return jmsReply;
@@ -192,9 +193,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(connectionFactory);
 		template.setReceiveTimeout(10000);
-		jakarta.jms.Message request = template.receive(requestQueue3);
+		Message request = template.receive(requestQueue3);
 		assertThat(request).isNotNull();
-		final jakarta.jms.Message jmsReply = request;
+		final Message jmsReply = request;
 		template.send(request.getJMSReplyTo(), session -> jmsReply);
 		assertThat(latch2.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(reply.get()).isNotNull();
@@ -234,9 +235,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(connectionFactory);
 		template.setReceiveTimeout(10000);
-		jakarta.jms.Message request = template.receive(requestQueue4);
+		Message request = template.receive(requestQueue4);
 		assertThat(request).isNotNull();
-		final jakarta.jms.Message jmsReply = request;
+		final Message jmsReply = request;
 		template.send(request.getJMSReplyTo(), session -> {
 			jmsReply.setJMSCorrelationID(jmsReply.getJMSMessageID());
 			return jmsReply;
@@ -280,9 +281,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(connectionFactory);
 		template.setReceiveTimeout(10000);
-		jakarta.jms.Message request = template.receive(requestQueue5);
+		Message request = template.receive(requestQueue5);
 		assertThat(request).isNotNull();
-		final jakarta.jms.Message jmsReply = request;
+		final Message jmsReply = request;
 		template.send(request.getJMSReplyTo(), session -> jmsReply);
 		assertThat(latch2.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(reply.get()).isNotNull();
@@ -321,9 +322,9 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 		JmsTemplate template = new JmsTemplate();
 		template.setConnectionFactory(connectionFactory);
 		template.setReceiveTimeout(10000);
-		jakarta.jms.Message request = template.receive(requestQueue6);
+		Message request = template.receive(requestQueue6);
 		assertThat(request).isNotNull();
-		final jakarta.jms.Message jmsReply = request;
+		final Message jmsReply = request;
 		template.send(request.getJMSReplyTo(), session -> {
 			jmsReply.setJMSCorrelationID(jmsReply.getJMSMessageID());
 			return jmsReply;
@@ -379,8 +380,8 @@ public class OutboundGatewayFunctionTests extends ActiveMQMultiContextTests {
 	}
 
 	private static void receiveAndSend(JmsTemplate template) {
-		jakarta.jms.Message request = template.receive(requestQueue7);
-		final jakarta.jms.Message jmsReply = request;
+		Message request = template.receive(requestQueue7);
+		final Message jmsReply = request;
 		try {
 			template.send(request.getJMSReplyTo(), session -> jmsReply);
 		}

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/inbound/MailReceiver.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/inbound/MailReceiver.java
@@ -16,6 +16,7 @@
 
 package org.springframework.integration.mail.inbound;
 
+import jakarta.mail.MessagingException;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -29,6 +30,6 @@ import org.jspecify.annotations.Nullable;
  */
 public interface MailReceiver {
 
-	Object @Nullable [] receive() throws jakarta.mail.MessagingException;
+	Object @Nullable [] receive() throws MessagingException;
 
 }

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/MailToStringTransformer.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/MailToStringTransformer.java
@@ -19,6 +19,7 @@ package org.springframework.integration.mail.transformer;
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.Charset;
 
+import jakarta.mail.Message;
 import jakarta.mail.Multipart;
 import jakarta.mail.Part;
 
@@ -52,7 +53,7 @@ public class MailToStringTransformer extends AbstractMailMessageTransformer<Stri
 	}
 
 	@Override
-	protected AbstractIntegrationMessageBuilder<String> doTransform(jakarta.mail.Message mailMessage) {
+	protected AbstractIntegrationMessageBuilder<String> doTransform(Message mailMessage) {
 		try {
 			String payload;
 			Object content = mailMessage.getContent();

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/inbound/ImapMailReceiverTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/inbound/ImapMailReceiverTests.java
@@ -691,7 +691,7 @@ public class ImapMailReceiverTests implements TestApplicationContextAware {
 				try {
 					receiver.receive();
 				}
-				catch (jakarta.mail.MessagingException e) {
+				catch (MessagingException e) {
 					if (e.getCause() instanceof NullPointerException) {
 						failed.getAndIncrement();
 					}

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/inbound/MailReceivingMessageSourceTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/inbound/MailReceivingMessageSourceTests.java
@@ -42,9 +42,9 @@ public class MailReceivingMessageSourceTests {
 		MimeMessage message3 = mock();
 		MimeMessage message4 = mock();
 
-		mailReceiver.messages.add(new jakarta.mail.Message[] {message1});
-		mailReceiver.messages.add(new jakarta.mail.Message[] {message2, message3});
-		mailReceiver.messages.add(new jakarta.mail.Message[] {message4});
+		mailReceiver.messages.add(new Message[] {message1});
+		mailReceiver.messages.add(new Message[] {message2, message3});
+		mailReceiver.messages.add(new Message[] {message4});
 
 		MailReceivingMessageSource source = new MailReceivingMessageSource(mailReceiver);
 		assertThat(source.receive().getPayload()).as("Wrong message for number 1").isEqualTo(message1);
@@ -64,7 +64,7 @@ public class MailReceivingMessageSourceTests {
 		}
 
 		@Override
-		public jakarta.mail.Message[] receive() {
+		public Message[] receive() {
 			return messages.poll();
 		}
 

--- a/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxIntegrationRequestMappingHandlerMapping.java
+++ b/spring-integration-webflux/src/main/java/org/springframework/integration/webflux/inbound/WebFluxIntegrationRequestMappingHandlerMapping.java
@@ -31,6 +31,7 @@ import org.springframework.integration.http.inbound.BaseHttpInboundEndpoint;
 import org.springframework.integration.http.inbound.CrossOrigin;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ReflectionUtils;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.reactive.result.condition.NameValueExpression;
@@ -141,7 +142,7 @@ public class WebFluxIntegrationRequestMappingHandlerMapping extends RequestMappi
 	 * @see RequestMappingHandlerMapping#getMappingForMethod
 	 */
 	private @Nullable RequestMappingInfo getMappingForEndpoint(WebFluxInboundEndpoint endpoint) {
-		org.springframework.web.bind.annotation.RequestMapping requestMappingAnnotation =
+		RequestMapping requestMappingAnnotation =
 				HttpContextUtils.convertRequestMappingToAnnotation(endpoint.getRequestMapping());
 		if (requestMappingAnnotation != null) {
 			return createRequestMappingInfo(requestMappingAnnotation, getCustomTypeCondition(endpoint.getClass()));

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/splitter/XPathMessageSplitter.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/splitter/XPathMessageSplitter.java
@@ -58,6 +58,7 @@ import org.springframework.xml.transform.TransformerFactoryUtils;
 import org.springframework.xml.xpath.XPathException;
 import org.springframework.xml.xpath.XPathExpression;
 import org.springframework.xml.xpath.XPathExpressionFactory;
+import org.springframework.xml.xpath.XPathParseException;
 
 /**
  * Message Splitter that uses an {@link XPathExpression} to split a
@@ -137,7 +138,7 @@ public class XPathMessageSplitter extends AbstractMessageSplitter {
 			this.jaxpExpression = xpath.compile(expression);
 		}
 		catch (XPathExpressionException e) {
-			throw new org.springframework.xml.xpath.XPathParseException(
+			throw new XPathParseException(
 					"Could not compile [" + expression + "] to a XPathExpression: " + e.getMessage(), e);
 		}
 	}

--- a/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/UnmarshallingTransformer.java
+++ b/spring-integration-xml/src/main/java/org/springframework/integration/xml/transformer/UnmarshallingTransformer.java
@@ -36,6 +36,7 @@ import org.springframework.integration.xml.source.SourceFactory;
 import org.springframework.oxm.Unmarshaller;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.ws.mime.MimeMessage;
 import org.springframework.xml.transform.StringSource;
 
 /**
@@ -164,7 +165,7 @@ public class UnmarshallingTransformer extends AbstractPayloadTransformer<Object,
 		}
 
 		@Nullable Object maybeUnmarshalMimeMessage(Object payload) throws IOException {
-			if (payload instanceof org.springframework.ws.mime.MimeMessage mimeMessage) {
+			if (payload instanceof MimeMessage mimeMessage) {
 				return org.springframework.ws.support.MarshallingUtils.unmarshal(this.delegate,
 					mimeMessage);
 			}

--- a/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/TestTemplatesFactory.java
+++ b/spring-integration-xml/src/test/java/org/springframework/integration/xml/config/TestTemplatesFactory.java
@@ -22,6 +22,7 @@ import javax.xml.transform.stream.StreamSource;
 
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 
 /**
  * @author Jonas Partner
@@ -29,7 +30,7 @@ import org.springframework.core.io.ClassPathResource;
 public class TestTemplatesFactory implements FactoryBean<Templates> {
 
 	public Templates getObject() throws Exception {
-		org.springframework.core.io.Resource xslResource = new ClassPathResource("test.xsl", getClass());
+		Resource xslResource = new ClassPathResource("test.xsl", getClass());
 		return TransformerFactory.newInstance().newTemplates(new StreamSource(xslResource.getInputStream()));
 	}
 

--- a/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpoint.java
+++ b/spring-integration-xmpp/src/main/java/org/springframework/integration/xmpp/inbound/ChatMessageListeningEndpoint.java
@@ -23,6 +23,7 @@ import org.jivesoftware.smack.StanzaListener;
 import org.jivesoftware.smack.XMPPConnection;
 import org.jivesoftware.smack.filter.StanzaFilter;
 import org.jivesoftware.smack.packet.ExtensionElement;
+import org.jivesoftware.smack.packet.Message;
 import org.jivesoftware.smack.packet.Stanza;
 import org.jspecify.annotations.Nullable;
 
@@ -122,7 +123,7 @@ public class ChatMessageListeningEndpoint extends AbstractXmppConnectionAwareEnd
 
 		@Override
 		public void processStanza(Stanza packet) {
-			if (packet instanceof org.jivesoftware.smack.packet.Message xmppMessage) {
+			if (packet instanceof Message xmppMessage) {
 				Map<String, ?> mappedHeaders =
 						ChatMessageListeningEndpoint.this.headerMapper.toHeadersFromRequest(xmppMessage.asBuilder());
 

--- a/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests.java
+++ b/spring-integration-xmpp/src/test/java/org/springframework/integration/xmpp/config/ChatMessageInboundChannelAdapterParserTests.java
@@ -34,6 +34,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.test.util.TestUtils;
 import org.springframework.integration.xmpp.inbound.ChatMessageListeningEndpoint;
+import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
@@ -107,7 +108,7 @@ public class ChatMessageInboundChannelAdapterParserTests {
 		JivePropertiesManager.addProperty(message, "foo", "foo");
 		JivePropertiesManager.addProperty(message, "bar", "bar");
 		stanzaListener.processStanza(message.build());
-		org.springframework.messaging.Message<?> siMessage = xmppInbound.receive(0);
+		Message<?> siMessage = xmppInbound.receive(0);
 		assertThat(siMessage.getHeaders().get("foo")).isEqualTo("foo");
 		assertThat(siMessage.getHeaders().get("xmpp_to")).isEqualTo("oleg");
 	}


### PR DESCRIPTION
Fixes   gh-11275

Replaced fullyqualifiedtype referenced with `import`
It make code more readeable and consistant.
these violation found in:https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/4bb42ce_2026073849/reports/diff/spring-integration/index.html 
Did fix some of the violation, most of the violation is `java.lang.string` we can import it, instead of using fullyqualified.