### PR TITLE
GH-11269: Clear active flag before closing client NIO selector

### DIFF
--- a/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
+++ b/spring-integration-ip/src/main/java/org/springframework/integration/ip/tcp/connection/TcpNioClientConnectionFactory.java
@@ -44,6 +44,7 @@ import org.springframework.util.Assert;
  * @author Christian Tzolov
  * @author Ngoc Nhan
  * @author Jooyoung Pyoung
+ * @author Burak Kalayci
  *
  * @since 2.0
  *
@@ -171,6 +172,7 @@ public class TcpNioClientConnectionFactory extends
 
 	@Override
 	public void stop() {
+		setActive(false);
 		Selector selectorToClose = this.selector;
 		if (selectorToClose != null) {
 			try {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -49,6 +49,7 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor.AbortPolicy;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ServerSocketFactory;
@@ -92,6 +93,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.with;
+import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.BDDMockito.willReturn;
@@ -106,6 +108,7 @@ import static org.mockito.Mockito.when;
  * @author John Anderson
  * @author Artem Bilan
  * @author Glenn Renfro
+ * @author Burak Kalayci
  *
  * @since 2.0
  *
@@ -905,6 +908,33 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 		assertThat(delayReadLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(reeReference.get()).isNotNull();
 		threadPoolExecutor.shutdown();
+	}
+
+	@Test
+	public void stopClearsActiveFlagBeforeClosingSelector() throws IOException {
+		TcpNioClientConnectionFactory factory = new TcpNioClientConnectionFactory("localhost", 0);
+		factory.setApplicationEventPublisher(this.nullPublisher);
+		factory.start();
+		try {
+			await().atMost(Duration.ofSeconds(10))
+					.until(() -> TestUtils.getPropertyValue(factory, "selector") != null);
+			Selector realSelector = (Selector) new DirectFieldAccessor(factory).getPropertyValue("selector");
+			AtomicBoolean activeWhenSelectorClosed = new AtomicBoolean();
+			Selector trackingSelector = mock(Selector.class, delegatesTo(realSelector));
+			doAnswer(invocation -> {
+				activeWhenSelectorClosed.set(factory.isActive());
+				realSelector.close();
+				return null;
+			}).when(trackingSelector).close();
+			new DirectFieldAccessor(factory).setPropertyValue("selector", trackingSelector);
+			factory.stop();
+			assertThat(activeWhenSelectorClosed.get())
+					.as("active must be false before the NIO selector is closed on stop()")
+					.isFalse();
+		}
+		finally {
+			factory.stop();
+		}
 	}
 
 	private static void testMulti(boolean multiAccept) throws InterruptedException, IOException {

--- a/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
+++ b/spring-integration-ip/src/test/java/org/springframework/integration/ip/tcp/connection/TcpNioConnectionTests.java
@@ -93,7 +93,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.awaitility.Awaitility.await;
 import static org.awaitility.Awaitility.with;
-import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.BDDMockito.willReturn;
@@ -915,26 +914,20 @@ public class TcpNioConnectionTests implements TestApplicationContextAware {
 		TcpNioClientConnectionFactory factory = new TcpNioClientConnectionFactory("localhost", 0);
 		factory.setApplicationEventPublisher(this.nullPublisher);
 		factory.start();
-		try {
-			await().atMost(Duration.ofSeconds(10))
-					.until(() -> TestUtils.getPropertyValue(factory, "selector") != null);
-			Selector realSelector = (Selector) new DirectFieldAccessor(factory).getPropertyValue("selector");
-			AtomicBoolean activeWhenSelectorClosed = new AtomicBoolean();
-			Selector trackingSelector = mock(Selector.class, delegatesTo(realSelector));
-			doAnswer(invocation -> {
-				activeWhenSelectorClosed.set(factory.isActive());
-				realSelector.close();
-				return null;
-			}).when(trackingSelector).close();
-			new DirectFieldAccessor(factory).setPropertyValue("selector", trackingSelector);
-			factory.stop();
-			assertThat(activeWhenSelectorClosed.get())
-					.as("active must be false before the NIO selector is closed on stop()")
-					.isFalse();
-		}
-		finally {
-			factory.stop();
-		}
+		await().until(() -> TestUtils.getPropertyValue(factory, "selector") != null);
+		Selector realSelector = (Selector) TestUtils.getPropertyValue(factory, "selector");
+		AtomicBoolean activeWhenSelectorClosed = new AtomicBoolean();
+		Selector trackingSelector = spy(realSelector);
+		doAnswer(invocation -> {
+			activeWhenSelectorClosed.set(factory.isActive());
+			realSelector.close();
+			return null;
+		}).when(trackingSelector).close();
+		new DirectFieldAccessor(factory).setPropertyValue("selector", trackingSelector);
+		factory.stop();
+		assertThat(activeWhenSelectorClosed.get())
+				.as("active must be false before the NIO selector is closed on stop()")
+				.isFalse();
 	}
 
 	private static void testMulti(boolean multiAccept) throws InterruptedException, IOException {


### PR DESCRIPTION
TcpNioClientConnectionFactory.stop() closed the NIO selector before AbstractConnectionFactory.stop() flipped `active` to false. The selector thread is blocked in select(), so close() wakes it immediately and the ClosedSelectorException handler still sees isActive() == true, which logs ERROR \"Selector closed\" on every normal shutdown.

This marks the factory inactive first, then closes the selector, then calls super.stop(). Unexpected selector closes while the factory is still running continue to log at ERROR.

Fixes #11269

### Tests

- `./gradlew :spring-integration-ip:test --tests org.springframework.integration.ip.tcp.connection.TcpNioConnectionTests` — 21/21

- `./gradlew :spring-integration-ip:test` — 350 tests, 0 failures, 18 skipped

- `./gradlew :spring-integration-ip:checkstyleMain :spring-integration-ip:checkstyleTest`