### PR TITLE
Fix race in FileWritingMessageHandler stop() losing track of an in-flight flush

### DIFF
--- a/spring-integration-file/src/main/java/org/springframework/integration/file/outbound/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/outbound/FileWritingMessageHandler.java
@@ -829,14 +829,17 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 			if (appendNoFlush) {
 				String absolutePath = fileToWriteTo.getAbsolutePath();
 				state = this.fileStates.get(absolutePath);
-				if (state != null // NOSONAR
-						&& (state.closing
-								|| (isString && state.stream != null) || (!isString && state.writer != null))) {
+
+				if (state != null &&
+						(state.closing || (isString && state.stream != null) ||
+								(!isString && state.writer != null))) {
+
 					if (!state.closing) {
 						state.close();
 					}
 					state = null;
 				}
+
 				if (state == null) {
 					if (isString) {
 						state = new FileState(createWriter(fileToWriteTo, true),
@@ -933,9 +936,9 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 		try {
 			for (Entry<String, FileState> entry : this.fileStates.entrySet()) {
 				FileState state = entry.getValue();
-				if (!state.closing
-						&& flushPredicate.shouldFlush(entry.getKey(), state.firstWrite, state.lastWrite,
-								filterMessage)) {
+				if (!state.closing &&
+						flushPredicate.shouldFlush(entry.getKey(), state.firstWrite, state.lastWrite, filterMessage)) {
+
 					state.closing = true;
 					toRemove.put(entry.getKey(), state);
 				}
@@ -963,15 +966,16 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 		boolean interrupted = false;
 		for (Entry<String, FileState> entry : toRemove.entrySet()) {
 			FileState state = entry.getValue();
+			String key = entry.getKey();
 			if (!interrupted && state.close()) {
 				this.lock.lock();
 				try {
-					this.fileStates.remove(entry.getKey(), state);
+					this.fileStates.remove(key, state);
 				}
 				finally {
 					this.lock.unlock();
 				}
-				FileWritingMessageHandler.this.logger.debug(() -> "Flushed: " + entry.getKey());
+				FileWritingMessageHandler.this.logger.debug(() -> "Flushed: " + key);
 			}
 			else { // interrupted (stop); leave it in 'fileStates' to be retried
 				interrupted = true;
@@ -979,7 +983,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 			}
 		}
 		if (interrupted) {
-			FileWritingMessageHandler.this.logger.debug(() -> "Interrupted during flush");
+			FileWritingMessageHandler.this.logger.debug("Interrupted during flush");
 		}
 	}
 
@@ -1109,6 +1113,7 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 					FileState state = entry.getValue();
 					if (!state.closing && (state.lastWrite < expired ||
 							(!FileWritingMessageHandler.this.flushWhenIdle && state.firstWrite < expired))) {
+
 						state.closing = true;
 						toRemove.put(entry.getKey(), state);
 					}

--- a/spring-integration-file/src/main/java/org/springframework/integration/file/outbound/FileWritingMessageHandler.java
+++ b/spring-integration-file/src/main/java/org/springframework/integration/file/outbound/FileWritingMessageHandler.java
@@ -35,7 +35,6 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.time.Duration;
 import java.util.BitSet;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -831,10 +830,12 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 				String absolutePath = fileToWriteTo.getAbsolutePath();
 				state = this.fileStates.get(absolutePath);
 				if (state != null // NOSONAR
-						&& ((isString && state.stream != null) || (!isString && state.writer != null))) {
-					state.close();
+						&& (state.closing
+								|| (isString && state.stream != null) || (!isString && state.writer != null))) {
+					if (!state.closing) {
+						state.close();
+					}
 					state = null;
-					this.fileStates.remove(absolutePath);
 				}
 				if (state == null) {
 					if (isString) {
@@ -930,12 +931,12 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 		Map<String, FileState> toRemove = new HashMap<>();
 		this.lock.lock();
 		try {
-			Iterator<Entry<String, FileState>> iterator = this.fileStates.entrySet().iterator();
-			while (iterator.hasNext()) {
-				Entry<String, FileState> entry = iterator.next();
+			for (Entry<String, FileState> entry : this.fileStates.entrySet()) {
 				FileState state = entry.getValue();
-				if (flushPredicate.shouldFlush(entry.getKey(), state.firstWrite, state.lastWrite, filterMessage)) {
-					iterator.remove();
+				if (!state.closing
+						&& flushPredicate.shouldFlush(entry.getKey(), state.firstWrite, state.lastWrite,
+								filterMessage)) {
+					state.closing = true;
 					toRemove.put(entry.getKey(), state);
 				}
 			}
@@ -959,29 +960,26 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 	}
 
 	private void doFlush(Map<String, FileState> toRemove) {
-		Map<String, FileState> toRestore = new HashMap<>();
 		boolean interrupted = false;
 		for (Entry<String, FileState> entry : toRemove.entrySet()) {
-			if (!interrupted && entry.getValue().close()) {
+			FileState state = entry.getValue();
+			if (!interrupted && state.close()) {
+				this.lock.lock();
+				try {
+					this.fileStates.remove(entry.getKey(), state);
+				}
+				finally {
+					this.lock.unlock();
+				}
 				FileWritingMessageHandler.this.logger.debug(() -> "Flushed: " + entry.getKey());
 			}
-			else { // interrupted (stop), re-add
+			else { // interrupted (stop); leave it in 'fileStates' to be retried
 				interrupted = true;
-				toRestore.put(entry.getKey(), entry.getValue());
+				state.closing = false;
 			}
 		}
 		if (interrupted) {
-			FileWritingMessageHandler.this.logger.debug(() ->
-					"Interrupted during flush; not flushed: " + toRestore.keySet());
-			this.lock.lock();
-			try {
-				for (Entry<String, FileState> entry : toRestore.entrySet()) {
-					this.fileStates.putIfAbsent(entry.getKey(), entry.getValue());
-				}
-			}
-			finally {
-				this.lock.unlock();
-			}
+			FileWritingMessageHandler.this.logger.debug(() -> "Interrupted during flush");
 		}
 	}
 
@@ -1054,6 +1052,8 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 
 		private volatile long lastWrite;
 
+		private volatile boolean closing;
+
 		FileState(BufferedWriter writer, Lock lock) {
 			this.writer = writer;
 			this.stream = null;
@@ -1105,15 +1105,12 @@ public class FileWritingMessageHandler extends AbstractReplyProducingMessageHand
 			try {
 				long expired = FileWritingMessageHandler.this.flushTask == null ? Long.MAX_VALUE
 						: (System.currentTimeMillis() - FileWritingMessageHandler.this.flushInterval);
-				Iterator<Entry<String, FileState>> iterator =
-						FileWritingMessageHandler.this.fileStates.entrySet().iterator();
-				while (iterator.hasNext()) {
-					Entry<String, FileState> entry = iterator.next();
+				for (Entry<String, FileState> entry : FileWritingMessageHandler.this.fileStates.entrySet()) {
 					FileState state = entry.getValue();
-					if (state.lastWrite < expired ||
-							(!FileWritingMessageHandler.this.flushWhenIdle && state.firstWrite < expired)) {
+					if (!state.closing && (state.lastWrite < expired ||
+							(!FileWritingMessageHandler.this.flushWhenIdle && state.firstWrite < expired))) {
+						state.closing = true;
 						toRemove.put(entry.getKey(), state);
-						iterator.remove();
 					}
 				}
 			}

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
@@ -32,6 +32,7 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -618,6 +619,62 @@ public class FileWritingMessageHandlerTests implements TestApplicationContextAwa
 		assertThat(closeWhileWriting.get()).isFalse();
 		handler.stop();
 		taskScheduler.destroy();
+	}
+
+	@Test
+	public void fileStateNotRemovedUntilActuallyClosed() throws Exception {
+		File tempFolder = new File(tempDir, UUID.randomUUID().toString());
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		BufferedOutputStream out = spy(new BufferedOutputStream(baos));
+		FileWritingMessageHandler handler = new FileWritingMessageHandler(tempFolder) {
+
+			@Override
+			protected BufferedOutputStream createOutputStream(File fileToWriteTo, boolean append) {
+				return out;
+			}
+
+		};
+		handler.setFileExistsMode(FileExistsMode.APPEND_NO_FLUSH);
+		handler.setFileNameGenerator(message -> "foo.txt");
+		ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+		taskScheduler.afterPropertiesSet();
+		handler.setTaskScheduler(taskScheduler);
+		handler.setOutputChannel(new NullChannel());
+		handler.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		handler.setFlushInterval(30000);
+		handler.afterPropertiesSet();
+		handler.start();
+
+		handler.handleMessage(new GenericMessage<>("foo".getBytes()));
+
+		CountDownLatch closing = new CountDownLatch(1);
+		CountDownLatch proceedClose = new CountDownLatch(1);
+		willAnswer(invocation -> {
+			closing.countDown();
+			proceedClose.await(5, TimeUnit.SECONDS);
+			return null;
+		}).given(out).close();
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<?> flush = executor.submit(() -> handler.flushIfNeeded((path, first, last) -> true));
+
+			assertThat(closing.await(5, TimeUnit.SECONDS)).isTrue();
+			// The close() is in progress (blocked); the file must still be tracked as open
+			// so that a concurrent stop() does not consider the handler fully flushed.
+			assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "fileStates")).hasSize(1);
+
+			proceedClose.countDown();
+			flush.get(5, TimeUnit.SECONDS);
+
+			assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "fileStates")).isEmpty();
+			verify(out).close();
+		}
+		finally {
+			executor.shutdownNow();
+			handler.stop();
+			taskScheduler.destroy();
+		}
 	}
 
 	@Test

--- a/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
+++ b/spring-integration-file/src/test/java/org/springframework/integration/file/outbound/FileWritingMessageHandlerTests.java
@@ -662,12 +662,12 @@ public class FileWritingMessageHandlerTests implements TestApplicationContextAwa
 			assertThat(closing.await(5, TimeUnit.SECONDS)).isTrue();
 			// The close() is in progress (blocked); the file must still be tracked as open
 			// so that a concurrent stop() does not consider the handler fully flushed.
-			assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "fileStates")).hasSize(1);
+			assertThat((Map<?, ?>) TestUtils.getPropertyValue(handler, "fileStates")).hasSize(1);
 
 			proceedClose.countDown();
 			flush.get(5, TimeUnit.SECONDS);
 
-			assertThat(TestUtils.<Map<?, ?>>getPropertyValue(handler, "fileStates")).isEmpty();
+			assertThat((Map<?, ?>) TestUtils.getPropertyValue(handler, "fileStates")).isEmpty();
 			verify(out).close();
 		}
 		finally {
@@ -766,11 +766,12 @@ public class FileWritingMessageHandlerTests implements TestApplicationContextAwa
 		DefaultFileNameGenerator fileNameGenerator = new DefaultFileNameGenerator();
 		fileNameGenerator.setExpression("'base/../../../escaped.txt'");
 		handler.setFileNameGenerator(fileNameGenerator);
+		handler.setBeanFactory(mock());
 
 		assertThatExceptionOfType(MessagingException.class)
-			.isThrownBy(() -> handler.handleMessage(message))
-			.withStackTraceContaining("trying to leave the target output directory")
-			.withRootCauseInstanceOf(InvalidPathException.class);
+				.isThrownBy(() -> handler.handleMessage(message))
+				.withStackTraceContaining("trying to leave the target output directory")
+				.withRootCauseInstanceOf(InvalidPathException.class);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- `FileWritingMessageHandler`'s scheduled `Flusher` (for `FileExistsMode.APPEND_NO_FLUSH`) removed a `FileState` from `fileStates` *before* actually closing its underlying stream/writer.
- `stop()` uses `fileStates.isEmpty()` as its "fully flushed" signal, so a concurrently-running flush pass could make that signal go true before (or without ever) actually closing the file - most sharply when the scheduled flush thread is interrupted by `stop()`'s `cancel(true)` while acquiring the per-file lock. The stream is then never closed and the entry is lost from tracking, leaking an open file handle past `stop()` / scheduler shutdown.
- This is the same mechanism previously diagnosed (but never fully closed) against `noFlushAppend()` in #8212 / #8179 ("Race condition with stop() while Flusher is running"). It still reproduces on current `main`, now surfacing as an intermittent inability to delete the JUnit `@TempDir` on Windows because of the leaked handle.
- Fix: mark a `FileState` `closing` when selected for flush and keep it in `fileStates` until `close()` actually succeeds, only removing it then. `getFileState()` and the `flushIfNeeded()`/`trigger()` selection treat a `closing` state as unavailable, so a concurrent write creates a fresh state instead of racing the in-flight close, and an in-progress flush isn't selected a second time.

## Test plan
- [x] Added `FileWritingMessageHandlerTests.fileStateNotRemovedUntilActuallyClosed()` - verified it fails against the pre-fix code and passes with the fix.
- [x] `./gradlew :spring-integration-file:test` - full module green, run repeatedly with no flakes/hangs.