### PR TITLE
Update JDBC Lock Registry links in Change History

### DIFF
--- a/src/reference/antora/modules/ROOT/pages/changes-4.2-4.3.adoc
+++ b/src/reference/antora/modules/ROOT/pages/changes-4.2-4.3.adoc
@@ -52,7 +52,7 @@ See xref:graph.adoc#integration-graph[Integration Graph] for more information.
 === JDBC Lock Registry
 
 We added `JdbcLockRegistry` for distributed locks shared through a database table.
-See xref:jdbc.adoc#jdbc-lock-registry[JDBC Lock Registry] for more information.
+See xref:jdbc/lock-registry.adoc[JDBC Lock Registry] for more information.
 
 [[leaderinitiator-for-lockregistry]]
 === `LeaderInitiator` for `LockRegistry`

--- a/src/reference/antora/modules/ROOT/pages/changes-5.3-5.4.adoc
+++ b/src/reference/antora/modules/ROOT/pages/changes-5.3-5.4.adoc
@@ -30,7 +30,7 @@ See xref:redis.adoc#redis-stream-outbound[Redis Stream Outbound Channel Adapter]
 == Renewable Lock Registry
 
 A Renewable lock registry has been introduced to allow renew lease of a distributed lock.
-See xref:jdbc.adoc#jdbc-lock-registry[JDBC implementation] for more information.
+See xref:jdbc/lock-registry.adoc[JDBC Lock Registry] for more information.
 
 [[x5.4-zeromq]]
 == ZeroMQ Support

--- a/src/reference/antora/modules/ROOT/pages/changes-5.5-6.0.adoc
+++ b/src/reference/antora/modules/ROOT/pages/changes-5.5-6.0.adoc
@@ -167,7 +167,7 @@ See xref:kafka.adoc[Spring for Apache Kafka Support] for more information.
 
 The `DefaultLockRepository` can now be supplied with a `PlatformTransactionManager` instead of relying on the primary bean from the application context.
 
-See xref:jdbc.adoc#jdbc-lock-registry[JDBC Lock Registry] for more information.
+See xref:jdbc/lock-registry.adoc[JDBC Lock Registry] for more information.
 
 [[x6.0-tcp]]
 == TCP/IP Changes

--- a/src/reference/antora/modules/ROOT/pages/changes-6.0-6.1.adoc
+++ b/src/reference/antora/modules/ROOT/pages/changes-6.0-6.1.adoc
@@ -81,4 +81,4 @@ See xref:amqp/rmq-streams.adoc[`RabbitMQ Stream Queue Support`] for more informa
 == JDBC Changes
 
 The `DefaultLockRepository` now exposes setters for `insert`, `update` and `renew` queries.
-See xref:jdbc.adoc#jdbc-lock-registry[ JDBC Lock Registry] for more information.
+See xref:jdbc/lock-registry.adoc[JDBC Lock Registry] for more information.


### PR DESCRIPTION
This commit updates the JDBC Lock Registry links in the following files:
- changes-6.0-6.1.adoc
- changes-5.5-6.0.adoc
- changes-5.3-5.4.adoc
- changes-4.2-4.3.adoc

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
