### PR TITLE
Use latest Spring Framework 7.1.0-SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ springDataVersion = "2026.1.0-SNAPSHOT"
 springGraphqlVersion = "2.1.0-SNAPSHOT"
 springKafkaVersion = "4.2.0-SNAPSHOT"
 springSecurityVersion = "7.2.0-SNAPSHOT"
-springVersion = "7.1.0-M1"
+springVersion = "7.1.0-SNAPSHOT"
 springWsVersion = "5.1.0-SNAPSHOT"
 
 # Third-party dependencies

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -123,6 +123,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Trung Pham
  * @author Christian Tzolov
+ * @author Glenn Renfro
  *
  * @since 2.0
  */

--- a/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/handler/support/MessagingMethodInvokerHelper.java
@@ -140,13 +140,13 @@ public class MessagingMethodInvokerHelper extends AbstractExpressionEvaluator im
 	private static final ExpressionParser EXPRESSION_PARSER_DEFAULT = EXPRESSION_PARSER;
 
 	private static final ExpressionParser EXPRESSION_PARSER_OFF =
-			new SpelExpressionParser(new SpelParserConfiguration(SpelCompilerMode.OFF, null));
+			new SpelExpressionParser(SpelParserConfiguration.builder().compilerMode(SpelCompilerMode.OFF).build());
 
 	private static final ExpressionParser EXPRESSION_PARSER_IMMEDIATE =
-			new SpelExpressionParser(new SpelParserConfiguration(SpelCompilerMode.IMMEDIATE, null));
+			new SpelExpressionParser(SpelParserConfiguration.builder().compilerMode(SpelCompilerMode.IMMEDIATE).build());
 
 	private static final ExpressionParser EXPRESSION_PARSER_MIXED =
-			new SpelExpressionParser(new SpelParserConfiguration(SpelCompilerMode.MIXED, null));
+			new SpelExpressionParser(SpelParserConfiguration.builder().compilerMode(SpelCompilerMode.MIXED).build());
 
 	private static final ParameterNameDiscoverer PARAMETER_NAME_DISCOVERER = new DefaultParameterNameDiscoverer();
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ExpressionEvaluatingCorrelationStrategyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ExpressionEvaluatingCorrelationStrategyTests.java
@@ -57,8 +57,9 @@ public class ExpressionEvaluatingCorrelationStrategyTests implements TestApplica
 	}
 
 	@Test
-	public void testCorrelationKeyWithMethodInvokingExpression() throws Exception {
-		ExpressionParser parser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
+	public void testCorrelationKeyWithMethodInvokingExpression() {
+		ExpressionParser parser = new SpelExpressionParser(SpelParserConfiguration.builder().autoGrowNullReferences()
+				.autoGrowCollections().build());
 		Expression expression = parser.parseExpression("payload.substring(0,1)");
 		strategy = new ExpressionEvaluatingCorrelationStrategy(expression);
 		strategy.setBeanFactory(TEST_INTEGRATION_CONTEXT);

--- a/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ExpressionEvaluatingCorrelationStrategyTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/aggregator/ExpressionEvaluatingCorrelationStrategyTests.java
@@ -38,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * @author Oleg Zhurakousky
  * @author Gunnar Hillert
  * @author Gary Russell
+ * @author Glenn Renfro
  */
 public class ExpressionEvaluatingCorrelationStrategyTests implements TestApplicationContextAware {
 

--- a/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/handler/MethodInvokingMessageProcessorTests.java
@@ -1119,7 +1119,8 @@ public class MethodInvokingMessageProcessorTests implements TestApplicationConte
 		foo = (Foo) new ProxyFactory(foo).getProxy();
 
 		SpelExpressionParser expressionParser =
-				new SpelExpressionParser(new SpelParserConfiguration(SpelCompilerMode.IMMEDIATE, null));
+				new SpelExpressionParser(SpelParserConfiguration.builder().compilerMode(SpelCompilerMode.IMMEDIATE).
+						build());
 
 		Expression expression = expressionParser.parseExpression("#target.handle(#root)");
 

--- a/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
+++ b/spring-integration-ftp/src/test/java/org/springframework/integration/ftp/inbound/FtpInboundRemoteFileSystemSynchronizerTests.java
@@ -107,7 +107,9 @@ public class FtpInboundRemoteFileSystemSynchronizerTests implements TestApplicat
 		CompositeFileListFilter<FTPFile> filter = new CompositeFileListFilter<>(filters);
 		synchronizer.setFilter(filter);
 
-		ExpressionParser expressionParser = new SpelExpressionParser(new SpelParserConfiguration(true, true));
+		ExpressionParser expressionParser =
+				new SpelExpressionParser(SpelParserConfiguration.builder().autoGrowCollections()
+						.autoGrowNullReferences().build());
 		Expression expression = expressionParser.parseExpression("'subdir/' + #this.toUpperCase() + '.a'");
 		synchronizer.setLocalFilenameGeneratorExpression(expression);
 		synchronizer.setBeanFactory(TEST_INTEGRATION_CONTEXT);

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/AbstractJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/AbstractJmsChannel.java
@@ -94,6 +94,11 @@ public abstract class AbstractJmsChannel extends AbstractMessageChannel {
 		return true;
 	}
 
+	/**
+	 * Converts {@link jakarta.jms.Message} to a Spring {@link Message}.
+	 * @return Spring {@link Message}
+	 * @throws MessageConversionException if the converter returns {@code null}.
+	 */
 	protected Message<?> fromJmsMessage(jakarta.jms.Message message) {
 		MessageConverter converter = this.jmsTemplate.getMessageConverter();
 		try {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/AbstractJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/AbstractJmsChannel.java
@@ -24,6 +24,7 @@ import org.springframework.integration.jms.DefaultJmsHeaderMapper;
 import org.springframework.integration.jms.DynamicJmsTemplateProperties;
 import org.springframework.integration.jms.JmsHeaderMapper;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.support.converter.MessageConversionException;
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.converter.MessagingMessageConverter;
 import org.springframework.messaging.Message;
@@ -97,6 +98,9 @@ public abstract class AbstractJmsChannel extends AbstractMessageChannel {
 		MessageConverter converter = this.jmsTemplate.getMessageConverter();
 		try {
 			Object converted = converter.fromMessage(message);
+			if (converted == null) {
+				throw new MessageConversionException("Message converter returned null for: " + message);
+			}
 			Message<?> messageToSend;
 			if (converted instanceof Message<?> convertedMessage) {
 				messageToSend = convertedMessage;

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/AbstractJmsChannel.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/channel/AbstractJmsChannel.java
@@ -95,7 +95,7 @@ public abstract class AbstractJmsChannel extends AbstractMessageChannel {
 	}
 
 	/**
-	 * Converts {@link jakarta.jms.Message} to a Spring {@link Message}.
+	 * Convert {@link jakarta.jms.Message} to a Spring {@link Message}.
 	 * @return Spring {@link Message}
 	 * @throws MessageConversionException if the converter returns {@code null}.
 	 */

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/ChannelPublishingJmsMessageListener.java
@@ -83,6 +83,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Ngoc Nhan
+ * @author Glenn Renfro
  *
  * @since 7.0
  */
@@ -400,6 +401,19 @@ public class ChannelPublishingJmsMessageListener
 		this.beanFactory = beanFactory;
 	}
 
+	/**
+	 * Processes an incoming JMS message, transforms it into a Spring Integration message,
+	 * delegates execution to the message gateway, and optionally constructs and sends a reply.
+	 * If inbound message conversion or header mapping fails, the error is routed to the configured
+	 * error channel on the gateway delegate. If no error channel is present, the runtime exception
+	 * is rethrown. When {@code expectReply} is enabled, the resulting reply is converted back to a JMS message,
+	 * populated with headers and correlation identifiers from the original request, and dispatched
+	 * to the resolved JMS destination.
+	 * @param jmsMessage the incoming {@link jakarta.jms.Message} to process
+	 * @param session the active JMS {@link jakarta.jms.Session} associated with the listener
+	 * @throws JMSException if a native JMS error occurs while processing, resolving destinations, or sending replies
+	 * @throws MessageConversionException if payload extraction produces a {@code null} result when required
+	 */
 	@Override
 	public void onMessage(jakarta.jms.Message jmsMessage, Session session) throws JMSException {
 		Message<?> requestMessage;

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/ChannelPublishingJmsMessageListener.java
@@ -60,6 +60,7 @@ import org.springframework.integration.support.utils.IntegrationUtils;
 import org.springframework.jms.listener.SessionAwareMessageListener;
 import org.springframework.jms.listener.adapter.ListenerExecutionFailedException;
 import org.springframework.jms.support.JmsUtils;
+import org.springframework.jms.support.converter.MessageConversionException;
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.converter.SimpleMessageConverter;
 import org.springframework.jms.support.destination.DestinationResolver;
@@ -408,6 +409,9 @@ public class ChannelPublishingJmsMessageListener
 				result = this.messageConverter.fromMessage(jmsMessage);
 				this.logger.debug(() -> "converted JMS Message [" + jmsMessage + "] to integration Message payload ["
 						+ result + "]");
+				if (result == null) {
+					throw new MessageConversionException("Message converter returned null for: " + jmsMessage);
+				}
 			}
 			else {
 				result = jmsMessage;

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/ChannelPublishingJmsMessageListener.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/ChannelPublishingJmsMessageListener.java
@@ -402,17 +402,13 @@ public class ChannelPublishingJmsMessageListener
 	}
 
 	/**
-	 * Processes an incoming JMS message, transforms it into a Spring Integration message,
-	 * delegates execution to the message gateway, and optionally constructs and sends a reply.
-	 * If inbound message conversion or header mapping fails, the error is routed to the configured
-	 * error channel on the gateway delegate. If no error channel is present, the runtime exception
-	 * is rethrown. When {@code expectReply} is enabled, the resulting reply is converted back to a JMS message,
-	 * populated with headers and correlation identifiers from the original request, and dispatched
-	 * to the resolved JMS destination.
+	 * Convert the JMS message to a Spring Integration message and send it to the gateway,
+	 * optionally sending a reply back to the JMS destination.
 	 * @param jmsMessage the incoming {@link jakarta.jms.Message} to process
 	 * @param session the active JMS {@link jakarta.jms.Session} associated with the listener
 	 * @throws JMSException if a native JMS error occurs while processing, resolving destinations, or sending replies
-	 * @throws MessageConversionException if payload extraction produces a {@code null} result when required
+	 * @throws MessageConversionException if request payload extraction produces a {@code null} result and no
+	 * error channel is configured, or if the reply message cannot be converted to a JMS message
 	 */
 	@Override
 	public void onMessage(jakarta.jms.Message jmsMessage, Session session) throws JMSException {
@@ -421,10 +417,12 @@ public class ChannelPublishingJmsMessageListener
 			final Object result;
 			if (this.extractRequestPayload) {
 				result = this.messageConverter.fromMessage(jmsMessage);
-				this.logger.debug(() -> "converted JMS Message [" + jmsMessage + "] to integration Message payload ["
-						+ result + "]");
 				if (result == null) {
 					throw new MessageConversionException("Message converter returned null for: " + jmsMessage);
+				}
+				else {
+					this.logger.debug(() -> "converted JMS Message [" + jmsMessage + "] to integration Message payload ["
+							+ result + "]");
 				}
 			}
 			else {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSource.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSource.java
@@ -27,6 +27,7 @@ import org.springframework.integration.jms.JmsHeaderMapper;
 import org.springframework.integration.jms.util.JmsAdapterUtils;
 import org.springframework.integration.support.AbstractIntegrationMessageBuilder;
 import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.support.converter.MessageConversionException;
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
@@ -139,6 +140,9 @@ public class JmsDestinationPollingSource extends AbstractMessageSource<Object> {
 				MessageConverter converter = this.jmsTemplate.getMessageConverter();
 				if (converter != null) {
 					object = converter.fromMessage(jmsMessage);
+					if (object == null) {
+						throw new MessageConversionException("Message converter returned null for: " + jmsMessage);
+					}
 				}
 			}
 			AbstractIntegrationMessageBuilder<?> builder =

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSource.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSource.java
@@ -42,6 +42,7 @@ import org.springframework.util.Assert;
  * @author Mark Fisher
  * @author Oleg Zhurakousky
  * @author Artem Bilan
+ * @author Glenn Renfro
  *
  * @since 7.0
  */
@@ -125,6 +126,7 @@ public class JmsDestinationPollingSource extends AbstractMessageSource<Object> {
 	 * Will receive a JMS {@link jakarta.jms.Message} converting and returning it as
 	 * a Spring Integration {@link Message}. This method will also use the current
 	 * {@link JmsHeaderMapper} instance to map JMS properties to the MessageHeaders.
+	 * @throws MessageConversionException if the converter returns {@code null}.
 	 */
 	@Override
 	protected @Nullable Object doReceive() {
@@ -138,11 +140,9 @@ public class JmsDestinationPollingSource extends AbstractMessageSource<Object> {
 			Object object = jmsMessage;
 			if (this.extractPayload) {
 				MessageConverter converter = this.jmsTemplate.getMessageConverter();
-				if (converter != null) {
-					object = converter.fromMessage(jmsMessage);
-					if (object == null) {
-						throw new MessageConversionException("Message converter returned null for: " + jmsMessage);
-					}
+				object = converter.fromMessage(jmsMessage);
+				if (object == null) {
+					throw new MessageConversionException("Message converter returned null for: " + jmsMessage);
 				}
 			}
 			AbstractIntegrationMessageBuilder<?> builder =

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSource.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSource.java
@@ -123,10 +123,11 @@ public class JmsDestinationPollingSource extends AbstractMessageSource<Object> {
 	}
 
 	/**
-	 * Will receive a JMS {@link jakarta.jms.Message} converting and returning it as
-	 * a Spring Integration {@link Message}. This method will also use the current
+	 * Receive a JMS {@link jakarta.jms.Message}, converting and returning it as
+	 * a Spring Integration {@link Message}. Use the current
 	 * {@link JmsHeaderMapper} instance to map JMS properties to the MessageHeaders.
-	 * @throws MessageConversionException if the converter returns {@code null}.
+	 * @throws MessagingException if header mapping or payload conversion fails, e.g. wrapping a
+	 * {@link MessageConversionException} when the converter returns {@code null} or fails to convert.
 	 */
 	@Override
 	protected @Nullable Object doReceive() {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
@@ -725,9 +725,9 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler
 	}
 
 	/**
-	 * Handles an incoming request message by dispatching it over JMS and returning the reply.
-	 * Ensures the component is initialized before processing. If a reply container is configured,
-	 * it manages the container lifecycle by auto-starting it and scheduling an idle stopper task
+	 * Handle an incoming request message by dispatching it over JMS and returning the reply.
+	 * Ensure the component is initialized before processing. If a reply container is configured,
+	 * manage the container lifecycle by auto-starting it and scheduling an idle stopper task
 	 * when an idle timeout is defined.
 	 * @param requestMessage the Spring Integration {@link Message} to process and send
 	 * @return the processed reply object or built reply message, or {@code null} if no reply
@@ -736,8 +736,9 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler
 	 *         and {@code requiresReply} is enabled
 	 * @throws MessageHandlingException if a underlying {@link jakarta.jms.JMSException} occurs
 	 *         during message handling
-	 * @throws MessageConversionException if payload extraction for a JMS reply produces a {@code null} using
-	 * 		   {@link SimpleMessageConverter}.
+	 * @throws MessageConversionException if the configured {@link MessageConverter} fails to convert the
+	 * request payload to a JMS message, or if it fails to convert the JMS reply, including when payload
+	 * extraction for the reply produces a {@code null} result.
 	 */
 	@Override
 	protected @Nullable Object handleRequestMessage(final Message<?> requestMessage) {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
@@ -90,6 +90,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Christian Tzolov
+ * @author Glenn Renfro
  *
  * @since 7.0
  */
@@ -723,6 +724,21 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler
 		return this.active;
 	}
 
+	/**
+	 * Handles an incoming request message by dispatching it over JMS and returning the reply.
+	 * Ensures the component is initialized before processing. If a reply container is configured,
+	 * it manages the container lifecycle by auto-starting it and scheduling an idle stopper task
+	 * when an idle timeout is defined.
+	 * @param requestMessage the Spring Integration {@link Message} to process and send
+	 * @return the processed reply object or built reply message, or {@code null} if no reply
+	 *         was received and a reply is not required
+	 * @throws MessageTimeoutException if no response is received within the timeout period
+	 *         and {@code requiresReply} is enabled
+	 * @throws MessageHandlingException if a underlying {@link jakarta.jms.JMSException} occurs
+	 *         during message handling
+	 * @throws MessageConversionException if payload extraction for a JMS reply produces a {@code null} using
+	 * 		   {@link SimpleMessageConverter}.
+	 */
 	@Override
 	protected @Nullable Object handleRequestMessage(final Message<?> requestMessage) {
 		if (!this.initialized) {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
@@ -796,10 +796,12 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler
 		Object result;
 		if (this.extractReplyPayload) {
 			result = this.messageConverter.fromMessage(jmsReply);
-			logger.debug(() ->
-					"converted JMS Message [" + jmsReply + "] to integration Message payload [" + result + "]");
 			if (result == null) {
 				throw new MessageConversionException("Message converter returned null for: " + jmsReply);
+			}
+			else {
+				logger.debug(() ->
+						"converted JMS Message [" + jmsReply + "] to integration Message payload [" + result + "]");
 			}
 		}
 		else {

--- a/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
+++ b/spring-integration-jms/src/main/java/org/springframework/integration/jms/outbound/JmsOutboundGateway.java
@@ -65,6 +65,7 @@ import org.springframework.integration.support.management.ManageableLifecycle;
 import org.springframework.jms.connection.ConnectionFactoryUtils;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 import org.springframework.jms.support.JmsUtils;
+import org.springframework.jms.support.converter.MessageConversionException;
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.jms.support.converter.SimpleMessageConverter;
 import org.springframework.jms.support.destination.DestinationResolver;
@@ -780,6 +781,9 @@ public class JmsOutboundGateway extends AbstractReplyProducingMessageHandler
 			result = this.messageConverter.fromMessage(jmsReply);
 			logger.debug(() ->
 					"converted JMS Message [" + jmsReply + "] to integration Message payload [" + result + "]");
+			if (result == null) {
+				throw new MessageConversionException("Message converter returned null for: " + jmsReply);
+			}
 		}
 		else {
 			result = jmsReply;

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
@@ -103,8 +103,6 @@ public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 		given(jmsTemplate.receive()).willReturn(jmsMessage);
 
 		PollableJmsChannel channel = new PollableJmsChannel(jmsTemplate);
-		channel.setBeanFactory(mock());
-		channel.afterPropertiesSet();
 
 		assertThatExceptionOfType(MessageConversionException.class)
 				.isThrownBy(() -> channel.receive(10000));

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
@@ -32,7 +32,6 @@ import org.apache.activemq.artemis.reader.MessageUtil;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.DefaultJmsHeaderMapper;
 import org.springframework.integration.jms.config.JmsChannelFactoryBean;
@@ -42,6 +41,7 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.JmsHeaders;
 import org.springframework.jms.support.converter.MessageConversionException;
 import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.jms.support.converter.SimpleMessageConverter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -49,6 +49,8 @@ import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -100,35 +102,15 @@ public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 		factoryBean.setDestinationName("nullPayloadPollableQueue");
 		factoryBean.setPubSubDomain(false);
 		factoryBean.setBeanFactory(mock());
+		MessageConverter messageConverter = spy(new SimpleMessageConverter());
+		given(messageConverter.fromMessage(any())).willReturn(null);
+		factoryBean.setMessageConverter(messageConverter);
 		factoryBean.afterPropertiesSet();
 		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
 		assertThat(channel.send(new GenericMessage<>("test1"))).isTrue();
 
-		// A JMS message converted to a null payload is a conversion failure, not a message to discard.
-		new DirectFieldAccessor(channel).setPropertyValue("jmsTemplate", nullConvertingTemplate(ccf));
-
 		assertThatExceptionOfType(MessageConversionException.class)
 				.isThrownBy(() -> channel.receive(10000));
-	}
-
-	private static JmsTemplate nullConvertingTemplate(CachingConnectionFactory ccf) {
-		JmsTemplate jmsTemplate = new JmsTemplate(ccf);
-		jmsTemplate.setDefaultDestinationName("nullPayloadPollableQueue");
-		jmsTemplate.setReceiveTimeout(10000);
-		jmsTemplate.setMessageConverter(new MessageConverter() {
-
-			@Override
-			public Object fromMessage(jakarta.jms.Message message) {
-				return null;
-			}
-
-			@Override
-			public jakarta.jms.Message toMessage(Object object, jakarta.jms.Session session) {
-				throw new UnsupportedOperationException();
-			}
-
-		});
-		return jmsTemplate;
 	}
 
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
@@ -32,6 +32,7 @@ import org.apache.activemq.artemis.reader.MessageUtil;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
+import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.DefaultJmsHeaderMapper;
 import org.springframework.integration.jms.config.JmsChannelFactoryBean;
@@ -39,12 +40,15 @@ import org.springframework.integration.support.MessageBuilder;
 import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.JmsHeaders;
+import org.springframework.jms.support.converter.MessageConversionException;
+import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -85,6 +89,46 @@ public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 		Message<?> result2 = channel.receive(10000);
 		assertThat(result2).isNotNull();
 		assertThat(result2.getPayload()).isEqualTo("test2");
+	}
+
+	@Test
+	public void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
+		JmsChannelFactoryBean factoryBean = new JmsChannelFactoryBean(false);
+		CachingConnectionFactory ccf = new CachingConnectionFactory(connectionFactory);
+		ccf.setCacheConsumers(false);
+		factoryBean.setConnectionFactory(ccf);
+		factoryBean.setDestinationName("nullPayloadPollableQueue");
+		factoryBean.setPubSubDomain(false);
+		factoryBean.setBeanFactory(mock());
+		factoryBean.afterPropertiesSet();
+		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
+		assertThat(channel.send(new GenericMessage<>("test1"))).isTrue();
+
+		// A JMS message converted to a null payload is a conversion failure, not a message to discard.
+		new DirectFieldAccessor(channel).setPropertyValue("jmsTemplate", nullConvertingTemplate(ccf));
+
+		assertThatExceptionOfType(MessageConversionException.class)
+				.isThrownBy(() -> channel.receive(10000));
+	}
+
+	private static JmsTemplate nullConvertingTemplate(CachingConnectionFactory ccf) {
+		JmsTemplate jmsTemplate = new JmsTemplate(ccf);
+		jmsTemplate.setDefaultDestinationName("nullPayloadPollableQueue");
+		jmsTemplate.setReceiveTimeout(10000);
+		jmsTemplate.setMessageConverter(new MessageConverter() {
+
+			@Override
+			public Object fromMessage(jakarta.jms.Message message) {
+				return null;
+			}
+
+			@Override
+			public jakarta.jms.Message toMessage(Object object, jakarta.jms.Session session) {
+				throw new UnsupportedOperationException();
+			}
+
+		});
+		return jmsTemplate;
 	}
 
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/PollableJmsChannelTests.java
@@ -34,6 +34,7 @@ import org.mockito.Mockito;
 
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
 import org.springframework.integration.jms.DefaultJmsHeaderMapper;
+import org.springframework.integration.jms.StubTextMessage;
 import org.springframework.integration.jms.config.JmsChannelFactoryBean;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.jms.connection.CachingConnectionFactory;
@@ -41,7 +42,6 @@ import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.JmsHeaders;
 import org.springframework.jms.support.converter.MessageConversionException;
 import org.springframework.jms.support.converter.MessageConverter;
-import org.springframework.jms.support.converter.SimpleMessageConverter;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
@@ -49,7 +49,6 @@ import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -95,19 +94,17 @@ public class PollableJmsChannelTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
-		JmsChannelFactoryBean factoryBean = new JmsChannelFactoryBean(false);
-		CachingConnectionFactory ccf = new CachingConnectionFactory(connectionFactory);
-		ccf.setCacheConsumers(false);
-		factoryBean.setConnectionFactory(ccf);
-		factoryBean.setDestinationName("nullPayloadPollableQueue");
-		factoryBean.setPubSubDomain(false);
-		factoryBean.setBeanFactory(mock());
-		MessageConverter messageConverter = spy(new SimpleMessageConverter());
-		given(messageConverter.fromMessage(any())).willReturn(null);
-		factoryBean.setMessageConverter(messageConverter);
-		factoryBean.afterPropertiesSet();
-		PollableJmsChannel channel = (PollableJmsChannel) factoryBean.getObject();
-		assertThat(channel.send(new GenericMessage<>("test1"))).isTrue();
+		jakarta.jms.Message jmsMessage = new StubTextMessage("test");
+
+		MessageConverter messageConverter = mock();
+
+		JmsTemplate jmsTemplate = mock();
+		given(jmsTemplate.getMessageConverter()).willReturn(messageConverter);
+		given(jmsTemplate.receive()).willReturn(jmsMessage);
+
+		PollableJmsChannel channel = new PollableJmsChannel(jmsTemplate);
+		channel.setBeanFactory(mock());
+		channel.afterPropertiesSet();
 
 		assertThatExceptionOfType(MessageConversionException.class)
 				.isThrownBy(() -> channel.receive(10000));

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
@@ -298,7 +298,6 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 		AbstractMessageListenerContainer container = TestUtils.getPropertyValue(channel, "container");
 		MessageListener listener = (MessageListener) container.getMessageListener();
 
-		// A JMS message converted to a null payload is a conversion failure, not a message to discard.
 		assertThatExceptionOfType(MessageConversionException.class)
 				.isThrownBy(() -> listener.onMessage(new StubTextMessage("Hello, world!")));
 	}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
@@ -45,6 +45,7 @@ import org.springframework.integration.test.util.TestUtils;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 import org.springframework.jms.support.JmsHeaders;
+import org.springframework.jms.support.converter.MessageConversionException;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageDeliveryException;
 import org.springframework.messaging.MessageHandler;
@@ -280,6 +281,26 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 		assertThatExceptionOfType(MessageDeliveryException.class)
 				.isThrownBy(() -> listener.onMessage(new StubTextMessage("Hello, world!")))
 				.withMessageContaining("Dispatcher has no subscribers for jms-channel 'noSubscribersChannel'.");
+	}
+
+	@Test
+	public void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
+		JmsChannelFactoryBean factoryBean = new JmsChannelFactoryBean(true);
+		factoryBean.setConnectionFactory(connectionFactory);
+		factoryBean.setDestinationName("nullPayloadSubscribableQueue");
+		factoryBean.setBeanName("nullPayloadChannel");
+		factoryBean.setMessageConverter(mock());
+		factoryBean.setBeanFactory(mock());
+		factoryBean.afterPropertiesSet();
+		SubscribableJmsChannel channel = (SubscribableJmsChannel) factoryBean.getObject();
+		channel.afterPropertiesSet();
+
+		AbstractMessageListenerContainer container = TestUtils.getPropertyValue(channel, "container");
+		MessageListener listener = (MessageListener) container.getMessageListener();
+
+		// A JMS message converted to a null payload is a conversion failure, not a message to discard.
+		assertThatExceptionOfType(MessageConversionException.class)
+				.isThrownBy(() -> listener.onMessage(new StubTextMessage("Hello, world!")));
 	}
 
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/channel/SubscribableJmsChannelTests.java
@@ -30,6 +30,7 @@ import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.BeanFactory;
@@ -42,6 +43,7 @@ import org.springframework.integration.jms.StubTextMessage;
 import org.springframework.integration.jms.config.JmsChannelFactoryBean;
 import org.springframework.integration.support.MessageBuilder;
 import org.springframework.integration.test.util.TestUtils;
+import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.listener.AbstractMessageListenerContainer;
 import org.springframework.jms.listener.DefaultMessageListenerContainer;
 import org.springframework.jms.support.JmsHeaders;
@@ -57,6 +59,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
@@ -285,21 +288,19 @@ public class SubscribableJmsChannelTests extends ActiveMQMultiContextTests {
 
 	@Test
 	public void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
-		JmsChannelFactoryBean factoryBean = new JmsChannelFactoryBean(true);
-		factoryBean.setConnectionFactory(connectionFactory);
-		factoryBean.setDestinationName("nullPayloadSubscribableQueue");
-		factoryBean.setBeanName("nullPayloadChannel");
-		factoryBean.setMessageConverter(mock());
-		factoryBean.setBeanFactory(mock());
-		factoryBean.afterPropertiesSet();
-		SubscribableJmsChannel channel = (SubscribableJmsChannel) factoryBean.getObject();
+		AbstractMessageListenerContainer container = mock();
+		JmsTemplate jmsTemplate = mock();
+		when(jmsTemplate.getMessageConverter()).thenReturn(mock());
+
+		SubscribableJmsChannel channel = new SubscribableJmsChannel(container, jmsTemplate);
+		channel.setBeanFactory(mock());
 		channel.afterPropertiesSet();
 
-		AbstractMessageListenerContainer container = TestUtils.getPropertyValue(channel, "container");
-		MessageListener listener = (MessageListener) container.getMessageListener();
+		ArgumentCaptor<MessageListener> listenerCaptor = ArgumentCaptor.forClass(MessageListener.class);
+		verify(container).setMessageListener(listenerCaptor.capture());
 
 		assertThatExceptionOfType(MessageConversionException.class)
-				.isThrownBy(() -> listener.onMessage(new StubTextMessage("Hello, world!")));
+				.isThrownBy(() -> listenerCaptor.getValue().onMessage(new StubTextMessage("Hello, world!")));
 	}
 
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
@@ -26,7 +26,6 @@ import org.springframework.jms.support.converter.MessageConversionException;
 import org.springframework.jms.support.converter.MessageConverter;
 import org.springframework.messaging.MessagingException;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.nullable;
@@ -38,7 +37,7 @@ import static org.mockito.Mockito.mock;
  *
  * @since 7.2
  */
-public class JmsDestinationPollingSourceTests implements TestApplicationContextAware {
+class JmsDestinationPollingSourceTests implements TestApplicationContextAware {
 
 	@Test
 	void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
@@ -55,28 +54,9 @@ public class JmsDestinationPollingSourceTests implements TestApplicationContextA
 		source.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		source.afterPropertiesSet();
 
-		// A JMS message converted to a null payload is a conversion failure, not a message to discard.
 		assertThatExceptionOfType(MessagingException.class)
 				.isThrownBy(source::receive)
 				.withCauseInstanceOf(MessageConversionException.class);
-	}
-
-	@Test
-	void payloadFromConverterIsUsed() throws Exception {
-		Message jmsMessage = new StubTextMessage("test");
-
-		MessageConverter converter = mock();
-		given(converter.fromMessage(any())).willReturn("converted");
-
-		JmsTemplate jmsTemplate = mock();
-		given(jmsTemplate.getMessageConverter()).willReturn(converter);
-		given(jmsTemplate.receiveSelected(nullable(String.class))).willReturn(jmsMessage);
-
-		JmsDestinationPollingSource source = new JmsDestinationPollingSource(jmsTemplate);
-		source.setBeanFactory(TEST_INTEGRATION_CONTEXT);
-		source.afterPropertiesSet();
-
-		assertThat(source.receive().getPayload()).isEqualTo("converted");
 	}
 
 }

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
@@ -19,8 +19,10 @@ package org.springframework.integration.jms.inbound;
 import jakarta.jms.Message;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.jms.StubTextMessage;
-import org.springframework.integration.test.support.TestApplicationContextAware;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.converter.MessageConversionException;
 import org.springframework.jms.support.converter.MessageConverter;
@@ -28,7 +30,6 @@ import org.springframework.messaging.MessagingException;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -37,21 +38,26 @@ import static org.mockito.Mockito.mock;
  *
  * @since 7.2
  */
-class JmsDestinationPollingSourceTests implements TestApplicationContextAware {
+class JmsDestinationPollingSourceTests {
 
 	@Test
 	void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
 		Message jmsMessage = new StubTextMessage("test");
 
 		MessageConverter converter = mock();
-		given(converter.fromMessage(any())).willReturn(null);
 
 		JmsTemplate jmsTemplate = mock();
 		given(jmsTemplate.getMessageConverter()).willReturn(converter);
-		given(jmsTemplate.receiveSelected(nullable(String.class))).willReturn(jmsMessage);
+		given(jmsTemplate.receiveSelected(any())).willReturn(jmsMessage);
+
+		BeanFactory beanFactory = mock();
+		String evaluationContextBeanName = IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME;
+		given(beanFactory.containsBean(evaluationContextBeanName)).willReturn(true);
+		given(beanFactory.getBean(evaluationContextBeanName, StandardEvaluationContext.class))
+				.willReturn(new StandardEvaluationContext());
 
 		JmsDestinationPollingSource source = new JmsDestinationPollingSource(jmsTemplate);
-		source.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		source.setBeanFactory(beanFactory);
 		source.afterPropertiesSet();
 
 		assertThatExceptionOfType(MessagingException.class)

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
@@ -19,9 +19,6 @@ package org.springframework.integration.jms.inbound;
 import jakarta.jms.Message;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.integration.context.IntegrationContextUtils;
 import org.springframework.integration.jms.StubTextMessage;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.support.converter.MessageConversionException;
@@ -50,15 +47,7 @@ class JmsDestinationPollingSourceTests {
 		given(jmsTemplate.getMessageConverter()).willReturn(converter);
 		given(jmsTemplate.receiveSelected(any())).willReturn(jmsMessage);
 
-		BeanFactory beanFactory = mock();
-		String evaluationContextBeanName = IntegrationContextUtils.INTEGRATION_EVALUATION_CONTEXT_BEAN_NAME;
-		given(beanFactory.containsBean(evaluationContextBeanName)).willReturn(true);
-		given(beanFactory.getBean(evaluationContextBeanName, StandardEvaluationContext.class))
-				.willReturn(new StandardEvaluationContext());
-
 		JmsDestinationPollingSource source = new JmsDestinationPollingSource(jmsTemplate);
-		source.setBeanFactory(beanFactory);
-		source.afterPropertiesSet();
 
 		assertThatExceptionOfType(MessagingException.class)
 				.isThrownBy(source::receive)

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.jms.inbound;
+
+import jakarta.jms.Message;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.integration.jms.StubTextMessage;
+import org.springframework.integration.test.support.TestApplicationContextAware;
+import org.springframework.jms.core.JmsTemplate;
+import org.springframework.jms.support.converter.MessageConversionException;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.messaging.MessagingException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Glenn Renfro
+ */
+public class JmsDestinationPollingSourceTests implements TestApplicationContextAware {
+
+	@Test
+	public void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
+		Message jmsMessage = new StubTextMessage("test");
+
+		MessageConverter converter = mock();
+		given(converter.fromMessage(any())).willReturn(null);
+
+		JmsTemplate jmsTemplate = mock();
+		given(jmsTemplate.getMessageConverter()).willReturn(converter);
+		given(jmsTemplate.receiveSelected(nullable(String.class))).willReturn(jmsMessage);
+
+		JmsDestinationPollingSource source = new JmsDestinationPollingSource(jmsTemplate);
+		source.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		source.afterPropertiesSet();
+
+		// A JMS message converted to a null payload is a conversion failure, not a message to discard.
+		assertThatExceptionOfType(MessagingException.class)
+				.isThrownBy(source::receive)
+				.withCauseInstanceOf(MessageConversionException.class);
+	}
+
+	@Test
+	public void payloadFromConverterIsUsed() throws Exception {
+		Message jmsMessage = new StubTextMessage("test");
+
+		MessageConverter converter = mock();
+		given(converter.fromMessage(any())).willReturn("converted");
+
+		JmsTemplate jmsTemplate = mock();
+		given(jmsTemplate.getMessageConverter()).willReturn(converter);
+		given(jmsTemplate.receiveSelected(nullable(String.class))).willReturn(jmsMessage);
+
+		JmsDestinationPollingSource source = new JmsDestinationPollingSource(jmsTemplate);
+		source.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		source.afterPropertiesSet();
+
+		assertThat(source.receive().getPayload()).isEqualTo("converted");
+	}
+
+}

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/inbound/JmsDestinationPollingSourceTests.java
@@ -35,11 +35,13 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author Glenn Renfro
+ *
+ * @since 7.2
  */
 public class JmsDestinationPollingSourceTests implements TestApplicationContextAware {
 
 	@Test
-	public void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
+	void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
 		Message jmsMessage = new StubTextMessage("test");
 
 		MessageConverter converter = mock();
@@ -60,7 +62,7 @@ public class JmsDestinationPollingSourceTests implements TestApplicationContextA
 	}
 
 	@Test
-	public void payloadFromConverterIsUsed() throws Exception {
+	void payloadFromConverterIsUsed() throws Exception {
 		Message jmsMessage = new StubTextMessage("test");
 
 		MessageConverter converter = mock();

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/JmsOutboundGatewayTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/JmsOutboundGatewayTests.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import jakarta.jms.Connection;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.Destination;
-import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.Session;
@@ -169,25 +168,13 @@ public class JmsOutboundGatewayTests extends ActiveMQMultiContextTests implement
 		gateway.setRequestDestinationName("testDestination");
 		gateway.setReplyDestinationName("testReplyDestination");
 		gateway.setCorrelationKey("JMSCorrelationID");
-		gateway.setMessageConverter(new MessageConverter() {
-
-			@Override
-			public Message toMessage(Object object, Session session) throws JMSException {
-				return session.createTextMessage((String) object);
-			}
-
-			@Override
-			public Object fromMessage(Message message) {
-				return null;
-			}
-
-		});
-		gateway.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		MessageConverter messageConverter = mock();
+		when(messageConverter.toMessage(any(), any())).thenReturn(mock());
+		gateway.setMessageConverter(messageConverter);
+		gateway.setBeanFactory(mock());
 
 		Connection connection = new StubConnection("reply");
 		when(connectionFactory.createConnection()).thenReturn(connection);
-
-		gateway.afterPropertiesSet();
 
 		// A JMS reply converted to a null payload is a conversion failure, not a discarded reply.
 		assertThatExceptionOfType(MessageHandlingException.class)

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/JmsOutboundGatewayTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/JmsOutboundGatewayTests.java
@@ -46,13 +46,18 @@ import org.springframework.jms.JmsException;
 import org.springframework.jms.connection.CachingConnectionFactory;
 import org.springframework.jms.core.JmsTemplate;
 import org.springframework.jms.core.MessageCreator;
+import org.springframework.jms.support.converter.MessageConversionException;
+import org.springframework.jms.support.converter.MessageConverter;
+import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.util.ObjectUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -153,6 +158,36 @@ public class JmsOutboundGatewayTests extends ActiveMQMultiContextTests implement
 			exec.shutdownNow();
 			taskScheduler.destroy();
 		}
+	}
+
+	@Test
+	public void nullPayloadFromConverterThrowsMessageConversionException() throws Exception {
+		JmsOutboundGateway gateway = new JmsOutboundGateway();
+		ConnectionFactory connectionFactory = mock();
+		gateway.setConnectionFactory(connectionFactory);
+		gateway.setRequestDestinationName("testDestination");
+		MessageConverter converter = mock();
+		gateway.setMessageConverter(converter);
+		gateway.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+
+		Connection connection = mock();
+		when(connectionFactory.createConnection()).thenReturn(connection);
+		Session session = mock();
+		when(connection.createSession(false, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+		when(session.createTemporaryQueue()).thenReturn(mock());
+		when(session.createQueue("testDestination")).thenReturn(mock());
+		when(converter.toMessage(any(), eq(session))).thenReturn(mock());
+		when(session.createProducer(any())).thenReturn(mock());
+		MessageConsumer consumer = mock();
+		when(session.createConsumer(any())).thenReturn(consumer);
+		when(consumer.receive(anyLong())).thenReturn(mock());
+
+		gateway.afterPropertiesSet();
+
+		// A JMS reply converted to a null payload is a conversion failure, not a discarded reply.
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> gateway.handleMessage(new GenericMessage<>("test request")))
+				.withRootCauseInstanceOf(MessageConversionException.class);
 	}
 
 	@Test

--- a/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/JmsOutboundGatewayTests.java
+++ b/spring-integration-jms/src/test/java/org/springframework/integration/jms/outbound/JmsOutboundGatewayTests.java
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import jakarta.jms.Connection;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.Destination;
+import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 import jakarta.jms.MessageConsumer;
 import jakarta.jms.Session;
@@ -38,6 +39,7 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.integration.channel.QueueChannel;
 import org.springframework.integration.expression.ValueExpression;
 import org.springframework.integration.jms.ActiveMQMultiContextTests;
+import org.springframework.integration.jms.StubConnection;
 import org.springframework.integration.jms.outbound.JmsOutboundGateway.ReplyContainerProperties;
 import org.springframework.integration.test.support.TestApplicationContextAware;
 import org.springframework.integration.test.util.TestUtils;
@@ -57,7 +59,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
@@ -166,21 +167,25 @@ public class JmsOutboundGatewayTests extends ActiveMQMultiContextTests implement
 		ConnectionFactory connectionFactory = mock();
 		gateway.setConnectionFactory(connectionFactory);
 		gateway.setRequestDestinationName("testDestination");
-		MessageConverter converter = mock();
-		gateway.setMessageConverter(converter);
+		gateway.setReplyDestinationName("testReplyDestination");
+		gateway.setCorrelationKey("JMSCorrelationID");
+		gateway.setMessageConverter(new MessageConverter() {
+
+			@Override
+			public Message toMessage(Object object, Session session) throws JMSException {
+				return session.createTextMessage((String) object);
+			}
+
+			@Override
+			public Object fromMessage(Message message) {
+				return null;
+			}
+
+		});
 		gateway.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 
-		Connection connection = mock();
+		Connection connection = new StubConnection("reply");
 		when(connectionFactory.createConnection()).thenReturn(connection);
-		Session session = mock();
-		when(connection.createSession(false, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
-		when(session.createTemporaryQueue()).thenReturn(mock());
-		when(session.createQueue("testDestination")).thenReturn(mock());
-		when(converter.toMessage(any(), eq(session))).thenReturn(mock());
-		when(session.createProducer(any())).thenReturn(mock());
-		MessageConsumer consumer = mock();
-		when(session.createConsumer(any())).thenReturn(consumer);
-		when(consumer.receive(anyLong())).thenReturn(mock());
 
 		gateway.afterPropertiesSet();
 

--- a/src/reference/antora/modules/ROOT/pages/jms.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jms.adoc
@@ -859,7 +859,7 @@ This means that the 'extract-request-payload' and 'extract-reply-payload' proper
 The `HeaderMappingMessageConverter` itself delegates to a target `MessageConverter` while also mapping the Spring Integration `MessageHeaders` to JMS message properties and back again.
 
 IMPORTANT: If `MessageConverter.fromMessage()` returns `null` (for example, because the JMS `Message` has no payload), Spring Integration treats this as a conversion failure and throws a `MessageConversionException`, rather than silently discarding the message.
-This applies to the inbound and outbound channel adapters, the inbound and outbound gateways, and JMS-backed message channels (see xref:jms.adoc#jms-channel[JMS-backed Message Channels]).
+This applies to the inbound channel adapters, the inbound and outbound gateways, and JMS-backed message channels.
 
 [[jms-channel]]
 == JMS-backed Message Channels

--- a/src/reference/antora/modules/ROOT/pages/jms.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jms.adoc
@@ -860,6 +860,7 @@ The `HeaderMappingMessageConverter` itself delegates to a target `MessageConvert
 
 IMPORTANT: If `MessageConverter.fromMessage()` returns `null` (for example, because the JMS `Message` has no payload), Spring Integration treats this as a conversion failure and throws a `MessageConversionException`, rather than silently discarding the message.
 This applies to the inbound channel adapters, the inbound and outbound gateways, and JMS-backed message channels.
+See <<jms-channel>>.
 
 [[jms-channel]]
 == JMS-backed Message Channels
@@ -931,7 +932,7 @@ Use `subscription` to name the subscription.
 Starting with version 7.1, the `AbstractJmsChannel` and its implementations use a `DefaultJmsHeaderMapper` internally to map all headers from the message-to-send to JMS message properties; and on consuming side, map all JMS message properties into message headers.
 The custom header-mapping and payload conversion logic can be done by the `org.springframework.jms.support.converter.MessagingMessageConverter` injection into the `JmsTemplate` used for `AbstractJmsChannel` instances.
 
-Starting with version 7.2, if the `MessageConverter` returns `null` when converting an incoming JMS `Message`, `AbstractJmsChannel` (and, therefore, `SubscribableJmsChannel` and `PollableJmsChannel`) treats it as a conversion failure and throws a `MessageConversionException` rather than discarding the message.
+Starting with version 7.2, if the `MessageConverter` returns `null` when converting an incoming JMS `Message`, the `AbstractJmsChannel` implementations treat it as a conversion failure and throw a `MessageConversionException` rather than discarding the message.
 
 [[jms-selectors]]
 == Using JMS Message Selectors

--- a/src/reference/antora/modules/ROOT/pages/jms.adoc
+++ b/src/reference/antora/modules/ROOT/pages/jms.adoc
@@ -858,6 +858,9 @@ NOTE: When you provide your own `MessageConverter` instance, it is still wrapped
 This means that the 'extract-request-payload' and 'extract-reply-payload' properties can affect the actual objects passed to your converter.
 The `HeaderMappingMessageConverter` itself delegates to a target `MessageConverter` while also mapping the Spring Integration `MessageHeaders` to JMS message properties and back again.
 
+IMPORTANT: If `MessageConverter.fromMessage()` returns `null` (for example, because the JMS `Message` has no payload), Spring Integration treats this as a conversion failure and throws a `MessageConversionException`, rather than silently discarding the message.
+This applies to the inbound and outbound channel adapters, the inbound and outbound gateways, and JMS-backed message channels (see xref:jms.adoc#jms-channel[JMS-backed Message Channels]).
+
 [[jms-channel]]
 == JMS-backed Message Channels
 
@@ -927,6 +930,8 @@ Use `subscription` to name the subscription.
 
 Starting with version 7.1, the `AbstractJmsChannel` and its implementations use a `DefaultJmsHeaderMapper` internally to map all headers from the message-to-send to JMS message properties; and on consuming side, map all JMS message properties into message headers.
 The custom header-mapping and payload conversion logic can be done by the `org.springframework.jms.support.converter.MessagingMessageConverter` injection into the `JmsTemplate` used for `AbstractJmsChannel` instances.
+
+Starting with version 7.2, if the `MessageConverter` returns `null` when converting an incoming JMS `Message`, `AbstractJmsChannel` (and, therefore, `SubscribableJmsChannel` and `PollableJmsChannel`) treats it as a conversion failure and throws a `MessageConversionException` rather than discarding the message.
 
 [[jms-selectors]]
 == Using JMS Message Selectors

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -43,3 +43,8 @@ See xref:jdbc/metadata-store.adoc[] for more information.
 
 The `RestTemplate`-based configuration for the HTTP outbound gateway and outbound channel adapter (the `rest-template` attribute, and the respective Java DSL and constructor options) is now deprecated in favor of `RestClient`-based configuration, which also gains new options for configuring error handling.
 See the xref:http.adoc[HTTP Support] chapter for more information about these and other changes.
+
+[[x7.2-jms-changes]]
+=== JMS Support Changes
+Spring Integration supports Spring Framework's ability to return `null` when converting a JMS `Message` where the payload has not been set.
+This also means that if a Spring `Message` uses the payload of a JMS `Message` that is null, a  `MessageConversionException` will be thrown.

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -46,5 +46,8 @@ See the xref:http.adoc[HTTP Support] chapter for more information about these an
 
 [[x7.2-jms-changes]]
 === JMS Support Changes
-Spring Integration supports Spring Framework's ability to return `null` when converting a JMS `Message` where the payload has not been set.
-This also means that if a Spring `Message` uses the payload of a JMS `Message` that is null, a  `MessageConversionException` will be thrown.
+
+Spring Framework's JMS `MessageConverter` implementations may now return `null` from `fromMessage()` when a JMS `Message` has no payload.
+A `null` payload conversion is treated as a conversion failure, a `MessageConversionException` is then thrown.
+This affects `AbstractJmsChannel`, `JmsDestinationPollingSource`, `ChannelPublishingJmsMessageListener`, and `JmsOutboundGateway`.
+See xref:jms.adoc[JMS Support] for more information.


### PR DESCRIPTION
The latest snapshots have introduced some breaking changes.
    Resolve the issues below
  - Treat a null result from `MessageConverter.fromMessage()` as a
  conversion failure across all inbound JMS paths.
  - Throw `MessageConversionException` from `AbstractJmsChannel`,
  `JmsDestinationPollingSource`, `ChannelPublishingJmsMessageListener`,
  and `JmsOutboundGateway` instead of silently discarding the message.
  - Remove the discard branch in `SubscribableJmsChannel `since a null
  conversion is no longer possible without an exception.
  - Add tests asserting `MessageConversionException` for each of the
  four affected components.
  - Updated core to use builder for `SpelParserConfiguration` as the
   constructor is now deprecated.


<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
