### PR TITLE
Restart Apache Commons `Tailer` if its background thread dies

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/tail/ApacheCommonsFileTailingMessageProducer.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/tail/ApacheCommonsFileTailingMessageProducer.java
@@ -17,6 +17,8 @@
 package org.springframework.integration.file.tail;
 
 import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ScheduledFuture;
 
 import org.apache.commons.io.input.Tailer;
 import org.apache.commons.io.input.TailerListener;
@@ -43,6 +45,8 @@ public class ApacheCommonsFileTailingMessageProducer extends FileTailingMessageP
 	private boolean reopen = false;
 
 	private volatile @Nullable Tailer tailer;
+
+	private volatile @Nullable ScheduledFuture<?> restartFuture;
 
 	/**
 	 * The delay between checks of the file for new content in milliseconds.
@@ -87,6 +91,18 @@ public class ApacheCommonsFileTailingMessageProducer extends FileTailingMessageP
 	@Override
 	protected void doStart() {
 		super.doStart();
+		runTailer();
+	}
+
+	/**
+	 * Build and run a new {@link Tailer}, arranging for it to be restarted (after
+	 * {@link #getMissingFileDelay()}) should its background thread terminate while this
+	 * adapter is still active. The underlying {@code commons-io} {@link Tailer} can leave
+	 * its reader in a broken state and let the thread die if a file rotation is observed
+	 * concurrently with the replacement file being briefly absent; without a restart, such
+	 * an event would otherwise silently stop message production forever.
+	 */
+	private void runTailer() {
 		Tailer theTailer =
 				Tailer.builder()
 						.setDelayDuration(this.pollingDelay)
@@ -96,13 +112,25 @@ public class ApacheCommonsFileTailingMessageProducer extends FileTailingMessageP
 						.setTailerListener(this.tailerListener)
 						.setStartThread(false)
 						.get();
-		getTaskExecutor().execute(theTailer);
 		this.tailer = theTailer;
+		getTaskExecutor().execute(() -> {
+			theTailer.run();
+			if (isActive()) {
+				long missingFileDelay = getMissingFileDelay();
+				publish("Tailer thread has died; restarting in " + missingFileDelay + " milliseconds");
+				this.restartFuture =
+						getTaskScheduler().schedule(this::runTailer, Instant.now().plusMillis(missingFileDelay));
+			}
+		});
 	}
 
 	@Override
 	protected void doStop() {
 		super.doStop();
+		ScheduledFuture<?> restartFutureToCancel = this.restartFuture;
+		if (restartFutureToCancel != null) {
+			restartFutureToCancel.cancel(true);
+		}
 		Tailer tailerToClose = this.tailer;
 		if (tailerToClose != null) {
 			tailerToClose.close();

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.io.input.Tailer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.junit.jupiter.api.AfterEach;
@@ -182,6 +183,66 @@ public class FileTailingMessageProducerTests implements TestApplicationContextAw
 		assertThat(eventRaised).as("idle event did not emit").isTrue();
 		adapter.stop();
 		file.delete();
+		taskScheduler.destroy();
+	}
+
+	@Test
+	public void apacheTailerRestartsAfterUnderlyingThreadDies() throws Exception {
+		ApacheCommonsFileTailingMessageProducer adapter = new ApacheCommonsFileTailingMessageProducer();
+		adapter.setPollingDelay(50);
+		adapter.setEnd(false);
+		adapter.setTailAttemptsDelay(200);
+		this.adapter = adapter;
+		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+		taskScheduler.afterPropertiesSet();
+		adapter.setTaskScheduler(taskScheduler);
+		adapter.setApplicationEventPublisher(event -> logger.debug(event));
+		File file = new File(this.testDir, "diesAndRestarts");
+		file.delete();
+		adapter.setFile(file);
+		QueueChannel outputChannel = new QueueChannel();
+		adapter.setOutputChannel(outputChannel);
+		adapter.setBeanFactory(mock(BeanFactory.class));
+		adapter.afterPropertiesSet();
+		adapter.start();
+		waitForField(adapter, "tailer");
+
+		FileOutputStream fos = new FileOutputStream(file);
+		fos.write("hello0\n".getBytes());
+		fos.close();
+		Message<?> message = outputChannel.receive(10000);
+		assertThat(message).as("expected a non-null message").isNotNull();
+		assertThat(message.getPayload()).isEqualTo("hello0");
+
+		DirectFieldAccessor accessor = new DirectFieldAccessor(adapter);
+		Tailer diedTailer = (Tailer) accessor.getPropertyValue("tailer");
+		diedTailer.close();
+
+		int n = 0;
+		Tailer restartedTailer;
+		while (true) {
+			restartedTailer = (Tailer) accessor.getPropertyValue("tailer");
+			if (restartedTailer != diedTailer) {
+				break;
+			}
+			if (n++ > 100) {
+				fail("adapter did not restart the tailer after it died");
+			}
+			Thread.sleep(100);
+		}
+
+		fos = new FileOutputStream(file, true);
+		fos.write("hello1\n".getBytes());
+		fos.close();
+
+		message = outputChannel.receive(10000);
+		assertThat(message).as("expected the restarted tailer to replay the file from the start").isNotNull();
+		assertThat(message.getPayload()).isEqualTo("hello0");
+
+		message = outputChannel.receive(10000);
+		assertThat(message).as("expected a non-null message after restart").isNotNull();
+		assertThat(message.getPayload()).isEqualTo("hello1");
+
 		taskScheduler.destroy();
 	}
 

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/tail/FileTailingMessageProducerTests.java
@@ -196,7 +196,8 @@ public class FileTailingMessageProducerTests implements TestApplicationContextAw
 		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
 		taskScheduler.afterPropertiesSet();
 		adapter.setTaskScheduler(taskScheduler);
-		adapter.setApplicationEventPublisher(event -> logger.debug(event));
+		adapter.setApplicationEventPublisher(event -> {
+		});
 		File file = new File(this.testDir, "diesAndRestarts");
 		file.delete();
 		adapter.setFile(file);
@@ -211,7 +212,7 @@ public class FileTailingMessageProducerTests implements TestApplicationContextAw
 		fos.write("hello0\n".getBytes());
 		fos.close();
 		Message<?> message = outputChannel.receive(10000);
-		assertThat(message).as("expected a non-null message").isNotNull();
+		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isEqualTo("hello0");
 
 		DirectFieldAccessor accessor = new DirectFieldAccessor(adapter);
@@ -236,11 +237,11 @@ public class FileTailingMessageProducerTests implements TestApplicationContextAw
 		fos.close();
 
 		message = outputChannel.receive(10000);
-		assertThat(message).as("expected the restarted tailer to replay the file from the start").isNotNull();
+		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isEqualTo("hello0");
 
 		message = outputChannel.receive(10000);
-		assertThat(message).as("expected a non-null message after restart").isNotNull();
+		assertThat(message).isNotNull();
 		assertThat(message.getPayload()).isEqualTo("hello1");
 
 		taskScheduler.destroy();


### PR DESCRIPTION
## Problem

`ApacheCommonsFileTailingMessageProducer` schedules the `commons-io` `Tailer` on
a task executor and never checks on it again:

```java
Tailer theTailer = Tailer.builder()...get();
getTaskExecutor().execute(theTailer);
this.tailer = theTailer;
```

If the `Tailer`'s background thread terminates for *any* reason, the adapter
silently stops producing messages forever - there is no restart logic, unlike
`OSDelegatingFileTailingMessageProducer`, which already reschedules the native
`tail` process via `startProcessMonitor()` if it dies while the adapter is
still running.

## How this is triggered in practice

Reading `Tailer.run()` (`commons-io` 2.22.0) shows a real path to that silent
death, on ordinary log rotation:

```java
if (length < position) {
    // File was rotated
    listener.fileRotated();
    try (RandomAccessResourceBridge save = reader) {
        reader = tailable.getRandomAccess(RAF_READ_ONLY_MODE); // (1)
        ...
        position = 0;
    } catch (final FileNotFoundException e) {
        // in this case we continue to use the previous reader and position values
        listener.fileNotFound();
        ThreadUtils.sleep(delayDuration);
    }
    continue;
}
```

If the reopen at (1) throws `FileNotFoundException` - a normal window during
rotation, when the old file has been moved/removed but the replacement hasn't
been created yet - the comment claims the previous `reader` is still usable.
It isn't: the try-with-resources already closed it as `save` before the reopen
attempt failed, and `reader` still points at that closed handle. Once the
replacement file grows past the stale `position`, the next poll takes the
`length > position` branch and calls `readLines(reader)` on the closed
resource, which throws. `Tailer.run()`'s outer `catch (Exception e)` swallows
it (`listener.handle(e)`) and the method returns - the tailing thread is gone
for good, with only a published event (if the caller happens to be listening
for `FileTailingEvent`s) as a trace.

I could not reproduce this race on Windows locally, because `File.renameTo()`
returns `false` there while the `Tailer` holds an open read handle on the
source file, so the "file briefly absent" window this needs never occurs; the
originally reported failure came from a POSIX CI runner where rename-in-place
is unremarkable.

## Fix

* Wrap the `Tailer` execution so that, once `Tailer.run()` returns while this
  adapter `isActive()`, a brand new `Tailer` is built and its start is
  scheduled after `tailAttemptsDelay`, mirroring
  `OSDelegatingFileTailingMessageProducer`'s existing restart behavior.
* Track and cancel any pending restart in `doStop()`.
* Added `FileTailingMessageProducerTests#apacheTailerRestartsAfterUnderlyingThreadDies`,
  which kills the underlying `Tailer` directly (instead of trying to
  reproduce the OS-timing-dependent rotation race) and asserts that message
  production resumes afterward.

## Test plan

- [x] `./gradlew :spring-integration-file:test --tests "org.springframework.integration.file.tail.*"` - all green, repeated runs stable
- [x] `./gradlew :spring-integration-file:checkstyleMain :spring-integration-file:checkstyleTest`