### PR TITLE
GH-11352: Propagate a failing close() when writing files

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/outbound/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/outbound/FileWritingMessageHandler.java
@@ -118,6 +118,7 @@ import org.springframework.util.StringUtils;
  * @author Christian Tzolov
  * @author Ngoc Nhan
  * @author Thomas Knall
+ * @author Jiwoo Lee
  *
  * @since 7.0
  */
@@ -674,24 +675,43 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 				bos.write(System.lineSeparator().getBytes());
 			}
 		}
-		finally {
-			cleanUpFileState(fileToWriteTo, state, bos);
+		catch (IOException | RuntimeException ex) {
+			cleanUpFileStateSuppressing(ex, fileToWriteTo, state, bos);
+			throw ex;
 		}
+		cleanUpFileState(fileToWriteTo, state, bos);
 	}
 
-	private void cleanUpFileState(File fileToWriteTo, @Nullable FileState state, @Nullable Closeable closeable) {
-		try {
-			if (state == null || this.flushTask == null) {
+	private void cleanUpFileState(File fileToWriteTo, @Nullable FileState state, @Nullable Closeable closeable)
+			throws IOException {
+
+		if (state == null || this.flushTask == null) {
+			try {
 				if (closeable != null) {
 					closeable.close();
 				}
+			}
+			finally {
 				clearState(fileToWriteTo, state);
 			}
-			else {
-				state.lastWrite = System.currentTimeMillis();
-			}
+		}
+		else {
+			state.lastWrite = System.currentTimeMillis();
+		}
+	}
+
+	/**
+	 * Clean up after a write that has already failed, adding any failure from the clean up
+	 * to the exception which is on its way out, the way try-with-resources does.
+	 */
+	private void cleanUpFileStateSuppressing(Throwable primary, File fileToWriteTo, @Nullable FileState state,
+			@Nullable Closeable closeable) {
+
+		try {
+			cleanUpFileState(fileToWriteTo, state, closeable);
 		}
 		catch (IOException ex) {
+			primary.addSuppressed(ex);
 		}
 	}
 
@@ -733,9 +753,11 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 				bos.write(System.lineSeparator().getBytes());
 			}
 		}
-		finally {
-			cleanUpFileState(fileToWriteTo, state, bos);
+		catch (IOException | RuntimeException ex) {
+			cleanUpFileStateSuppressing(ex, fileToWriteTo, state, bos);
+			throw ex;
 		}
+		cleanUpFileState(fileToWriteTo, state, bos);
 	}
 
 	private File handleStringMessage(String content, @Nullable File originalFile, File tempFile, File resultFile,
@@ -776,9 +798,11 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 				writer.newLine();
 			}
 		}
-		finally {
-			cleanUpFileState(fileToWriteTo, state, writer);
+		catch (IOException | RuntimeException ex) {
+			cleanUpFileStateSuppressing(ex, fileToWriteTo, state, writer);
+			throw ex;
 		}
+		cleanUpFileState(fileToWriteTo, state, writer);
 	}
 
 	private File determineFileToWrite(File resultFile, File tempFile) {

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
@@ -17,12 +17,16 @@
 package org.springframework.integration.file.outbound;
 
 import java.io.BufferedOutputStream;
+import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.attribute.PosixFilePermission;
@@ -90,6 +94,7 @@ import static org.mockito.Mockito.when;
  * @author Alen Turkovic
  * @author Glenn Renfro
  * @author Thomas Knall
+ * @author Jiwoo Lee
  */
 public class FileWritingMessageHandlerTests implements TestApplicationContextAware {
 
@@ -774,6 +779,49 @@ public class FileWritingMessageHandlerTests implements TestApplicationContextAwa
 		assertThat(result).isNotNull();
 		assertThat(result.getPayload()).isInstanceOf(File.class);
 		return (File) result.getPayload();
+	}
+
+	@Test
+	void closeFailureIsReportedAndTheFileIsNotPromoted(@TempDir File localRoot) throws Exception {
+		File out = new File(localRoot, "out");
+		// A writer whose close() fails the way a full disk does: the buffered content
+		// never reaches the file and the IOException surfaces from close().
+		FileWritingMessageHandler handler = new FileWritingMessageHandler(out) {
+
+			@Override
+			protected BufferedWriter createWriter(File fileToWriteTo, boolean append)
+					throws FileNotFoundException {
+
+				Writer target;
+				try {
+					target = new FileWriter(fileToWriteTo, append);
+				}
+				catch (IOException ex) {
+					throw new FileNotFoundException(ex.getMessage());
+				}
+				return new BufferedWriter(target) {
+
+					@Override
+					public void close() throws IOException {
+						target.close();
+						throw new IOException("No space left on device");
+					}
+
+				};
+			}
+
+		};
+		handler.setFileNameGenerator(message -> "payload.txt");
+		handler.setOutputChannel(new NullChannel());
+		handler.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		handler.setApplicationContext(new GenericApplicationContext());
+		handler.afterPropertiesSet();
+
+		assertThatExceptionOfType(MessageHandlingException.class)
+				.isThrownBy(() -> handler.handleMessage(new GenericMessage<>("important payload")))
+				.withStackTraceContaining("java.io.IOException: No space left on device");
+
+		assertThat(new File(out, "payload.txt")).doesNotExist();
 	}
 
 }

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
@@ -782,8 +782,8 @@ public class FileWritingMessageHandlerTests implements TestApplicationContextAwa
 	}
 
 	@Test
-	void closeFailureIsReportedAndTheFileIsNotPromoted(@TempDir File localRoot) throws Exception {
-		File out = new File(localRoot, "out");
+	void closeFailureIsReportedAndTheFileIsNotPromoted() throws Exception {
+		File out = new File(this.tempDir, "out");
 		// A writer whose close() fails the way a full disk does: the buffered content
 		// never reaches the file and the IOException surfaces from close().
 		FileWritingMessageHandler handler = new FileWritingMessageHandler(out) {


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-integration/issues/11352

`cleanUpFileState()` discarded every `IOException`, including the one raised by closing the buffered writer or stream. All three write paths call it from a `finally` block, and `close()` is where the buffer is flushed, so a full disk was reported as a successful write and the truncated temporary file was still renamed onto the result file.

`cleanUpFileState()` now propagates and the callers invoke it on the success path, where a failure reaches the caller. On the failure path it goes through `cleanUpFileStateSuppressing()`, which attaches the close error to the exception already on its way out instead of replacing it, the way try-with-resources does. `clearState()` still runs in both cases and the `APPEND_NO_FLUSH` branch is unchanged. Keeping a single `finally` and handing it the in-flight exception would work too and would keep the call sites shorter; happy to reshape it that way if you prefer.

Verified with `./gradlew --rerun-tasks :spring-integration-file:check`: 332 tests, 0 failures, 6 skipped, checkstyle clean on main and test. `FileWritingMessageHandler` is referenced only from this module, so that is the whole affected surface. Reverting just the production file makes the new test fail and leaves the other 331 passing.

Contributed on behalf of [Goatshave](https://github.com/Goatshave).
