### PR TITLE
Copy upstream message headers into the outgoing MessageBuilder using …

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/AbstractMailMessageTransformer.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/transformer/AbstractMailMessageTransformer.java
@@ -40,6 +40,7 @@ import org.springframework.messaging.Message;
  * @author Mark Fisher
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Amlan Mishra
  */
 public abstract class AbstractMailMessageTransformer<T> implements Transformer, BeanFactoryAware {
 
@@ -73,7 +74,9 @@ public abstract class AbstractMailMessageTransformer<T> implements Transformer, 
 		}
 		AbstractIntegrationMessageBuilder<T> builder;
 		builder = doTransform(mailMessage);
-		return builder.copyHeaders(extractHeaderMapFromMailMessage(mailMessage)).build();
+		return builder.copyHeaders(extractHeaderMapFromMailMessage(mailMessage))
+				.copyHeadersIfAbsent(message.getHeaders())
+				.build();
 	}
 
 	protected abstract AbstractIntegrationMessageBuilder<T> doTransform(jakarta.mail.Message mailMessage);

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/transformer/MailToStringTransformerTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/transformer/MailToStringTransformerTests.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.mail.transformer;
+
+import com.icegreen.greenmail.util.GreenMailUtil;
+import jakarta.mail.internet.InternetAddress;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.integration.mail.MailHeaders;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+
+import static org.assertj.core.api.Assertions.as;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.MAP;
+
+/**
+ * @author Amlan Mishra
+ *
+ * @since 7.0.7
+ */
+class MailToStringTransformerTests {
+
+	@Test
+	void upstreamHeadersPreservedDuringTransformation() throws Exception {
+
+		jakarta.mail.Message mailMessage = GreenMailUtil.newMimeMessage("");
+		mailMessage.setText("test email content");
+		mailMessage.setSubject("email-subject");
+		mailMessage.setFrom(new InternetAddress("sender@example.com"));
+
+		Message<jakarta.mail.Message> message = MessageBuilder.withPayload(mailMessage)
+				.setHeader("customUpstreamHeader", "customValue")
+				.setHeader(MailHeaders.SUBJECT, "upstream-subject-to-be-overridden")
+				.build();
+
+
+		MailToStringTransformer transformer = new MailToStringTransformer();
+
+		Message<?> result = transformer.transform(message);
+
+		assertThat(result)
+				.returns("test email content", Message::getPayload)
+				.extracting(Message::getHeaders, as(MAP))
+				.containsEntry("customUpstreamHeader", "customValue")
+				.containsEntry(MailHeaders.FROM, "sender@example.com")
+				.containsEntry(MailHeaders.SUBJECT, "email-subject");
+	}
+
+}


### PR DESCRIPTION
Fix AbstractMailMessageTransformer losing upstream headers

### Summary
`AbstractMailMessageTransformer` previously only populated the outgoing message builder with headers extracted from the raw `jakarta.mail.Message` payload via `copyHeaders(...)`. As a result, any upstream message headers attached prior in the integration flow (e.g., correlation IDs, tracing headers, custom metadata) were lost during transformation.

### Changes
* Updated `AbstractMailMessageTransformer.transform()` to invoke `.copyHeadersIfAbsent(message.getHeaders())` on the `MessageBuilder`.
* Preserves upstream message headers while maintaining precedence for headers directly extracted from the mail message.
* Added unit test coverage verifying both header retention and precedence rules.

Fixes #11281