### PR TITLE
Update all Spring Dependencies except SF

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,13 @@
 [versions]
 # Spring Portfolio dependencies. Usually managed by release train
-micrometerTracingVersion = "1.8.0-M1"
-micrometerVersion = "1.18.0-M1"
+micrometerTracingVersion = "1.8.0-SNAPSHOT"
+micrometerVersion = "1.18.0-SNAPSHOT"
 reactorVersion = "2026.0.0-SNAPSHOT"
-springAmqpVersion = "4.2.0-M1"
-springDataVersion = "2026.1.0-M1"
+springAmqpVersion = "4.2.0-SNAPSHOT"
+springDataVersion = "2026.1.0-SNAPSHOT"
 springGraphqlVersion = "2.0.5"
-springKafkaVersion = "4.2.0-M1"
-springSecurityVersion = "7.1.1"
+springKafkaVersion = "4.2.0-SNAPSHOT"
+springSecurityVersion = "7.2.0-SNAPSHOT"
 springVersion = "7.1.0-M1"
 springWsVersion = "5.0.2"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,11 +5,11 @@ micrometerVersion = "1.18.0-SNAPSHOT"
 reactorVersion = "2026.0.0-SNAPSHOT"
 springAmqpVersion = "4.2.0-SNAPSHOT"
 springDataVersion = "2026.1.0-SNAPSHOT"
-springGraphqlVersion = "2.0.5"
+springGraphqlVersion = "2.1.0-SNAPSHOT"
 springKafkaVersion = "4.2.0-SNAPSHOT"
 springSecurityVersion = "7.2.0-SNAPSHOT"
 springVersion = "7.1.0-M1"
-springWsVersion = "5.0.2"
+springWsVersion = "5.1.0-SNAPSHOT"
 
 # Third-party dependencies
 apacheSshdVersion = "2.19.0"

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/MetricsCaptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/metrics/MetricsCaptor.java
@@ -50,7 +50,7 @@ public interface MetricsCaptor {
 	 * @param f the function.
 	 * @return the builder.
 	 */
-	GaugeBuilder gaugeBuilder(String name, @Nullable Object obj, ToDoubleFunction<Object> f);
+	GaugeBuilder gaugeBuilder(String name, Object obj, ToDoubleFunction<Object> f);
 
 	/**
 	 * Start a sample collection.

--- a/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptor.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/support/management/micrometer/MicrometerMetricsCaptor.java
@@ -83,7 +83,7 @@ public class MicrometerMetricsCaptor implements MetricsCaptor {
 	}
 
 	@Override
-	public GaugeBuilder gaugeBuilder(String name, @Nullable Object obj, ToDoubleFunction<Object> f) {
+	public GaugeBuilder gaugeBuilder(String name, Object obj, ToDoubleFunction<Object> f) {
 		return new MicroGaugeBuilder(getMeterRegistry(), name, obj, f);
 	}
 
@@ -268,7 +268,7 @@ public class MicrometerMetricsCaptor implements MetricsCaptor {
 
 		private final Gauge.Builder<Object> builder;
 
-		protected MicroGaugeBuilder(MeterRegistry meterRegistry, String name, @Nullable Object obj, ToDoubleFunction<Object> f) {
+		protected MicroGaugeBuilder(MeterRegistry meterRegistry, String name, Object obj, ToDoubleFunction<Object> f) {
 			this.meterRegistry = meterRegistry;
 			this.builder = Gauge.builder(name, obj, f);
 		}


### PR DESCRIPTION
- SF Dependency update will be in another PR
- SI MicroGaugeBuilder no longer accepts null for obj
  - This tracks with latest changes to Micrometer
  - Since all known impls in the project pass `this` there is no side effect

<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.md).
-->
