### PR TITLE
GH-11280: Make mail selector a CheckedFunction

### DIFF
--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/ImapIdleChannelAdapterSpec.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/ImapIdleChannelAdapterSpec.java
@@ -24,9 +24,9 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import jakarta.mail.Authenticator;
+import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import org.aopalliance.aop.Advice;
@@ -43,6 +43,7 @@ import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.PropertiesBuilder;
 import org.springframework.integration.transaction.TransactionInterceptorBuilder;
 import org.springframework.integration.transaction.TransactionSynchronizationFactory;
+import org.springframework.integration.util.CheckedFunction;
 import org.springframework.transaction.TransactionManager;
 import org.springframework.transaction.interceptor.TransactionInterceptor;
 import org.springframework.util.Assert;
@@ -53,6 +54,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Freya Nair
+ * @author Amlan Mishra
  *
  * @since 5.0
  */
@@ -112,15 +114,15 @@ public class ImapIdleChannelAdapterSpec
 	}
 
 	/**
-	 * Configure a {@link Function} to select messages. The argument for the function
+	 * Configure a {@link CheckedFunction} to select messages. The argument for the function
 	 * is a {@link jakarta.mail.internet.MimeMessage}; {@code apply} returns a boolean
 	 * result (true means select the message).
 	 * @param selectorFunction the selectorFunction.
 	 * @return the spec.
 	 * @see FunctionExpression
 	 */
-	public ImapIdleChannelAdapterSpec selector(Function<MimeMessage, Boolean> selectorFunction) {
-		return selectorExpression(new FunctionExpression<>(selectorFunction));
+	public ImapIdleChannelAdapterSpec selector(CheckedFunction<MimeMessage, Boolean, MessagingException> selectorFunction) {
+		return selectorExpression(new FunctionExpression<>(selectorFunction.unchecked()));
 	}
 
 	/**

--- a/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/MailInboundChannelAdapterSpec.java
+++ b/spring-integration-mail/src/main/java/org/springframework/integration/mail/dsl/MailInboundChannelAdapterSpec.java
@@ -20,9 +20,9 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Consumer;
-import java.util.function.Function;
 
 import jakarta.mail.Authenticator;
+import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
 import org.jspecify.annotations.Nullable;
@@ -35,6 +35,7 @@ import org.springframework.integration.mail.inbound.AbstractMailReceiver;
 import org.springframework.integration.mail.inbound.MailReceivingMessageSource;
 import org.springframework.integration.mapping.HeaderMapper;
 import org.springframework.integration.support.PropertiesBuilder;
+import org.springframework.integration.util.CheckedFunction;
 import org.springframework.util.Assert;
 
 /**
@@ -46,6 +47,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Amlan Mishra
  *
  * @since 5.0
  */
@@ -101,16 +103,16 @@ MailInboundChannelAdapterSpec<S extends MailInboundChannelAdapterSpec<S, R>, R e
 	}
 
 	/**
-	 * Configure a {@link Function} to select messages. The argument for the function
+	 * Configure a {@link CheckedFunction} to select messages. The argument for the function
 	 * is a {@link jakarta.mail.internet.MimeMessage}; {@code apply} returns a boolean
 	 * result (true means select the message).
 	 * @param selectorFunction the selectorFunction.
 	 * @return the spec.
 	 * @see FunctionExpression
 	 */
-	public S selector(Function<MimeMessage, Boolean> selectorFunction) {
+	public S selector(CheckedFunction<MimeMessage, Boolean, MessagingException> selectorFunction) {
 		assertReceiver();
-		this.receiver.setSelectorExpression(new FunctionExpression<>(selectorFunction));
+		this.receiver.setSelectorExpression(new FunctionExpression<>(selectorFunction.unchecked()));
 		return _this();
 	}
 

--- a/spring-integration-mail/src/test/java/org/springframework/integration/mail/dsl/MailTests.java
+++ b/spring-integration-mail/src/test/java/org/springframework/integration/mail/dsl/MailTests.java
@@ -237,6 +237,7 @@ public class MailTests {
 									.userFlag("testSIUserFlag")
 									.autoCloseFolder(false)
 									.simpleContent(true)
+									.selector(message -> message.getSubject().equals("Test Email"))
 									.javaMailProperties(p -> p.put("mail.debug", "false")),
 							e -> e.autoStartup(true)
 									.poller(p -> p.fixedDelay(1000)))
@@ -256,6 +257,7 @@ public class MailTests {
 									.put("mail.imap.connectionpoolsize", "5"))
 							.shouldReconnectAutomatically(false)
 							.simpleContent(true)
+							.selector(message -> message.getSubject().equals("Test Email"))
 							.headerMapper(mailHeaderMapper()))
 					.channel(MessageChannels.queue("imapIdleChannel"))
 					.get();


### PR DESCRIPTION
## Make mail selector accept `CheckedFunction`

### Summary

The mail DSL `selector()` methods previously accepted a regular `Function<MimeMessage, Boolean>`. This prevented selector functions from directly handling `MessagingException`.

Updated the mail selector to accept a `CheckedFunction<MimeMessage, Boolean, MessagingException>`, allowing checked `MessagingException` handling while preserving the existing selector behavior.

### Changes

* Updated the mail DSL selector to accept `CheckedFunction<MimeMessage, Boolean, MessagingException>`.
* Applied the same change to the IMAP and mail inbound adapter specifications.
* Updated the existing `MailTests` to configure function-based selectors for the IMAP and IMAP IDLE flows.
* Verified the changes with the full `spring-integration-mail` test suite.

Fixes #11280