### PR TITLE
GH-11277: Fix local directory creation race in remote file GET

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/remote/gateway/AbstractRemoteFileOutboundGateway.java
@@ -23,6 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -77,6 +78,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Mauro Molinari
  * @author Jooyoung Pyoung
+ * @author Jiwoo Lee
  *
  * @since 2.1
  */
@@ -1428,7 +1430,12 @@ public abstract class AbstractRemoteFileOutboundGateway<F> extends AbstractReply
 		File localDir = ExpressionUtils.expressionToFile(this.localDirectoryExpression, evaluationContext, message,
 				"Local Directory");
 		if (!localDir.exists()) {
-			Assert.isTrue(localDir.mkdirs(), () -> "Failed to make local directory: " + localDir);
+			try {
+				Files.createDirectories(localDir.toPath());
+			}
+			catch (IOException ex) {
+				throw new IllegalArgumentException("Failed to make local directory: " + localDir, ex);
+			}
 		}
 		return localDir;
 	}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -23,7 +23,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -31,10 +30,6 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
@@ -43,7 +38,6 @@ import org.mockito.ArgumentCaptor;
 
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
-import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.filters.AbstractSimplePatternFileListFilter;
 import org.springframework.integration.file.remote.AbstractFileInfo;
@@ -78,7 +72,6 @@ import static org.mockito.Mockito.when;
  * @author Liu Jiong
  * @author Artem Bilan
  * @author Jooyoung Pyoung
- * @author Jiwoo Lee
  *
  * @since 2.1
  */
@@ -814,64 +807,6 @@ public class RemoteFileOutboundGatewayTests implements TestApplicationContextAwa
 		File out = new File(this.tmpDir + "/x/f1");
 		assertThat(out.exists()).isTrue();
 		out.delete();
-	}
-
-	@Test
-	public void testGetConcurrentCreateSameLocalDirectory(@TempDir File localRoot) throws Exception {
-		SessionFactory sessionFactory = mock();
-		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(sessionFactory, "get", "payload");
-		gw.setLocalDirectoryExpression(
-				new FunctionExpression<Message<?>>((message) -> message.getHeaders().get("localDir")));
-		gw.afterPropertiesSet();
-		when(sessionFactory.getSession()).thenReturn(new TestSession() {
-
-			@Override
-			public TestLsEntry[] list(String path) {
-				return new TestLsEntry[] {
-						new TestLsEntry(path, 1234, false, false, 12345, "-rw-r--r--")
-				};
-			}
-
-			@Override
-			public void read(String source, OutputStream outputStream) throws IOException {
-				outputStream.write("testfile".getBytes(StandardCharsets.UTF_8));
-			}
-
-		});
-
-		int concurrency = 8;
-		ExecutorService executorService = Executors.newFixedThreadPool(concurrency);
-		AtomicReference<Throwable> failure = new AtomicReference<>();
-		try {
-			for (int round = 0; round < 50; round++) {
-				File localDirectory = new File(localRoot, "local-" + round);
-				CountDownLatch getsDone = new CountDownLatch(concurrency);
-				for (int i = 0; i < concurrency; i++) {
-					Message<String> message = MessageBuilder.withPayload("f" + i)
-							.setHeader("localDir", localDirectory.getAbsolutePath())
-							.build();
-					executorService.execute(() -> {
-						try {
-							gw.handleRequestMessage(message);
-						}
-						catch (Throwable ex) {
-							failure.compareAndSet(null, ex);
-						}
-						finally {
-							getsDone.countDown();
-						}
-					});
-				}
-				assertThat(getsDone.await(10, TimeUnit.SECONDS)).isTrue();
-				assertThat(failure.get()).isNull();
-				for (int i = 0; i < concurrency; i++) {
-					assertThat(new File(localDirectory, "f" + i)).exists();
-				}
-			}
-		}
-		finally {
-			executorService.shutdownNow();
-		}
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -23,6 +23,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -30,6 +31,10 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
@@ -38,6 +43,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.integration.expression.FunctionExpression;
 import org.springframework.integration.file.FileHeaders;
 import org.springframework.integration.file.filters.AbstractSimplePatternFileListFilter;
 import org.springframework.integration.file.remote.AbstractFileInfo;
@@ -72,6 +78,7 @@ import static org.mockito.Mockito.when;
  * @author Liu Jiong
  * @author Artem Bilan
  * @author Jooyoung Pyoung
+ * @author Jiwoo Lee
  *
  * @since 2.1
  */
@@ -807,6 +814,67 @@ public class RemoteFileOutboundGatewayTests implements TestApplicationContextAwa
 		File out = new File(this.tmpDir + "/x/f1");
 		assertThat(out.exists()).isTrue();
 		out.delete();
+	}
+
+	@Test
+	public void testGetConcurrentCreateSameLocalDirectory(@TempDir File localRoot) throws Exception {
+		SessionFactory sessionFactory = mock(SessionFactory.class);
+		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(sessionFactory, "get", "payload");
+		// A non-ValueExpression skips the eager setupLocalDirectory() in afterPropertiesSet(),
+		// so the directory is created per message on the calling thread.
+		gw.setLocalDirectoryExpression(
+				new FunctionExpression<Message<?>>((message) -> message.getHeaders().get("localDir")));
+		gw.afterPropertiesSet();
+		when(sessionFactory.getSession()).thenReturn(new TestSession() {
+
+			@Override
+			public TestLsEntry[] list(String path) {
+				return new TestLsEntry[] {
+						new TestLsEntry(path, 1234, false, false, 12345, "-rw-r--r--")
+				};
+			}
+
+			@Override
+			public void read(String source, OutputStream outputStream) throws IOException {
+				outputStream.write("testfile".getBytes(StandardCharsets.UTF_8));
+			}
+
+		});
+
+		int concurrency = 8;
+		ExecutorService executorService = Executors.newFixedThreadPool(concurrency);
+		AtomicReference<Throwable> failure = new AtomicReference<>();
+		try {
+			for (int round = 0; round < 50; round++) {
+				File localDirectory = new File(localRoot, "local-" + round);
+				CountDownLatch getsDone = new CountDownLatch(concurrency);
+				for (int i = 0; i < concurrency; i++) {
+					// A distinct remote file per thread; only the destination directory is shared.
+					Message<String> message = MessageBuilder.withPayload("f" + i)
+							.setHeader("localDir", localDirectory.getAbsolutePath())
+							.build();
+					executorService.execute(() -> {
+						try {
+							gw.handleRequestMessage(message);
+						}
+						catch (Throwable ex) { // NOSONAR - the race surfaces as an unchecked exception
+							failure.compareAndSet(null, ex);
+						}
+						finally {
+							getsDone.countDown();
+						}
+					});
+				}
+				assertThat(getsDone.await(10, TimeUnit.SECONDS)).isTrue();
+				assertThat(failure.get()).isNull();
+				for (int i = 0; i < concurrency; i++) {
+					assertThat(new File(localDirectory, "f" + i)).exists();
+				}
+			}
+		}
+		finally {
+			executorService.shutdownNow();
+		}
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/remote/gateway/RemoteFileOutboundGatewayTests.java
@@ -818,10 +818,8 @@ public class RemoteFileOutboundGatewayTests implements TestApplicationContextAwa
 
 	@Test
 	public void testGetConcurrentCreateSameLocalDirectory(@TempDir File localRoot) throws Exception {
-		SessionFactory sessionFactory = mock(SessionFactory.class);
+		SessionFactory sessionFactory = mock();
 		TestRemoteFileOutboundGateway gw = new TestRemoteFileOutboundGateway(sessionFactory, "get", "payload");
-		// A non-ValueExpression skips the eager setupLocalDirectory() in afterPropertiesSet(),
-		// so the directory is created per message on the calling thread.
 		gw.setLocalDirectoryExpression(
 				new FunctionExpression<Message<?>>((message) -> message.getHeaders().get("localDir")));
 		gw.afterPropertiesSet();
@@ -849,7 +847,6 @@ public class RemoteFileOutboundGatewayTests implements TestApplicationContextAwa
 				File localDirectory = new File(localRoot, "local-" + round);
 				CountDownLatch getsDone = new CountDownLatch(concurrency);
 				for (int i = 0; i < concurrency; i++) {
-					// A distinct remote file per thread; only the destination directory is shared.
 					Message<String> message = MessageBuilder.withPayload("f" + i)
 							.setHeader("localDir", localDirectory.getAbsolutePath())
 							.build();
@@ -857,7 +854,7 @@ public class RemoteFileOutboundGatewayTests implements TestApplicationContextAwa
 						try {
 							gw.handleRequestMessage(message);
 						}
-						catch (Throwable ex) { // NOSONAR - the race surfaces as an unchecked exception
+						catch (Throwable ex) {
 							failure.compareAndSet(null, ex);
 						}
 						finally {

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/outbound/FtpServerOutboundTests.java
@@ -23,6 +23,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
+import java.nio.file.FileSystemException;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
@@ -211,8 +212,8 @@ public class FtpServerOutboundTests extends FtpTestSupport {
 	@Test
 	public void testInt2866InvalidLocalDirectoryExpression() {
 		assertThatCode(() -> this.invalidDirExpression.send(new GenericMessage<Object>("/ftpSource/ ftpSource1.txt")))
-				.hasRootCauseInstanceOf(IllegalArgumentException.class)
-				.hasStackTraceContaining("Failed to make local directory");
+				.hasRootCauseInstanceOf(FileSystemException.class)
+				.hasStackTraceContaining("java.lang.IllegalArgumentException: Failed to make local directory");
 	}
 
 	@Test

--- a/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
+++ b/spring-integration-sftp/src/test/java/org/springframework/integration/sftp/outbound/SftpServerOutboundTests.java
@@ -25,6 +25,7 @@ import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.FileSystemException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -191,8 +192,8 @@ public class SftpServerOutboundTests extends SftpTestSupport {
 		assertThatExceptionOfType(Exception.class)
 				.isThrownBy(() ->
 						this.invalidDirExpression.send(new GenericMessage<Object>("sftpSource/ sftpSource1.txt")))
-				.withRootCauseInstanceOf(IllegalArgumentException.class)
-				.withStackTraceContaining("Failed to make local directory");
+				.withRootCauseInstanceOf(FileSystemException.class)
+				.withStackTraceContaining("java.lang.IllegalArgumentException: Failed to make local directory");
 	}
 
 	@Test


### PR DESCRIPTION
Fixes: #11277

## The defect

`AbstractRemoteFileOutboundGateway.generateLocalDirectory()` creates the local directory with a non-atomic `exists()`/`mkdirs()` sequence, per message, on the calling thread:

```java
if (!localDir.exists()) {
	Assert.isTrue(localDir.mkdirs(), () -> "Failed to make local directory: " + localDir);
}
```

The eager creation in `afterPropertiesSet()` does not cover this, because it is restricted to a `ValueExpression`:

```java
if (this.localDirectoryExpression instanceof ValueExpression) {
	setupLocalDirectory();
}
```

So with a `local-directory-expression` the directory is never pre-created and creation relies entirely on the per-message path. Concurrent messages resolving to the same, not-yet-existing directory all pass `!localDir.exists()`, only one `mkdirs()` wins, and the losing threads get `false` and fail:

```
java.lang.IllegalArgumentException: Failed to make local directory: /private/tmp/junit-.../local-0
	at org.springframework.util.Assert.isTrue(Assert.java:136)
	at org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway.generateLocalDirectory(AbstractRemoteFileOutboundGateway.java:1431)
	at org.springframework.integration.file.remote.gateway.AbstractRemoteFileOutboundGateway.get(AbstractRemoteFileOutboundGateway.java:1175)
```

The directory exists at that point and the transfer could have proceeded.

The code is identical in `v6.0.0`, `v6.3.0`, `v7.0.0` and `main`.

## The change

Use `Files.createDirectories()`, which is idempotent and does not report an already-existing directory as a failure, and propagate a genuine creation failure as the cause:

```java
if (!localDir.exists()) {
	try {
		Files.createDirectories(localDir.toPath());
	}
	catch (IOException ex) {
		throw new IllegalArgumentException("Failed to make local directory: " + localDir, ex);
	}
}
```

This mirrors `FileWritingMessageHandler`, which has used the same call for the same class of problem since #11254.

## The two adjusted tests

Attaching the `IOException` as cause moves the *root* cause of the reported `IllegalArgumentException` from itself to a `FileSystemException`:

```
MessageHandlingException
  └ MessagingException: Failed to execute on session
      └ IllegalArgumentException: Failed to make local directory     <- was the root cause
          └ FileSystemException: Read-only file system               <- is the root cause now
```

`FtpServerOutboundTests.testInt2866InvalidLocalDirectoryExpression` and its `SftpServerOutboundTests` counterpart pinned that position with `hasRootCauseInstanceOf(IllegalArgumentException.class)`. That held only because `Assert.isTrue()` left the chain empty, so the exception happened to be its own root - it was not an intentional assertion about the root.

They now assert the same type and message where they occur in the chain rather than at its root:

```java
.hasStackTraceContaining("java.lang.IllegalArgumentException: Failed to make local directory");
```

`hasCauseInstanceOf()` would not work either - the `IllegalArgumentException` sits two levels down, under the `MessagingException` from the session template.

**These assertions pass against the unfixed gateway as well**, so they assert the contract rather than encoding this change. Verified by restoring only the production file to the base commit and re-running both classes - green.

## Tests

`RemoteFileOutboundGatewayTests.testGetConcurrentCreateSameLocalDirectory` - 8 threads, 50 rounds, a fresh local directory per round, one distinct remote file per thread so only the destination directory is shared. It takes an isolated `@TempDir` parameter rather than the shared static one, so it cannot perturb `testMputRecursive`.

The previous revision was verified only against `:spring-integration-file:check`, which is how the `-ftp` and `-sftp` failures were missed. All three modules that build on this class are now in scope:

| module | result |
| --- | --- |
| `:spring-integration-file:check` | **332 tests, 0 failures, 8 skipped** |
| `:spring-integration-ftp:test` | **92 tests, 0 failures, 5 skipped** |
| `:spring-integration-sftp:test` | **92 tests, 0 failures, 1 skipped** |

`checkstyleMain` and `checkstyleTest` pass for all three.

Revert check: restoring only the production file with `git checkout <base> -- <file>` (not `git stash`, which would have been a no-op after the commit) makes exactly the new test fail - 36 tests completed, 1 failed.

## Scope

**`setupLocalDirectory()` has the same shape** (`exists()` then `mkdirs()`, at line 612) but runs once from `afterPropertiesSet()` on a single thread, so it cannot race. I left it alone to keep the diff minimal - happy to align it for consistency if you prefer.

**`AbstractInboundFileSynchronizingMessageSource` and `FileReadingMessageSource`** carry the same pattern. The former I have not traced to a concurrent caller; the latter is guarded by `running.getAndSet(true)` in `start()`. Both look safe today, but they are the same class of code and might be worth a sweep separately.

No open PR touches `AbstractRemoteFileOutboundGateway.java`.

Contributed on behalf of [Goatshave](https://github.com/Goatshave).
