### PR TITLE
Add Kafka share consumer channel adapter

### DIFF
--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/Kafka.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/Kafka.java
@@ -25,7 +25,9 @@ import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.core.ShareConsumerFactory;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
+import org.springframework.kafka.listener.AbstractShareKafkaMessageListenerContainer;
 import org.springframework.kafka.listener.ConsumerProperties;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.GenericMessageListenerContainer;
@@ -331,6 +333,60 @@ public final class Kafka {
 	}
 
 	/**
+	 * Create an initial {@link KafkaShareMessageDrivenChannelAdapterSpec} for a Kafka
+	 * share group (KIP-932 queue) consumer, from an already configured container. If
+	 * the listener container is not already a bean it will be registered in the
+	 * application context. If the adapter spec has an {@code id}, the bean name will be
+	 * that id appended with '.container'. Otherwise, the bean name will be generated
+	 * from the container class name.
+	 * @param shareListenerContainer the {@link AbstractShareKafkaMessageListenerContainer}.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
+	 * @return the KafkaShareMessageDrivenChannelAdapterSpec.
+	 */
+	public static <K, V> KafkaShareMessageDrivenChannelAdapterSpec<K, V, ?> shareMessageDrivenChannelAdapter(
+			AbstractShareKafkaMessageListenerContainer<K, V> shareListenerContainer) {
+
+		return new KafkaShareMessageDrivenChannelAdapterSpec<>(shareListenerContainer);
+	}
+
+	/**
+	 * Create an initial
+	 * {@link KafkaShareMessageDrivenChannelAdapterSpec.KafkaShareMessageDrivenChannelAdapterListenerContainerSpec}
+	 * for a Kafka share group (KIP-932 queue) consumer.
+	 * @param shareConsumerFactory the {@link ShareConsumerFactory}.
+	 * @param containerProperties the {@link ContainerProperties} to use.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
+	 * @return the KafkaShareMessageDrivenChannelAdapterSpec.KafkaShareMessageDrivenChannelAdapterListenerContainerSpec.
+	 */
+	public static <K, V>
+	KafkaShareMessageDrivenChannelAdapterSpec.KafkaShareMessageDrivenChannelAdapterListenerContainerSpec<K, V> shareMessageDrivenChannelAdapter(
+			ShareConsumerFactory<K, V> shareConsumerFactory, ContainerProperties containerProperties) {
+
+		return shareMessageDrivenChannelAdapter(
+				new KafkaShareMessageListenerContainerSpec<>(shareConsumerFactory, containerProperties));
+	}
+
+	/**
+	 * Create an initial
+	 * {@link KafkaShareMessageDrivenChannelAdapterSpec.KafkaShareMessageDrivenChannelAdapterListenerContainerSpec}
+	 * for a Kafka share group (KIP-932 queue) consumer.
+	 * @param shareConsumerFactory the {@link ShareConsumerFactory}.
+	 * @param topics the topics vararg.
+	 * @param <K> the Kafka message key type.
+	 * @param <V> the Kafka message value type.
+	 * @return the KafkaShareMessageDrivenChannelAdapterSpec.KafkaShareMessageDrivenChannelAdapterListenerContainerSpec.
+	 */
+	public static <K, V>
+	KafkaShareMessageDrivenChannelAdapterSpec.KafkaShareMessageDrivenChannelAdapterListenerContainerSpec<K, V> shareMessageDrivenChannelAdapter(
+			ShareConsumerFactory<K, V> shareConsumerFactory, String... topics) {
+
+		return shareMessageDrivenChannelAdapter(
+				new KafkaShareMessageListenerContainerSpec<>(shareConsumerFactory, topics));
+	}
+
+	/**
 	 * Create an initial {@link KafkaProducerMessageHandlerSpec}.
 	 * @param kafkaTemplate the {@link ReplyingKafkaTemplate} to use
 	 * @param <K> the Kafka message key type.
@@ -460,6 +516,14 @@ public final class Kafka {
 
 		return new KafkaMessageDrivenChannelAdapterSpec
 				.KafkaMessageDrivenChannelAdapterListenerContainerSpec<>(spec, listenerMode);
+	}
+
+	private static <K, V>
+	KafkaShareMessageDrivenChannelAdapterSpec.KafkaShareMessageDrivenChannelAdapterListenerContainerSpec<K, V> shareMessageDrivenChannelAdapter(
+			KafkaShareMessageListenerContainerSpec<K, V> spec) {
+
+		return new KafkaShareMessageDrivenChannelAdapterSpec
+				.KafkaShareMessageDrivenChannelAdapterListenerContainerSpec<>(spec);
 	}
 
 	private Kafka() {

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaShareMessageDrivenChannelAdapterSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaShareMessageDrivenChannelAdapterSpec.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.dsl;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.integration.dsl.ComponentsRegistration;
+import org.springframework.integration.dsl.MessageProducerSpec;
+import org.springframework.integration.kafka.inbound.KafkaShareMessageDrivenChannelAdapter;
+import org.springframework.kafka.listener.AbstractShareKafkaMessageListenerContainer;
+import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
+import org.springframework.kafka.support.converter.RecordMessageConverter;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link MessageProducerSpec} implementation for the
+ * {@link KafkaShareMessageDrivenChannelAdapter}.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ * @param <S> the target {@link KafkaShareMessageDrivenChannelAdapterSpec} implementation type.
+ *
+ * @author Artem Bilan
+ *
+ * @since 7.2
+ */
+public class KafkaShareMessageDrivenChannelAdapterSpec<K, V, S extends KafkaShareMessageDrivenChannelAdapterSpec<K, V, S>>
+		extends MessageProducerSpec<S, KafkaShareMessageDrivenChannelAdapter<K, V>>
+		implements ComponentsRegistration {
+
+	private final AbstractShareKafkaMessageListenerContainer<K, V> container;
+
+	KafkaShareMessageDrivenChannelAdapterSpec(AbstractShareKafkaMessageListenerContainer<K, V> shareListenerContainer) {
+		super(new KafkaShareMessageDrivenChannelAdapter<>(shareListenerContainer));
+		this.container = shareListenerContainer;
+	}
+
+	/**
+	 * Set the message converter to use.
+	 * @param messageConverter the converter.
+	 * @return the spec.
+	 */
+	public S recordMessageConverter(RecordMessageConverter messageConverter) {
+		this.target.setRecordMessageConverter(messageConverter);
+		return _this();
+	}
+
+	/**
+	 * Specify a {@link RecordFilterStrategy} to discard records before they are
+	 * converted and sent.
+	 * @param recordFilterStrategy the {@link RecordFilterStrategy} to use.
+	 * @return the spec.
+	 */
+	public S recordFilterStrategy(RecordFilterStrategy<K, V> recordFilterStrategy) {
+		this.target.setRecordFilterStrategy(recordFilterStrategy);
+		return _this();
+	}
+
+	/**
+	 * When using a type-aware message converter (such as {@code StringJsonMessageConverter}),
+	 * set the payload type the converter should create. Defaults to {@link Object}.
+	 * @param payloadType the type.
+	 * @return the spec.
+	 */
+	public S payloadType(Class<?> payloadType) {
+		this.target.setPayloadType(payloadType);
+		return _this();
+	}
+
+	/**
+	 * Set to true to bind the source consumer record in the header named
+	 * {@link org.springframework.integration.IntegrationMessageHeaderAccessor#SOURCE_DATA}.
+	 * @param bindSourceRecord true to bind.
+	 * @return the spec.
+	 */
+	public S bindSourceRecord(boolean bindSourceRecord) {
+		this.target.setBindSourceRecord(bindSourceRecord);
+		return _this();
+	}
+
+	@Override
+	public Map<Object, @Nullable String> getComponentsToRegister() {
+		return Collections.<Object, @Nullable String>singletonMap(
+				this.container, getId() == null ? null : getId() + ".container");
+	}
+
+	/**
+	 * A {@link org.springframework.kafka.listener.ShareKafkaMessageListenerContainer} configuration
+	 * {@link KafkaShareMessageDrivenChannelAdapterSpec} extension.
+	 * @param <K> the key type.
+	 * @param <V> the value type.
+	 */
+	public static class KafkaShareMessageDrivenChannelAdapterListenerContainerSpec<K, V> extends
+			KafkaShareMessageDrivenChannelAdapterSpec<K, V,
+					KafkaShareMessageDrivenChannelAdapterListenerContainerSpec<K, V>> {
+
+		private final KafkaShareMessageListenerContainerSpec<K, V> spec;
+
+		KafkaShareMessageDrivenChannelAdapterListenerContainerSpec(KafkaShareMessageListenerContainerSpec<K, V> spec) {
+			super(spec.getObject());
+			this.spec = spec;
+		}
+
+		/**
+		 * Configure a listener container by invoking the {@link Consumer} callback, with a
+		 * {@link KafkaShareMessageListenerContainerSpec} argument.
+		 * @param configurer the configurer Java 8 Lambda.
+		 * @return the spec.
+		 */
+		public KafkaShareMessageDrivenChannelAdapterListenerContainerSpec<K, V> configureListenerContainer(
+				Consumer<KafkaShareMessageListenerContainerSpec<K, V>> configurer) {
+
+			Assert.notNull(configurer, "The 'configurer' cannot be null");
+			configurer.accept(this.spec);
+			return _this();
+		}
+
+		@Override
+		public Map<Object, @Nullable String> getComponentsToRegister() {
+			return Collections.<Object, @Nullable String>singletonMap(this.spec.getObject(), this.spec.getId());
+		}
+
+	}
+
+}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaShareMessageListenerContainerSpec.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/dsl/KafkaShareMessageListenerContainerSpec.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.dsl;
+
+import java.time.Duration;
+
+import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
+
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.integration.dsl.IntegrationComponentSpec;
+import org.springframework.kafka.core.ShareConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.ShareConsumerRecordRecoverer;
+import org.springframework.kafka.listener.ShareKafkaMessageListenerContainer;
+
+/**
+ * A helper class in the Builder pattern style to delegate options to the
+ * {@link ShareKafkaMessageListenerContainer}.
+ * <p>
+ * Only options that the share consumer container actually honors are exposed here;
+ * unlike {@link KafkaMessageListenerContainerSpec}, options such as {@code ackMode},
+ * {@code pollTimeout}, {@code consumerRebalanceListener}, and {@code idleEventInterval}
+ * are not applicable to share consumers and are deliberately omitted.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Artem Bilan
+ *
+ * @since 7.2
+ */
+public class KafkaShareMessageListenerContainerSpec<K, V>
+		extends IntegrationComponentSpec<KafkaShareMessageListenerContainerSpec<K, V>,
+				ShareKafkaMessageListenerContainer<K, V>> {
+
+	KafkaShareMessageListenerContainerSpec(ShareConsumerFactory<K, V> shareConsumerFactory,
+			ContainerProperties containerProperties) {
+
+		this.target = new ShareKafkaMessageListenerContainer<>(shareConsumerFactory, containerProperties);
+	}
+
+	KafkaShareMessageListenerContainerSpec(ShareConsumerFactory<K, V> shareConsumerFactory, String... topics) {
+		this(shareConsumerFactory, new ContainerProperties(topics));
+	}
+
+	@Override
+	public KafkaShareMessageListenerContainerSpec<K, V> id(String id) {
+		return super.id(id);
+	}
+
+	/**
+	 * Specify the number of consumer threads to create within the container. Each
+	 * thread creates its own {@code ShareConsumer} instance and all of them
+	 * participate in the same share group.
+	 * @param concurrency the concurrency.
+	 * @return the spec.
+	 * @see ShareKafkaMessageListenerContainer#setConcurrency(int)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> concurrency(int concurrency) {
+		this.target.setConcurrency(concurrency);
+		return this;
+	}
+
+	/**
+	 * Set the {@code client.id} to use for the consumer(s).
+	 * @param clientId the client id.
+	 * @return the spec.
+	 * @see ShareKafkaMessageListenerContainer#setClientId(String)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> clientId(String clientId) {
+		this.target.setClientId(clientId);
+		return this;
+	}
+
+	/**
+	 * Set the group id for this container. Overrides any {@code group.id} property
+	 * provided by the consumer factory configuration.
+	 * @param groupId the group id.
+	 * @return the spec.
+	 * @see ContainerProperties#setGroupId(String)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> groupId(String groupId) {
+		this.target.getContainerProperties().setGroupId(groupId);
+		return this;
+	}
+
+	/**
+	 * Set the acknowledgment mode for the container.
+	 * @param shareAckMode the {@link ContainerProperties.ShareAckMode}; default
+	 * {@code EXPLICIT}.
+	 * @return the spec.
+	 * @see ContainerProperties#setShareAckMode(ContainerProperties.ShareAckMode)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> shareAckMode(ContainerProperties.ShareAckMode shareAckMode) {
+		this.target.getContainerProperties().setShareAckMode(shareAckMode);
+		return this;
+	}
+
+	/**
+	 * Set the timeout for detecting unacknowledged records in
+	 * {@link ContainerProperties.ShareAckMode#MANUAL} mode. Default 30 seconds.
+	 * @param shareAcknowledgmentTimeout the timeout.
+	 * @return the spec.
+	 * @see ContainerProperties#setShareAcknowledgmentTimeout(Duration)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> shareAcknowledgmentTimeout(
+			Duration shareAcknowledgmentTimeout) {
+
+		this.target.getContainerProperties().setShareAcknowledgmentTimeout(shareAcknowledgmentTimeout);
+		return this;
+	}
+
+	/**
+	 * Set whether to use {@code commitSync()} or {@code commitAsync()} for share
+	 * consumer acknowledgment commits. Default {@code true} (sync).
+	 * @param syncShareCommits true to use {@code commitSync()}.
+	 * @return the spec.
+	 * @see ContainerProperties#setSyncShareCommits(boolean)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> syncShareCommits(boolean syncShareCommits) {
+		this.target.getContainerProperties().setSyncShareCommits(syncShareCommits);
+		return this;
+	}
+
+	/**
+	 * Set the callback to be invoked when acknowledgement commits complete; useful
+	 * with {@link #syncShareCommits(boolean) syncShareCommits(false)} for visibility
+	 * into async commit success or failure.
+	 * @param acknowledgementCommitCallback the callback.
+	 * @return the spec.
+	 * @see ContainerProperties#setAcknowledgementCommitCallback(AcknowledgementCommitCallback)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> acknowledgementCommitCallback(
+			AcknowledgementCommitCallback acknowledgementCommitCallback) {
+
+		this.target.getContainerProperties().setAcknowledgementCommitCallback(acknowledgementCommitCallback);
+		return this;
+	}
+
+	/**
+	 * Set a {@link ShareConsumerRecordRecoverer} to use when a listener throws an
+	 * exception. The recoverer determines whether to accept, release, or reject the
+	 * failed record. Default: reject (archive, no redelivery).
+	 * @param shareConsumerRecordRecoverer the recoverer.
+	 * @return the spec.
+	 * @see ShareKafkaMessageListenerContainer#setShareConsumerRecordRecoverer(ShareConsumerRecordRecoverer)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> shareConsumerRecordRecoverer(
+			ShareConsumerRecordRecoverer shareConsumerRecordRecoverer) {
+
+		this.target.setShareConsumerRecordRecoverer(shareConsumerRecordRecoverer);
+		return this;
+	}
+
+	/**
+	 * Set the executor for threads that poll the consumer(s). Needs at least
+	 * {@link #concurrency(int) concurrency} threads.
+	 * @param consumerTaskExecutor the executor.
+	 * @return the spec.
+	 * @see ContainerProperties#setListenerTaskExecutor(AsyncTaskExecutor)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> listenerTaskExecutor(AsyncTaskExecutor consumerTaskExecutor) {
+		this.target.getContainerProperties().setListenerTaskExecutor(consumerTaskExecutor);
+		return this;
+	}
+
+	/**
+	 * Set the maximum time to wait for the consumer thread(s) to start.
+	 * @param consumerStartTimeout the timeout.
+	 * @return the spec.
+	 * @see ContainerProperties#setConsumerStartTimeout(Duration)
+	 */
+	public KafkaShareMessageListenerContainerSpec<K, V> consumerStartTimeout(Duration consumerStartTimeout) {
+		this.target.getContainerProperties().setConsumerStartTimeout(consumerStartTimeout);
+		return this;
+	}
+
+}

--- a/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaShareMessageDrivenChannelAdapter.java
+++ b/spring-integration-kafka/src/main/java/org/springframework/integration/kafka/inbound/KafkaShareMessageDrivenChannelAdapter.java
@@ -1,0 +1,366 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.inbound;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ShareConsumer;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.AttributeAccessor;
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.context.OrderlyShutdownCapable;
+import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.integration.kafka.support.RawRecordHeaderErrorMessageStrategy;
+import org.springframework.integration.support.ErrorMessageUtils;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.integration.support.json.JacksonMessagingUtils;
+import org.springframework.kafka.listener.AbstractShareKafkaMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.MessageListener;
+import org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter;
+import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
+import org.springframework.kafka.listener.adapter.ShareRecordMessagingMessageListenerAdapter;
+import org.springframework.kafka.support.JacksonPresent;
+import org.springframework.kafka.support.JsonKafkaHeaderMapper;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.ShareAcknowledgment;
+import org.springframework.kafka.support.converter.ConversionException;
+import org.springframework.kafka.support.converter.KafkaMessageHeaders;
+import org.springframework.kafka.support.converter.MessagingMessageConverter;
+import org.springframework.kafka.support.converter.RecordMessageConverter;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+
+/**
+ * Message-driven channel adapter for Kafka share groups (KIP-932 queues), backed by a
+ * {@link AbstractShareKafkaMessageListenerContainer}.
+ * <p>
+ * Share consumers support only explicit topics (no topic patterns or partition
+ * assignment), no batch listeners, and no consumer seeks; this adapter therefore has
+ * no {@code ListenerMode}, no {@code RecordFilterStrategy} ack-discard flag, no retry
+ * template, and does not implement {@code Pausable}.
+ * <p>
+ * The behavior depends on the container's {@link ContainerProperties.ShareAckMode}:
+ * <ul>
+ * <li>{@code EXPLICIT} (the default) and {@code IMPLICIT} - the listener receives no
+ * {@link ShareAcknowledgment}; the container itself sends {@code ACCEPT} after the flow
+ * returns normally, and consults the container's {@code ShareConsumerRecordRecoverer}
+ * (default: reject) when the flow throws.</li>
+ * <li>{@code MANUAL} - the {@link ShareAcknowledgment} is provided in the
+ * {@link KafkaHeaders#ACKNOWLEDGMENT} message header (together with the
+ * {@link KafkaHeaders#CONSUMER} header), and whichever flow receives the message is
+ * responsible for calling exactly one of {@code acknowledge()}, {@code release()}, or
+ * {@code reject()} on it. The container will not poll again - and will not stop -
+ * until every record from the current poll has been terminally acknowledged, so a flow
+ * that never acknowledges (or hands the message off without acknowledging) stalls the
+ * consumer thread permanently. This adapter acknowledges on the flow's behalf only when
+ * no flow ever received the message: it rejects a record that failed conversion, and
+ * accepts a record discarded by a {@link RecordFilterStrategy}.</li>
+ * </ul>
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Artem Bilan
+ *
+ * @since 7.2
+ *
+ * @see AbstractShareKafkaMessageListenerContainer
+ * @see ShareAcknowledgment
+ */
+public class KafkaShareMessageDrivenChannelAdapter<K, V> extends MessageProducerSupport
+		implements KafkaInboundEndpoint, OrderlyShutdownCapable {
+
+	private final AbstractShareKafkaMessageListenerContainer<K, V> shareListenerContainer;
+
+	private final IntegrationRecordMessageListener recordListener = new IntegrationRecordMessageListener();
+
+	private final IntegrationShareRecordMessageListener shareRecordListener =
+			new IntegrationShareRecordMessageListener();
+
+	private @Nullable RecordFilterStrategy<K, V> recordFilterStrategy;
+
+	private boolean bindSourceRecord;
+
+	/**
+	 * Construct an instance with the provided container.
+	 * @param shareListenerContainer the container.
+	 */
+	@SuppressWarnings({"this-escape", "removal"})
+	public KafkaShareMessageDrivenChannelAdapter(
+			AbstractShareKafkaMessageListenerContainer<K, V> shareListenerContainer) {
+
+		Assert.notNull(shareListenerContainer, "shareListenerContainer is required");
+		Assert.isNull(shareListenerContainer.getContainerProperties().getMessageListener(),
+				"Container must not already have a listener");
+		Assert.notNull(shareListenerContainer.getContainerProperties().getTopics(),
+				"Share consumers support only explicit topics; " +
+						"'topicPattern' and 'topicPartitions' are not supported");
+		this.shareListenerContainer = shareListenerContainer;
+		this.shareListenerContainer.setAutoStartup(false);
+		setErrorMessageStrategy(new RawRecordHeaderErrorMessageStrategy());
+
+		MessagingMessageConverter messageConverter = new MessagingMessageConverter();
+		// For consistency with the rest of Spring Integration channel adapters
+		messageConverter.setGenerateMessageId(true);
+		messageConverter.setGenerateTimestamp(true);
+
+		if (JacksonPresent.isJackson3Present()) {
+			JsonKafkaHeaderMapper headerMapper = new JsonKafkaHeaderMapper();
+			headerMapper.addTrustedPackages(
+					JacksonMessagingUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
+			messageConverter.setHeaderMapper(headerMapper);
+		}
+		else if (JacksonPresent.isJackson2Present()) {
+			var headerMapper = new org.springframework.kafka.support.DefaultKafkaHeaderMapper();
+			headerMapper.addTrustedPackages(
+					org.springframework.integration.support.json.JacksonJsonUtils.DEFAULT_TRUSTED_PACKAGES
+							.toArray(new String[0]));
+			messageConverter.setHeaderMapper(headerMapper);
+		}
+
+		this.recordListener.setMessageConverter(messageConverter);
+		this.shareRecordListener.setMessageConverter(messageConverter);
+	}
+
+	/**
+	 * Set the message converter to use.
+	 * @param messageConverter the converter.
+	 */
+	public void setRecordMessageConverter(RecordMessageConverter messageConverter) {
+		this.recordListener.setMessageConverter(messageConverter);
+		this.shareRecordListener.setMessageConverter(messageConverter);
+	}
+
+	/**
+	 * Specify a {@link RecordFilterStrategy} to discard records before they are
+	 * converted and sent. A discarded record is terminally acknowledged (accepted) by
+	 * this adapter when the container's {@link ContainerProperties.ShareAckMode} is
+	 * {@code MANUAL}.
+	 * @param recordFilterStrategy the {@link RecordFilterStrategy} to use.
+	 */
+	public void setRecordFilterStrategy(RecordFilterStrategy<K, V> recordFilterStrategy) {
+		this.recordFilterStrategy = recordFilterStrategy;
+	}
+
+	/**
+	 * When using a type-aware message converter such as {@code StringJsonMessageConverter},
+	 * set the payload type the converter should create. Defaults to {@link Object}.
+	 * @param payloadType the type.
+	 */
+	public void setPayloadType(Class<?> payloadType) {
+		this.recordListener.setFallbackType(payloadType);
+		this.shareRecordListener.setFallbackType(payloadType);
+	}
+
+	/**
+	 * Set to true to bind the source consumer record in the header named
+	 * {@link IntegrationMessageHeaderAccessor#SOURCE_DATA}.
+	 * @param bindSourceRecord true to bind.
+	 */
+	public void setBindSourceRecord(boolean bindSourceRecord) {
+		this.bindSourceRecord = bindSourceRecord;
+	}
+
+	@Override
+	public String getComponentType() {
+		return "kafka:share-message-driven-channel-adapter";
+	}
+
+	@Override
+	protected void onInit() {
+		super.onInit();
+
+		ContainerProperties containerProperties = this.shareListenerContainer.getContainerProperties();
+		if (ContainerProperties.ShareAckMode.MANUAL.equals(containerProperties.getShareAckMode())) {
+			if (getErrorChannel() != null) {
+				this.logger.warn(() -> "An 'errorChannel' is configured together with ShareAckMode.MANUAL. " +
+						"The error channel subscriber becomes responsible for terminally acknowledging " +
+						"the failed record's ShareAcknowledgment; otherwise the consumer thread stalls " +
+						"and the container cannot be stopped.");
+			}
+			containerProperties.setMessageListener(this.shareRecordListener);
+		}
+		else {
+			containerProperties.setMessageListener(this.recordListener);
+		}
+	}
+
+	@Override
+	protected void doStart() {
+		this.shareListenerContainer.start();
+	}
+
+	@Override
+	protected void doStop() {
+		this.shareListenerContainer.stop();
+	}
+
+	@Override
+	public int beforeShutdown() {
+		this.shareListenerContainer.stop();
+		return getPhase();
+	}
+
+	@Override
+	public int afterShutdown() {
+		return getPhase();
+	}
+
+	private void setAttributesIfNecessary(ConsumerRecord<K, V> record, @Nullable Message<?> message) {
+		if (getErrorChannel() != null) {
+			AttributeAccessor attributes = ATTRIBUTES_HOLDER.get();
+			if (attributes == null) {
+				attributes = ErrorMessageUtils.getAttributeAccessor(null, null);
+				ATTRIBUTES_HOLDER.set(attributes);
+			}
+			attributes.setAttribute(ErrorMessageUtils.INPUT_MESSAGE_CONTEXT_KEY, message);
+			attributes.setAttribute(KafkaHeaders.RAW_DATA, record);
+		}
+	}
+
+	@Override
+	protected AttributeAccessor getErrorMessageAttributes(@Nullable Message<?> message) {
+		AttributeAccessor attributes = ATTRIBUTES_HOLDER.get();
+		if (attributes == null) {
+			return super.getErrorMessageAttributes(message);
+		}
+		else {
+			return attributes;
+		}
+	}
+
+	private void doSendMessage(Message<?> message) {
+		try {
+			sendMessage(message);
+		}
+		finally {
+			ATTRIBUTES_HOLDER.remove();
+		}
+	}
+
+	private static void acknowledgeIfNecessary(@Nullable ShareAcknowledgment acknowledgment,
+			Consumer<ShareAcknowledgment> ackAction) {
+
+		if (acknowledgment != null) {
+			try {
+				ackAction.accept(acknowledgment);
+			}
+			catch (IllegalStateException ex) {
+				// already terminally acknowledged, presumably by a downstream flow
+			}
+		}
+	}
+
+	/**
+	 * Process a record delivered by either listener, converting it to a
+	 * {@link Message} and sending it, or terminally acknowledging it on the flow's
+	 * behalf when no flow ever receives it (filtered, or failed conversion).
+	 * @param record the record.
+	 * @param acknowledgment the acknowledgment, or {@code null} outside
+	 * {@code ShareAckMode.MANUAL}.
+	 * @param messageSupplier converts the record to a {@link Message}.
+	 */
+	private void sendRecord(ConsumerRecord<K, V> record, @Nullable ShareAcknowledgment acknowledgment,
+			Supplier<Message<?>> messageSupplier) {
+
+		RecordFilterStrategy<K, V> filter = this.recordFilterStrategy;
+		if (filter != null && filter.filter(record)) {
+			acknowledgeIfNecessary(acknowledgment, ShareAcknowledgment::acknowledge);
+			return;
+		}
+
+		Message<?> message;
+		try {
+			message = messageSupplier.get();
+		}
+		catch (RuntimeException ex) {
+			setAttributesIfNecessary(record, null);
+			RuntimeException exception = new ConversionException("Failed to convert to message", record, ex);
+			if (sendErrorMessageIfNecessary(null, exception)) {
+				acknowledgeIfNecessary(acknowledgment, ShareAcknowledgment::reject);
+				return;
+			}
+			else {
+				throw ex;
+			}
+		}
+
+		doSendMessage(enhanceHeadersAndSaveAttributes(message, record));
+	}
+
+	private Message<?> enhanceHeadersAndSaveAttributes(Message<?> message, ConsumerRecord<K, V> record) {
+		Supplier<Message<?>> messageSupplier = () -> message;
+		BiConsumer<String, Object> headersAcceptor;
+
+		if (message.getHeaders() instanceof KafkaMessageHeaders kafkaMessageHeaders) {
+			Map<String, Object> rawHeaders = kafkaMessageHeaders.getRawHeaders();
+			headersAcceptor = rawHeaders::put;
+		}
+		else {
+			MessageBuilder<?> builder = MessageBuilder.fromMessage(message);
+			headersAcceptor = builder::setHeader;
+			messageSupplier = builder::build;
+		}
+
+		if (this.bindSourceRecord) {
+			headersAcceptor.accept(IntegrationMessageHeaderAccessor.SOURCE_DATA, record);
+		}
+
+		Message<?> messageToReturn = messageSupplier.get();
+
+		setAttributesIfNecessary(record, messageToReturn);
+		return messageToReturn;
+	}
+
+	private class IntegrationShareRecordMessageListener
+			extends ShareRecordMessagingMessageListenerAdapter<K, V> {
+
+		IntegrationShareRecordMessageListener() {
+			super(null, null, null);
+		}
+
+		@Override
+		public void onShareRecord(ConsumerRecord<K, V> record,
+				@Nullable ShareAcknowledgment acknowledgment, @Nullable ShareConsumer<?, ?> consumer) {
+
+			sendRecord(record, acknowledgment, () -> toMessagingMessage(record, acknowledgment, consumer));
+		}
+
+	}
+
+	private class IntegrationRecordMessageListener extends MessagingMessageListenerAdapter<K, V>
+			implements MessageListener<K, V> {
+
+		IntegrationRecordMessageListener() {
+			super(null, null);
+		}
+
+		@Override
+		public void onMessage(ConsumerRecord<K, V> record) {
+			sendRecord(record, null, () -> toMessagingMessage(record, null, null));
+		}
+
+	}
+
+}

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaShareDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaShareDslTests.java
@@ -98,11 +98,11 @@ public class KafkaShareDslTests {
 			DefaultKafkaProducerFactory<String, String> producerFactory =
 					new DefaultKafkaProducerFactory<>(producerProps);
 			KafkaTemplate<String, String> template = new KafkaTemplate<>(producerFactory);
-			template.send(TEST_TOPIC, "key", "foo").get(10, TimeUnit.SECONDS);
+			template.send(TEST_TOPIC, "key", "test").get(10, TimeUnit.SECONDS);
 
 			Message<?> received = this.shareListeningResults.receive(30000);
 			assertThat(received).isNotNull();
-			assertThat(received.getPayload()).isEqualTo("FOO");
+			assertThat(received.getPayload()).isEqualTo("TEST");
 
 			assertThat(this.applicationContext.containsBean("shareContainer")).isTrue();
 			AbstractShareKafkaMessageListenerContainer<?, ?> container =

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaShareDslTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/dsl/KafkaShareDslTests.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.dsl;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.config.EnableIntegration;
+import org.springframework.integration.dsl.IntegrationFlow;
+import org.springframework.integration.kafka.inbound.KafkaShareMessageDrivenChannelAdapter;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.DefaultShareConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ShareConsumerFactory;
+import org.springframework.kafka.listener.AbstractShareKafkaMessageListenerContainer;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 7.2
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(
+		topics = KafkaShareDslTests.TEST_TOPIC,
+		partitions = 1,
+		brokerProperties = {
+				"share.coordinator.state.topic.replication.factor=1",
+				"share.coordinator.state.topic.min.isr=1"
+		})
+public class KafkaShareDslTests {
+
+	static final String TEST_TOPIC = "share-dsl-test-topic";
+
+	static final String GROUP_ID = "share-dsl-group";
+
+	@Value("${spring.kafka.bootstrap-servers}")
+	private String bootstrapServers;
+
+	@Autowired
+	private ConfigurableApplicationContext applicationContext;
+
+	@Autowired
+	private PollableChannel shareListeningResults;
+
+	@Test
+	void testShareMessageDrivenChannelAdapter() throws Exception {
+		setShareAutoOffsetResetEarliest();
+
+		KafkaShareMessageDrivenChannelAdapter<?, ?> adapter =
+				this.applicationContext.getBean(KafkaShareMessageDrivenChannelAdapter.class);
+		adapter.start();
+		try {
+			Map<String, Object> producerProps = new HashMap<>();
+			producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServers);
+			producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+			producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+			producerProps.put(ProducerConfig.LINGER_MS_CONFIG, 0);
+			DefaultKafkaProducerFactory<String, String> producerFactory =
+					new DefaultKafkaProducerFactory<>(producerProps);
+			KafkaTemplate<String, String> template = new KafkaTemplate<>(producerFactory);
+			template.send(TEST_TOPIC, "key", "foo").get(10, TimeUnit.SECONDS);
+
+			Message<?> received = this.shareListeningResults.receive(30000);
+			assertThat(received).isNotNull();
+			assertThat(received.getPayload()).isEqualTo("FOO");
+
+			assertThat(this.applicationContext.containsBean("shareContainer")).isTrue();
+			AbstractShareKafkaMessageListenerContainer<?, ?> container =
+					this.applicationContext.getBean("shareContainer", AbstractShareKafkaMessageListenerContainer.class);
+			assertThat(container.isAutoStartup()).isFalse();
+
+			producerFactory.destroy();
+		}
+		finally {
+			adapter.stop();
+		}
+	}
+
+	private void setShareAutoOffsetResetEarliest() throws Exception {
+		Map<String, Object> adminProperties = new HashMap<>();
+		adminProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServers);
+		ConfigEntry entry = new ConfigEntry("share.auto.offset.reset", "earliest");
+		AlterConfigOp op = new AlterConfigOp(entry, AlterConfigOp.OpType.SET);
+		Map<ConfigResource, Collection<AlterConfigOp>> configs =
+				Map.of(new ConfigResource(ConfigResource.Type.GROUP, GROUP_ID), List.of(op));
+		try (Admin admin = Admin.create(adminProperties)) {
+			admin.incrementalAlterConfigs(configs).all().get();
+		}
+	}
+
+	@Configuration
+	@EnableIntegration
+	public static class ContextConfiguration {
+
+		@Value("${spring.kafka.bootstrap-servers}")
+		private String embeddedKafkaBrokers;
+
+		@Bean
+		public ShareConsumerFactory<String, String> shareConsumerFactory() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, this.embeddedKafkaBrokers);
+			props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+			props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+			props.put(ConsumerConfig.GROUP_ID_CONFIG, GROUP_ID);
+			return new DefaultShareConsumerFactory<>(props);
+		}
+
+		@Bean
+		public IntegrationFlow shareListenerFromKafkaFlow() {
+			return IntegrationFlow
+					.from(Kafka.shareMessageDrivenChannelAdapter(shareConsumerFactory(), TEST_TOPIC)
+									.configureListenerContainer(c -> c.id("shareContainer").concurrency(1))
+									.autoStartup(false))
+					.<String, String>transform(String::toUpperCase)
+					.channel(c -> c.queue("shareListeningResults"))
+					.get();
+		}
+
+	}
+
+}

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/ShareMessageDrivenAdapterTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/ShareMessageDrivenAdapterTests.java
@@ -141,7 +141,7 @@ class ShareMessageDrivenAdapterTests implements TestApplicationContextAware {
 		adapter.afterPropertiesSet();
 		adapter.start();
 
-		produceRecords(embeddedKafka, EXPLICIT_TOPIC, "key0", "foo", "key1", "bar");
+		produceRecords(embeddedKafka, EXPLICIT_TOPIC, "key0", "value0", "key1", "value1");
 
 		Message<?> received1 = out.receive(20000);
 		Message<?> received2 = out.receive(20000);
@@ -177,7 +177,7 @@ class ShareMessageDrivenAdapterTests implements TestApplicationContextAware {
 		adapter.afterPropertiesSet();
 		adapter.start();
 
-		produceRecords(embeddedKafka, MANUAL_TOPIC, "key0", "foo", "key1", "bar", "key2", "baz");
+		produceRecords(embeddedKafka, MANUAL_TOPIC, "key0", "value0", "key1", "value1", "key2", "value2");
 
 		for (int i = 0; i < 3; i++) {
 			Message<?> received = out.receive(20000);
@@ -217,7 +217,7 @@ class ShareMessageDrivenAdapterTests implements TestApplicationContextAware {
 		adapter.afterPropertiesSet();
 		adapter.start();
 
-		produceRecords(embeddedKafka, MANUAL_ERROR_TOPIC, "key0", "foo", "key1", "bar");
+		produceRecords(embeddedKafka, MANUAL_ERROR_TOPIC, "key0", "value0", "key1", "value1");
 
 		Message<?> errorMessage = errorChannel.receive(20000);
 		assertThat(errorMessage).isInstanceOf(ErrorMessage.class);
@@ -271,7 +271,7 @@ class ShareMessageDrivenAdapterTests implements TestApplicationContextAware {
 		adapter.afterPropertiesSet();
 		adapter.start();
 
-		produceRecords(embeddedKafka, CONVERSION_ERROR_TOPIC, "key0", "foo");
+		produceRecords(embeddedKafka, CONVERSION_ERROR_TOPIC, "key0", "value0");
 
 		Message<?> error = errorChannel.receive(20000);
 		assertThat(error).isNotNull();
@@ -319,7 +319,7 @@ class ShareMessageDrivenAdapterTests implements TestApplicationContextAware {
 		adapter.afterPropertiesSet();
 		adapter.start();
 
-		produceRecords(embeddedKafka, CONVERSION_ERROR_NO_CHANNEL_TOPIC, "key0", "foo");
+		produceRecords(embeddedKafka, CONVERSION_ERROR_NO_CHANNEL_TOPIC, "key0", "value0");
 
 		assertThat(recovererLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(recovererAction.get()).isEqualTo(AcknowledgeType.REJECT);
@@ -371,18 +371,18 @@ class ShareMessageDrivenAdapterTests implements TestApplicationContextAware {
 		KafkaShareMessageDrivenChannelAdapter<String, String> adapter =
 				register(new KafkaShareMessageDrivenChannelAdapter<>(container));
 		adapter.setRecordMessageConverter(new StringJacksonJsonMessageConverter());
-		adapter.setPayloadType(Foo.class);
+		adapter.setPayloadType(TestPayload.class);
 		QueueChannel out = new QueueChannel();
 		adapter.setOutputChannel(out);
 		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
 		adapter.afterPropertiesSet();
 		adapter.start();
 
-		produceRecords(embeddedKafka, PAYLOAD_TYPE_TOPIC, "key0", "{\"bar\":\"baz\"}");
+		produceRecords(embeddedKafka, PAYLOAD_TYPE_TOPIC, "key0", "{\"value\":\"test\"}");
 
 		Message<?> received = out.receive(20000);
 		assertThat(received).isNotNull();
-		assertThat(received.getPayload()).isEqualTo(new Foo("baz"));
+		assertThat(received.getPayload()).isEqualTo(new TestPayload("test"));
 	}
 
 	@Test
@@ -402,7 +402,7 @@ class ShareMessageDrivenAdapterTests implements TestApplicationContextAware {
 		ShareConsumerFactory<String, String> consumerFactory = Mockito.mock();
 		AbstractShareKafkaMessageListenerContainer<String, String> container =
 				new ShareKafkaMessageListenerContainer<>(consumerFactory,
-						new ContainerProperties(Pattern.compile("foo.*")));
+						new ContainerProperties(Pattern.compile("share-.*")));
 
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> new KafkaShareMessageDrivenChannelAdapter<>(container))
@@ -462,7 +462,7 @@ class ShareMessageDrivenAdapterTests implements TestApplicationContextAware {
 		}
 	}
 
-	record Foo(String bar) {
+	record TestPayload(String value) {
 
 	}
 

--- a/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/ShareMessageDrivenAdapterTests.java
+++ b/spring-integration-kafka/src/test/java/org/springframework/integration/kafka/inbound/ShareMessageDrivenAdapterTests.java
@@ -1,0 +1,469 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.integration.kafka.inbound;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AlterConfigOp;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import org.springframework.integration.IntegrationMessageHeaderAccessor;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.test.support.TestApplicationContextAware;
+import org.springframework.kafka.core.DefaultShareConsumerFactory;
+import org.springframework.kafka.core.ShareConsumerFactory;
+import org.springframework.kafka.listener.AbstractShareKafkaMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.MessageListener;
+import org.springframework.kafka.listener.ShareKafkaMessageListenerContainer;
+import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.ShareAcknowledgment;
+import org.springframework.kafka.support.TopicPartitionOffset;
+import org.springframework.kafka.support.converter.ConversionException;
+import org.springframework.kafka.support.converter.RecordMessageConverter;
+import org.springframework.kafka.support.converter.StringJacksonJsonMessageConverter;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.ErrorMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * @author Artem Bilan
+ *
+ * @since 7.2
+ */
+@EmbeddedKafka(
+		topics = {
+				ShareMessageDrivenAdapterTests.EXPLICIT_TOPIC,
+				ShareMessageDrivenAdapterTests.MANUAL_TOPIC,
+				ShareMessageDrivenAdapterTests.MANUAL_ERROR_TOPIC,
+				ShareMessageDrivenAdapterTests.CONVERSION_ERROR_TOPIC,
+				ShareMessageDrivenAdapterTests.CONVERSION_ERROR_NO_CHANNEL_TOPIC,
+				ShareMessageDrivenAdapterTests.FILTER_TOPIC,
+				ShareMessageDrivenAdapterTests.PAYLOAD_TYPE_TOPIC
+		},
+		partitions = 1,
+		brokerProperties = {
+				"share.coordinator.state.topic.replication.factor=1",
+				"share.coordinator.state.topic.min.isr=1"
+		})
+class ShareMessageDrivenAdapterTests implements TestApplicationContextAware {
+
+	static final String EXPLICIT_TOPIC = "share-explicit-test";
+
+	static final String MANUAL_TOPIC = "share-manual-ack-test";
+
+	static final String MANUAL_ERROR_TOPIC = "share-manual-error-test";
+
+	static final String CONVERSION_ERROR_TOPIC = "share-conversion-error-test";
+
+	static final String CONVERSION_ERROR_NO_CHANNEL_TOPIC = "share-conversion-error-no-channel-test";
+
+	static final String FILTER_TOPIC = "share-filter-test";
+
+	static final String PAYLOAD_TYPE_TOPIC = "share-payload-type-test";
+
+	private final List<KafkaShareMessageDrivenChannelAdapter<?, ?>> adapters = new ArrayList<>();
+
+	/**
+	 * Register an adapter for an unconditional stop in {@link #stopAdapters()}.
+	 * The tests share a single embedded broker for the whole class, so an adapter left
+	 * running by a failed test keeps re-polling that broker and fails the rest of them.
+	 */
+	private <K, V> KafkaShareMessageDrivenChannelAdapter<K, V> register(
+			KafkaShareMessageDrivenChannelAdapter<K, V> adapter) {
+
+		this.adapters.add(adapter);
+		return adapter;
+	}
+
+	@AfterEach
+	void stopAdapters() {
+		this.adapters.forEach(KafkaShareMessageDrivenChannelAdapter::stop);
+		this.adapters.clear();
+	}
+
+	@Test
+	void testExplicitModeRecordDelivery(EmbeddedKafkaBroker embeddedKafka) throws Exception {
+		String groupId = "share-explicit-group";
+		setShareAutoOffsetResetEarliest(embeddedKafka, groupId);
+
+		ShareConsumerFactory<String, String> consumerFactory = shareConsumerFactory(embeddedKafka, groupId);
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(consumerFactory, new ContainerProperties(EXPLICIT_TOPIC));
+		KafkaShareMessageDrivenChannelAdapter<String, String> adapter =
+				register(new KafkaShareMessageDrivenChannelAdapter<>(container));
+		QueueChannel out = new QueueChannel();
+		adapter.setOutputChannel(out);
+		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		adapter.afterPropertiesSet();
+		adapter.start();
+
+		produceRecords(embeddedKafka, EXPLICIT_TOPIC, "key0", "foo", "key1", "bar");
+
+		Message<?> received1 = out.receive(20000);
+		Message<?> received2 = out.receive(20000);
+		assertThat(received1).isNotNull();
+		assertThat(received2).isNotNull();
+
+		// KafkaHeaders.GROUP_ID is not asserted here: it is populated via a thread-bound value that
+		// only the classic KafkaMessageListenerContainer sets (KafkaUtils.setConsumerGroupId());
+		// ShareKafkaMessageListenerContainer does not, so the header is inherently absent.
+		MessageHeaders headers = received1.getHeaders();
+		assertThat(headers)
+				.containsEntry(KafkaHeaders.RECEIVED_TOPIC, EXPLICIT_TOPIC)
+				.containsEntry(KafkaHeaders.RECEIVED_PARTITION, 0)
+				.containsKeys(MessageHeaders.ID, MessageHeaders.TIMESTAMP, KafkaHeaders.OFFSET)
+				.doesNotContainKeys(KafkaHeaders.ACKNOWLEDGMENT, KafkaHeaders.CONSUMER);
+	}
+
+	@Test
+	void testManualModeAcknowledgment(EmbeddedKafkaBroker embeddedKafka) throws Exception {
+		String groupId = "share-manual-ack-group";
+		setShareAutoOffsetResetEarliest(embeddedKafka, groupId);
+
+		ContainerProperties containerProperties = new ContainerProperties(MANUAL_TOPIC);
+		containerProperties.setShareAckMode(ContainerProperties.ShareAckMode.MANUAL);
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(shareConsumerFactory(embeddedKafka, groupId),
+						containerProperties);
+		KafkaShareMessageDrivenChannelAdapter<String, String> adapter =
+				register(new KafkaShareMessageDrivenChannelAdapter<>(container));
+		QueueChannel out = new QueueChannel();
+		adapter.setOutputChannel(out);
+		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		adapter.afterPropertiesSet();
+		adapter.start();
+
+		produceRecords(embeddedKafka, MANUAL_TOPIC, "key0", "foo", "key1", "bar", "key2", "baz");
+
+		for (int i = 0; i < 3; i++) {
+			Message<?> received = out.receive(20000);
+			assertThat(received).isNotNull();
+			Object consumer = received.getHeaders().get(KafkaHeaders.CONSUMER);
+			assertThat(consumer).isNotNull();
+			Object acknowledgment = received.getHeaders().get(KafkaHeaders.ACKNOWLEDGMENT);
+			assertThat(acknowledgment).isInstanceOf(ShareAcknowledgment.class);
+			((ShareAcknowledgment) acknowledgment).acknowledge();
+		}
+	}
+
+	@Test
+	void testManualModeErrorChannelOwnsAck(EmbeddedKafkaBroker embeddedKafka) throws Exception {
+		String groupId = "share-manual-error-group";
+		setShareAutoOffsetResetEarliest(embeddedKafka, groupId);
+
+		ContainerProperties containerProperties = new ContainerProperties(MANUAL_ERROR_TOPIC);
+		containerProperties.setShareAckMode(ContainerProperties.ShareAckMode.MANUAL);
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(shareConsumerFactory(embeddedKafka, groupId),
+						containerProperties);
+		KafkaShareMessageDrivenChannelAdapter<String, String> adapter =
+				register(new KafkaShareMessageDrivenChannelAdapter<>(container));
+		QueueChannel out = new QueueChannel() {
+
+			@Override
+			protected boolean doSend(Message<?> message, long timeout) {
+				throw new RuntimeException("intended");
+			}
+
+		};
+		adapter.setOutputChannel(out);
+		QueueChannel errorChannel = new QueueChannel();
+		adapter.setErrorChannel(errorChannel);
+		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		adapter.afterPropertiesSet();
+		adapter.start();
+
+		produceRecords(embeddedKafka, MANUAL_ERROR_TOPIC, "key0", "foo", "key1", "bar");
+
+		Message<?> errorMessage = errorChannel.receive(20000);
+		assertThat(errorMessage).isInstanceOf(ErrorMessage.class);
+		assertThat(errorMessage.getHeaders().get(KafkaHeaders.RAW_DATA)).isInstanceOf(ConsumerRecord.class);
+		Message<?> originalMessage = ((ErrorMessage) errorMessage).getOriginalMessage();
+		assertThat(originalMessage).isNotNull();
+		Object acknowledgment = originalMessage.getHeaders().get(KafkaHeaders.ACKNOWLEDGMENT);
+		assertThat(acknowledgment).isInstanceOf(ShareAcknowledgment.class);
+
+		// The error channel subscriber owns the acknowledgment for the failed record.
+		((ShareAcknowledgment) acknowledgment).reject();
+
+		// A second record is still delivered, proving the poll loop was not stalled.
+		Message<?> secondMessage = errorChannel.receive(20000);
+		assertThat(secondMessage).isNotNull();
+		Message<?> secondOriginal = ((ErrorMessage) secondMessage).getOriginalMessage();
+		assertThat(secondOriginal).isNotNull();
+		((ShareAcknowledgment) secondOriginal.getHeaders().get(KafkaHeaders.ACKNOWLEDGMENT)).reject();
+	}
+
+	@Test
+	void testConversionErrorGoesToErrorChannel(EmbeddedKafkaBroker embeddedKafka) throws Exception {
+		String groupId = "share-conversion-error-group";
+		setShareAutoOffsetResetEarliest(embeddedKafka, groupId);
+
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(shareConsumerFactory(embeddedKafka, groupId),
+						new ContainerProperties(CONVERSION_ERROR_TOPIC));
+		KafkaShareMessageDrivenChannelAdapter<String, String> adapter =
+				register(new KafkaShareMessageDrivenChannelAdapter<>(container));
+		adapter.setRecordMessageConverter(new RecordMessageConverter() {
+
+			@Override
+			public Message<?> toMessage(ConsumerRecord<?, ?> record, Object acknowledgment, Object consumer,
+					Type type) {
+
+				throw new RuntimeException("testError");
+			}
+
+			@Override
+			public ProducerRecord<?, ?> fromMessage(Message<?> message, String defaultTopic) {
+				return null;
+			}
+
+		});
+		QueueChannel out = new QueueChannel();
+		adapter.setOutputChannel(out);
+		PollableChannel errorChannel = new QueueChannel();
+		adapter.setErrorChannel(errorChannel);
+		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		adapter.afterPropertiesSet();
+		adapter.start();
+
+		produceRecords(embeddedKafka, CONVERSION_ERROR_TOPIC, "key0", "foo");
+
+		Message<?> error = errorChannel.receive(20000);
+		assertThat(error).isNotNull();
+		assertThat(error.getPayload()).isInstanceOf(ConversionException.class);
+		ConversionException conversionException = (ConversionException) error.getPayload();
+		assertThat(conversionException.getMessage()).contains("Failed to convert to message");
+		assertThat(conversionException.getRecord()).isNotNull();
+	}
+
+	@Test
+	void testConversionErrorWithoutErrorChannelIsRejected(EmbeddedKafkaBroker embeddedKafka) throws Exception {
+		String groupId = "share-conversion-error-no-channel-group";
+		setShareAutoOffsetResetEarliest(embeddedKafka, groupId);
+
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(shareConsumerFactory(embeddedKafka, groupId),
+						new ContainerProperties(CONVERSION_ERROR_NO_CHANNEL_TOPIC));
+		CountDownLatch recovererLatch = new CountDownLatch(1);
+		AtomicReference<AcknowledgeType> recovererAction = new AtomicReference<>();
+		container.setShareConsumerRecordRecoverer((record, ex) -> {
+			recovererAction.set(AcknowledgeType.REJECT);
+			recovererLatch.countDown();
+			return AcknowledgeType.REJECT;
+		});
+		KafkaShareMessageDrivenChannelAdapter<String, String> adapter =
+				register(new KafkaShareMessageDrivenChannelAdapter<>(container));
+		adapter.setRecordMessageConverter(new RecordMessageConverter() {
+
+			@Override
+			public Message<?> toMessage(ConsumerRecord<?, ?> record, Object acknowledgment, Object consumer,
+					Type type) {
+
+				throw new RuntimeException("testError");
+			}
+
+			@Override
+			public ProducerRecord<?, ?> fromMessage(Message<?> message, String defaultTopic) {
+				return null;
+			}
+
+		});
+		QueueChannel out = new QueueChannel();
+		adapter.setOutputChannel(out);
+		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		adapter.afterPropertiesSet();
+		adapter.start();
+
+		produceRecords(embeddedKafka, CONVERSION_ERROR_NO_CHANNEL_TOPIC, "key0", "foo");
+
+		assertThat(recovererLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(recovererAction.get()).isEqualTo(AcknowledgeType.REJECT);
+	}
+
+	@Test
+	void testRecordFilterStrategyAndBindSourceRecord(EmbeddedKafkaBroker embeddedKafka) throws Exception {
+		String groupId = "share-filter-group";
+		setShareAutoOffsetResetEarliest(embeddedKafka, groupId);
+
+		ContainerProperties containerProperties = new ContainerProperties(FILTER_TOPIC);
+		containerProperties.setShareAckMode(ContainerProperties.ShareAckMode.MANUAL);
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(shareConsumerFactory(embeddedKafka, groupId),
+						containerProperties);
+		KafkaShareMessageDrivenChannelAdapter<String, String> adapter =
+				register(new KafkaShareMessageDrivenChannelAdapter<>(container));
+		adapter.setRecordFilterStrategy((RecordFilterStrategy<String, String>) record ->
+				Integer.parseInt(record.key()) % 2 != 0);
+		adapter.setBindSourceRecord(true);
+		QueueChannel out = new QueueChannel();
+		adapter.setOutputChannel(out);
+		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		adapter.afterPropertiesSet();
+		adapter.start();
+
+		produceRecords(embeddedKafka, FILTER_TOPIC, "0", "v0", "1", "v1", "2", "v2", "3", "v3");
+
+		for (int i = 0; i < 2; i++) {
+			Message<?> received = out.receive(20000);
+			assertThat(received).isNotNull();
+			assertThat(received.getHeaders().get(KafkaHeaders.RECEIVED_KEY)).isIn("0", "2");
+			assertThat(received.getHeaders().get(IntegrationMessageHeaderAccessor.SOURCE_DATA))
+					.isInstanceOf(ConsumerRecord.class);
+			Object acknowledgment = received.getHeaders().get(KafkaHeaders.ACKNOWLEDGMENT);
+			((ShareAcknowledgment) acknowledgment).acknowledge();
+		}
+		assertThat(out.receive(1000)).isNull();
+	}
+
+	@Test
+	void testPayloadType(EmbeddedKafkaBroker embeddedKafka) throws Exception {
+		String groupId = "share-payload-type-group";
+		setShareAutoOffsetResetEarliest(embeddedKafka, groupId);
+
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(shareConsumerFactory(embeddedKafka, groupId),
+						new ContainerProperties(PAYLOAD_TYPE_TOPIC));
+		KafkaShareMessageDrivenChannelAdapter<String, String> adapter =
+				register(new KafkaShareMessageDrivenChannelAdapter<>(container));
+		adapter.setRecordMessageConverter(new StringJacksonJsonMessageConverter());
+		adapter.setPayloadType(Foo.class);
+		QueueChannel out = new QueueChannel();
+		adapter.setOutputChannel(out);
+		adapter.setBeanFactory(TEST_INTEGRATION_CONTEXT);
+		adapter.afterPropertiesSet();
+		adapter.start();
+
+		produceRecords(embeddedKafka, PAYLOAD_TYPE_TOPIC, "key0", "{\"bar\":\"baz\"}");
+
+		Message<?> received = out.receive(20000);
+		assertThat(received).isNotNull();
+		assertThat(received.getPayload()).isEqualTo(new Foo("baz"));
+	}
+
+	@Test
+	void testConstructorRejectsContainerThatAlreadyHasAListener() {
+		ShareConsumerFactory<String, String> consumerFactory = Mockito.mock();
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(consumerFactory, new ContainerProperties(EXPLICIT_TOPIC));
+		container.getContainerProperties().setMessageListener((MessageListener<String, String>) record -> { });
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new KafkaShareMessageDrivenChannelAdapter<>(container))
+				.withMessageContaining("Container must not already have a listener");
+	}
+
+	@Test
+	void testConstructorRejectsTopicPattern() {
+		ShareConsumerFactory<String, String> consumerFactory = Mockito.mock();
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(consumerFactory,
+						new ContainerProperties(Pattern.compile("foo.*")));
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new KafkaShareMessageDrivenChannelAdapter<>(container))
+				.withMessageContaining("Share consumers support only explicit topics");
+	}
+
+	@Test
+	void testConstructorRejectsTopicPartitions() {
+		ShareConsumerFactory<String, String> consumerFactory = Mockito.mock();
+		AbstractShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(consumerFactory,
+						new ContainerProperties(new TopicPartitionOffset(EXPLICIT_TOPIC, 0)));
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new KafkaShareMessageDrivenChannelAdapter<>(container))
+				.withMessageContaining("Share consumers support only explicit topics");
+	}
+
+	private static ShareConsumerFactory<String, String> shareConsumerFactory(EmbeddedKafkaBroker embeddedKafka,
+			String groupId) {
+
+		Map<String, Object> consumerProps = new HashMap<>();
+		consumerProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, embeddedKafka.getBrokersAsString());
+		consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+		consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+		return new DefaultShareConsumerFactory<>(consumerProps);
+	}
+
+	private static void produceRecords(EmbeddedKafkaBroker embeddedKafka, String topic, String... keysAndValues)
+			throws Exception {
+
+		Map<String, Object> producerProps = new HashMap<>();
+		producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, embeddedKafka.getBrokersAsString());
+		producerProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		producerProps.put(ProducerConfig.LINGER_MS_CONFIG, 0);
+		try (KafkaProducer<String, String> producer = new KafkaProducer<>(producerProps)) {
+			for (int i = 0; i < keysAndValues.length; i += 2) {
+				producer.send(new ProducerRecord<>(topic, keysAndValues[i], keysAndValues[i + 1])).get();
+			}
+		}
+	}
+
+	private static void setShareAutoOffsetResetEarliest(EmbeddedKafkaBroker embeddedKafka, String groupId)
+			throws Exception {
+
+		String bootstrapServers = embeddedKafka.getBrokersAsString();
+		Map<String, Object> adminProperties = new HashMap<>();
+		adminProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		ConfigEntry entry = new ConfigEntry("share.auto.offset.reset", "earliest");
+		AlterConfigOp op = new AlterConfigOp(entry, AlterConfigOp.OpType.SET);
+		Map<ConfigResource, Collection<AlterConfigOp>> configs =
+				Map.of(new ConfigResource(ConfigResource.Type.GROUP, groupId), List.of(op));
+		try (Admin admin = Admin.create(adminProperties)) {
+			admin.incrementalAlterConfigs(configs).all().get();
+		}
+	}
+
+	record Foo(String bar) {
+
+	}
+
+}

--- a/src/reference/antora/modules/ROOT/pages/kafka.adoc
+++ b/src/reference/antora/modules/ROOT/pages/kafka.adoc
@@ -358,6 +358,104 @@ Notice that, in this case, the adapter is given an `id` (`topic2Adapter`).
 The container is registered in the application context with a name of `topic2Adapter.container`.
 If the adapter does not have an `id` property, the container's bean name is the container's fully qualified class name plus `#n`, where `n` is incremented for each container.
 
+[[kafka-share-inbound]]
+== Message-driven Channel Adapter for Share Groups
+
+Apache Kafka's share groups (https://cwiki.apache.org/confluence/display/KAFKA/KIP-932%3A+Queues+for+Kafka[KIP-932], "queues for Kafka") let several consumers cooperatively process records from the same partitions, with the broker distributing individual records rather than whole partitions.
+See the https://docs.spring.io/spring-kafka/reference/kafka/kafka-queues.html[Kafka Queues chapter] of the Spring for Apache Kafka reference for background.
+
+The `KafkaShareMessageDrivenChannelAdapter` (`org.springframework.integration.kafka.inbound.KafkaShareMessageDrivenChannelAdapter`) is the share-group counterpart of `KafkaMessageDrivenChannelAdapter`.
+It is built from a `spring-kafka` `ShareKafkaMessageListenerContainer` (a subclass of `AbstractShareKafkaMessageListenerContainer`) rather than an `AbstractMessageListenerContainer`, and it is a distinct component because the two container hierarchies are not interchangeable: share consumer containers support only explicit topics (no topic patterns, no partition assignment), no batch listeners, no consumer seeks, and no `CommonErrorHandler`.
+Consequently, this adapter has no `mode` (record only), no `RecordFilterStrategy` ack-discard flag, no retry template, and does not support pause/resume.
+
+IMPORTANT: A share consumer container must be constructed with explicit topics.
+Building one from a `Pattern` or a `TopicPartitionOffset` results in an `IllegalArgumentException` when the adapter is constructed, since the underlying Kafka `ShareConsumer` client supports only `subscribe(Collection<String>)`.
+
+=== Acknowledgment Modes
+
+The container's `ContainerProperties.ShareAckMode` determines how a delivered record is acknowledged:
+
+* `EXPLICIT` (the default) and `IMPLICIT` - the listener receives no acknowledgment handle.
+The container itself sends `ACCEPT` after the flow returns normally, and consults the container's `ShareConsumerRecordRecoverer` (default: reject, i.e. archive with no redelivery) when the flow throws.
+* `MANUAL` - the `ShareAcknowledgment` is provided in the `KafkaHeaders.ACKNOWLEDGMENT` message header (together with the `ShareConsumer` in `KafkaHeaders.CONSUMER`), and *whichever flow receives the message is responsible for calling exactly one of* `acknowledge()`, `release()`, or `reject()` on it.
+
+IMPORTANT: In `MANUAL` mode, the container will not poll again - and will not stop - until every record from the current poll has been terminally acknowledged.
+A flow that never acknowledges (or that hands the message off asynchronously without acknowledging) stalls the consumer thread permanently and prevents the adapter from stopping.
+If an error channel is configured, the error channel subscriber becomes responsible for acknowledging the failed record; the adapter itself acknowledges on the flow's behalf only in the two cases where no flow ever receives the message: it rejects a record that failed conversion, and it accepts a record discarded by a `RecordFilterStrategy`.
+
+Because the acknowledgment and consumer headers exist only to support `MANUAL` mode, they are absent from messages produced in `EXPLICIT` and `IMPLICIT` mode.
+
+[[kafka-share-inbound-configuration]]
+=== Configuration
+
+The following example shows how to configure a share-group message-driven channel adapter:
+
+[tabs]
+======
+Java DSL::
++
+[source, java, role="primary"]
+----
+@Bean
+public IntegrationFlow shareListenerFromKafkaFlow() {
+    return IntegrationFlow
+            .from(Kafka.shareMessageDrivenChannelAdapter(shareConsumerFactory(), "someTopic")
+                    .configureListenerContainer(c -> c
+                            .shareAckMode(ContainerProperties.ShareAckMode.MANUAL)
+                            .concurrency(3)
+                            .id("someTopicContainer")))
+            .handle(m -> {
+                ShareAcknowledgment ack = m.getHeaders().get(KafkaHeaders.ACKNOWLEDGMENT, ShareAcknowledgment.class);
+                // process the payload...
+                ack.acknowledge();
+            })
+            .get();
+}
+
+@Bean
+public ShareConsumerFactory<String, String> shareConsumerFactory() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddress);
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, "someGroup");
+    // set more properties
+    return new DefaultShareConsumerFactory<>(props);
+}
+----
+
+Java::
++
+[source, java, role="secondary"]
+----
+@Bean
+public KafkaShareMessageDrivenChannelAdapter<String, String>
+            adapter(ShareKafkaMessageListenerContainer<String, String> container) {
+    KafkaShareMessageDrivenChannelAdapter<String, String> adapter =
+            new KafkaShareMessageDrivenChannelAdapter<>(container);
+    adapter.setOutputChannel(received());
+    return adapter;
+}
+
+@Bean
+public ShareKafkaMessageListenerContainer<String, String> container() {
+    ContainerProperties properties = new ContainerProperties("someTopic");
+    // set more properties
+    return new ShareKafkaMessageListenerContainer<>(shareConsumerFactory(), properties);
+}
+
+@Bean
+public ShareConsumerFactory<String, String> shareConsumerFactory() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddress);
+    // set more properties
+    return new DefaultShareConsumerFactory<>(props);
+}
+----
+======
+
+There is no XML namespace support for this adapter.
+
+As with the Java DSL for the classic message-driven adapter, the listener container does not have to be declared as a separate `@Bean`; the DSL registers it in the application context, named `<id>.container` when the adapter spec has an `id`, or generated from the container class name otherwise.
+
 [[kafka-inbound-pollable]]
 == Inbound Channel Adapter
 

--- a/src/reference/antora/modules/ROOT/pages/kafka.adoc
+++ b/src/reference/antora/modules/ROOT/pages/kafka.adoc
@@ -184,9 +184,9 @@ XML::
                                     kafka-template="template"
                                     auto-startup="false"
                                     channel="inputToKafka"
-                                    topic="foo"
+                                    topic="some-topic"
                                     sync="false"
-                                    message-key-expression="'bar'"
+                                    message-key-expression="'some-key'"
                                     send-failure-channel="failures"
                                     send-success-channel="successes"
                                     error-message-strategy="ems"
@@ -327,7 +327,7 @@ XML::
     </constructor-arg>
     <constructor-arg>
         <bean class="org.springframework.kafka.listener.config.ContainerProperties">
-            <constructor-arg name="topics" value="foo" />
+            <constructor-arg name="topics" value="some-topic" />
         </bean>
     </constructor-arg>
 

--- a/src/reference/antora/modules/ROOT/pages/whats-new.adoc
+++ b/src/reference/antora/modules/ROOT/pages/whats-new.adoc
@@ -17,6 +17,9 @@ Java 17 is still the baseline, but Java 25 is supported.
 [[x7.2-new-components]]
 === New Components
 
+A new `KafkaShareMessageDrivenChannelAdapter` provides a message-driven inbound channel adapter for Apache Kafka share groups (queues), built on `spring-kafka`'s `ShareKafkaMessageListenerContainer`.
+See xref:kafka.adoc#kafka-share-inbound[Message-driven Channel Adapter for Share Groups] for more information.
+
 [[x7.2-general-changes]]
 === General Changes
 


### PR DESCRIPTION
Kafka share groups (KIP-932 queues) have no Spring Integration inbound
support, since AbstractShareKafkaMessageListenerContainer is a
separate container hierarchy from AbstractMessageListenerContainer
and is incompatible with the existing KafkaMessageDrivenChannelAdapter.

* Add KafkaShareMessageDrivenChannelAdapter, a message-driven inbound
  channel adapter backed by a ShareKafkaMessageListenerContainer.
  It selects between two listeners based on ContainerProperties.ShareAckMode:
  a ShareRecordMessagingMessageListenerAdapter subclass for MANUAL mode,
  and a MessagingMessageListenerAdapter/MessageListener for EXPLICIT/IMPLICIT.
  In MANUAL mode, acknowledgment ownership follows the message: whichever
  flow receives it must acknowledge it, and the adapter only acknowledges
  on the flow's behalf when no flow ever receives the record (filtered or
  failed conversion).
* Add Java DSL support: Kafka.shareMessageDrivenChannelAdapter(),
  KafkaShareMessageListenerContainerSpec, and
  KafkaShareMessageDrivenChannelAdapterSpec.
* Add reference documentation for the new adapter and a what's-new entry.
* No XML namespace support for this adapter.
