### PR TITLE
GH-11377: Fix `equals()` contract in the `AdviceMessage`

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/message/AdviceMessage.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/message/AdviceMessage.java
@@ -36,6 +36,7 @@ import org.springframework.messaging.support.GenericMessage;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Alexander Makarov
  *
  * @since 2.2
  */
@@ -84,13 +85,9 @@ public class AdviceMessage<T> extends GenericMessage<T> {
 
 	@Override
 	public boolean equals(@Nullable Object o) {
-		if (super.equals(o)) {
-			return true;
-		}
-		if (o instanceof AdviceMessage<?> that) {
-			return Objects.equals(this.inputMessage, that.inputMessage);
-		}
-		return false;
+		return o instanceof AdviceMessage<?> that
+				&& super.equals(o)
+				&& Objects.equals(this.inputMessage, that.inputMessage);
 	}
 
 	@Override

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/AdviceMessageTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/AdviceMessageTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-present the original author or authors.
+ * Copyright 2026-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,24 +28,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Alexander Makarov
+ *
+ * @since 7.0.7
  */
 public class AdviceMessageTests {
 
-	@Test
-	public void equalsWhenPayloadHeadersAndInputMessageMatch() {
-		Message<?> inputMessage = new GenericMessage<>("input");
-		MessageHeaders headers = new GenericMessage<>("ignored").getHeaders();
+	private static final Message<?> INPUT_MESSAGE = new GenericMessage<>("input");
 
-		AdviceMessage<String> one = new AdviceMessage<>("test", headers, inputMessage);
-		AdviceMessage<String> two = new AdviceMessage<>("test", headers, inputMessage);
+	@Test
+	void equalsWhenPayloadHeadersAndInputMessageMatch() {
+		MessageHeaders headers = new MessageHeaders(null);
+
+		AdviceMessage<String> one = new AdviceMessage<>("test", headers, INPUT_MESSAGE);
+		AdviceMessage<String> two = new AdviceMessage<>("test", headers, INPUT_MESSAGE);
 
 		assertThat(one).isEqualTo(two);
 		assertThat(one.hashCode()).isEqualTo(two.hashCode());
 	}
 
 	@Test
-	public void notEqualsWhenInputMessageDiffers() {
-		MessageHeaders headers = new GenericMessage<>("ignored").getHeaders();
+	void notEqualsWhenInputMessageDiffers() {
+		MessageHeaders headers = new MessageHeaders(null);
 
 		AdviceMessage<String> one = new AdviceMessage<>("test", headers, new GenericMessage<>("input1"));
 		AdviceMessage<String> two = new AdviceMessage<>("test", headers, new GenericMessage<>("input2"));
@@ -54,42 +57,36 @@ public class AdviceMessageTests {
 	}
 
 	@Test
-	public void notEqualsWhenPayloadDiffersButInputMessageIsShared() {
-		Message<?> inputMessage = new GenericMessage<>("input");
-
-		AdviceMessage<String> one = new AdviceMessage<>("test1", inputMessage);
-		AdviceMessage<String> two = new AdviceMessage<>("test2", inputMessage);
+	void notEqualsWhenPayloadDiffersButInputMessageIsShared() {
+		AdviceMessage<String> one = new AdviceMessage<>("test1", INPUT_MESSAGE);
+		AdviceMessage<String> two = new AdviceMessage<>("test2", INPUT_MESSAGE);
 
 		assertThat(one).isNotEqualTo(two);
 	}
 
 	@Test
-	public void notEqualsWhenHeadersDifferButPayloadAndInputMessageAreShared() {
-		Message<?> inputMessage = new GenericMessage<>("input");
-
-		AdviceMessage<String> one = new AdviceMessage<>("test", Map.of("testHeader", "one"), inputMessage);
-		AdviceMessage<String> two = new AdviceMessage<>("test", Map.of("testHeader", "two"), inputMessage);
+	void notEqualsWhenHeadersDifferButPayloadAndInputMessageAreShared() {
+		AdviceMessage<String> one = new AdviceMessage<>("test", Map.of("testHeader", "one"), INPUT_MESSAGE);
+		AdviceMessage<String> two = new AdviceMessage<>("test", Map.of("testHeader", "two"), INPUT_MESSAGE);
 
 		assertThat(one).isNotEqualTo(two);
 	}
 
 	@Test
-	public void notEqualsPlainGenericMessage() {
-		Message<?> inputMessage = new GenericMessage<>("input");
-		MessageHeaders headers = new GenericMessage<>("ignored").getHeaders();
+	void notEqualsPlainGenericMessage() {
+		MessageHeaders headers = new MessageHeaders(null);
 
-		AdviceMessage<String> adviceMessage = new AdviceMessage<>("test", headers, inputMessage);
+		AdviceMessage<String> adviceMessage = new AdviceMessage<>("test", headers, INPUT_MESSAGE);
 		GenericMessage<String> genericMessage = new GenericMessage<>("test", headers);
 
 		assertThat(adviceMessage).isNotEqualTo(genericMessage);
 	}
 
 	@Test
-	public void notEqualsNullOrOtherType() {
+	void notEqualsNullOrOtherType() {
 		AdviceMessage<String> adviceMessage = new AdviceMessage<>("test", new GenericMessage<>("input"));
 
-		assertThat(adviceMessage).isNotEqualTo(null);
-		assertThat(adviceMessage).isNotEqualTo("test");
+		assertThat(adviceMessage).isNotEqualTo(null).isNotEqualTo("test");
 	}
 
 }

--- a/spring-integration-core/src/test/java/org/springframework/integration/message/AdviceMessageTests.java
+++ b/spring-integration-core/src/test/java/org/springframework/integration/message/AdviceMessageTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.message;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.support.GenericMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Alexander Makarov
+ */
+public class AdviceMessageTests {
+
+	@Test
+	public void equalsWhenPayloadHeadersAndInputMessageMatch() {
+		Message<?> inputMessage = new GenericMessage<>("input");
+		MessageHeaders headers = new GenericMessage<>("ignored").getHeaders();
+
+		AdviceMessage<String> one = new AdviceMessage<>("test", headers, inputMessage);
+		AdviceMessage<String> two = new AdviceMessage<>("test", headers, inputMessage);
+
+		assertThat(one).isEqualTo(two);
+		assertThat(one.hashCode()).isEqualTo(two.hashCode());
+	}
+
+	@Test
+	public void notEqualsWhenInputMessageDiffers() {
+		MessageHeaders headers = new GenericMessage<>("ignored").getHeaders();
+
+		AdviceMessage<String> one = new AdviceMessage<>("test", headers, new GenericMessage<>("input1"));
+		AdviceMessage<String> two = new AdviceMessage<>("test", headers, new GenericMessage<>("input2"));
+
+		assertThat(one).isNotEqualTo(two);
+	}
+
+	@Test
+	public void notEqualsWhenPayloadDiffersButInputMessageIsShared() {
+		Message<?> inputMessage = new GenericMessage<>("input");
+
+		AdviceMessage<String> one = new AdviceMessage<>("test1", inputMessage);
+		AdviceMessage<String> two = new AdviceMessage<>("test2", inputMessage);
+
+		assertThat(one).isNotEqualTo(two);
+	}
+
+	@Test
+	public void notEqualsWhenHeadersDifferButPayloadAndInputMessageAreShared() {
+		Message<?> inputMessage = new GenericMessage<>("input");
+
+		AdviceMessage<String> one = new AdviceMessage<>("test", Map.of("testHeader", "one"), inputMessage);
+		AdviceMessage<String> two = new AdviceMessage<>("test", Map.of("testHeader", "two"), inputMessage);
+
+		assertThat(one).isNotEqualTo(two);
+	}
+
+	@Test
+	public void notEqualsPlainGenericMessage() {
+		Message<?> inputMessage = new GenericMessage<>("input");
+		MessageHeaders headers = new GenericMessage<>("ignored").getHeaders();
+
+		AdviceMessage<String> adviceMessage = new AdviceMessage<>("test", headers, inputMessage);
+		GenericMessage<String> genericMessage = new GenericMessage<>("test", headers);
+
+		assertThat(adviceMessage).isNotEqualTo(genericMessage);
+	}
+
+	@Test
+	public void notEqualsNullOrOtherType() {
+		AdviceMessage<String> adviceMessage = new AdviceMessage<>("test", new GenericMessage<>("input"));
+
+		assertThat(adviceMessage).isNotEqualTo(null);
+		assertThat(adviceMessage).isNotEqualTo("test");
+	}
+
+}


### PR DESCRIPTION
`equals()` now requires the argument to be an `AdviceMessage`, delegates payload and headers to `super.equals()`, and then compares `inputMessage`. All three have to match, which keeps it consistent with the existing `hashCode()`. Also adds `AdviceMessageTests`, since `equals()` and `hashCode()` had no coverage at all, which is how this slipped through. Four of the six new tests fail against the current implementation.

Fixes #11377